### PR TITLE
Fix DateTime parsing/toString and stop using constructor.name

### DIFF
--- a/src/datatypes/clinical.coffee
+++ b/src/datatypes/clinical.coffee
@@ -13,6 +13,12 @@ module.exports.Code = class Code
 module.exports.Concept = class Concept
   constructor: (@codes = [], @display) ->
 
+  # Define a simple getter to allow type-checking of this class without instanceof
+  # and in a way that survives minification (as opposed to checking constructor.name)
+  Object.defineProperties @prototype,
+    isConcept:
+      get: -> true
+
   hasMatch: (code) ->
     codesInList(toCodeList(code), @codes)
 

--- a/src/datatypes/datetime.coffee
+++ b/src/datatypes/datetime.coffee
@@ -6,7 +6,7 @@ module.exports.DateTime = class DateTime
   @FIELDS: [@Unit.YEAR, @Unit.MONTH, @Unit.DAY, @Unit.HOUR, @Unit.MINUTE, @Unit.SECOND, @Unit.MILLISECOND]
 
   @parse: (string) ->
-    match = regex = /(\d{4})(-(\d{2}))?(-(\d{2}))?(T((\d{2})(\:(\d{2})(\:(\d{2})(\.(\d+))?)?)?)?(([+-])(\d{2})(\:?(\d{2}))?)?)?/.exec string
+    match = regex = /(\d{4})(-(\d{2}))?(-(\d{2}))?(T((\d{2})(\:(\d{2})(\:(\d{2})(\.(\d+))?)?)?)?(Z|(([+-])(\d{2})(\:?(\d{2}))?))?)?/.exec string
 
     if match?[0] is string
       args = [match[1], match[3], match[5], match[8], match[10], match[12], match[14]]
@@ -15,9 +15,11 @@ module.exports.DateTime = class DateTime
       # convert them all to integers
       args = ((if arg? then parseInt(arg,10)) for arg in args)
       # convert timezone offset to decimal and add it to arguments
-      if match[17]?
-        num = parseInt(match[17],10) + (if match[19]? then parseInt(match[19],10) / 60 else 0)
-        args.push(if match[16] is '+' then num else num * -1)
+      if match[18]?
+        num = parseInt(match[18],10) + (if match[20]? then parseInt(match[20],10) / 60 else 0)
+        args.push(if match[17] is '+' then num else num * -1)
+      else if match[15] == 'Z'
+        args.push(0)
       new DateTime(args...)
     else
       null
@@ -347,7 +349,6 @@ module.exports.DateTime = class DateTime
   _pad: (num) ->
     String("0" + num).slice(-2)
 
-  # TODO: Needs unit tests!
   toString: () ->
     str = ''
     if @year?
@@ -363,14 +364,14 @@ module.exports.DateTime = class DateTime
               if @second?
                 str += ':' + @_pad(@second)
                 if @millisecond?
-                  str += '.' + @_pad(@millisecond)
+                  str += '.' + String("00" + @millisecond).slice(-3)
 
     if str.indexOf('T') != -1 and @timezoneOffset?
       str += if @timezoneOffset < 0 then '-' else '+'
       offsetHours = Math.floor(Math.abs(@timezoneOffset))
       str += @_pad(offsetHours)
       offsetMin = (Math.abs(@timezoneOffset) - offsetHours) * 60
-      str += @_pad(offsetMin)
+      str += ':' + @_pad(offsetMin)
 
     str
 

--- a/src/datatypes/datetime.coffee
+++ b/src/datatypes/datetime.coffee
@@ -50,6 +50,12 @@ module.exports.DateTime = class DateTime
     if not @timezoneOffset?
       @timezoneOffset = (new Date()).getTimezoneOffset() / 60 * -1
 
+  # Define a simple getter to allow type-checking of this class without instanceof
+  # and in a way that survives minification (as opposed to checking constructor.name)
+  Object.defineProperties @prototype,
+    isDateTime:
+      get: -> true
+
   copy: () ->
     new DateTime(@year, @month, @day, @hour, @minute, @second, @millisecond, @timezoneOffset)
 

