### PR TITLE
Fix bug with Time addition

### DIFF
--- a/src/example/browser/cql4browsers.js
+++ b/src/example/browser/cql4browsers.js
@@ -46298,6 +46298,13 @@
       if (!isValidDecimal(value.value)) {
         return true;
       }
+    } else if ((value.isTime != null) && value.isTime()) {
+      if (value.after(MAX_TIME_VALUE)) {
+        return true;
+      }
+      if (value.before(MIN_TIME_VALUE)) {
+        return true;
+      }
     } else if (value.isDateTime) {
       if (value.after(MAX_DATETIME_VALUE)) {
         return true;
@@ -46310,13 +46317,6 @@
         return true;
       }
       if (value.before(MIN_DATE_VALUE)) {
-        return true;
-      }
-    } else if (value.isTime) {
-      if (value.after(MAX_TIME_VALUE)) {
-        return true;
-      }
-      if (value.before(MIN_TIME_VALUE)) {
         return true;
       }
     } else if (Number.isInteger(value)) {

--- a/src/util/math.coffee
+++ b/src/util/math.coffee
@@ -18,15 +18,15 @@ module.exports.overflowsOrUnderflows = (value) ->
   return false unless value?
   if value.isQuantity
     return true unless isValidDecimal(value.value)
+  else if value.isTime? && value.isTime()
+    return true if value.after(MAX_TIME_VALUE)
+    return true if value.before(MIN_TIME_VALUE)
   else if value.isDateTime
     return true if value.after(MAX_DATETIME_VALUE)
     return true if value.before(MIN_DATETIME_VALUE)
   else if value.isDate
     return true if value.after(MAX_DATE_VALUE)
     return true if value.before(MIN_DATE_VALUE)
-  else if value.isTime
-    return true if value.after(MAX_TIME_VALUE)
-    return true if value.before(MIN_TIME_VALUE)
   else if Number.isInteger(value)
     return true unless isValidInteger(value)
   else

--- a/test/elm/arithmetic/data.coffee
+++ b/test/elm/arithmetic/data.coffee
@@ -15,6 +15,7 @@ define Eleven: 11
 define OnePlusTwo: 1 + 2
 define AddMultiple: 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10
 define AddVariables: Ten + Eleven
+define AddTime: Time(12) + 1 'hour'
 ###
 
 module.exports['Add'] = {
@@ -321,6 +322,55 @@ module.exports['Add'] = {
                   "localId" : "31",
                   "name" : "Eleven",
                   "type" : "ExpressionRef"
+               } ]
+            }
+         }, {
+            "localId" : "38",
+            "name" : "AddTime",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "38",
+                  "s" : [ {
+                     "value" : [ "define ","AddTime",": " ]
+                  }, {
+                     "r" : "37",
+                     "s" : [ {
+                        "r" : "35",
+                        "s" : [ {
+                           "r" : "34",
+                           "value" : [ "Time","(","12",")" ]
+                        } ]
+                     }, {
+                        "value" : [ " + " ]
+                     }, {
+                        "r" : "36",
+                        "s" : [ {
+                           "value" : [ "1 ","'hour'" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "37",
+               "type" : "Add",
+               "operand" : [ {
+                  "localId" : "35",
+                  "type" : "Time",
+                  "hour" : {
+                     "localId" : "34",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "12",
+                     "type" : "Literal"
+                  }
+               }, {
+                  "localId" : "36",
+                  "value" : 1,
+                  "unit" : "hour",
+                  "type" : "Quantity"
                } ]
             }
          } ]

--- a/test/elm/arithmetic/data.cql
+++ b/test/elm/arithmetic/data.cql
@@ -4,6 +4,7 @@ define Eleven: 11
 define OnePlusTwo: 1 + 2
 define AddMultiple: 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10
 define AddVariables: Ten + Eleven
+define AddTime: Time(12) + 1 'hour'
 
 // @Test: Subtract
 define Ten: 10

--- a/test/elm/arithmetic/test.coffee
+++ b/test/elm/arithmetic/test.coffee
@@ -42,6 +42,9 @@ describe 'Add', ->
   it 'should add variables', ->
     @addVariables.exec(@ctx).should.equal 21
 
+  it 'should add Time/Quantity', ->
+    @addTime.exec(@ctx).isTime().should.be.true()
+
 describe 'Subtract', ->
   @beforeEach ->
     setup @, data


### PR DESCRIPTION
Fixes a bug with Time addition (and perhaps other operators that check for overflow and underflow). `Time(12) + '1 hour'`

Math `overflowsOrUnderflows` was checking for `isDateTime` before `isTime`, and since all `Time`s are `DateTime`s currently, it was falsely reporting underflow when the instance was actually just a `Time` (year 0).

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository. 
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `yarn run build-everything` if coffeescript source changed.

**Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
