### PR TITLE
Bug - fixed wrong check for areNumeric() in union and intersect

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@ It is strongly recommended to include a person from each of those projects as a 
 - [ ] Tests have been run locally and pass
 - [ ] Code coverage has not gone down and all code touched or added is covered.
 - [ ] All dependent libraries are appropriately updated or have a corresponding PR related to this change
+- [ ] `cql4browsers.js` built with `yarn run build-everything` if coffeescript source changed.
 
 **Reviewer:**
 

--- a/README.md
+++ b/README.md
@@ -261,4 +261,11 @@ execute `cake watch-test-data`.
 
 To watch for _all_ changes (Coffeescript _and_ CQL), use:
 
-    cake watch-all
+   `cake watch-all`
+
+
+# Pull Requests
+
+If coffeescript source is modified, `cql4browsers.js` needs to be included. Otherwise Travis CI will fail. To generate this file, run:
+
+  `yarn run build-everything`

--- a/src/datatypes/interval.coffee
+++ b/src/datatypes/interval.coffee
@@ -118,7 +118,7 @@ module.exports.Interval = class Interval
       [h, hc] = switch
         when cmp.greaterThanOrEquals(a.high, b.high) then [@high, @highClosed]
         when cmp.lessThanOrEquals(a.high, b.high) then [other.high, other.highClosed]
-        when areNumeric(a.low, b.low) then [highestNumericUncertainty(a.high, b.high), true]
+        when areNumeric(a.high, b.high) then [highestNumericUncertainty(a.high, b.high), true]
         # TODO: Do we need to support quantities here?
         when areDateTimes(a.high, b.high) and a.high.isMorePrecise(b.high) then [other.high, other.highClosed]
         else [@high, @highClosed]
@@ -141,7 +141,7 @@ module.exports.Interval = class Interval
       [h, hc] = switch
         when cmp.lessThanOrEquals(a.high, b.high) then [@high, @highClosed]
         when cmp.greaterThanOrEquals(a.high, b.high) then [other.high, other.highClosed]
-        when areNumeric(a.low, b.low) then [lowestNumericUncertainty(a.high, b.high), true]
+        when areNumeric(a.high, b.high) then [lowestNumericUncertainty(a.high, b.high), true]
         # TODO: Do we need to support quantities here?
         when areDateTimes(a.high, b.high) and b.high.isMorePrecise(a.high) then [other.high, other.highClosed]
         else [@high, @highClosed]

--- a/src/example/browser/cql4browsers.js
+++ b/src/example/browser/cql4browsers.js
@@ -1940,7 +1940,7 @@
               return [this.high, this.highClosed];
             case !cmp.lessThanOrEquals(a.high, b.high):
               return [other.high, other.highClosed];
-            case !areNumeric(a.low, b.low):
+            case !areNumeric(a.high, b.high):
               return [highestNumericUncertainty(a.high, b.high), true];
             case !(areDateTimes(a.high, b.high) && a.high.isMorePrecise(b.high)):
               return [other.high, other.highClosed];
@@ -1981,7 +1981,7 @@
               return [this.high, this.highClosed];
             case !cmp.greaterThanOrEquals(a.high, b.high):
               return [other.high, other.highClosed];
-            case !areNumeric(a.low, b.low):
+            case !areNumeric(a.high, b.high):
               return [lowestNumericUncertainty(a.high, b.high), true];
             case !(areDateTimes(a.high, b.high) && b.high.isMorePrecise(a.high)):
               return [other.high, other.highClosed];


### PR DESCRIPTION
Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository. 
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change

**Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
