### PR TITLE
Use hh:mm:ss.fff for all Time formatting strings

### DIFF
--- a/src/datatypes/datetime.coffee
+++ b/src/datatypes/datetime.coffee
@@ -291,7 +291,7 @@ class DateTime
     if @isTime() then @toStringTime() else @toStringDateTime()
 
   toStringTime: () ->
-    str = 'T'
+    str = ''
     if @hour?
       str += + @_pad(@hour)
       if @minute?

--- a/src/elm/type.coffee
+++ b/src/elm/type.coffee
@@ -147,8 +147,8 @@ module.exports.ToTime = class ToTime extends Expression
     if arg? and typeof arg != 'undefined'
       timeString = arg.toString()
       # Return null if string doesn't represent a valid ISO-8601 Time
-      # Thh:mm:ss.fff(+|-)hh:mm or Thh:mm:ss.fffZ
-      matches = /T((\d{2})(\:(\d{2})(\:(\d{2})(\.(\d+))?)?)?)?(Z|(([+-])(\d{2})(\:?(\d{2}))?))?/.exec timeString
+      # hh:mm:ss.fff or hh:mm:ss.fff
+      matches = /^((\d{2})(\:(\d{2})(\:(\d{2})(\.(\d+))?)?)?)?$/.exec timeString
       return null unless matches?
       hours = matches[2]
       minutes = matches[4]
@@ -167,14 +167,8 @@ module.exports.ToTime = class ToTime extends Expression
       if milliseconds?
         milliseconds = parseInt(normalizeMillisecondsField(milliseconds))
 
-      if matches[11]?
-        tz = parseInt(matches[12],10) + (if matches[14]? then parseInt(matches[14],10) / 60 else 0)
-        timezoneOffset = if matches[11] is '+' then tz else tz * -1
-      else if matches[9] == 'Z'
-        timezoneOffset = 0
-
-      # Time is implemented as Datetime with year 0, month 1, day 1
-      return new DateTime(0, 1, 1, hours, minutes, seconds, milliseconds, timezoneOffset)
+      # Time is implemented as Datetime with year 0, month 1, day 1 and null timezoneOffset
+      return new DateTime(0, 1, 1, hours, minutes, seconds, milliseconds, null)
     else
       return null
 