--- a/src/datatypes/interval.coffee
+++ b/src/datatypes/interval.coffee
@@ -7,6 +7,12 @@ cmp = require '../util/comparison'
 module.exports.Interval = class Interval
   constructor: (@low, @high, @lowClosed = true, @highClosed = true) ->
 
+  # Define a simple getter to allow type-checking of this class without instanceof
+  # and in a way that survives minification (as opposed to checking constructor.name)
+  Object.defineProperties @prototype,
+    isInterval:
+      get: -> true
+
   contains: (item, precision) ->
     if item instanceof Interval then throw new Error("Argument to contains must be a point")
     closed = @toClosed()
@@ -228,7 +234,7 @@ module.exports.Interval = class Interval
 
   toClosed: () ->
     point = @low ? @high
-    if typeof(point) is 'number' or point instanceof DateTime or point?.constructor?.name == 'Quantity'
+    if typeof(point) is 'number' or point instanceof DateTime or point?.isQuantity
       low = switch
         when @lowClosed and not @low? then minValueForInstance point
         when not @lowClosed and @low? then successor @low

--- a/src/elm/aggregate.coffee
+++ b/src/elm/aggregate.coffee
@@ -10,8 +10,8 @@ quantitiesOrArg = (arr) ->
   if arr.length == 0
     return arr
 
-  allQs = arr.every (x) -> x.constructor.name == "Quantity"
-  someQs = arr.some (x) -> x.constructor.name == "Quantity"
+  allQs = arr.every (x) -> x.isQuantity
+  someQs = arr.some (x) -> x.isQuantity
   if allQs
     unit = arr[0].unit
     values = []

--- a/src/elm/arithmetic.coffee
+++ b/src/elm/arithmetic.coffee
@@ -14,7 +14,7 @@ module.exports.Add = class Add extends Expression
       null
     else
       args?.reduce (x,y) ->
-        if x.constructor.name == 'Quantity'  or x.constructor.name == 'DateTime'
+        if x.isQuantity  or x.isDateTime
           Quantity.doAddition(x,y)
         else
           x + y
@@ -29,7 +29,7 @@ module.exports.Subtract = class Subtract extends Expression
       null
     else
       args.reduce (x,y) ->
-        if x.constructor.name == 'Quantity' or x.constructor.name == 'DateTime'
+        if x.isQuantity or x.isDateTime
           Quantity.doSubtraction(x,y)
         else
           x - y
@@ -44,7 +44,7 @@ module.exports.Multiply = class Multiply extends Expression
       null
     else
       args?.reduce (x,y) ->
-        if x.constructor.name == 'Quantity' or y.constructor.name == 'Quantity'
+        if x.isQuantity or y.isQuantity
           Quantity.doMultiplication(x,y)
         else
           x * y
@@ -59,7 +59,7 @@ module.exports.Divide = class Divide extends Expression
       null
     else
       args?.reduce (x,y) ->
-        if x.constructor.name == 'Quantity'
+        if x.isQuantity
           Quantity.doDivision(x,y)
         else
           x / y
@@ -118,7 +118,7 @@ module.exports.Abs = class Abs extends  Expression
     arg = @execArgs(ctx)
     if (not arg?)
       null
-    else if arg.constructor.name == 'Quantity'
+    else if arg.isQuantity
       Quantity.createQuantity( Math.abs(arg.value), arg.unit)
     else
       Math.abs arg
@@ -131,7 +131,7 @@ module.exports.Negate = class Negate extends Expression
     arg = @execArgs(ctx)
     if (not arg?)
       null
-    else if arg.constructor.name == 'Quantity'
+    else if arg.isQuantity
       Quantity.createQuantity(arg.value * -1, arg.unit)
     else
       arg * -1

--- a/src/elm/clinical.coffee
+++ b/src/elm/clinical.coffee
@@ -102,6 +102,12 @@ module.exports.Concept = class Concept extends Expression
     @codes = json.code
     @display = json.display
 
