### PR TITLE
Null if cant convert

### DIFF
--- a/src/elm/type.coffee
+++ b/src/elm/type.coffee
@@ -4,6 +4,7 @@
 { Concept } = require '../datatypes/clinical'
 { parseQuantity } = require './quantity'
 { isValidDecimal, isValidInteger, limitDecimalPrecision } = require('../util/math')
+{ normalizeMillisecondsField, normalizeMillisecondsFieldInString } = require '../util/util'
 
 # TODO: Casting and Conversion needs unit tests!
 
@@ -74,8 +75,7 @@ module.exports.ToDecimal = class ToDecimal extends Expression
       decimal = parseFloat(arg.toString())
       decimal = limitDecimalPrecision(decimal)
       return decimal if isValidDecimal(decimal)
-     else
-      return null
+    return null
 
 module.exports.ToInteger = class ToInteger extends Expression
   constructor: (json) ->
@@ -86,8 +86,7 @@ module.exports.ToInteger = class ToInteger extends Expression
     if arg? and typeof arg != 'undefined'
       integer = parseInt(arg.toString())
       return integer if isValidInteger(integer)
-    else
-      return null
+    return null
 
 module.exports.ToQuantity = class ToQuantity extends Expression
   constructor: (json) ->
@@ -116,10 +115,38 @@ module.exports.ToTime = class ToTime extends Expression
   exec: (ctx) ->
     arg = @execArgs(ctx)
     if arg? and typeof arg != 'undefined'
-      dt = DateTime.parse(arg.toString())
-      if dt? and typeof dt != 'undefined' then dt.getTime() else null
+      timeString = arg.toString()
+      # Return null if string doesn't represent a valid ISO-8601 Time
+      # Thh:mm:ss.fff(+|-)hh:mm or Thh:mm:ss.fffZ
+      matches = /T((\d{2})(\:(\d{2})(\:(\d{2})(\.(\d+))?)?)?)?(Z|(([+-])(\d{2})(\:?(\d{2}))?))?/.exec timeString
+      return null unless matches?
+      hours = matches[2]
+      minutes = matches[4]
+      seconds = matches[6]
+      # Validate h/m/s if they exist, but allow null
+      if hours?
+        return null unless hours >= 0 and hours <= 23
+        hours = parseInt(hours, 10)
+      if minutes?
+        return null unless minutes >= 0 and minutes <= 59
+        minutes = parseInt(minutes, 10)
+      if seconds?
+        return null unless seconds >= 0 and seconds <= 59
+        seconds = parseInt(seconds, 10)
+      milliseconds = matches[8]
+      if milliseconds?
+        milliseconds = parseInt(normalizeMillisecondsField(milliseconds))
+
+      if matches[11]?
+        tz = parseInt(matches[12],10) + (if matches[14]? then parseInt(matches[14],10) / 60 else 0)
+        timezoneOffset = if matches[11] is '+' then tz else tz * -1
+      else if matches[9] == 'Z'
+        timezoneOffset = 0
+
+      # Time is implemented as Datetime with year 0, month 1, day 1
+      return new DateTime(0, 1, 1, hours, minutes, seconds, milliseconds, timezoneOffset)
     else
-      null
+      return null
 
 module.exports.Convert = class Convert extends Expression
   constructor: (json) ->
@@ -149,7 +176,6 @@ module.exports.Convert = class Convert extends Expression
         new ToTime({"type": "ToTime", "operand": @operand}).execute(ctx)
       else
         @execArgs(ctx)
-
 module.exports.Is = class Is extends UnimplementedExpression
 
 module.exports.IntervalTypeSpecifier = class IntervalTypeSpecifier extends UnimplementedExpression

