### PR TITLE
Return false for AnyInValueSet if codes is null

### DIFF
--- a/src/elm/clinical.coffee
+++ b/src/elm/clinical.coffee
@@ -39,6 +39,7 @@ module.exports.AnyInValueSet = class AnyInValueSet extends Expression
     throw new Error("ValueSet must be provided to InValueSet function") unless valueset? and valueset.isValueSet
 
     codes = @codes.exec(ctx)
+    return false unless codes?
     for code in codes
       return true if valueset.hasMatch(code)
     return false

--- a/src/example/browser/cql4browsers.js
+++ b/src/example/browser/cql4browsers.js
@@ -4250,6 +4250,9 @@
         throw new Error("ValueSet must be provided to InValueSet function");
       }
       codes = this.codes.exec(ctx);
+      if (codes == null) {
+        return false;
+      }
       for (i = 0, len = codes.length; i < len; i++) {
         code = codes[i];
         if (valueset.hasMatch(code)) {

--- a/test/elm/clinical/data.coffee
+++ b/test/elm/clinical/data.coffee
@@ -202,6 +202,7 @@ define WrongListOfCodes: { Code { code: 'M' }, Code { code: 'F', system: '3.16.8
 define InListOfCodesExpressionRef: ListOfCodes in "Female"
 define InWrongListOfCodes: WrongListOfCodes in "Female"
 define ListOfCodesWithNull: { Code { code: 'M' }, (null as Code), Code { code: 'F', system: '2.16.840.1.113883.18.2' } } in "Female"
+define ListOfCodesNull: (null as List<Code>) in "Female"
 ###
 
 module.exports['InValueSet'] = {
@@ -1753,6 +1754,81 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "119",
+                  "name" : "Female"
+               }
+            }
+         }, {
+            "localId" : "128",
+            "name" : "ListOfCodesNull",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "128",
+                  "s" : [ {
+                     "value" : [ "define ","ListOfCodesNull",": " ]
+                  }, {
+                     "r" : "127",
+                     "s" : [ {
+                        "r" : "125",
+                        "s" : [ {
+                           "value" : [ "(" ]
+                        }, {
+                           "r" : "125",
+                           "s" : [ {
+                              "r" : "122",
+                              "value" : [ "null"," as " ]
+                           }, {
+                              "r" : "124",
+                              "s" : [ {
+                                 "value" : [ "List<" ]
+                              }, {
+                                 "r" : "123",
+                                 "s" : [ {
+                                    "value" : [ "Code" ]
+                                 } ]
+                              }, {
+                                 "value" : [ ">" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     }, {
+                        "value" : [ " in " ]
+                     }, {
+                        "r" : "126",
+                        "s" : [ {
+                           "value" : [ "\"Female\"" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "127",
+               "type" : "AnyInValueSet",
+               "codes" : {
+                  "localId" : "125",
+                  "strict" : false,
+                  "type" : "As",
+                  "operand" : {
+                     "localId" : "122",
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "localId" : "124",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "123",
+                        "name" : "{urn:hl7-org:elm-types:r1}Code",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }
+               },
+               "valueset" : {
+                  "localId" : "126",
                   "name" : "Female"
                }
             }

--- a/test/elm/clinical/data.cql
+++ b/test/elm/clinical/data.cql
@@ -33,6 +33,8 @@ define WrongListOfCodes: { Code { code: 'M' }, Code { code: 'F', system: '3.16.8
 define InListOfCodesExpressionRef: ListOfCodes in "Female"
 define InWrongListOfCodes: WrongListOfCodes in "Female"
 define ListOfCodesWithNull: { Code { code: 'M' }, (null as Code), Code { code: 'F', system: '2.16.840.1.113883.18.2' } } in "Female"
+define ListOfCodesNull: (null as List<Code>) in "Female"
+
 
 // @Test: Patient Property In ValueSet
 valueset "Female": '2.16.840.1.113883.3.560.100.2'

--- a/test/elm/clinical/test.coffee
+++ b/test/elm/clinical/test.coffee
@@ -97,6 +97,9 @@ describe 'InValueSet', ->
   it 'should ignore null codes in list', ->
     @listOfCodesWithNull.exec(@ctx).should.be.true()
 
+  it 'should return false for null list of codes', ->
+    @listOfCodesNull.exec(@ctx).should.be.false()
+
 describe 'Patient Property In ValueSet', ->
   @beforeEach ->
     setup @, data, [], vsets


### PR DESCRIPTION
https://github.com/HL7/cql/blob/master/spec/09-b-cqlreference.adoc#128-in-valueset doesn't explicitly call out what to do if the list argument is null, but this follows the pattern of the code overload if the code is null.

https://jira.mitre.org/browse/BONNIE-2112

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository. 
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `yarn run build-everything` if coffeescript source changed.

**Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