+  # Define a simple getter to allow type-checking of this class without instanceof
+  # and in a way that survives minification (as opposed to checking constructor.name)
+  Object.defineProperties @prototype,
+    isConcept:
+      get: -> true
+
   toCode: (ctx, code) ->
     system = ctx.getCodeSystem(code.system.name)?.id
     return new dt.Code(code.code, system, code.version, code.display)

--- a/src/elm/datetime.coffee
+++ b/src/elm/datetime.coffee
@@ -8,6 +8,12 @@ module.exports.DateTime = class DateTime extends Expression
   constructor: (@json) ->
     super
 
+  # Define a simple getter to allow type-checking of this class without instanceof
+  # and in a way that survives minification (as opposed to checking constructor.name)
+  Object.defineProperties @prototype,
+    isDateTime:
+      get: -> true
+
   exec: (ctx) ->
     for property in DateTime.PROPERTIES
       # if json does not contain 'timezoneOffset' set it to the executionDateTime from the context
@@ -24,6 +30,12 @@ module.exports.Time = class Time extends Expression
     super
     for property in Time.PROPERTIES
       if json[property]? then @[property] = build json[property]
+
+  # Define a simple getter to allow type-checking of this class without instanceof
+  # and in a way that survives minification (as opposed to checking constructor.name)
+  Object.defineProperties @prototype,
+    isTime:
+      get: -> true
 
   exec: (ctx) ->
     args = ((if @[p]? then @[p].execute(ctx)) for p in Time.PROPERTIES)

--- a/src/elm/interval.coffee
+++ b/src/elm/interval.coffee
@@ -13,6 +13,12 @@ module.exports.Interval = class Interval extends Expression
     @low = build(json.low)
     @high = build(json.high)
 
+  # Define a simple getter to allow type-checking of this class without instanceof
+  # and in a way that survives minification (as opposed to checking constructor.name)
+  Object.defineProperties @prototype,
+    isInterval:
+      get: -> true
+
   exec: (ctx) ->
     new dtivl.Interval(@low.execute(ctx), @high.execute(ctx), @lowClosed, @highClosed)
 

--- a/src/elm/list.coffee
+++ b/src/elm/list.coffee
@@ -9,6 +9,12 @@ module.exports.List = class List extends Expression
     super
     @elements = (build json.element) ? []
 
+  # Define a simple getter to allow type-checking of this class without instanceof
+  # and in a way that survives minification (as opposed to checking constructor.name)
+  Object.defineProperties @prototype,
+    isList:
+      get: -> true
+
   exec: (ctx) ->
     (item.execute(ctx) for item in @elements)
 

--- a/src/elm/literal.coffee
+++ b/src/elm/literal.coffee
@@ -24,6 +24,12 @@ module.exports.BooleanLiteral = class BooleanLiteral extends Literal
     super
     @value = @value is 'true'
 
+  # Define a simple getter to allow type-checking of this class without instanceof
+  # and in a way that survives minification (as opposed to checking constructor.name)
+  Object.defineProperties @prototype,
+    isBooleanLiteral:
+      get: -> true
+
   exec: (ctx) ->
     @value
 
@@ -31,6 +37,12 @@ module.exports.IntegerLiteral = class IntegerLiteral extends Literal
   constructor: (json) ->
     super
     @value = parseInt(@value, 10)
+
+  # Define a simple getter to allow type-checking of this class without instanceof
+  # and in a way that survives minification (as opposed to checking constructor.name)
+  Object.defineProperties @prototype,
+    isIntegerLiteral:
+      get: -> true
 
   exec: (ctx) ->
     @value
@@ -40,12 +52,24 @@ module.exports.DecimalLiteral = class DecimalLiteral extends Literal
     super
     @value = parseFloat(@value)
 
+  # Define a simple getter to allow type-checking of this class without instanceof
+  # and in a way that survives minification (as opposed to checking constructor.name)
+  Object.defineProperties @prototype,
+    isDecimalLiteral:
+      get: -> true
+
   exec: (ctx) ->
     @value
 
 module.exports.StringLiteral = class StringLiteral extends Literal
   constructor: (json) ->
     super