--- a/src/example/browser/cql4browsers.js
+++ b/src/example/browser/cql4browsers.js
@@ -7941,17 +7941,13 @@
   module.exports.Is = Is = (function(superClass) {
     extend(Is, superClass);
 
-    function Is(json) {
-      Is.__super__.constructor.apply(this, arguments);
-      this.operand = json.operand;
-      this.toType = json.toType;
+    function Is() {
+      return Is.__super__.constructor.apply(this, arguments);
     }
-
-    Is.prototype.exec = function(ctx) {};
 
     return Is;
 
-  })(Expression);
+  })(UnimplementedExpression);
 
   module.exports.IntervalTypeSpecifier = IntervalTypeSpecifier = (function(superClass) {
     extend(IntervalTypeSpecifier, superClass);

--- a/src/util/math.coffee
+++ b/src/util/math.coffee
@@ -14,15 +14,15 @@ module.exports.MAX_TIME_VALUE = MAX_TIME_VALUE = DateTime.parse("0000-01-01T23:5
 
 
 module.exports.isValidInteger = isValidInteger = (integer) ->
-  throw new Error("Unable to parse Integer") if isNaN(integer)
-  throw new Error("Maximum Integer value exceeded") if integer > MAX_INT_VALUE
-  throw new Error("Minimum Integer value exceeded") if integer < MIN_INT_VALUE
+  return false if isNaN(integer)
+  return false if integer > MAX_INT_VALUE
+  return false if integer < MIN_INT_VALUE
   return true
 
 module.exports.isValidDecimal = isValidDecimal = (decimal) ->
-  throw new Error("Unable to parse Decimal") if isNaN(decimal)
-  throw new Error("Maximum Decimal value exceeded") if decimal > MAX_FLOAT_VALUE
-  throw new Error("Minimum Decimal value exceeded") if decimal < MIN_FLOAT_VALUE
+  return false if isNaN(decimal)
+  return false if decimal > MAX_FLOAT_VALUE
+  return false if decimal < MIN_FLOAT_VALUE
   return true
 
 module.exports.limitDecimalPrecision = (decimal) ->

--- a/src/util/util.coffee
+++ b/src/util/util.coffee
@@ -32,3 +32,25 @@ module.exports.makeJsDate = () ->
   `new Date(...arguments)`
 
 module.exports.jsDate = Date
+module.exports.normalizeMillisecondsFieldInString = normalizeMillisecondsFieldInString = (string, matches) ->
+  msString = matches[14]
+  # TODO: verify we are only removing numeral digits
+  msString = normalizeMillisecondsField(msString)
+  [beforeMs, msAndAfter] = string.split('.')
+  timezoneSeparator = getTimezoneSeparatorFromString(msAndAfter)
+
+  timezoneField = msAndAfter?.split(timezoneSeparator)[1] if !!timezoneSeparator
+  timezoneField = '' if !timezoneField?
+  string = beforeMs + '.' + msString + timezoneSeparator + timezoneField
+
+module.exports.normalizeMillisecondsField = normalizeMillisecondsField = (msString) ->
+  # fix up milliseconds by padding zeros and/or truncating (5 --> 500, 50 --> 500, 54321 --> 543, etc.)
+  msString = (msString + "00").substring(0, 3)
+
+module.exports.getTimezoneSeparatorFromString = getTimezoneSeparatorFromString = (string) ->
+  if string?.match(/-/)?.length == 1
+    timezoneSeparator = '-'
+  else if string?.match(/\+/)?.length == 1
+    timezoneSeparator = '+'
+  else
+    timezoneSeparator = ''

--- a/test/datatypes/date.coffee
+++ b/test/datatypes/date.coffee
@@ -41,15 +41,15 @@ describe 'Date', ->
     d = new Date(2012, 10, 25)
     d.toString().should.eql '2012-10-25'
 
-  it 'should throw runtime error when parsing non-string', ->
-    should(() => Date.parse 20121025).throw(/.*Invalid Date String.*/)
+  it 'should return null when parsing non-string', ->
+    should(Date.parse 20121025).be.null()
 
-  it 'should throw runtime error when parsing invalid string format', ->
-    should(() => Date.parse '20121025').throw(/.*Invalid Date String.*/)
+  it 'should return null when parsing invalid string format', ->
+    should(Date.parse '20121025').be.null()
 
-  it 'should throw runtime error when parsing invalid date/time values', ->
-    should(() => Date.parse '0000-00-00').throw(/.*Invalid Date String.*/)
-    should(() => Date.parse '2000-11-31').throw(/.*Invalid Date String.*/)
+  it 'should return null when parsing invalid date/time values', ->
+    should(Date.parse '0000-00-00').be.null()
+    should(Date.parse '2000-11-31').be.null()
 
   it 'should not parse null input', ->
     should.not.exist Date.parse null

--- a/test/datatypes/datetime.coffee
+++ b/test/datatypes/datetime.coffee
@@ -128,18 +128,18 @@ describe 'DateTime', ->
     d = new DateTime(2012, 10, 25, 12, 55, 14, 953, -5)
     d.toString().should.eql '2012-10-25T12:55:14.953-05:00'
 
-  it 'should throw runtime error when parsing non-string', ->
-    should(() => DateTime.parse 20121025).throw(/.*Invalid DateTime String.*/)
+  it 'should be null when parsing non-string', ->
+    should(DateTime.parse 20121025).be.null()
 
-  it 'should throw runtime error when parsing invalid string format', ->
-    should(() => DateTime.parse '20121025').throw(/.*Invalid DateTime String.*/)
+  it 'should be null when parsing invalid string format', ->
+    should(DateTime.parse '20121025').be.null()
 
-  it 'should throw runtime error when parsing invalid date/time values', ->
-    should(() => DateTime.parse '0000-00-00').throw(/.*Invalid DateTime String.*/)
-    should(() => DateTime.parse '2000-11-31T23:59:59.999').throw(/.*Invalid DateTime String.*/)
+  it 'should be null when parsing invalid date/time values', ->
+    should(DateTime.parse '0000-00-00').be.null()
+    should(DateTime.parse '2000-11-31T23:59:59.999').be.null()
 
-  it.skip 'should throw when ms field contains non-numeric characters after thousandths place', ->
-    should(() => DateTime.parse '2000-11-30T23:59:59.999abc').throw(/.*Invalid DateTime String.*/)
+  it.skip 'should be null when ms field contains non-numeric characters after thousandths place', ->
+    should(DateTime.parse '2000-11-30T23:59:59.999abc').be.null()
 
   it 'should not parse null input', ->
     should.not.exist DateTime.parse null

--- a/test/elm/convert/data.coffee
+++ b/test/elm/convert/data.coffee
@@ -25,6 +25,11 @@ define negQuantityStr: convert '-10 \'A\'' to Quantity
 define quantityStrDecimal: convert '10.0 \'mA\'' to Quantity
 define dateTimeStr: convert '2015-01-02' to DateTime
 define dateStr: convert '2015-01-02' to Date
+define NullConvert: convert 'foo' to DateTime
+define ZDateTime: convert '2014-01-01T14:30:00.0Z' to DateTime // January 1st, 2014, 2:30PM UTC
+define TimezoneDateTime: convert '2014-01-01T14:30:00.0-07:00' to DateTime // January 1st, 2014, 2:30PM Mountain Standard (GMT-7:00)
+define ZTime: convert 'T14:30:00.0Z' to Time // 2:30PM UTC
+define TimezoneTime: convert 'T14:30:00.0-07:00' to Time // 2:30PM Mountain Standard (GMT-7:00)
 ###
 
 module.exports['FromString'] = {
@@ -659,6 +664,211 @@ module.exports['FromString'] = {
                   "localId" : "58",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "2015-01-02",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "64",
+            "name" : "NullConvert",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "64",
+                  "s" : [ {
+                     "value" : [ "define ","NullConvert",": " ]
+                  }, {
+                     "r" : "63",
+                     "s" : [ {
+                        "value" : [ "convert " ]
+                     }, {
+                        "r" : "62",
+                        "s" : [ {
+                           "value" : [ "'foo'" ]
+                        } ]
+                     }, {
+                        "value" : [ " to " ]
+                     }, {
+                        "r" : "61",
+                        "s" : [ {
+                           "value" : [ "DateTime" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "63",
+               "type" : "ToDateTime",
+               "operand" : {
+                  "localId" : "62",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "foo",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "68",
+            "name" : "ZDateTime",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "68",
+                  "s" : [ {
+                     "value" : [ "define ","ZDateTime",": " ]
+                  }, {
+                     "r" : "67",
+                     "s" : [ {
+                        "value" : [ "convert " ]
+                     }, {
+                        "r" : "66",
+                        "s" : [ {
+                           "value" : [ "'2014-01-01T14:30:00.0Z'" ]
+                        } ]
+                     }, {
+                        "value" : [ " to " ]
+                     }, {
+                        "r" : "65",
+                        "s" : [ {
+                           "value" : [ "DateTime" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "67",
+               "type" : "ToDateTime",
+               "operand" : {
+                  "localId" : "66",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "2014-01-01T14:30:00.0Z",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "72",
+            "name" : "TimezoneDateTime",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "72",
+                  "s" : [ {
+                     "value" : [ "define ","TimezoneDateTime",": " ]
+                  }, {
+                     "r" : "71",
+                     "s" : [ {
+                        "value" : [ "convert " ]
+                     }, {
+                        "r" : "70",
+                        "s" : [ {
+                           "value" : [ "'2014-01-01T14:30:00.0-07:00'" ]
+                        } ]
+                     }, {
+                        "value" : [ " to " ]
+                     }, {
+                        "r" : "69",
+                        "s" : [ {
+                           "value" : [ "DateTime" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "71",
+               "type" : "ToDateTime",
+               "operand" : {
+                  "localId" : "70",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "2014-01-01T14:30:00.0-07:00",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "76",
+            "name" : "ZTime",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "76",
+                  "s" : [ {
+                     "value" : [ "define ","ZTime",": " ]
+                  }, {
+                     "r" : "75",
+                     "s" : [ {
+                        "value" : [ "convert " ]
+                     }, {
+                        "r" : "74",
+                        "s" : [ {
+                           "value" : [ "'T14:30:00.0Z'" ]
+                        } ]
+                     }, {
+                        "value" : [ " to " ]
+                     }, {
+                        "r" : "73",
+                        "s" : [ {
+                           "value" : [ "Time" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "75",
+               "type" : "ToTime",
+               "operand" : {
+                  "localId" : "74",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "T14:30:00.0Z",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "80",
+            "name" : "TimezoneTime",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "80",
+                  "s" : [ {
+                     "value" : [ "define ","TimezoneTime",": " ]
+                  }, {
+                     "r" : "79",
+                     "s" : [ {
+                        "value" : [ "convert " ]
+                     }, {
+                        "r" : "78",
+                        "s" : [ {
+                           "value" : [ "'T14:30:00.0-07:00'" ]
+                        } ]
+                     }, {
+                        "value" : [ " to " ]
+                     }, {
+                        "r" : "77",
+                        "s" : [ {
+                           "value" : [ "Time" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "79",
+               "type" : "ToTime",
+               "operand" : {
+                  "localId" : "78",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "T14:30:00.0-07:00",
                   "type" : "Literal"
                }
             }
@@ -2582,6 +2792,16 @@ context Patient
 define NullArgTime: ToTime((null as String))
 define IncorrectFormatTime: ToTime('10:00PM')
 define InvalidTime: ToTime('25:99.000+00.00')
+define TimeH: ToTime('T02')
+define TimeHM: ToTime('T02:04')
+define TimeHMS: ToTime('T02:04:59')
+define TimeHMSMs: ToTime('T02:04:59.123')
+define TimeHMSMsZ: ToTime('T02:04:59.123Z')
+define TimeHMSMsTimezone: ToTime('T02:04:59.123+01')
+define TimeHMSMsFullTimezone: ToTime('T02:04:59.123+01:00')
+define HourTooHigh: ToTime('T24')
+define MinuteTooHigh: ToTime('T23:60')
+define SecondTooHigh: ToTime('T23:59:60')
 ###
 
 module.exports['ToTime'] = {
@@ -2743,6 +2963,689 @@ module.exports['ToTime'] = {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "25:99.000+00.00",
                   "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "15",
+            "name" : "TimeH",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "15",
+                  "s" : [ {
+                     "value" : [ "define ","TimeH",": " ]
+                  }, {
+                     "r" : "14",
+                     "s" : [ {
+                        "value" : [ "ToTime","(" ]
+                     }, {
+                        "r" : "13",
+                        "s" : [ {
+                           "value" : [ "'T02'" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "14",
+               "type" : "ToTime",
+               "operand" : {
+                  "localId" : "13",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "T02",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "18",
+            "name" : "TimeHM",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "18",
+                  "s" : [ {
+                     "value" : [ "define ","TimeHM",": " ]
+                  }, {
+                     "r" : "17",
+                     "s" : [ {
+                        "value" : [ "ToTime","(" ]
+                     }, {
+                        "r" : "16",
+                        "s" : [ {
+                           "value" : [ "'T02:04'" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "17",
+               "type" : "ToTime",
+               "operand" : {
+                  "localId" : "16",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "T02:04",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "21",
+            "name" : "TimeHMS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "21",
+                  "s" : [ {
+                     "value" : [ "define ","TimeHMS",": " ]
+                  }, {
+                     "r" : "20",
+                     "s" : [ {
+                        "value" : [ "ToTime","(" ]
+                     }, {
+                        "r" : "19",
+                        "s" : [ {
+                           "value" : [ "'T02:04:59'" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "20",
+               "type" : "ToTime",
+               "operand" : {
+                  "localId" : "19",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "T02:04:59",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "24",
+            "name" : "TimeHMSMs",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "24",
+                  "s" : [ {
+                     "value" : [ "define ","TimeHMSMs",": " ]
+                  }, {
+                     "r" : "23",
+                     "s" : [ {
+                        "value" : [ "ToTime","(" ]
+                     }, {
+                        "r" : "22",
+                        "s" : [ {
+                           "value" : [ "'T02:04:59.123'" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "23",
+               "type" : "ToTime",
+               "operand" : {
+                  "localId" : "22",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "T02:04:59.123",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "27",
+            "name" : "TimeHMSMsZ",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "27",
+                  "s" : [ {
+                     "value" : [ "define ","TimeHMSMsZ",": " ]
+                  }, {
+                     "r" : "26",
+                     "s" : [ {
+                        "value" : [ "ToTime","(" ]
+                     }, {
+                        "r" : "25",
+                        "s" : [ {
+                           "value" : [ "'T02:04:59.123Z'" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "26",
+               "type" : "ToTime",
+               "operand" : {
+                  "localId" : "25",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "T02:04:59.123Z",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "30",
+            "name" : "TimeHMSMsTimezone",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "30",
+                  "s" : [ {
+                     "value" : [ "define ","TimeHMSMsTimezone",": " ]
+                  }, {
+                     "r" : "29",
+                     "s" : [ {
+                        "value" : [ "ToTime","(" ]
+                     }, {
+                        "r" : "28",
+                        "s" : [ {
+                           "value" : [ "'T02:04:59.123+01'" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "29",
+               "type" : "ToTime",
+               "operand" : {
+                  "localId" : "28",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "T02:04:59.123+01",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "33",
+            "name" : "TimeHMSMsFullTimezone",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "33",
+                  "s" : [ {
+                     "value" : [ "define ","TimeHMSMsFullTimezone",": " ]
+                  }, {
+                     "r" : "32",
+                     "s" : [ {
+                        "value" : [ "ToTime","(" ]
+                     }, {
+                        "r" : "31",
+                        "s" : [ {
+                           "value" : [ "'T02:04:59.123+01:00'" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "32",
+               "type" : "ToTime",
+               "operand" : {
+                  "localId" : "31",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "T02:04:59.123+01:00",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "36",
+            "name" : "HourTooHigh",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "36",
+                  "s" : [ {
+                     "value" : [ "define ","HourTooHigh",": " ]
+                  }, {
+                     "r" : "35",
+                     "s" : [ {
+                        "value" : [ "ToTime","(" ]
+                     }, {
+                        "r" : "34",
+                        "s" : [ {
+                           "value" : [ "'T24'" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "35",
+               "type" : "ToTime",
+               "operand" : {
+                  "localId" : "34",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "T24",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "39",
+            "name" : "MinuteTooHigh",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "39",
+                  "s" : [ {
+                     "value" : [ "define ","MinuteTooHigh",": " ]
+                  }, {
+                     "r" : "38",
+                     "s" : [ {
+                        "value" : [ "ToTime","(" ]
+                     }, {
+                        "r" : "37",
+                        "s" : [ {
+                           "value" : [ "'T23:60'" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "38",
+               "type" : "ToTime",
+               "operand" : {
+                  "localId" : "37",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "T23:60",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "42",
+            "name" : "SecondTooHigh",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "42",
+                  "s" : [ {
+                     "value" : [ "define ","SecondTooHigh",": " ]
+                  }, {
+                     "r" : "41",
+                     "s" : [ {
+                        "value" : [ "ToTime","(" ]
+                     }, {
+                        "r" : "40",
+                        "s" : [ {
+                           "value" : [ "'T23:59:60'" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "41",
+               "type" : "ToTime",
+               "operand" : {
+                  "localId" : "40",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "T23:59:60",
+                  "type" : "Literal"
+               }
+            }
+         } ]
+      }
+   }
+}
+
+### ToBoolean
+library TestSnippet version '1'
+using QUICK
+context Patient
+define IsTrue: ToBoolean('y')
+define IsFalse: ToBoolean('0')
+define IsNull: ToBoolean('falsetto')
+###
+
+module.exports['ToBoolean'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "1",
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "localId" : "4",
+            "name" : "IsTrue",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "4",
+                  "s" : [ {
+                     "value" : [ "define ","IsTrue",": " ]
+                  }, {
+                     "r" : "3",
+                     "s" : [ {
+                        "value" : [ "ToBoolean","(" ]
+                     }, {
+                        "r" : "2",
+                        "s" : [ {
+                           "value" : [ "'y'" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "3",
+               "type" : "ToBoolean",
+               "operand" : {
+                  "localId" : "2",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "y",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "7",
+            "name" : "IsFalse",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "7",
+                  "s" : [ {
+                     "value" : [ "define ","IsFalse",": " ]
+                  }, {
+                     "r" : "6",
+                     "s" : [ {
+                        "value" : [ "ToBoolean","(" ]
+                     }, {
+                        "r" : "5",
+                        "s" : [ {
+                           "value" : [ "'0'" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "6",
+               "type" : "ToBoolean",
+               "operand" : {
+                  "localId" : "5",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "0",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "10",
+            "name" : "IsNull",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "10",
+                  "s" : [ {
+                     "value" : [ "define ","IsNull",": " ]
+                  }, {
+                     "r" : "9",
+                     "s" : [ {
+                        "value" : [ "ToBoolean","(" ]
+                     }, {
+                        "r" : "8",
+                        "s" : [ {
+                           "value" : [ "'falsetto'" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "9",
+               "type" : "ToBoolean",
+               "operand" : {
+                  "localId" : "8",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "falsetto",
+                  "type" : "Literal"
+               }
+            }
+         } ]
+      }
+   }
+}
+
+### ToConcept
+library TestSnippet version '1'
+using QUICK
+context Patient
+define IsValid: ToConcept(Code { system: 'http://loinc.org', code: '8480-6' }) // Concept { codes: { Code { system: 'http://loinc.org', code: '8480-6' } } }
+define IsNull: ToConcept(null as Code)
+###
+
+module.exports['ToConcept'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "1",
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "localId" : "6",
+            "name" : "IsValid",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "6",
+                  "s" : [ {
+                     "value" : [ "define ","IsValid",": " ]
+                  }, {
+                     "r" : "5",
+                     "s" : [ {
+                        "value" : [ "ToConcept","(" ]
+                     }, {
+                        "r" : "4",
+                        "s" : [ {
+                           "value" : [ "Code"," { " ]
+                        }, {
+                           "s" : [ {
+                              "value" : [ "system",": " ]
+                           }, {
+                              "r" : "2",
+                              "s" : [ {
+                                 "value" : [ "'http://loinc.org'" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "s" : [ {
+                              "value" : [ "code",": " ]
+                           }, {
+                              "r" : "3",
+                              "s" : [ {
+                                 "value" : [ "'8480-6'" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ " }" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "5",
+               "type" : "ToConcept",
+               "operand" : {
+                  "localId" : "4",
+                  "classType" : "{urn:hl7-org:elm-types:r1}Code",
+                  "type" : "Instance",
+                  "element" : [ {
+                     "name" : "system",
+                     "value" : {
+                        "localId" : "2",
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "http://loinc.org",
+                        "type" : "Literal"
+                     }
+                  }, {
+                     "name" : "code",
+                     "value" : {
+                        "localId" : "3",
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "8480-6",
+                        "type" : "Literal"
+                     }
+                  } ]
+               }
+            }
+         }, {
+            "localId" : "11",
+            "name" : "IsNull",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "11",
+                  "s" : [ {
+                     "value" : [ "define ","IsNull",": " ]
+                  }, {
+                     "r" : "10",
+                     "s" : [ {
+                        "value" : [ "ToConcept","(" ]
+                     }, {
+                        "r" : "9",
+                        "s" : [ {
+                           "r" : "7",
+                           "value" : [ "null"," as " ]
+                        }, {
+                           "r" : "8",
+                           "s" : [ {
+                              "value" : [ "Code" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "10",
+               "type" : "ToConcept",
+               "operand" : {
+                  "localId" : "9",
+                  "strict" : false,
+                  "type" : "As",
+                  "operand" : {
+                     "localId" : "7",
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "localId" : "8",
+                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "NamedTypeSpecifier"
+                  }
                }
             }
          } ]

--- a/test/elm/convert/data.cql
+++ b/test/elm/convert/data.cql
@@ -14,6 +14,11 @@ define negQuantityStr: convert '-10 \'A\'' to Quantity
 define quantityStrDecimal: convert '10.0 \'mA\'' to Quantity
 define dateTimeStr: convert '2015-01-02' to DateTime
 define dateStr: convert '2015-01-02' to Date
+define NullConvert: convert 'foo' to DateTime
+define ZDateTime: convert '2014-01-01T14:30:00.0Z' to DateTime // January 1st, 2014, 2:30PM UTC
+define TimezoneDateTime: convert '2014-01-01T14:30:00.0-07:00' to DateTime // January 1st, 2014, 2:30PM Mountain Standard (GMT-7:00)
+define ZTime: convert 'T14:30:00.0Z' to Time // 2:30PM UTC
+define TimezoneTime: convert 'T14:30:00.0-07:00' to Time // 2:30PM Mountain Standard (GMT-7:00)
 
 // @Test: FromInteger
 define string10: convert 10 to String
@@ -79,3 +84,22 @@ define NullArg: ToQuantity((null as String))
 define NullArgTime: ToTime((null as String))
 define IncorrectFormatTime: ToTime('10:00PM')
 define InvalidTime: ToTime('25:99.000+00.00')
+define TimeH: ToTime('T02')
+define TimeHM: ToTime('T02:04')
+define TimeHMS: ToTime('T02:04:59')
+define TimeHMSMs: ToTime('T02:04:59.123')
+define TimeHMSMsZ: ToTime('T02:04:59.123Z')
+define TimeHMSMsTimezone: ToTime('T02:04:59.123+01')
+define TimeHMSMsFullTimezone: ToTime('T02:04:59.123+01:00')
+define HourTooHigh: ToTime('T24')
+define MinuteTooHigh: ToTime('T23:60')
+define SecondTooHigh: ToTime('T23:59:60')
+
+// @Test: ToBoolean
+define IsTrue: ToBoolean('y')
+define IsFalse: ToBoolean('0')
+define IsNull: ToBoolean('falsetto')
+
+// @Test: ToConcept
+define IsValid: ToConcept(Code { system: 'http://loinc.org', code: '8480-6' }) // Concept { codes: { Code { system: 'http://loinc.org', code: '8480-6' } } }
+define IsNull: ToConcept(null as Code)

--- a/test/elm/quantity/test.coffee
+++ b/test/elm/quantity/test.coffee
@@ -1,6 +1,6 @@
 should = require 'should'
 setup = require '../../setup'
-{Quantity} = require '../../../lib/elm/quantity'
+{ Quantity, doAddition, doSubtraction, doMultiplication, doDivision } = require '../../../lib/elm/quantity'
 
 describe 'Quantity', ->
   it 'should allow creation of Quantity with valid ucum units', ->
@@ -79,3 +79,27 @@ describe 'Quantity', ->
     minute.equals(new Quantity({unit: "minutes", value: 4})).should.be.true()
     second.equals(new Quantity({unit: "seconds", value: 4})).should.be.true()
     millisecond.equals(new Quantity({unit: "milliseconds", value: 4})).should.be.true()
+  it 'added to Quantity with invalid ucum units results in null', ->
+    quantity1 = new Quantity({unit:"m", value: 2})
+    quantity2 = new Quantity({unit: "m", value: 2})
+    quantity2.unit = "fakeUnit"
+    should(doAddition(quantity1, quantity2)).be.null()
+
+  it 'subtracted from Quantity with invalid ucum units results in null', ->
+    quantity1 = new Quantity({unit:"m", value: 2})
+    quantity2 = new Quantity({unit: "m", value: 2})
+    quantity2.unit = "fakeUnit"
+    should(doSubtraction(quantity1, quantity2)).be.null()
+
+  it 'multiplied by Quantity with invalid ucum units results in null', ->
+    quantity1 = new Quantity({unit:"m", value: 2})
+    quantity2 = new Quantity({unit: "m", value: 2})
+    quantity2.unit = "fakeUnit"
+    should(doMultiplication(quantity1, ".")).be.null()
+
+  it 'divided by Quantity with invalid ucum units results in null', ->
+    quantity1 = new Quantity({unit:"m", value: 2})
+    quantity2 = new Quantity({unit: "m", value: 2})
+    quantity2.unit = "fakeUnit"
+    should(doDivision(quantity1, "/")).be.null()
+

--- a/test/generator/build.gradle
+++ b/test/generator/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'info.cqframework', name: 'cql-to-elm', version: '1.3.6-SNAPSHOT'
+    compile group: 'info.cqframework', name: 'cql-to-elm', version: '1.3.7-SNAPSHOT'
     compile group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.7'
 }
 


### PR DESCRIPTION
Some tests in this PR depend on the DateTime equality changes in https://github.com/cqframework/cql-execution/tree/bonnie_v1.3_equivalence_equality_updates

The main reason for the PR is to return null instead of throwing errors when things can't be converted, which is a change in the CQL spec.

Along the way, a couple of bugs were discovered that this PR also fixes.
1. ToTime wasn't parsing strings properly, so this PR ports over some of the DateTime.parse logic and adjusts it to be appropriate for Time.  Some helper functions were moved to util in order to facilitate this change.

2. Quantity arithmetic operators (+,-,.,/) were allowing quantities of different units to be operated on.  So `'1 m' + '1 foobar'` would be treated as `'1 m' + null`, which is `'1 m'`.  While the Quantity constructor guards against invalid UCUM units, so this case is not very likely, it was still possible.  The spec says that both Quantities must have the same units, so now `null` is returned if they don't.

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

https://jira.mitre.org/browse/BONNIE-1727

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository. 
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (some tests depend on bonnie_v1.3_equivalence_equality_updates, but they pass if that branch is included locally.  leaving unchecked to serve as marker for dependency)
- [x] Code coverage has not gone down and all code touched or added is covered. (all green lines in files changed are covered)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change N/A
- [ ] Regression test run and regressions logged to Jira

**Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