--- a/src/example/browser/cql4browsers.js
+++ b/src/example/browser/cql4browsers.js
@@ -966,7 +966,7 @@
 
     DateTime.prototype.toStringTime = function() {
       var str;
-      str = 'T';
+      str = '';
       if (this.hour != null) {
         str += +this._pad(this.hour);
         if (this.minute != null) {
@@ -8594,11 +8594,11 @@
     }
 
     ToTime.prototype.exec = function(ctx) {
-      var arg, hours, matches, milliseconds, minutes, seconds, timeString, timezoneOffset, tz;
+      var arg, hours, matches, milliseconds, minutes, seconds, timeString;
       arg = this.execArgs(ctx);
       if ((arg != null) && typeof arg !== 'undefined') {
         timeString = arg.toString();
-        matches = /T((\d{2})(\:(\d{2})(\:(\d{2})(\.(\d+))?)?)?)?(Z|(([+-])(\d{2})(\:?(\d{2}))?))?/.exec(timeString);
+        matches = /^((\d{2})(\:(\d{2})(\:(\d{2})(\.(\d+))?)?)?)?$/.exec(timeString);
         if (matches == null) {
           return null;
         }
@@ -8627,13 +8627,7 @@
         if (milliseconds != null) {
           milliseconds = parseInt(normalizeMillisecondsField(milliseconds));
         }
-        if (matches[11] != null) {
-          tz = parseInt(matches[12], 10) + (matches[14] != null ? parseInt(matches[14], 10) / 60 : 0);
-          timezoneOffset = matches[11] === '+' ? tz : tz * -1;
-        } else if (matches[9] === 'Z') {
-          timezoneOffset = 0;
-        }
-        return new DateTime(0, 1, 1, hours, minutes, seconds, milliseconds, timezoneOffset);
+        return new DateTime(0, 1, 1, hours, minutes, seconds, milliseconds, null);
       } else {
         return null;
       }

--- a/test/elm/convert/data.coffee
+++ b/test/elm/convert/data.coffee
@@ -28,8 +28,7 @@ define dateStr: convert '2015-01-02' to Date
 define NullConvert: convert 'foo' to DateTime
 define ZDateTime: convert '2014-01-01T14:30:00.0Z' to DateTime // January 1st, 2014, 2:30PM UTC
 define TimezoneDateTime: convert '2014-01-01T14:30:00.0-07:00' to DateTime // January 1st, 2014, 2:30PM Mountain Standard (GMT-7:00)
-define ZTime: convert 'T14:30:00.0Z' to Time // 2:30PM UTC
-define TimezoneTime: convert 'T14:30:00.0-07:00' to Time // 2:30PM Mountain Standard (GMT-7:00)
+define TimezoneTime: convert '14:30:00.0-07:00' to Time // 2:30PM Mountain Standard (GMT-7:00)
 ###
 
 module.exports['FromString'] = {
@@ -793,7 +792,7 @@ module.exports['FromString'] = {
             }
          }, {
             "localId" : "76",
-            "name" : "ZTime",
+            "name" : "TimezoneTime",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
@@ -801,7 +800,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "76",
                   "s" : [ {
-                     "value" : [ "define ","ZTime",": " ]
+                     "value" : [ "define ","TimezoneTime",": " ]
                   }, {
                      "r" : "75",
                      "s" : [ {
@@ -809,7 +808,7 @@ module.exports['FromString'] = {
                      }, {
                         "r" : "74",
                         "s" : [ {
-                           "value" : [ "'T14:30:00.0Z'" ]
+                           "value" : [ "'14:30:00.0-07:00'" ]
                         } ]
                      }, {
                         "value" : [ " to " ]
@@ -828,48 +827,7 @@ module.exports['FromString'] = {
                "operand" : {
                   "localId" : "74",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "T14:30:00.0Z",
-                  "type" : "Literal"
-               }
-            }
-         }, {
-            "localId" : "80",
-            "name" : "TimezoneTime",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "80",
-                  "s" : [ {
-                     "value" : [ "define ","TimezoneTime",": " ]
-                  }, {
-                     "r" : "79",
-                     "s" : [ {
-                        "value" : [ "convert " ]
-                     }, {
-                        "r" : "78",
-                        "s" : [ {
-                           "value" : [ "'T14:30:00.0-07:00'" ]
-                        } ]
-                     }, {
-                        "value" : [ " to " ]
-                     }, {
-                        "r" : "77",
-                        "s" : [ {
-                           "value" : [ "Time" ]
-                        } ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "expression" : {
-               "localId" : "79",
-               "type" : "ToTime",
-               "operand" : {
-                  "localId" : "78",
-                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "T14:30:00.0-07:00",
+                  "value" : "14:30:00.0-07:00",
                   "type" : "Literal"
                }
             }
@@ -3281,17 +3239,14 @@ using QUICK
 context Patient
 define NullArgTime: ToTime((null as String))
 define IncorrectFormatTime: ToTime('10:00PM')
-define InvalidTime: ToTime('25:99.000+00.00')
-define TimeH: ToTime('T02')
-define TimeHM: ToTime('T02:04')
-define TimeHMS: ToTime('T02:04:59')
-define TimeHMSMs: ToTime('T02:04:59.123')
-define TimeHMSMsZ: ToTime('T02:04:59.123Z')
-define TimeHMSMsTimezone: ToTime('T02:04:59.123+01')
-define TimeHMSMsFullTimezone: ToTime('T02:04:59.123+01:00')
-define HourTooHigh: ToTime('T24')
-define MinuteTooHigh: ToTime('T23:60')
-define SecondTooHigh: ToTime('T23:59:60')
+define InvalidTime: ToTime('25:99.000')
+define TimeH: ToTime('02')
+define TimeHM: ToTime('02:04')
+define TimeHMS: ToTime('02:04:59')
+define TimeHMSMs: ToTime('02:04:59.123')
+define HourTooHigh: ToTime('24')
+define MinuteTooHigh: ToTime('23:60')
+define SecondTooHigh: ToTime('23:59:60')
 ###
 
 module.exports['ToTime'] = {
@@ -3437,7 +3392,7 @@ module.exports['ToTime'] = {
                      }, {
                         "r" : "10",
                         "s" : [ {
-                           "value" : [ "'25:99.000+00.00'" ]
+                           "value" : [ "'25:99.000'" ]
                         } ]
                      }, {
                         "value" : [ ")" ]
@@ -3451,7 +3406,7 @@ module.exports['ToTime'] = {
                "operand" : {
                   "localId" : "10",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "25:99.000+00.00",
+                  "value" : "25:99.000",
                   "type" : "Literal"
                }
             }
@@ -3473,7 +3428,7 @@ module.exports['ToTime'] = {
                      }, {
                         "r" : "13",
                         "s" : [ {
-                           "value" : [ "'T02'" ]
+                           "value" : [ "'02'" ]
                         } ]
                      }, {
                         "value" : [ ")" ]
@@ -3487,7 +3442,7 @@ module.exports['ToTime'] = {
                "operand" : {
                   "localId" : "13",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "T02",
+                  "value" : "02",
                   "type" : "Literal"
                }
             }
@@ -3509,7 +3464,7 @@ module.exports['ToTime'] = {
                      }, {
                         "r" : "16",
                         "s" : [ {
-                           "value" : [ "'T02:04'" ]
+                           "value" : [ "'02:04'" ]
                         } ]
                      }, {
                         "value" : [ ")" ]
@@ -3523,7 +3478,7 @@ module.exports['ToTime'] = {
                "operand" : {
                   "localId" : "16",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "T02:04",
+                  "value" : "02:04",
                   "type" : "Literal"
                }
             }
@@ -3545,7 +3500,7 @@ module.exports['ToTime'] = {
                      }, {
                         "r" : "19",
                         "s" : [ {
-                           "value" : [ "'T02:04:59'" ]
+                           "value" : [ "'02:04:59'" ]
                         } ]
                      }, {
                         "value" : [ ")" ]
@@ -3559,7 +3514,7 @@ module.exports['ToTime'] = {
                "operand" : {
                   "localId" : "19",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "T02:04:59",
+                  "value" : "02:04:59",
                   "type" : "Literal"
                }
             }
@@ -3581,7 +3536,7 @@ module.exports['ToTime'] = {
                      }, {
                         "r" : "22",
                         "s" : [ {
-                           "value" : [ "'T02:04:59.123'" ]
+                           "value" : [ "'02:04:59.123'" ]
                         } ]
                      }, {
                         "value" : [ ")" ]
@@ -3595,13 +3550,13 @@ module.exports['ToTime'] = {
                "operand" : {
                   "localId" : "22",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "T02:04:59.123",
+                  "value" : "02:04:59.123",
                   "type" : "Literal"
                }
             }
          }, {
             "localId" : "27",
-            "name" : "TimeHMSMsZ",
+            "name" : "HourTooHigh",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
@@ -3609,7 +3564,7 @@ module.exports['ToTime'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","TimeHMSMsZ",": " ]
+                     "value" : [ "define ","HourTooHigh",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -3617,7 +3572,7 @@ module.exports['ToTime'] = {
                      }, {
                         "r" : "25",
                         "s" : [ {
-                           "value" : [ "'T02:04:59.123Z'" ]
+                           "value" : [ "'24'" ]
                         } ]
                      }, {
                         "value" : [ ")" ]
@@ -3631,13 +3586,13 @@ module.exports['ToTime'] = {
                "operand" : {
                   "localId" : "25",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "T02:04:59.123Z",
+                  "value" : "24",
                   "type" : "Literal"
                }
             }
          }, {
             "localId" : "30",
-            "name" : "TimeHMSMsTimezone",
+            "name" : "MinuteTooHigh",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
@@ -3645,7 +3600,7 @@ module.exports['ToTime'] = {
                "s" : {
                   "r" : "30",
                   "s" : [ {
-                     "value" : [ "define ","TimeHMSMsTimezone",": " ]
+                     "value" : [ "define ","MinuteTooHigh",": " ]
                   }, {
                      "r" : "29",
                      "s" : [ {
@@ -3653,7 +3608,7 @@ module.exports['ToTime'] = {
                      }, {
                         "r" : "28",
                         "s" : [ {
-                           "value" : [ "'T02:04:59.123+01'" ]
+                           "value" : [ "'23:60'" ]
                         } ]
                      }, {
                         "value" : [ ")" ]
@@ -3667,13 +3622,13 @@ module.exports['ToTime'] = {
                "operand" : {
                   "localId" : "28",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "T02:04:59.123+01",
+                  "value" : "23:60",
                   "type" : "Literal"
                }
             }
          }, {
             "localId" : "33",
-            "name" : "TimeHMSMsFullTimezone",
+            "name" : "SecondTooHigh",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
@@ -3681,7 +3636,7 @@ module.exports['ToTime'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","TimeHMSMsFullTimezone",": " ]
+                     "value" : [ "define ","SecondTooHigh",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -3689,7 +3644,7 @@ module.exports['ToTime'] = {
                      }, {
                         "r" : "31",
                         "s" : [ {
-                           "value" : [ "'T02:04:59.123+01:00'" ]
+                           "value" : [ "'23:59:60'" ]
                         } ]
                      }, {
                         "value" : [ ")" ]
@@ -3703,115 +3658,7 @@ module.exports['ToTime'] = {
                "operand" : {
                   "localId" : "31",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "T02:04:59.123+01:00",
-                  "type" : "Literal"
-               }
-            }
-         }, {
-            "localId" : "36",
-            "name" : "HourTooHigh",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "36",
-                  "s" : [ {
-                     "value" : [ "define ","HourTooHigh",": " ]
-                  }, {
-                     "r" : "35",
-                     "s" : [ {
-                        "value" : [ "ToTime","(" ]
-                     }, {
-                        "r" : "34",
-                        "s" : [ {
-                           "value" : [ "'T24'" ]
-                        } ]
-                     }, {
-                        "value" : [ ")" ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "expression" : {
-               "localId" : "35",
-               "type" : "ToTime",
-               "operand" : {
-                  "localId" : "34",
-                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "T24",
-                  "type" : "Literal"
-               }
-            }
-         }, {
-            "localId" : "39",
-            "name" : "MinuteTooHigh",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "39",
-                  "s" : [ {
-                     "value" : [ "define ","MinuteTooHigh",": " ]
-                  }, {
-                     "r" : "38",
-                     "s" : [ {
-                        "value" : [ "ToTime","(" ]
-                     }, {
-                        "r" : "37",
-                        "s" : [ {
-                           "value" : [ "'T23:60'" ]
-                        } ]
-                     }, {
-                        "value" : [ ")" ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "expression" : {
-               "localId" : "38",
-               "type" : "ToTime",
-               "operand" : {
-                  "localId" : "37",
-                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "T23:60",
-                  "type" : "Literal"
-               }
-            }
-         }, {
-            "localId" : "42",
-            "name" : "SecondTooHigh",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "42",
-                  "s" : [ {
-                     "value" : [ "define ","SecondTooHigh",": " ]
-                  }, {
-                     "r" : "41",
-                     "s" : [ {
-                        "value" : [ "ToTime","(" ]
-                     }, {
-                        "r" : "40",
-                        "s" : [ {
-                           "value" : [ "'T23:59:60'" ]
-                        } ]
-                     }, {
-                        "value" : [ ")" ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "expression" : {
-               "localId" : "41",
-               "type" : "ToTime",
-               "operand" : {
-                  "localId" : "40",
-                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "T23:59:60",
+                  "value" : "23:59:60",
                   "type" : "Literal"
                }
             }
@@ -6036,7 +5883,7 @@ module.exports['ConvertsToString'] = {
 library TestSnippet version '1'
 using QUICK
 context Patient
-define IsTrue: ConvertsToTime('T02:04:59.123+01:00')
+define IsTrue: ConvertsToTime('02:04:59.123')
 define IsFalse: ConvertsToTime('foo')
 define IsNull: ConvertsToTime(null as String)
 ###
@@ -6091,7 +5938,7 @@ module.exports['ConvertsToTime'] = {
                      }, {
                         "r" : "2",
                         "s" : [ {
-                           "value" : [ "'T02:04:59.123+01:00'" ]
+                           "value" : [ "'02:04:59.123'" ]
                         } ]
                      }, {
                         "value" : [ ")" ]
@@ -6105,7 +5952,7 @@ module.exports['ConvertsToTime'] = {
                "operand" : {
                   "localId" : "2",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "T02:04:59.123+01:00",
+                  "value" : "02:04:59.123",
                   "type" : "Literal"
                }
             }

--- a/test/elm/convert/data.cql
+++ b/test/elm/convert/data.cql
@@ -17,8 +17,7 @@ define dateStr: convert '2015-01-02' to Date
 define NullConvert: convert 'foo' to DateTime
 define ZDateTime: convert '2014-01-01T14:30:00.0Z' to DateTime // January 1st, 2014, 2:30PM UTC
 define TimezoneDateTime: convert '2014-01-01T14:30:00.0-07:00' to DateTime // January 1st, 2014, 2:30PM Mountain Standard (GMT-7:00)
-define ZTime: convert 'T14:30:00.0Z' to Time // 2:30PM UTC
-define TimezoneTime: convert 'T14:30:00.0-07:00' to Time // 2:30PM Mountain Standard (GMT-7:00)
+define TimezoneTime: convert '14:30:00.0-07:00' to Time // 2:30PM Mountain Standard (GMT-7:00)
 
 // @Test: FromInteger
 define string10: convert 10 to String
@@ -95,17 +94,14 @@ define InvalidDenominator: ToRatio('1.0 \'mg\':2.0 \'cc\'')
 // @Test: ToTime
 define NullArgTime: ToTime((null as String))
 define IncorrectFormatTime: ToTime('10:00PM')
-define InvalidTime: ToTime('25:99.000+00.00')
-define TimeH: ToTime('T02')
-define TimeHM: ToTime('T02:04')
-define TimeHMS: ToTime('T02:04:59')
-define TimeHMSMs: ToTime('T02:04:59.123')
-define TimeHMSMsZ: ToTime('T02:04:59.123Z')
-define TimeHMSMsTimezone: ToTime('T02:04:59.123+01')
-define TimeHMSMsFullTimezone: ToTime('T02:04:59.123+01:00')
-define HourTooHigh: ToTime('T24')
-define MinuteTooHigh: ToTime('T23:60')
-define SecondTooHigh: ToTime('T23:59:60')
+define InvalidTime: ToTime('25:99.000')
+define TimeH: ToTime('02')
+define TimeHM: ToTime('02:04')
+define TimeHMS: ToTime('02:04:59')
+define TimeHMSMs: ToTime('02:04:59.123')
+define HourTooHigh: ToTime('24')
+define MinuteTooHigh: ToTime('23:60')
+define SecondTooHigh: ToTime('23:59:60')
 
 // @Test: ToBoolean
 define UpperCaseTrue: ToBoolean('TRUE')
@@ -171,6 +167,6 @@ define IsFalse: ConvertsToString(Code { system: 'http://loinc.org', code: '8480-
 define IsNull: ConvertsToString(null as String)
 
 // @Test: ConvertsToTime
-define IsTrue: ConvertsToTime('T02:04:59.123+01:00')
+define IsTrue: ConvertsToTime('02:04:59.123')
 define IsFalse: ConvertsToTime('foo')
 define IsNull: ConvertsToTime(null as String)

--- a/test/elm/convert/test.coffee
+++ b/test/elm/convert/test.coffee
@@ -80,14 +80,6 @@ describe 'FromString', ->
     expectedDateTime = new DateTime(2014, 1, 1, 14, 30, 0, 0, -7)
     @timezoneDateTime.exec(@ctx).equals(expectedDateTime).should.be.true()
 
-  it 'should convert Time string with Z', ->
-    expectedTime = new DateTime(0, 1, 1, 14, 30, 0, 0, 0)
-    @zTime.exec(@ctx).equals(expectedTime).should.be.true()
-
-  it 'should convert Time string with timezone offset', ->
-    expectedTime = new DateTime(0, 1, 1, 14, 30, 0, 0, -7)
-    @timezoneTime.exec(@ctx).equals(expectedTime).should.be.true()
-
 describe 'FromInteger', ->
   @beforeEach ->
     setup @, data
@@ -339,33 +331,24 @@ describe 'ToTime', ->
   it "should be null for invalid time-of-day", ->
     should(@invalidTime.exec(@ctx)).be.null()
 
-  it "should work with for Thh", ->
-    expectedDateTime = new DateTime(0,1,1,2)
+  it "should work with for hh", ->
+    # NOTE: We need to pass in null timezoneOffset because DateTime assumes
+    # execution context timezoneOffset while time does not have a
+    # timezoneOffset
+    expectedDateTime = new DateTime(0,1,1,2,null,null,null,null)
     @timeH.exec(@ctx).equals(expectedDateTime).should.be.true()
 
-  it "should work with for Thh:mm", ->
-    expectedDateTime = new DateTime(0,1,1,2,4)
+  it "should work with for hh:mm", ->
+    expectedDateTime = new DateTime(0,1,1,2,4,null,null,null)
     @timeHM.exec(@ctx).equals(expectedDateTime).should.be.true()
 
-  it "should work with for Thh:mm:ss", ->
-    expectedDateTime = new DateTime(0,1,1,2,4,59)
+  it "should work with for hh:mm:ss", ->
+    expectedDateTime = new DateTime(0,1,1,2,4,59,null,null)
     @timeHMS.exec(@ctx).equals(expectedDateTime).should.be.true()
 
-  it "should work with for Thh:mm:ss.fff", ->
-    expectedDateTime = new DateTime(0,1,1,2,4,59,123)
+  it "should work with for hh:mm:ss.fff", ->
+    expectedDateTime = new DateTime(0,1,1,2,4,59,123, null)
     @timeHMSMs.exec(@ctx).equals(expectedDateTime).should.be.true()
-
-  it "should work with for Thh:mm:ss.fffZ", ->
-    expectedDateTime = new DateTime(0,1,1,2,4,59,123,0)
-    @timeHMSMsZ.exec(@ctx).equals(expectedDateTime).should.be.true()
-
-  it "should work with for Thh:mm:ss.fff+hh:mm", ->
-    expectedDateTime = new DateTime(0,1,1,2,4,59,123,1)
-    @timeHMSMsTimezone.exec(@ctx).equals(expectedDateTime).should.be.true()
-
-  it "should work with for Thh:mm:ss.fff+hh", ->
-    expectedDateTime = new DateTime(0,1,1,2,4,59,123,1)
-    @timeHMSMsFullTimezone.exec(@ctx).equals(expectedDateTime).should.be.true()
 
   it "should be null for hour over 24", ->
     should(@hourTooHigh.exec(@ctx)).be.null()

--- a/test/elm/interval/test.coffee
+++ b/test/elm/interval/test.coffee
@@ -1864,43 +1864,43 @@ describe 'TimeIntervalExpand', ->
 
   xit 'expands a millisecond precision datetime', ->
     # define MsPrecPerHour: expand { Interval[@T01:00:00.000+00:00, @T03:00:00.000+00:00] } per hour
-    e = '{ [T01:00:00.000, T01:59:59.999], [T02:00:00.000, T02:59:59.999] }'
+    e = '{ [01:00:00.000, 01:59:59.999], [02:00:00.000, 02:59:59.999] }'
     prettyList(@msPrecPerHour.exec(@ctx)).should.equal e
 
     # define MsPrecPerMinute: expand { Interval[@T01:00:00.000+00:00, @T01:02:00.000+00:00] } per minute
-    e = '{ [T01:00:00.000, T01:00:59.999], [T01:01:00.000, T01:01:59.999] }'
+    e = '{ [01:00:00.000, 01:00:59.999], [01:01:00.000, 01:01:59.999] }'
     prettyList(@msPrecPerMinute.exec(@ctx)).should.equal e
 
     # define MsPrecPerSecond: expand { Interval[@T01:00:00.000+00:00, @T01:00:02.000+00:00] } per second
-    e = '{ [T01:00:00.000, T01:00:00.999], [T01:00:01.000, T01:00:01.999] }'
+    e = '{ [01:00:00.000, 01:00:00.999], [01:00:01.000, 01:00:01.999] }'
     prettyList(@msPrecPerSecond.exec(@ctx)).should.equal e
 
     # define MsPrecPerMillisecond: expand { Interval[@T01:00:00.000+00:00, @T01:00:00.001+00:00] } per millisecond
-    e = '{ [T01:00:00.000, T01:00:00.000], [T01:00:00.001, T01:00:00.001] }'
+    e = '{ [01:00:00.000, 01:00:00.000], [01:00:00.001, 01:00:00.001] }'
     prettyList(@msPrecPerMillisecond.exec(@ctx)).should.equal e
 
   xit 'expands a second precision datetime', ->
     # define SecPrecPerHour: expand { Interval[@T01:00:00+00:00, @T03:00:00+00:00] } per hour
-    e = '{ [T01:00:00, T01:59:59], [T02:00:00, T02:59:59] }'
+    e = '{ [01:00:00, 01:59:59], [02:00:00, 02:59:59] }'
     prettyList(@secPrecPerHour.exec(@ctx)).should.equal e
 
     # define SecPrecPerMinute: expand { Interval[@T01:00:00+00:00, @T01:02:00+00:00] } per minute
-    e = '{ [T01:00:00, T01:00:59], [T01:01:00, T01:01:59] }'
+    e = '{ [01:00:00, 01:00:59], [01:01:00, 01:01:59] }'
     prettyList(@secPrecPerMinute.exec(@ctx)).should.equal e
 
     # define SecPrecPerSecond: expand { Interval[@T01:00:00+00:00, @T01:00:01+00:00] } per second
-    e = '{ [T01:00:00, T01:00:00], [T01:00:01, T01:00:01] }'
+    e = '{ [01:00:00, 01:00:00], [01:00:01, 01:00:01] }'
     prettyList(@secPrecPerSecond.exec(@ctx)).should.equal e
 
     should.not.exist @secPrecPerMillisecond.exec(@ctx)
 
   xit 'expands a minute precision datetime', ->
     # define MinPrecPerHour: expand { Interval[@T01:00+00:00, @T03:00+00:00] } per hour
-    e = '{ [T01:00, T01:59], [T02:00, T02:59] }'
+    e = '{ [01:00, 01:59], [02:00, 02:59] }'
     prettyList(@minPrecPerHour.exec(@ctx)).should.equal e
 
     # define MinPrecPerMinute: expand { Interval[@T01:00+00:00, @T01:01+00:00] } per minute
-    e = '{ [T01:00, T01:00], [T01:01, T01:01] }'
+    e = '{ [01:00, 01:00], [01:01, 01:01] }'
     prettyList(@minPrecPerMinute.exec(@ctx)).should.equal e
 
     should.not.exist @minPrecPerSecond.exec(@ctx)
@@ -1908,7 +1908,7 @@ describe 'TimeIntervalExpand', ->
 
   xit 'expands an hour precision datetime', ->
     # define HourPrecPerHour: expand { Interval[@T01+00:00, @T02+00:00] } per hour
-    e = '{ [T01, T01], [T02, T02] }'
+    e = '{ [01, 01], [02, 02] }'
     prettyList(@hourPrecPerHour.exec(@ctx)).should.equal e
 
     should.not.exist @hourPrecPerMinute.exec(@ctx)


### PR DESCRIPTION
Time uses hh:mm:ss.fff instead of Thh:mm:ss.fff+Z/(hh:mm) for string formatting now.

https://jira.mitre.org/browse/BONNIE-1996

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository. 
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change N/A
- [x] `cql4browsers.js` built with `yarn run build-everything` if coffeescript source changed.

**Reviewer:**

Name: @jbradl11 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