+
+  # Define a simple getter to allow type-checking of this class without instanceof
+  # and in a way that survives minification (as opposed to checking constructor.name)
+  Object.defineProperties @prototype,
+    isStringLiteral:
+      get: -> true
 
   exec: (ctx) ->
     # TODO: Remove these replacements when CQL-to-ELM fixes bug: https://github.com/cqframework/clinical_quality_language/issues/82

--- a/src/elm/quantity.coffee
+++ b/src/elm/quantity.coffee
@@ -23,6 +23,12 @@ module.exports.Quantity = class Quantity extends Expression
     if !is_valid_ucum_unit(@unit)
       throw new Error("\'#{@unit}\' is not a valid UCUM unit.")
 
+  # Define a simple getter to allow type-checking of this class without instanceof
+  # and in a way that survives minification (as opposed to checking constructor.name)
+  Object.defineProperties @prototype,
+    isQuantity:
+      get: -> true
+
   clone: () ->
     new Quantity({value: @value, unit: @unit})
 

--- a/src/elm/structured.coffee
+++ b/src/elm/structured.coffee
@@ -30,6 +30,12 @@ module.exports.Tuple = class Tuple extends Expression
       name: el.name
       value: build el.value
 
+  # Define a simple getter to allow type-checking of this class without instanceof
+  # and in a way that survives minification (as opposed to checking constructor.name)
+  Object.defineProperties @prototype,
+    isTuple:
+      get: -> true
+
   exec: (ctx) ->
     val = {}
     for el in @elements

--- a/src/runtime/context.coffee
+++ b/src/runtime/context.coffee
@@ -164,7 +164,7 @@ module.exports.Context = class Context
       spec.element.every (x) => (typeof val[x.name] is "undefined" || @matchesTypeSpecifier(val[x.name], x.type))
 
   matchesIntervalTypeSpecifier: (val, spec) ->
-    val.constructor?.name is "Interval" &&
+    val.isInterval &&
       ((! val.low?) || @matchesTypeSpecifier(val.low, spec.pointType)) &&
       ((! val.high?) || @matchesTypeSpecifier(val.high, spec.pointType))
 
@@ -174,25 +174,25 @@ module.exports.Context = class Context
       when "{urn:hl7-org:elm-types:r1}Decimal" then typeof val is "number"
       when "{urn:hl7-org:elm-types:r1}Integer" then typeof val is "number" && Math.floor(val) == val
       when "{urn:hl7-org:elm-types:r1}String" then typeof val is "string"
-      when "{urn:hl7-org:elm-types:r1}Concept" then val?.constructor?.name is 'Concept'
-      when "{urn:hl7-org:elm-types:r1}DateTime" then val?.constructor?.name is 'DateTime'
-      when "{urn:hl7-org:elm-types:r1}Quantity" then val?.constructor?.name is 'Quantity'
-      when "{urn:hl7-org:elm-types:r1}Time" then val?.constructor?.name is 'DateTime' && val.isTime()
+      when "{urn:hl7-org:elm-types:r1}Concept" then val?.isConcept
+      when "{urn:hl7-org:elm-types:r1}DateTime" then val?.isDateTime
+      when "{urn:hl7-org:elm-types:r1}Quantity" then val?.isQuantity
+      when "{urn:hl7-org:elm-types:r1}Time" then val?.isDateTime && val.isTime()
       else true # TODO: Better checking of custom or complex types
 
   matchesInstanceType: (val, inst) ->
