### PR TITLE
CQL v1.3 #1435 Exists operator ignore null elements in lists

### DIFF
--- a/src/elm/list.coffee
+++ b/src/elm/list.coffee
@@ -23,7 +23,16 @@ module.exports.Exists = class Exists extends Expression
     super
 
   exec: (ctx) ->
-    @execArgs(ctx)?.length > 0
+    list = @execArgs(ctx)
+    # if list exists and has non empty length we need to make sure it isnt just full of nulls
+    if list?.length > 0
+      for item in list
+        # return true if we found an item that isnt null.
+        return true if item != null
+      false
+    else
+      false
+
 
 # Equal is completely handled by overloaded#Equal
 

--- a/src/elm/list.coffee
+++ b/src/elm/list.coffee
@@ -29,9 +29,7 @@ module.exports.Exists = class Exists extends Expression
       for item in list
         # return true if we found an item that isnt null.
         return true if item != null
-      false
-    else
-      false
+    false
 
 
 # Equal is completely handled by overloaded#Equal

--- a/src/example/browser/cql4browsers.js
+++ b/src/example/browser/cql4browsers.js
@@ -4509,8 +4509,19 @@
     }
 
     Exists.prototype.exec = function(ctx) {
-      var ref2;
-      return ((ref2 = this.execArgs(ctx)) != null ? ref2.length : void 0) > 0;
+      var item, j, len, list;
+      list = this.execArgs(ctx);
+      if ((list != null ? list.length : void 0) > 0) {
+        for (j = 0, len = list.length; j < len; j++) {
+          item = list[j];
+          if (item !== null) {
+            return true;
+          }
+        }
+        return false;
+      } else {
+        return false;
+      }
     };
 
     return Exists;

--- a/src/example/browser/cql4browsers.js
+++ b/src/example/browser/cql4browsers.js
@@ -4518,10 +4518,8 @@
             return true;
           }
         }
-        return false;
-      } else {
-        return false;
       }
+      return false;
     };
 
     return Exists;

--- a/test/elm/list/data.coffee
+++ b/test/elm/list/data.coffee
@@ -287,6 +287,7 @@ define ListWithOneNull: exists ({ null })
 define ListWithTwoNulls: exists ({ null, null })
 define ListStartingWithNull: exists ({ null, 3, 4 })
 define ListWithNull: exists ({ 3, null, 5 })
+define NullExists: exists (null)
 ###
 
 module.exports['Exists'] = {
@@ -623,6 +624,48 @@ module.exports['Exists'] = {
                      "value" : "5",
                      "type" : "Literal"
                   } ]
