### PR TITLE
maximum/mininum DateTime now uses execution timezoneOffset

### DIFF
--- a/src/elm/arithmetic.coffee
+++ b/src/elm/arithmetic.coffee
@@ -208,7 +208,7 @@ module.exports.MinValue = class MinValue extends Expression
     if MIN_VALUES[@valueType]
       if @valueType == '{urn:hl7-org:elm-types:r1}DateTime'
         minDateTime = MIN_VALUES[@valueType].copy()
-        minDateTime.timezoneOffset = parseFloat(ctx.getTimezoneOffset())
+        minDateTime.timezoneOffset = ctx.getTimezoneOffset()
         return minDateTime
       else
         MIN_VALUES[@valueType]
@@ -230,7 +230,7 @@ module.exports.MaxValue = class MaxValue extends Expression
     if MAX_VALUES[@valueType]?
       if @valueType == '{urn:hl7-org:elm-types:r1}DateTime'
         maxDateTime = MAX_VALUES[@valueType].copy()
-        maxDateTime.timezoneOffset = parseFloat(ctx.getTimezoneOffset())
+        maxDateTime.timezoneOffset = ctx.getTimezoneOffset()
         return maxDateTime
       else
         MAX_VALUES[@valueType]

--- a/src/elm/arithmetic.coffee
+++ b/src/elm/arithmetic.coffee
@@ -206,7 +206,12 @@ module.exports.MinValue = class MinValue extends Expression
 
   exec: (ctx) ->
     if MIN_VALUES[@valueType]
-      MIN_VALUES[@valueType]
+      if @valueType == '{urn:hl7-org:elm-types:r1}DateTime'
+        minDateTime = MIN_VALUES[@valueType].copy()
+        minDateTime.timezoneOffset = parseFloat(ctx.getTimezoneOffset())
+        return minDateTime
+      else
+        MIN_VALUES[@valueType]
     else
       throw new Error("Minimum not supported for #{@valueType}")
 
@@ -223,7 +228,12 @@ module.exports.MaxValue = class MaxValue extends Expression
 
   exec: (ctx) ->
     if MAX_VALUES[@valueType]?
-      MAX_VALUES[@valueType]
+      if @valueType == '{urn:hl7-org:elm-types:r1}DateTime'
+        maxDateTime = MAX_VALUES[@valueType].copy()
+        maxDateTime.timezoneOffset = parseFloat(ctx.getTimezoneOffset())
+        return maxDateTime
+      else
+        MAX_VALUES[@valueType]
     else
       throw new Error("Maximum not supported for #{@valueType}")
 