-    switch inst.constructor?.name
-      when "BooleanLiteral" then typeof val is "boolean"
-      when "DecimalLiteral" then typeof val is "number"
-      when "IntegerLiteral" then typeof val is "number" && Math.floor(val) == val
-      when "StringLiteral" then typeof val is "string"
-      when "Concept" then val?.constructor?.name is "Concept"
-      when "DateTime" then val?.constructor?.name is "DateTime"
-      when "Quantity" then val?.constructor?.name is "Quantity"
-      when "Time" then val?.constructor?.name is "DateTime" && val.isTime()
-      when "List" then @matchesListInstanceType(val, inst)
-      when "Tuple" then @matchesTupleInstanceType(val, inst)
-      when "Interval" then @matchesIntervalInstanceType(val, inst)
+    switch
+      when inst.isBooleanLiteral then typeof val is "boolean"
+      when inst.isDecimalLiteral then typeof val is "number"
+      when inst.isIntegerLiteral then typeof val is "number" && Math.floor(val) == val
+      when inst.isStringLiteral then typeof val is "string"
+      when inst.isConcept then val?.isConcept
+      when inst.isDateTime then val?.isDateTime
+      when inst.isQuantity then val?.isQuantity
+      when inst.isTime then val?.isDateTime && val.isTime()
+      when inst.isList then @matchesListInstanceType(val, inst)
+      when inst.isTuple then @matchesTupleInstanceType(val, inst)
+      when inst.isInterval then @matchesIntervalInstanceType(val, inst)
       else true # default to true when we don't know for sure
 
   matchesListInstanceType: (val, list) ->
@@ -205,7 +205,7 @@ module.exports.Context = class Context
 
   matchesIntervalInstanceType: (val, ivl) ->
     pointType = ivl.low ? ivl.high
-    val.constructor?.name is "Interval" &&
+    val.isInterval &&
       ((! val.low?) || @matchesInstanceType(val.low, pointType)) &&
       ((! val.high?) || @matchesInstanceType(val.high, pointType))
 

--- a/src/util/comparison.coffee
+++ b/src/util/comparison.coffee
@@ -5,7 +5,7 @@ areNumbers = (a, b) ->
   typeof a is 'number' and typeof b is 'number'
 
 areDateTimesOrQuantities = (a, b) ->
-  (a instanceof DateTime and b instanceof DateTime) or (a?.constructor?.name == 'Quantity' and b?.constructor?.name == 'Quantity')
+  (a instanceof DateTime and b instanceof DateTime) or (a?.isQuantity and b?.isQuantity)
 
 isUncertainty = (x) ->
   x instanceof Uncertainty
@@ -90,7 +90,7 @@ module.exports.equals = equals = (a, b) ->
   return null unless a? and b?
 
   # If one is a Quantity, use the Quantity equals function
-  return a.equals b if a?.constructor?.name == 'Quantity'
+  return a.equals b if a?.isQuantity
 
   # If one is an Uncertainty, convert the other to an Uncertainty
   if a instanceof Uncertainty then b = Uncertainty.from(b)

--- a/src/util/math.coffee
+++ b/src/util/math.coffee
@@ -28,7 +28,7 @@ module.exports.successor = successor = (val) ->
     # For uncertainties, if the high is the max val, don't increment it
     high = try successor val.high; catch e then val.high
     new Uncertainty(successor(val.low), high)
-  else if val?.constructor?.name == 'Quantity'
+  else if val?.isQuantity
     succ = val.clone()
     succ.value = successor val.value
     succ
@@ -49,7 +49,7 @@ module.exports.predecessor = predecessor = (val) ->
     # For uncertainties, if the low is the min val, don't decrement it
     low = try predecessor val.low; catch e then val.low
     new Uncertainty(low, predecessor(val.high))
-  else if val?.constructor?.name == 'Quantity'
+  else if val?.isQuantity
     pred = val.clone()
     pred.value = predecessor val.value
     pred
@@ -61,7 +61,7 @@ module.exports.maxValueForInstance = (val) ->
     if parseInt(val) is val then MAX_INT_VALUE else MAX_FLOAT_VALUE
   else if val instanceof DateTime
     MAX_DATE_VALUE
-  else if val?.constructor?.name == 'Quantity'
+  else if val?.isQuantity
     val2 = val.clone()
     val2.value = maxValueForInstance val2.value
     val2
@@ -73,7 +73,7 @@ module.exports.minValueForInstance = (val) ->
     if parseInt(val) is val then MIN_INT_VALUE else MIN_FLOAT_VALUE
   else if val instanceof DateTime
     MIN_DATE_VALUE