+               }
+            }
+         }, {
+            "localId" : "35",
+            "name" : "NullExists",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "35",
+                  "s" : [ {
+                     "value" : [ "define ","NullExists",": " ]
+                  }, {
+                     "r" : "34",
+                     "s" : [ {
+                        "value" : [ "exists " ]
+                     }, {
+                        "r" : "33",
+                        "s" : [ {
+                           "value" : [ "(","null",")" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "34",
+               "type" : "Exists",
+               "operand" : {
+                  "type" : "As",
+                  "operand" : {
+                     "localId" : "33",
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }
                }
             }
          } ]

--- a/test/elm/list/data.coffee
+++ b/test/elm/list/data.coffee
@@ -283,6 +283,10 @@ using QUICK
 context Patient
 define EmptyList: exists (List<Integer>{})
 define FullList: exists ({ 1, 2, 3 })
+define ListWithOneNull: exists ({ null })
+define ListWithTwoNulls: exists ({ null, null })
+define ListStartingWithNull: exists ({ null, 3, 4 })
+define ListWithNull: exists ({ 3, null, 5 })
 ###
 
 module.exports['Exists'] = {
@@ -414,6 +418,209 @@ module.exports['Exists'] = {
                      "localId" : "8",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "3",
+                     "type" : "Literal"
+                  } ]
+               }
+            }
+         }, {
+            "localId" : "15",
+            "name" : "ListWithOneNull",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "15",
+                  "s" : [ {
+                     "value" : [ "define ","ListWithOneNull",": " ]
+                  }, {
+                     "r" : "14",
+                     "s" : [ {
+                        "value" : [ "exists " ]
+                     }, {
+                        "r" : "13",
+                        "s" : [ {
+                           "value" : [ "(" ]
+                        }, {
+                           "r" : "13",
+                           "s" : [ {
+                              "value" : [ "{ ","null"," }" ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "14",
+               "type" : "Exists",
+               "operand" : {
+                  "localId" : "13",
+                  "type" : "List",
+                  "element" : [ {
+                     "localId" : "12",
+                     "type" : "Null"
+                  } ]
+               }
+            }
+         }, {
+            "localId" : "20",
+            "name" : "ListWithTwoNulls",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "20",
+                  "s" : [ {
+                     "value" : [ "define ","ListWithTwoNulls",": " ]
+                  }, {
+                     "r" : "19",
+                     "s" : [ {
+                        "value" : [ "exists " ]
+                     }, {
+                        "r" : "18",
+                        "s" : [ {
+                           "value" : [ "(" ]
+                        }, {
+                           "r" : "18",
+                           "s" : [ {
+                              "value" : [ "{ ","null",", ","null"," }" ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "19",
+               "type" : "Exists",
+               "operand" : {
+                  "localId" : "18",
+                  "type" : "List",
+                  "element" : [ {
+                     "localId" : "16",
+                     "type" : "Null"
+                  }, {
+                     "localId" : "17",
+                     "type" : "Null"
+                  } ]
+               }
+            }
+         }, {
+            "localId" : "26",
+            "name" : "ListStartingWithNull",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "26",
+                  "s" : [ {
+                     "value" : [ "define ","ListStartingWithNull",": " ]
+                  }, {
+                     "r" : "25",
+                     "s" : [ {
+                        "value" : [ "exists " ]
+                     }, {
+                        "r" : "24",
+                        "s" : [ {
+                           "value" : [ "(" ]
+                        }, {
+                           "r" : "24",
+                           "s" : [ {
+                              "value" : [ "{ ","null",", ","3",", ","4"," }" ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "25",
+               "type" : "Exists",
+               "operand" : {
+                  "localId" : "24",
+                  "type" : "List",
+                  "element" : [ {
+                     "asType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "As",
+                     "operand" : {
+                        "localId" : "21",
+                        "type" : "Null"
+                     }
+                  }, {
+                     "localId" : "22",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "3",
+                     "type" : "Literal"
+                  }, {
+                     "localId" : "23",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "4",
+                     "type" : "Literal"
+                  } ]
+               }
+            }
+         }, {
+            "localId" : "32",
+            "name" : "ListWithNull",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "32",
+                  "s" : [ {
+                     "value" : [ "define ","ListWithNull",": " ]
+                  }, {
+                     "r" : "31",
+                     "s" : [ {
+                        "value" : [ "exists " ]
+                     }, {
+                        "r" : "30",
+                        "s" : [ {
+                           "value" : [ "(" ]
+                        }, {
+                           "r" : "30",
+                           "s" : [ {
+                              "value" : [ "{ ","3",", ","null",", ","5"," }" ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "31",
+               "type" : "Exists",
+               "operand" : {
+                  "localId" : "30",
+                  "type" : "List",
+                  "element" : [ {
+                     "localId" : "27",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "3",
+                     "type" : "Literal"
+                  }, {
+                     "asType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "As",
+                     "operand" : {
+                        "localId" : "28",
+                        "type" : "Null"
+                     }
+                  }, {
+                     "localId" : "29",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "5",
                      "type" : "Literal"
                   } ]
                }

--- a/test/elm/list/data.cql
+++ b/test/elm/list/data.cql
@@ -13,6 +13,7 @@ define ListWithOneNull: exists ({ null })
 define ListWithTwoNulls: exists ({ null, null })
 define ListStartingWithNull: exists ({ null, 3, 4 })
 define ListWithNull: exists ({ 3, null, 5 })
+define NullExists: exists (null)
 
 // @Test: Equal
 define EqualIntList: {1, 2, 3} = {1, 2, 3}

--- a/test/elm/list/data.cql
+++ b/test/elm/list/data.cql
@@ -9,6 +9,10 @@ define EmptyList: List<Integer>{}
 // @Test: Exists
 define EmptyList: exists (List<Integer>{})
 define FullList: exists ({ 1, 2, 3 })
+define ListWithOneNull: exists ({ null })
+define ListWithTwoNulls: exists ({ null, null })
+define ListStartingWithNull: exists ({ null, 3, 4 })
+define ListWithNull: exists ({ 3, null, 5 })
 
 // @Test: Equal
 define EqualIntList: {1, 2, 3} = {1, 2, 3}

--- a/test/elm/list/test.coffee
+++ b/test/elm/list/test.coffee
@@ -28,6 +28,18 @@ describe 'Exists', ->
   it 'should return true for full list', ->
     @fullList.exec(@ctx).should.be.true()
 
+  it 'should return false for list with only one null', ->
+    @listWithOneNull.exec(@ctx).should.be.false()
+
+  it 'should return false for list with only two nulls', ->
+    @listWithTwoNulls.exec(@ctx).should.be.false()
+
+  it 'should return true for list starting with null and with non-null elements', ->
+    @listStartingWithNull.exec(@ctx).should.be.true()
+
+  it 'should return true for list with null and non-null elements', ->
+    @listWithNull.exec(@ctx).should.be.true()
+
 describe 'Equal', ->
   @beforeEach ->
     setup @, data

--- a/test/elm/list/test.coffee
+++ b/test/elm/list/test.coffee
@@ -40,6 +40,12 @@ describe 'Exists', ->
   it 'should return true for list with null and non-null elements', ->
     @listWithNull.exec(@ctx).should.be.true()
 
+  # NOTE: This test is misleading due to list promotion of the null to a list with null.
+  # Test will remain as it still tests a different list creation method. Additionally, it
+  # will be useful if list promotion is disabled.
+  it 'should return false for null argument', ->
+    @nullExists.exec(@ctx).should.be.false()
+
 describe 'Equal', ->
   @beforeEach ->
     setup @, data


### PR DESCRIPTION
Now ignoring null elements in lists.

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository. 
It is strongly recommended to include a person from each of those projects as a reviewer.

Bonnie JIRA link - https://jira.mitre.org/browse/BONNIE-1712

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass: Existing non-related tests still fail. Related tests pass. `-f Exists` to run tests
- [x] Code coverage has not gone down and all code touched or added is covered. Code coverage cannot be calculated with failing tests. Will be skipped for now.
- [x] ~All dependent libraries are appropriately updated or have a corresponding PR related to this change~ Will be completed later at end of 1.3 updates.

**Reviewer:**

Name: @losborne
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code