### PR TITLE
Add test for equality of singluar time units

### DIFF
--- a/test/elm/quantity/test.coffee
+++ b/test/elm/quantity/test.coffee
@@ -63,3 +63,19 @@ describe 'Quantity', ->
     result = numerator.dividedBy(denominator)
     result.unit.should.equal "1"
     result.value.should.equal -2.75
+
+  it 'should allow for singular time units', ->
+    year = new Quantity({unit: "year", value: 4})
+    month = new Quantity({unit: "month", value: 4})
+    day = new Quantity({unit: "day", value: 4})
+    hour = new Quantity({unit: "hour", value: 4})
+    minute = new Quantity({unit: "minute", value: 4})
+    second = new Quantity({unit: "second", value: 4})
+    millisecond = new Quantity({unit: "millisecond", value: 4})
+    year.equals(new Quantity({unit: "years", value: 4})).should.be.true()
+    month.equals(new Quantity({unit: "months", value: 4})).should.be.true()
+    day.equals(new Quantity({unit: "days", value: 4})).should.be.true()
+    hour.equals(new Quantity({unit: "hours", value: 4})).should.be.true()
+    minute.equals(new Quantity({unit: "minutes", value: 4})).should.be.true()
+    second.equals(new Quantity({unit: "seconds", value: 4})).should.be.true()
+    millisecond.equals(new Quantity({unit: "milliseconds", value: 4})).should.be.true()


### PR DESCRIPTION
1.3 updates specified that singular time units are allowed. cql-execution already supported this but it was untested. Added tests showing that singular date-time units are equal to the plural units.

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository. 
It is strongly recommended to include a person from each of those projects as a reviewer.
https://jira.mitre.org/browse/BONNIE-1718
**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change

**Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