-  else if val?.constructor?.name == 'Quantity'
+  else if val?.isQuantity
     val2 = val.clone()
     val2.value = minValueForInstance val2.value
     val2

--- a/test/datatypes/datetime.coffee
+++ b/test/datatypes/datetime.coffee
@@ -47,18 +47,30 @@ describe 'DateTime', ->
     d.should.eql new DateTime(2012, 10, 25, 12)
     d = DateTime.parse '2012-10-25T12-05'
     d.should.eql new DateTime(2012, 10, 25, 12, null, null, null, -5)
+    d = DateTime.parse '2012-10-25T12-05:30'
+    d.should.eql new DateTime(2012, 10, 25, 12, null, null, null, -5.5)
+    d = DateTime.parse '2012-10-25T12Z'
+    d.should.eql new DateTime(2012, 10, 25, 12, null, null, null, 0)
 
   it 'should parse yyyy-mm-ddThh:mm with and without timezone offset', ->
     d = DateTime.parse '2012-10-25T12:55'
     d.should.eql new DateTime(2012, 10, 25, 12, 55)
+    d = DateTime.parse '2012-10-25T12:55+05'
+    d.should.eql new DateTime(2012, 10, 25, 12, 55, null, null, 5)
     d = DateTime.parse '2012-10-25T12:55+05:30'
     d.should.eql new DateTime(2012, 10, 25, 12, 55, null, null, 5.5)
+    d = DateTime.parse '2012-10-25T12:55Z'
+    d.should.eql new DateTime(2012, 10, 25, 12, 55, null, null, 0)
 
   it 'should parse yyyy-mm-ddThh:mm:ss with and without timezone offset', ->
     d = DateTime.parse '2012-10-25T12:55:14'
     d.should.eql new DateTime(2012, 10, 25, 12, 55, 14)
     d = DateTime.parse '2012-10-25T12:55:14+01'
     d.should.eql new DateTime(2012, 10, 25, 12, 55, 14, null, 1)
+    d = DateTime.parse '2012-10-25T12:55:14+01:30'
+    d.should.eql new DateTime(2012, 10, 25, 12, 55, 14, null, 1.5)
+    d = DateTime.parse '2012-10-25T12:55:14Z'
+    d.should.eql new DateTime(2012, 10, 25, 12, 55, 14, null, 0)
 
   it 'should parse yyyy-mm-ddThh:mm:ss.s with and without timezone offset', ->
     d = DateTime.parse '2012-10-25T12:55:14.9'
@@ -75,6 +87,46 @@ describe 'DateTime', ->
 
     d = DateTime.parse '2012-10-25T12:55:14.953-01'
     d.should.eql new DateTime(2012, 10, 25, 12, 55, 14, 953, -1)
+
+    d = DateTime.parse '2012-10-25T12:55:14.953-01:30'
+    d.should.eql new DateTime(2012, 10, 25, 12, 55, 14, 953, -1.5)
+
+    d = DateTime.parse '2012-10-25T12:55:14.953Z'
+    d.should.eql new DateTime(2012, 10, 25, 12, 55, 14, 953, 0)
+
+  it 'should toString yyyy', ->
+    d = new DateTime(2012)
+    d.toString().should.eql '2012'
+
+  it 'should toString yyyy-mm', ->
+    d = new DateTime(2012, 10)
+    d.toString().should.eql '2012-10'
+
+  it 'should toString yyyy-mm-dd', ->
+    d = new DateTime(2012, 10, 25)
+    d.toString().should.eql '2012-10-25'
+
+  it 'should toString yyyy-mm-ddThh', ->
+    d = new DateTime(2012, 10, 25, 12, null, null, null, -5)
+    d.toString().should.eql '2012-10-25T12-05:00'
+
+  it 'should toString yyyy-mm-ddThh:mm', ->
+    d = new DateTime(2012, 10, 25, 12, 55, null, null, -5)
+    d.toString().should.eql '2012-10-25T12:55-05:00'
+
+  it 'should toString yyyy-mm-ddThh:mm:ss', ->
+    d = new DateTime(2012, 10, 25, 12, 55, 14, null, -5)
+    d.toString().should.eql '2012-10-25T12:55:14-05:00'
+
+  it 'should toString yyyy-mm-ddThh:mm:ss.sss', ->
+    d = new DateTime(2012, 10, 25, 12, 55, 14, 9, -5)
+    d.toString().should.eql '2012-10-25T12:55:14.009-05:00'
+
+    d = new DateTime(2012, 10, 25, 12, 55, 14, 95, -5)
+    d.toString().should.eql '2012-10-25T12:55:14.095-05:00'
+
+    d = new DateTime(2012, 10, 25, 12, 55, 14, 953, -5)
+    d.toString().should.eql '2012-10-25T12:55:14.953-05:00'
 
   it 'should not parse invalid strings', ->
     should.not.exist DateTime.parse '20121025'