--- a/src/example/browser/cql4browsers.js
+++ b/src/example/browser/cql4browsers.js
@@ -3275,7 +3275,7 @@
       if (MIN_VALUES[this.valueType]) {
         if (this.valueType === '{urn:hl7-org:elm-types:r1}DateTime') {
           minDateTime = MIN_VALUES[this.valueType].copy();
-          minDateTime.timezoneOffset = parseFloat(ctx.getTimezoneOffset());
+          minDateTime.timezoneOffset = ctx.getTimezoneOffset();
           return minDateTime;
         } else {
           return MIN_VALUES[this.valueType];
@@ -3314,7 +3314,7 @@
       if (MAX_VALUES[this.valueType] != null) {
         if (this.valueType === '{urn:hl7-org:elm-types:r1}DateTime') {
           maxDateTime = MAX_VALUES[this.valueType].copy();
-          maxDateTime.timezoneOffset = parseFloat(ctx.getTimezoneOffset());
+          maxDateTime.timezoneOffset = ctx.getTimezoneOffset();
           return maxDateTime;
         } else {
           return MAX_VALUES[this.valueType];

--- a/src/example/browser/cql4browsers.js
+++ b/src/example/browser/cql4browsers.js
@@ -3271,8 +3271,15 @@
     }
 
     MinValue.prototype.exec = function(ctx) {
+      var minDateTime;
       if (MIN_VALUES[this.valueType]) {
-        return MIN_VALUES[this.valueType];
+        if (this.valueType === '{urn:hl7-org:elm-types:r1}DateTime') {
+          minDateTime = MIN_VALUES[this.valueType].copy();
+          minDateTime.timezoneOffset = parseFloat(ctx.getTimezoneOffset());
+          return minDateTime;
+        } else {
+          return MIN_VALUES[this.valueType];
+        }
       } else {
         throw new Error("Minimum not supported for " + this.valueType);
       }
@@ -3303,8 +3310,15 @@
     }
 
     MaxValue.prototype.exec = function(ctx) {
+      var maxDateTime;
       if (MAX_VALUES[this.valueType] != null) {
-        return MAX_VALUES[this.valueType];
+        if (this.valueType === '{urn:hl7-org:elm-types:r1}DateTime') {
+          maxDateTime = MAX_VALUES[this.valueType].copy();
+          maxDateTime.timezoneOffset = parseFloat(ctx.getTimezoneOffset());
+          return maxDateTime;
+        } else {
+          return MAX_VALUES[this.valueType];
+        }
       } else {
         throw new Error("Maximum not supported for " + this.valueType);
       }

--- a/test/elm/arithmetic/test.coffee
+++ b/test/elm/arithmetic/test.coffee
@@ -2,6 +2,7 @@ should = require 'should'
 setup = require '../../setup'
 data = require './data'
 Q = require '../../../lib/elm/quantity'
+DT = require '../../../lib/datatypes/datatypes'
 
 
 validateQuantity = (object,expectedValue,expectedUnit) ->
@@ -160,6 +161,18 @@ describe 'MaxValue', ->
     dateTimeResult.minute.should.equal(59)
     dateTimeResult.second.should.equal(59)
     dateTimeResult.millisecond.should.equal(999)
+
+  it 'of DateTime should work with different execution timezoneOffsets', ->
+    @ctx.executionDateTime.timezoneOffset = -4.0
+    dateTimeResult = @maxDateTime.exec(@ctx)
+    dateTimeResult.year.should.equal(9999)
+    dateTimeResult.month.should.equal(12)
+    dateTimeResult.day.should.equal(31)
+    dateTimeResult.hour.should.equal(23)
+    dateTimeResult.minute.should.equal(59)
+    dateTimeResult.second.should.equal(59)
+    dateTimeResult.millisecond.should.equal(999)
+    dateTimeResult.timezoneOffset.should.equal(-4.0)
 
   it 'of Time should return maximum representable Time value', ->
     timeResult = @maxTime.exec(@ctx)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1343,9 +1343,9 @@ growl@1.10.5, "growl@~> 1.10.0":
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
 handlebars@^4.0.3:
-  version "4.0.12"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.12.tgz#2c15c8a96d46da5e266700518ba8cb8d919d5bc5"
-  integrity sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.0.tgz#0d6a6f34ff1f63cecec8423aa4169827bf787c3a"
+  integrity sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==
   dependencies:
     async "^2.5.0"
     optimist "^0.6.1"


### PR DESCRIPTION
This PR includes a fix for `maximum DateTime` and `minimum DateTime`, so that they use the execution DateTime timezoneoffset.

Bonnie is currently using the branch `bonnie-v3.1.1`, which included this change for a patch release.

Internal Ticket: https://jira.mitre.org/browse/BONNIE-1897
External Ticket: https://oncprojectracking.healthit.gov/support/projects/BONNIE/issues/BONNIE-521

It also upadates handlebars (a dependency of nyc), which was being flagged by yarn audit.

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository. 
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change (there are JIRA sub-tasks to track that they will be completed)
- [x] Bonnie Frontend Regression Passes (HEAD~1 vs HEAD) (only expected opioid regressions due to unlocked cql logic.  used `min-max-datetime` bonnie branch.
- [x] Bonnie Frontend Excel Regression Passes (HEAD~1 vs HEAD)
- [x] Bonnie Backend Excel Regression Passes (HEAD~1 vs HEAD) (Only expected opioidd differences)


**Reviewer:**

Name: @daco101 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
