### PR TITLE
This alias

### DIFF
--- a/src/example/browser/cql4browsers.js
+++ b/src/example/browser/cql4browsers.js
@@ -45246,7 +45246,11 @@
     Context.prototype.get = function(identifier) {
       var ref;
       if (identifier === "$this") {
-        return this.context_values;
+        if (typeof this.context_values[identifier] !== 'undefined') {
+          return this.context_values[identifier];
+        } else {
+          return this.context_values;
+        }
       } else if (typeof this.context_values[identifier] !== 'undefined') {
         return this.context_values[identifier];
       } else {

--- a/src/example/browser/cql4browsers.js
+++ b/src/example/browser/cql4browsers.js
@@ -45245,14 +45245,10 @@
 
     Context.prototype.get = function(identifier) {
       var ref;
-      if (identifier === "$this") {
-        if (typeof this.context_values[identifier] !== 'undefined') {
-          return this.context_values[identifier];
-        } else {
-          return this.context_values;
-        }
-      } else if (typeof this.context_values[identifier] !== 'undefined') {
+      if (typeof this.context_values[identifier] !== 'undefined') {
         return this.context_values[identifier];
+      } else if (identifier === "$this") {
+        return this.context_values;
       } else {
         return (ref = this.parent) != null ? ref.get(identifier) : void 0;
       }

--- a/src/runtime/context.coffee
+++ b/src/runtime/context.coffee
@@ -92,15 +92,12 @@ module.exports.Context = class Context
     @parent?.getConcept(name)
 
   get: (identifier) ->
-    if identifier == "$this"
-      if typeof @context_values[identifier] isnt 'undefined'
-        @context_values[identifier]
-      else
-        @context_values
     # Check for undefined because if its null, we actually *do* want to return null (rather than looking at parent),
     # but if it's really undefined, *then* look at the parent
-    else if typeof @context_values[identifier] isnt 'undefined'
+    if typeof @context_values[identifier] isnt 'undefined'
       @context_values[identifier]
+    else if identifier == "$this"
+      @context_values
     else
       @parent?.get(identifier)
 

--- a/src/runtime/context.coffee
+++ b/src/runtime/context.coffee
@@ -93,7 +93,10 @@ module.exports.Context = class Context
 
   get: (identifier) ->
     if identifier == "$this"
-      @context_values
+      if typeof @context_values[identifier] isnt 'undefined'
+        @context_values[identifier]
+      else
+        @context_values
     # Check for undefined because if its null, we actually *do* want to return null (rather than looking at parent),
     # but if it's really undefined, *then* look at the parent
     else if typeof @context_values[identifier] isnt 'undefined'

--- a/test/elm/query/data.coffee
+++ b/test/elm/query/data.coffee
@@ -399,6 +399,261 @@ module.exports['DateRangeOptimizedQuery'] = {
    }
 }
 
+### FunctionQuery
+library TestSnippet version '1'
+using QUICK
+context Patient
+define function "FunctionWithThis"(Encounter List<"Encounter">): Count(Encounter.period EncounterPeriod return EncounterPeriod)
+define queryWithThis: "FunctionWithThis"([Encounter] E) > 0
+###
+
+module.exports['FunctionQuery'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "1",
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "localId" : "10",
+            "name" : "FunctionWithThis",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "10",
+                  "s" : [ {
+                     "value" : [ "define function ","\"FunctionWithThis\"","(","Encounter"," " ]
+                  }, {
+                     "r" : "3",
+                     "s" : [ {
+                        "value" : [ "List<" ]
+                     }, {
+                        "r" : "2",
+                        "s" : [ {
+                           "value" : [ "\"Encounter\"" ]
+                        } ]
+                     }, {
+                        "value" : [ ">" ]
+                     } ]
+                  }, {
+                     "value" : [ "): " ]
+                  }, {
+                     "r" : "9",
+                     "s" : [ {
+                        "r" : "9",
+                        "s" : [ {
+                           "value" : [ "Count","(" ]
+                        }, {
+                           "r" : "8",
+                           "s" : [ {
+                              "s" : [ {
+                                 "r" : "5",
+                                 "s" : [ {
+                                    "r" : "4",
+                                    "s" : [ {
+                                       "s" : [ {
+                                          "value" : [ "Encounter",".","period" ]
+                                       } ]
+                                    } ]
+                                 }, {
+                                    "value" : [ " ","EncounterPeriod" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " " ]
+                           }, {
+                              "r" : "7",
+                              "s" : [ {
+                                 "value" : [ "return " ]
+                              }, {
+                                 "r" : "6",
+                                 "s" : [ {
+                                    "value" : [ "EncounterPeriod" ]
+                                 } ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "9",
+               "type" : "Count",
+               "source" : {
+                  "localId" : "8",
+                  "type" : "Query",
+                  "source" : [ {
+                     "localId" : "5",
+                     "alias" : "EncounterPeriod",
+                     "expression" : {
+                        "localId" : "4",
+                        "type" : "Query",
+                        "source" : [ {
+                           "alias" : "$this",
+                           "expression" : {
+                              "name" : "Encounter",
+                              "type" : "OperandRef"
+                           }
+                        } ],
+                        "where" : {
+                           "type" : "Not",
+                           "operand" : {
+                              "type" : "IsNull",
+                              "operand" : {
+                                 "path" : "period",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "$this",
+                                    "type" : "AliasRef"
+                                 }
+                              }
+                           }
+                        },
+                        "return" : {
+                           "expression" : {
+                              "path" : "period",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "$this",
+                                 "type" : "AliasRef"
+                              }
+                           }
+                        }
+                     }
+                  } ],
+                  "relationship" : [ ],
+                  "return" : {
+                     "localId" : "7",
+                     "expression" : {
+                        "localId" : "6",
+                        "name" : "EncounterPeriod",
+                        "type" : "AliasRef"
+                     }
+                  }
+               }
+            },
+            "operand" : [ {
+               "name" : "Encounter",
+               "operandTypeSpecifier" : {
+                  "localId" : "3",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "2",
+                     "name" : "{http://hl7.org/fhir}Encounter",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }
+            } ]
+         }, {
+            "localId" : "17",
+            "name" : "queryWithThis",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "17",
+                  "s" : [ {
+                     "value" : [ "define ","queryWithThis",": " ]
+                  }, {
+                     "r" : "16",
+                     "s" : [ {
+                        "r" : "14",
+                        "s" : [ {
+                           "value" : [ "\"FunctionWithThis\"","(" ]
+                        }, {
+                           "r" : "13",
+                           "s" : [ {
+                              "s" : [ {
+                                 "r" : "12",
+                                 "s" : [ {
+                                    "r" : "11",
+                                    "s" : [ {
+                                       "r" : "11",
+                                       "s" : [ {
+                                          "value" : [ "[","Encounter","]" ]
+                                       } ]
+                                    } ]
+                                 }, {
+                                    "value" : [ " ","E" ]
+                                 } ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     }, {
+                        "r" : "15",
+                        "value" : [ " ",">"," ","0" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "16",
+               "type" : "Greater",
+               "operand" : [ {
+                  "localId" : "14",
+                  "name" : "FunctionWithThis",
+                  "type" : "FunctionRef",
+                  "operand" : [ {
+                     "localId" : "13",
+                     "type" : "Query",
+                     "source" : [ {
+                        "localId" : "12",
+                        "alias" : "E",
+                        "expression" : {
+                           "localId" : "11",
+                           "dataType" : "{http://hl7.org/fhir}Encounter",
+                           "templateId" : "encounter-qicore-qicore-encounter",
+                           "type" : "Retrieve"
+                        }
+                     } ],
+                     "relationship" : [ ]
+                  } ]
+               }, {
+                  "localId" : "15",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "0",
+                  "type" : "Literal"
+               } ]
+            }
+         } ]
+      }
+   }
+}
+
 ### IncludesQuery
 library TestSnippet version '1'
 using QUICK

--- a/test/elm/query/data.cql
+++ b/test/elm/query/data.cql
@@ -5,6 +5,10 @@ define EncountersDuringMP: [Encounter] E where E.period during MeasurementPeriod
 define AmbulatoryEncountersDuringMP: [Encounter: "Ambulatory/ED Visit"] E where E.period during MeasurementPeriod
 define AmbulatoryEncountersIncludedInMP: [Encounter: "Ambulatory/ED Visit"] E where E.period included in MeasurementPeriod
 
+// @Test: FunctionQuery
+define function "FunctionWithThis"(Encounter List<"Encounter">): Count(Encounter.period EncounterPeriod return EncounterPeriod)
+define queryWithThis: "FunctionWithThis"([Encounter] E) > 0
+
 // @Test: IncludesQuery
 valueset "Ambulatory/ED Visit": '2.16.840.1.113883.3.464.1003.101.12.1061'
 parameter MeasurementPeriod default Interval[DateTime(2013, 1, 1), DateTime(2014, 1, 1))

--- a/test/elm/query/test.coffee
+++ b/test/elm/query/test.coffee
@@ -24,6 +24,14 @@ describe 'DateRangeOptimizedQuery', ->
     e.should.have.length(1)
     e[0].id().should.equal 'http://cqframework.org/3/5'
 
+describe 'FunctionQuery', ->
+  @beforeEach ->
+    setup @, data, [ p1 ], vsets
+
+  it 'function with this' , ->
+    functionReturnsDates = @queryWithThis.exec(@ctx)
+    functionReturnsDates.should.eql true
+
 describe.skip 'IncludesQuery', ->
   @beforeEach ->
     setup @, data, [ p1 ], vsets


### PR DESCRIPTION
Apparently a Function that takes in a Query as a parameter will generate an alias of "$this".  When this the case, the returned value would be **@context_values['$this']** and not **@context_values**.

Shame on me for not running a regression on calculations.  This can be seen in CMS136.  A regression has been run for all Cypress patients and all calculations now match what they had previously.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository. 
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] `cql4browsers.js` built with `yarn run build-everything` if coffeescript source changed.

**Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