--- a/test/elm/aggregate/test.coffee
+++ b/test/elm/aggregate/test.coffee
@@ -2,7 +2,7 @@ should = require 'should'
 setup = require '../../setup'
 data = require './data'
 validateQuantity = (object,expectedValue,expectedUnit) ->
-  object.constructor.name.should.equal "Quantity"
+  object.isQuantity.should.be.true()
   object.value.should.equal expectedValue
   object.unit.should.equal expectedUnit
 

--- a/test/elm/arithmetic/test.coffee
+++ b/test/elm/arithmetic/test.coffee
@@ -5,10 +5,10 @@ Q = require '../../../lib/elm/quantity'
 
 
 validateQuantity = (object,expectedValue,expectedUnit) ->
-  object.constructor.name.should.equal "Quantity"
+  object.isQuantity.should.be.true()
   q = Q.createQuantity(expectedValue,expectedUnit)
   q.equals(object).should.be.true("Expected "+ object + " to equal " + q)
-  
+
 doQuantityMathTests = (tests, operator) ->
   func = switch operator
            when "*" then Q.doMultiplication
@@ -420,7 +420,7 @@ describe 'Quantity', ->
   it "should be able to perform Quantity Addition", ->
     validateQuantity @add_q_q.exec(@ctx), 20 , 'days'
     adq = @add_d_q.exec(@ctx)
-    adq.constructor.name.should.equal "DateTime"
+    adq.isDateTime.should.be.true()
     adq.year.should.equal 2000
     adq.month.should.equal 1
     adq.day.should.equal 11
@@ -431,7 +431,7 @@ describe 'Quantity', ->
   it "should be able to perform Quantity Subtraction", ->
     validateQuantity @sub_q_q.exec(@ctx), 0, 'days'
     sdq = @sub_d_q.exec(@ctx)
-    sdq.constructor.name.should.equal "DateTime"
+    sdq.isDateTime.should.be.true()
     sdq.year.should.equal 1999
     sdq.month.should.equal 12
     sdq.day.should.equal 22


### PR DESCRIPTION
This PR addresses two concerns:

**DateTime Parsing/ToString Fixes**

The specification indicates that DateTimes can indicate UTC via the `Z` postfix (rather than `+00:00`).  This PR updates the DateTime parser to support that.

The specification also indicates that `ToString(DateTime)` should have the format `YYYY-MM-DDThh:mm:ss.fff(+|-)hh:mm`, but we erroneously output it as `YYYY-MM-DDThh:mm:ss.ff(+|-)hhmm` (note only 2 places for milliseconds and no `:` in the offset).  This PR also fixes that.

**Webpack Compatibility**

Some projects may wish to use this library with Webpack.  When Webpack minimizes javascript, it renames classes to shorter versions (e.g., `Quantity` might get renamed to just `Q`).  When this happens, logic like `a.constructor.name == 'Quantity'` no longer works.  For this reason, we needed another way to identify the few classes we often identify by constructor.  This PR implements that via the use of getters (like `isQuantity`).

This Webpack-related change should be fully backward-compatible and introduce no regressions or changes in logic at all.

_NOTE: There is still a Webpack issue related to the ucum library, but that should be addressed separately.  That is still under investigation._

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository. 
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change

**Reviewer:**

Name:  jbrad11
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
