### PR TITLE
Implement basic function overloading and refactor support for Is

### DIFF
--- a/src/cql-patient.js
+++ b/src/cql-patient.js
@@ -7,9 +7,18 @@ class Record {
   }
 
   _is(namespace, name) {
-    // Stub out typeHierarchy, because there's no hierarchy in this simple cql-patient exmaple
-    const typeHierarchy = ['Patient', 'DomainResource', 'Resource'];
-    return namespace === 'http://hl7.org/fhir' && typeHierarchy.includes(name);
+    return this._typeHierarchy().some(t => t.namespace === namespace && t.name === name);
+  }
+
+  _typeHierarchy() {
+    return [
+      {
+        namespace: 'https://github.com/cqframework/cql-execution/simple',
+        name: this.json.recordType
+      },
+      { namespace: 'https://github.com/cqframework/cql-execution/simple', name: 'Record' },
+      { namespace: 'urn:hl7-org:elm-types:r1', name: 'Any' }
+    ];
   }
 
   _recursiveGet(field) {

--- a/src/elm/library.js
+++ b/src/elm/library.js
@@ -63,14 +63,12 @@ class Library {
   }
 
   getFunction(identifier) {
-    return this.functions[identifier][0];
+    return this.functions[identifier];
   }
 
   get(identifier) {
     return (
-      this.expressions[identifier] ||
-      this.includes[identifier] ||
-      this.functions[identifier][this.functions[identifier].length - 1]
+      this.expressions[identifier] || this.includes[identifier] || this.getFunction(identifier)
     );
   }
 

--- a/src/elm/reusable.js
+++ b/src/elm/reusable.js
@@ -50,20 +50,41 @@ class FunctionRef extends Expression {
     this.library = json.libraryName;
   }
   exec(ctx) {
-    let functionDef, child_ctx;
+    let functionDefs, child_ctx;
     if (this.library) {
       const lib = ctx.get(this.library);
-      functionDef = lib ? lib.getFunction(this.name) : undefined;
+      functionDefs = lib ? lib.getFunction(this.name) : undefined;
       const libCtx = ctx.getLibraryContext(this.library);
       child_ctx = libCtx ? libCtx.childContext() : undefined;
     } else {
-      functionDef = ctx.get(this.name);
+      functionDefs = ctx.get(this.name);
       child_ctx = ctx.childContext();
     }
     const args = this.execArgs(ctx);
-    if (args.length !== functionDef.parameters.length) {
-      throw new Error('incorrect number of arguments supplied');
+
+    // Filter out functions w/ wrong number of arguments.
+    functionDefs = functionDefs.filter(f => f.parameters.length === args.length);
+    // If there is still > 1 matching function, filter by argument types
+    if (functionDefs.length > 1) {
+      functionDefs = functionDefs.filter(f => {
+        let match = true;
+        for (let i = 0; i < args.length && match; i++) {
+          match = ctx.matchesTypeSpecifier(args[i], f.parameters[i].operandTypeSpecifier);
+        }
+        return match;
+      });
     }
+    // If there is still > 1 matching function, calculate a score based on quality of matches
+    if (functionDefs.length > 1) {
+      // TODO
+    }
+
+    if (functionDefs.length === 0) {
+      throw new Error('no function with matching signature could be found');
+    }
+    // By this point, we should have only one function, but until implementation is completed,
+    // use the last one (no matter how many still remain)
+    const functionDef = functionDefs[functionDefs.length - 1];
     for (let i = 0; i < functionDef.parameters.length; i++) {
       child_ctx.set(functionDef.parameters[i].name, args[i]);
     }

--- a/src/simple-modelinfo.xml
+++ b/src/simple-modelinfo.xml
@@ -4,14 +4,15 @@
                targetQualifier="simple" patientClassName="Simple.Patient"
                patientBirthDatePropertyName="birthDate" xmlns:xs="http://www.w3.org/2001/XMLSchema"
                xmlns:ns4="urn:hl7-org:elm-modelinfo:r1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="Patient" retrievable="true">
+    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="Record" baseType="System.Any" retrievable="false">
         <ns4:element name="id" elementType="System.String"/>
+    </ns4:typeInfo>
+    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="Patient" baseType="Simple.Record" retrievable="true">
         <ns4:element name="name" elementType="System.String"/>
         <ns4:element name="gender" elementType="System.String"/>
         <ns4:element name="birthDate" elementType="System.DateTime"/>
     </ns4:typeInfo>
-    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="Encounter" retrievable="true" primaryCodePath="code">
-        <ns4:element name="id" elementType="System.String"/>
+    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="Encounter" baseType="Simple.Record" retrievable="true" primaryCodePath="code">
         <ns4:element name="code" elementType="System.Code"/>
         <ns4:element name="status" elementType="System.Code"/>
         <ns4:element name="period">
@@ -20,10 +21,9 @@
             </ns4:elementTypeSpecifier>
         </ns4:element>
     </ns4:typeInfo>
-    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="Condition" retrievable="true" primaryCodePath="code">
-        <ns4:element name="id" elementType="System.String"/>
-        <ns4:element name="status" elementType="System.Code"/>
+    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="Condition" baseType="Simple.Record" retrievable="true" primaryCodePath="code">
         <ns4:element name="code" elementType="System.Code"/>
+        <ns4:element name="status" elementType="System.Code"/>
         <ns4:element name="period">
             <ns4:elementTypeSpecifier xsi:type="ns4:IntervalTypeSpecifier">
                 <ns4:pointTypeSpecifier xsi:type="ns4:NamedTypeSpecifier" modelName="System" name="DateTime"/>

--- a/test/elm/reusable/data.cql
+++ b/test/elm/reusable/data.cql
@@ -10,14 +10,45 @@ define Foo: Life
 define function "foo bar"(a Integer, b Integer) :
   a + b
 
-define testValue: "foo bar" (1,2)
+define testValue: "foo bar"(1,2)
 
-// @Test: FunctionOverloads
-define function "foo bar" (a System.Integer) :
+// @Test: FunctionOverloadsWithSingleArgument
+define function process(a System.Integer) :
   a + 1
 
-define function "foo bar" (a System.String) :
+define function process(a System.String) :
   'Hello ' + a
 
-define testValue1: "foo bar"(1)
-define testValue2: "foo bar"('World')
+define testValue1: process(1)
+define testValue2: process('World')
+
+// @Test: FunctionOverloadsWithMultipleArguments
+define function process(inverse System.Boolean, a System.Integer) :
+  if inverse then a - 1 else a + 1
+
+define function process(inverse System.Boolean, a System.String) :
+  if inverse then 'Goodbye ' + a else 'Hello ' + a
+
+define testValue1: process(true, 1)
+define testValue2: process(true, 'World')
+
+// @Test: FunctionOverloadsWithDifferentNumberOfArguments
+define function process(a System.String) :
+  'Hello ' + a
+
+define function process(a System.String, isSpanish System.Boolean) :
+  if isSpanish then 'Hola ' + a + ' from Spain' else 'Hello ' + a + ' from England'
+
+define testValue1: process('World')
+define testValue2: process('World', true)
+define testValue3: process('World', false)
+
+// @Test: FunctionOverloadsWithArgumentsFromCustomDataModel
+define function process(e Simple.Encounter) :
+  'Encounter ' + e.id
+
+define function process(c Simple.Condition) :
+  'Condition ' + c.id
+
+define testValue1: process(First([Encounter]))
+define testValue2: process(First([Condition]))

--- a/test/elm/reusable/data.js
+++ b/test/elm/reusable/data.js
@@ -182,7 +182,7 @@ context Patient
 define function "foo bar"(a Integer, b Integer) :
   a + b
 
-define testValue: "foo bar" (1,2)
+define testValue: "foo bar"(1,2)
 */
 
 module.exports['FunctionDefinitions'] = {
@@ -311,7 +311,7 @@ module.exports['FunctionDefinitions'] = {
                      "r" : "10",
                      "s" : [ {
                         "r" : "8",
-                        "value" : [ "\"foo bar\""," (","1",",","2",")" ]
+                        "value" : [ "\"foo bar\"","(","1",",","2",")" ]
                      } ]
                   } ]
                }
@@ -337,21 +337,21 @@ module.exports['FunctionDefinitions'] = {
    }
 }
 
-/* FunctionOverloads
+/* FunctionOverloadsWithSingleArgument
 library TestSnippet version '1'
 using Simple version '1.0.0'
 context Patient
-define function "foo bar" (a System.Integer) :
+define function process(a System.Integer) :
   a + 1
 
-define function "foo bar" (a System.String) :
+define function process(a System.String) :
   'Hello ' + a
 
-define testValue1: "foo bar"(1)
-define testValue2: "foo bar"('World')
+define testValue1: process(1)
+define testValue2: process('World')
 */
 
-module.exports['FunctionOverloads'] = {
+module.exports['FunctionOverloadsWithSingleArgument'] = {
    "library" : {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
@@ -389,7 +389,7 @@ module.exports['FunctionOverloads'] = {
             }
          }, {
             "localId" : "6",
-            "name" : "foo bar",
+            "name" : "process",
             "context" : "Patient",
             "accessLevel" : "Public",
             "type" : "FunctionDef",
@@ -398,7 +398,7 @@ module.exports['FunctionOverloads'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define function ","\"foo bar\""," (","a"," " ]
+                     "value" : [ "define function ","process","(","a"," " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -447,7 +447,7 @@ module.exports['FunctionOverloads'] = {
             } ]
          }, {
             "localId" : "11",
-            "name" : "foo bar",
+            "name" : "process",
             "context" : "Patient",
             "accessLevel" : "Public",
             "type" : "FunctionDef",
@@ -456,7 +456,7 @@ module.exports['FunctionOverloads'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define function ","\"foo bar\""," (","a"," " ]
+                     "value" : [ "define function ","process","(","a"," " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -522,14 +522,14 @@ module.exports['FunctionOverloads'] = {
                      "r" : "13",
                      "s" : [ {
                         "r" : "12",
-                        "value" : [ "\"foo bar\"","(","1",")" ]
+                        "value" : [ "process","(","1",")" ]
                      } ]
                   } ]
                }
             } ],
             "expression" : {
                "localId" : "13",
-               "name" : "foo bar",
+               "name" : "process",
                "type" : "FunctionRef",
                "operand" : [ {
                   "localId" : "12",
@@ -552,7 +552,7 @@ module.exports['FunctionOverloads'] = {
                   }, {
                      "r" : "16",
                      "s" : [ {
-                        "value" : [ "\"foo bar\"","(" ]
+                        "value" : [ "process","(" ]
                      }, {
                         "r" : "15",
                         "s" : [ {
@@ -566,13 +566,1117 @@ module.exports['FunctionOverloads'] = {
             } ],
             "expression" : {
                "localId" : "16",
-               "name" : "foo bar",
+               "name" : "process",
                "type" : "FunctionRef",
                "operand" : [ {
                   "localId" : "15",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "World",
                   "type" : "Literal"
+               } ]
+            }
+         } ]
+      }
+   }
+}
+
+/* FunctionOverloadsWithMultipleArguments
+library TestSnippet version '1'
+using Simple version '1.0.0'
+context Patient
+define function process(inverse System.Boolean, a System.Integer) :
+  if inverse then a - 1 else a + 1
+
+define function process(inverse System.Boolean, a System.String) :
+  if inverse then 'Goodbye ' + a else 'Hello ' + a
+
+define testValue1: process(true, 1)
+define testValue2: process(true, 'World')
+*/
+
+module.exports['FunctionOverloadsWithMultipleArguments'] = {
+   "library" : {
+      "annotation" : [ {
+         "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
+         "type" : "CqlToElmInfo"
+      } ],
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "1",
+            "localIdentifier" : "Simple",
+            "uri" : "https://github.com/cqframework/cql-execution/simple",
+            "version" : "1.0.0"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "localId" : "12",
+            "name" : "process",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "12",
+                  "s" : [ {
+                     "value" : [ "define function ","process","(","inverse"," " ]
+                  }, {
+                     "r" : "2",
+                     "s" : [ {
+                        "value" : [ "System",".","Boolean" ]
+                     } ]
+                  }, {
+                     "value" : [ ", ","a"," " ]
+                  }, {
+                     "r" : "3",
+                     "s" : [ {
+                        "value" : [ "System",".","Integer" ]
+                     } ]
+                  }, {
+                     "value" : [ ") :\n  " ]
+                  }, {
+                     "r" : "11",
+                     "s" : [ {
+                        "r" : "11",
+                        "s" : [ {
+                           "value" : [ "if " ]
+                        }, {
+                           "r" : "4",
+                           "s" : [ {
+                              "value" : [ "inverse" ]
+                           } ]
+                        }, {
+                           "value" : [ " then " ]
+                        }, {
+                           "r" : "7",
+                           "s" : [ {
+                              "r" : "5",
+                              "s" : [ {
+                                 "value" : [ "a" ]
+                              } ]
+                           }, {
+                              "r" : "6",
+                              "value" : [ " - ","1" ]
+                           } ]
+                        }, {
+                           "value" : [ " else " ]
+                        }, {
+                           "r" : "10",
+                           "s" : [ {
+                              "r" : "8",
+                              "s" : [ {
+                                 "value" : [ "a" ]
+                              } ]
+                           }, {
+                              "r" : "9",
+                              "value" : [ " + ","1" ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "11",
+               "type" : "If",
+               "condition" : {
+                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "As",
+                  "operand" : {
+                     "localId" : "4",
+                     "name" : "inverse",
+                     "type" : "OperandRef"
+                  }
+               },
+               "then" : {
+                  "localId" : "7",
+                  "type" : "Subtract",
+                  "operand" : [ {
+                     "localId" : "5",
+                     "name" : "a",
+                     "type" : "OperandRef"
+                  }, {
+                     "localId" : "6",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "1",
+                     "type" : "Literal"
+                  } ]
+               },
+               "else" : {
+                  "localId" : "10",
+                  "type" : "Add",
+                  "operand" : [ {
+                     "localId" : "8",
+                     "name" : "a",
+                     "type" : "OperandRef"
+                  }, {
+                     "localId" : "9",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "1",
+                     "type" : "Literal"
+                  } ]
+               }
+            },
+            "operand" : [ {
+               "name" : "inverse",
+               "operandTypeSpecifier" : {
+                  "localId" : "2",
+                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "a",
+               "operandTypeSpecifier" : {
+                  "localId" : "3",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "localId" : "23",
+            "name" : "process",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "23",
+                  "s" : [ {
+                     "value" : [ "define function ","process","(","inverse"," " ]
+                  }, {
+                     "r" : "13",
+                     "s" : [ {
+                        "value" : [ "System",".","Boolean" ]
+                     } ]
+                  }, {
+                     "value" : [ ", ","a"," " ]
+                  }, {
+                     "r" : "14",
+                     "s" : [ {
+                        "value" : [ "System",".","String" ]
+                     } ]
+                  }, {
+                     "value" : [ ") :\n  " ]
+                  }, {
+                     "r" : "22",
+                     "s" : [ {
+                        "r" : "22",
+                        "s" : [ {
+                           "value" : [ "if " ]
+                        }, {
+                           "r" : "15",
+                           "s" : [ {
+                              "value" : [ "inverse" ]
+                           } ]
+                        }, {
+                           "value" : [ " then " ]
+                        }, {
+                           "r" : "18",
+                           "s" : [ {
+                              "r" : "16",
+                              "s" : [ {
+                                 "value" : [ "'Goodbye '" ]
+                              } ]
+                           }, {
+                              "value" : [ " + " ]
+                           }, {
+                              "r" : "17",
+                              "s" : [ {
+                                 "value" : [ "a" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ " else " ]
+                        }, {
+                           "r" : "21",
+                           "s" : [ {
+                              "r" : "19",
+                              "s" : [ {
+                                 "value" : [ "'Hello '" ]
+                              } ]
+                           }, {
+                              "value" : [ " + " ]
+                           }, {
+                              "r" : "20",
+                              "s" : [ {
+                                 "value" : [ "a" ]
+                              } ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "22",
+               "type" : "If",
+               "condition" : {
+                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "As",
+                  "operand" : {
+                     "localId" : "15",
+                     "name" : "inverse",
+                     "type" : "OperandRef"
+                  }
+               },
+               "then" : {
+                  "localId" : "18",
+                  "type" : "Concatenate",
+                  "operand" : [ {
+                     "localId" : "16",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "Goodbye ",
+                     "type" : "Literal"
+                  }, {
+                     "localId" : "17",
+                     "name" : "a",
+                     "type" : "OperandRef"
+                  } ]
+               },
+               "else" : {
+                  "localId" : "21",
+                  "type" : "Concatenate",
+                  "operand" : [ {
+                     "localId" : "19",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "Hello ",
+                     "type" : "Literal"
+                  }, {
+                     "localId" : "20",
+                     "name" : "a",
+                     "type" : "OperandRef"
+                  } ]
+               }
+            },
+            "operand" : [ {
+               "name" : "inverse",
+               "operandTypeSpecifier" : {
+                  "localId" : "13",
+                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "a",
+               "operandTypeSpecifier" : {
+                  "localId" : "14",
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "localId" : "27",
+            "name" : "testValue1",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "27",
+                  "s" : [ {
+                     "value" : [ "define ","testValue1",": " ]
+                  }, {
+                     "r" : "26",
+                     "s" : [ {
+                        "r" : "24",
+                        "value" : [ "process","(","true",", ","1",")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "26",
+               "name" : "process",
+               "type" : "FunctionRef",
+               "operand" : [ {
+                  "localId" : "24",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "value" : "true",
+                  "type" : "Literal"
+               }, {
+                  "localId" : "25",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "1",
+                  "type" : "Literal"
+               } ]
+            }
+         }, {
+            "localId" : "31",
+            "name" : "testValue2",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "31",
+                  "s" : [ {
+                     "value" : [ "define ","testValue2",": " ]
+                  }, {
+                     "r" : "30",
+                     "s" : [ {
+                        "r" : "28",
+                        "value" : [ "process","(","true",", " ]
+                     }, {
+                        "r" : "29",
+                        "s" : [ {
+                           "value" : [ "'World'" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "30",
+               "name" : "process",
+               "type" : "FunctionRef",
+               "operand" : [ {
+                  "localId" : "28",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "value" : "true",
+                  "type" : "Literal"
+               }, {
+                  "localId" : "29",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "World",
+                  "type" : "Literal"
+               } ]
+            }
+         } ]
+      }
+   }
+}
+
+/* FunctionOverloadsWithDifferentNumberOfArguments
+library TestSnippet version '1'
+using Simple version '1.0.0'
+context Patient
+define function process(a System.String) :
+  'Hello ' + a
+
+define function process(a System.String, isSpanish System.Boolean) :
+  if isSpanish then 'Hola ' + a + ' from Spain' else 'Hello ' + a + ' from England'
+
+define testValue1: process('World')
+define testValue2: process('World', true)
+define testValue3: process('World', false)
+*/
+
+module.exports['FunctionOverloadsWithDifferentNumberOfArguments'] = {
+   "library" : {
+      "annotation" : [ {
+         "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
+         "type" : "CqlToElmInfo"
+      } ],
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "1",
+            "localIdentifier" : "Simple",
+            "uri" : "https://github.com/cqframework/cql-execution/simple",
+            "version" : "1.0.0"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "localId" : "6",
+            "name" : "process",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "6",
+                  "s" : [ {
+                     "value" : [ "define function ","process","(","a"," " ]
+                  }, {
+                     "r" : "2",
+                     "s" : [ {
+                        "value" : [ "System",".","String" ]
+                     } ]
+                  }, {
+                     "value" : [ ") :\n  " ]
+                  }, {
+                     "r" : "5",
+                     "s" : [ {
+                        "r" : "5",
+                        "s" : [ {
+                           "r" : "3",
+                           "s" : [ {
+                              "value" : [ "'Hello '" ]
+                           } ]
+                        }, {
+                           "value" : [ " + " ]
+                        }, {
+                           "r" : "4",
+                           "s" : [ {
+                              "value" : [ "a" ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "5",
+               "type" : "Concatenate",
+               "operand" : [ {
+                  "localId" : "3",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "Hello ",
+                  "type" : "Literal"
+               }, {
+                  "localId" : "4",
+                  "name" : "a",
+                  "type" : "OperandRef"
+               } ]
+            },
+            "operand" : [ {
+               "name" : "a",
+               "operandTypeSpecifier" : {
+                  "localId" : "2",
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "localId" : "21",
+            "name" : "process",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "21",
+                  "s" : [ {
+                     "value" : [ "define function ","process","(","a"," " ]
+                  }, {
+                     "r" : "7",
+                     "s" : [ {
+                        "value" : [ "System",".","String" ]
+                     } ]
+                  }, {
+                     "value" : [ ", ","isSpanish"," " ]
+                  }, {
+                     "r" : "8",
+                     "s" : [ {
+                        "value" : [ "System",".","Boolean" ]
+                     } ]
+                  }, {
+                     "value" : [ ") :\n  " ]
+                  }, {
+                     "r" : "20",
+                     "s" : [ {
+                        "r" : "20",
+                        "s" : [ {
+                           "value" : [ "if " ]
+                        }, {
+                           "r" : "9",
+                           "s" : [ {
+                              "value" : [ "isSpanish" ]
+                           } ]
+                        }, {
+                           "value" : [ " then " ]
+                        }, {
+                           "r" : "14",
+                           "s" : [ {
+                              "r" : "12",
+                              "s" : [ {
+                                 "r" : "10",
+                                 "s" : [ {
+                                    "value" : [ "'Hola '" ]
+                                 } ]
+                              }, {
+                                 "value" : [ " + " ]
+                              }, {
+                                 "r" : "11",
+                                 "s" : [ {
+                                    "value" : [ "a" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " + " ]
+                           }, {
+                              "r" : "13",
+                              "s" : [ {
+                                 "value" : [ "' from Spain'" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ " else " ]
+                        }, {
+                           "r" : "19",
+                           "s" : [ {
+                              "r" : "17",
+                              "s" : [ {
+                                 "r" : "15",
+                                 "s" : [ {
+                                    "value" : [ "'Hello '" ]
+                                 } ]
+                              }, {
+                                 "value" : [ " + " ]
+                              }, {
+                                 "r" : "16",
+                                 "s" : [ {
+                                    "value" : [ "a" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " + " ]
+                           }, {
+                              "r" : "18",
+                              "s" : [ {
+                                 "value" : [ "' from England'" ]
+                              } ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "20",
+               "type" : "If",
+               "condition" : {
+                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "As",
+                  "operand" : {
+                     "localId" : "9",
+                     "name" : "isSpanish",
+                     "type" : "OperandRef"
+                  }
+               },
+               "then" : {
+                  "localId" : "14",
+                  "type" : "Concatenate",
+                  "operand" : [ {
+                     "localId" : "12",
+                     "type" : "Concatenate",
+                     "operand" : [ {
+                        "localId" : "10",
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "Hola ",
+                        "type" : "Literal"
+                     }, {
+                        "localId" : "11",
+                        "name" : "a",
+                        "type" : "OperandRef"
+                     } ]
+                  }, {
+                     "localId" : "13",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : " from Spain",
+                     "type" : "Literal"
+                  } ]
+               },
+               "else" : {
+                  "localId" : "19",
+                  "type" : "Concatenate",
+                  "operand" : [ {
+                     "localId" : "17",
+                     "type" : "Concatenate",
+                     "operand" : [ {
+                        "localId" : "15",
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "Hello ",
+                        "type" : "Literal"
+                     }, {
+                        "localId" : "16",
+                        "name" : "a",
+                        "type" : "OperandRef"
+                     } ]
+                  }, {
+                     "localId" : "18",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : " from England",
+                     "type" : "Literal"
+                  } ]
+               }
+            },
+            "operand" : [ {
+               "name" : "a",
+               "operandTypeSpecifier" : {
+                  "localId" : "7",
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "isSpanish",
+               "operandTypeSpecifier" : {
+                  "localId" : "8",
+                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "localId" : "24",
+            "name" : "testValue1",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "24",
+                  "s" : [ {
+                     "value" : [ "define ","testValue1",": " ]
+                  }, {
+                     "r" : "23",
+                     "s" : [ {
+                        "value" : [ "process","(" ]
+                     }, {
+                        "r" : "22",
+                        "s" : [ {
+                           "value" : [ "'World'" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "23",
+               "name" : "process",
+               "type" : "FunctionRef",
+               "operand" : [ {
+                  "localId" : "22",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "World",
+                  "type" : "Literal"
+               } ]
+            }
+         }, {
+            "localId" : "28",
+            "name" : "testValue2",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "28",
+                  "s" : [ {
+                     "value" : [ "define ","testValue2",": " ]
+                  }, {
+                     "r" : "27",
+                     "s" : [ {
+                        "value" : [ "process","(" ]
+                     }, {
+                        "r" : "25",
+                        "s" : [ {
+                           "value" : [ "'World'" ]
+                        } ]
+                     }, {
+                        "r" : "26",
+                        "value" : [ ", ","true",")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "27",
+               "name" : "process",
+               "type" : "FunctionRef",
+               "operand" : [ {
+                  "localId" : "25",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "World",
+                  "type" : "Literal"
+               }, {
+                  "localId" : "26",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "value" : "true",
+                  "type" : "Literal"
+               } ]
+            }
+         }, {
+            "localId" : "32",
+            "name" : "testValue3",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "32",
+                  "s" : [ {
+                     "value" : [ "define ","testValue3",": " ]
+                  }, {
+                     "r" : "31",
+                     "s" : [ {
+                        "value" : [ "process","(" ]
+                     }, {
+                        "r" : "29",
+                        "s" : [ {
+                           "value" : [ "'World'" ]
+                        } ]
+                     }, {
+                        "r" : "30",
+                        "value" : [ ", ","false",")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "31",
+               "name" : "process",
+               "type" : "FunctionRef",
+               "operand" : [ {
+                  "localId" : "29",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "World",
+                  "type" : "Literal"
+               }, {
+                  "localId" : "30",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "value" : "false",
+                  "type" : "Literal"
+               } ]
+            }
+         } ]
+      }
+   }
+}
+
+/* FunctionOverloadsWithArgumentsFromCustomDataModel
+library TestSnippet version '1'
+using Simple version '1.0.0'
+context Patient
+define function process(e Simple.Encounter) :
+  'Encounter ' + e.id
+
+define function process(c Simple.Condition) :
+  'Condition ' + c.id
+
+define testValue1: process(First([Encounter]))
+define testValue2: process(First([Condition]))
+*/
+
+module.exports['FunctionOverloadsWithArgumentsFromCustomDataModel'] = {
+   "library" : {
+      "annotation" : [ {
+         "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
+         "type" : "CqlToElmInfo"
+      } ],
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "1",
+            "localIdentifier" : "Simple",
+            "uri" : "https://github.com/cqframework/cql-execution/simple",
+            "version" : "1.0.0"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "localId" : "7",
+            "name" : "process",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "7",
+                  "s" : [ {
+                     "value" : [ "define function ","process","(","e"," " ]
+                  }, {
+                     "r" : "2",
+                     "s" : [ {
+                        "value" : [ "Simple",".","Encounter" ]
+                     } ]
+                  }, {
+                     "value" : [ ") :\n  " ]
+                  }, {
+                     "r" : "6",
+                     "s" : [ {
+                        "r" : "6",
+                        "s" : [ {
+                           "r" : "3",
+                           "s" : [ {
+                              "value" : [ "'Encounter '" ]
+                           } ]
+                        }, {
+                           "value" : [ " + " ]
+                        }, {
+                           "r" : "5",
+                           "s" : [ {
+                              "r" : "4",
+                              "s" : [ {
+                                 "value" : [ "e" ]
+                              } ]
+                           }, {
+                              "value" : [ "." ]
+                           }, {
+                              "r" : "5",
+                              "s" : [ {
+                                 "value" : [ "id" ]
+                              } ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "6",
+               "type" : "Concatenate",
+               "operand" : [ {
+                  "localId" : "3",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "Encounter ",
+                  "type" : "Literal"
+               }, {
+                  "localId" : "5",
+                  "path" : "id",
+                  "type" : "Property",
+                  "source" : {
+                     "localId" : "4",
+                     "name" : "e",
+                     "type" : "OperandRef"
+                  }
+               } ]
+            },
+            "operand" : [ {
+               "name" : "e",
+               "operandTypeSpecifier" : {
+                  "localId" : "2",
+                  "name" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "localId" : "13",
+            "name" : "process",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "13",
+                  "s" : [ {
+                     "value" : [ "define function ","process","(","c"," " ]
+                  }, {
+                     "r" : "8",
+                     "s" : [ {
+                        "value" : [ "Simple",".","Condition" ]
+                     } ]
+                  }, {
+                     "value" : [ ") :\n  " ]
+                  }, {
+                     "r" : "12",
+                     "s" : [ {
+                        "r" : "12",
+                        "s" : [ {
+                           "r" : "9",
+                           "s" : [ {
+                              "value" : [ "'Condition '" ]
+                           } ]
+                        }, {
+                           "value" : [ " + " ]
+                        }, {
+                           "r" : "11",
+                           "s" : [ {
+                              "r" : "10",
+                              "s" : [ {
+                                 "value" : [ "c" ]
+                              } ]
+                           }, {
+                              "value" : [ "." ]
+                           }, {
+                              "r" : "11",
+                              "s" : [ {
+                                 "value" : [ "id" ]
+                              } ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "12",
+               "type" : "Concatenate",
+               "operand" : [ {
+                  "localId" : "9",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "Condition ",
+                  "type" : "Literal"
+               }, {
+                  "localId" : "11",
+                  "path" : "id",
+                  "type" : "Property",
+                  "source" : {
+                     "localId" : "10",
+                     "name" : "c",
+                     "type" : "OperandRef"
+                  }
+               } ]
+            },
+            "operand" : [ {
+               "name" : "c",
+               "operandTypeSpecifier" : {
+                  "localId" : "8",
+                  "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "localId" : "17",
+            "name" : "testValue1",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "17",
+                  "s" : [ {
+                     "value" : [ "define ","testValue1",": " ]
+                  }, {
+                     "r" : "16",
+                     "s" : [ {
+                        "value" : [ "process","(" ]
+                     }, {
+                        "r" : "15",
+                        "s" : [ {
+                           "value" : [ "First","(" ]
+                        }, {
+                           "r" : "14",
+                           "s" : [ {
+                              "value" : [ "[","Encounter","]" ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "16",
+               "name" : "process",
+               "type" : "FunctionRef",
+               "operand" : [ {
+                  "localId" : "15",
+                  "type" : "First",
+                  "source" : {
+                     "localId" : "14",
+                     "dataType" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
+                     "type" : "Retrieve"
+                  }
+               } ]
+            }
+         }, {
+            "localId" : "21",
+            "name" : "testValue2",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "21",
+                  "s" : [ {
+                     "value" : [ "define ","testValue2",": " ]
+                  }, {
+                     "r" : "20",
+                     "s" : [ {
+                        "value" : [ "process","(" ]
+                     }, {
+                        "r" : "19",
+                        "s" : [ {
+                           "value" : [ "First","(" ]
+                        }, {
+                           "r" : "18",
+                           "s" : [ {
+                              "value" : [ "[","Condition","]" ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "20",
+               "name" : "process",
+               "type" : "FunctionRef",
+               "operand" : [ {
+                  "localId" : "19",
+                  "type" : "First",
+                  "source" : {
+                     "localId" : "18",
+                     "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+                     "type" : "Retrieve"
+                  }
                } ]
             }
          } ]

--- a/test/elm/reusable/patients.js
+++ b/test/elm/reusable/patients.js
@@ -1,0 +1,66 @@
+const p1 = {
+  recordType: 'Patient',
+  id: '3',
+  name: 'Bob Jones',
+  gender: 'M',
+  birthDate: '1974-07-12T11:15',
+  records: [
+    {
+      recordType: 'Encounter',
+      id: 'http://cqframework.org/3/1',
+      code: {
+        code: '185349003',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: 'Encounter for "check-up" (procedure)'
+      },
+      period: { low: '1978-07-15T10:00', high: '1978-07-15T10:45' }
+    },
+    {
+      recordType: 'Condition',
+      id: 'http://cqframework.org/3/2',
+      code: {
+        code: '1532007',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: 'Viral pharyngitis (disorder)'
+      },
+      period: { low: '1982-03-12', high: '1982-03-26' }
+    },
+    {
+      recordType: 'Encounter',
+      id: 'http://cqframework.org/3/3',
+      code: {
+        code: '406547006',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: 'Urgent follow-up (procedure)'
+      },
+      period: { low: '1982-03-15T15:00', high: '1982-03-15T15:30' }
+    },
+    {
+      recordType: 'Condition',
+      id: 'http://cqframework.org/3/4',
+      code: {
+        code: '109962001',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: "Diffuse non-Hodgkin's lymphoma (disorder)"
+      },
+      period: { low: '2010-10-24', high: '2011-02-01T11:55:00' }
+    },
+    {
+      recordType: 'Encounter',
+      id: 'http://cqframework.org/3/5',
+      code: {
+        code: '185349003',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: 'Encounter for "check-up" (procedure)'
+      },
+      period: { low: '2013-05-23T10:00', high: '2013-05-23T11:00' }
+    }
+  ]
+};
+
+module.exports = { p1 };

--- a/test/elm/reusable/reusable-test.js
+++ b/test/elm/reusable/reusable-test.js
@@ -1,5 +1,6 @@
 const setup = require('../../setup');
 const data = require('./data');
+const { p1 } = require('./patients');
 
 describe('ExpressionDef', () => {
   beforeEach(function () {
@@ -45,15 +46,56 @@ describe('FunctionDefinitions', () => {
   });
 });
 
-describe.skip('FunctionOverloads', function () {
+describe('FunctionOverloadsWithSingleArgument', function () {
   beforeEach(function () {
     setup(this, data);
   });
 
-  it('should be able to use the function with Integer argument', function () {
+  it('should be able to invoke the correct function based on argument type', function () {
     let e = this.testValue1.exec(this.ctx);
     e.should.equal(2);
     e = this.testValue2.exec(this.ctx);
     e.should.equal('Hello World');
+  });
+});
+
+describe('FunctionOverloadsWithMultipleArguments', function () {
+  beforeEach(function () {
+    setup(this, data);
+  });
+
+  it('should be able to invoke the correct function based on argument type', function () {
+    let e = this.testValue1.exec(this.ctx);
+    e.should.equal(0);
+    e = this.testValue2.exec(this.ctx);
+    e.should.equal('Goodbye World');
+  });
+});
+
+describe('FunctionOverloadsWithDifferentNumberOfArguments', function () {
+  beforeEach(function () {
+    setup(this, data);
+  });
+
+  it('should be able to invoke the correct function based on number of arguments', function () {
+    let e = this.testValue1.exec(this.ctx);
+    e.should.equal('Hello World');
+    e = this.testValue2.exec(this.ctx);
+    e.should.equal('Hola World from Spain');
+    e = this.testValue3.exec(this.ctx);
+    e.should.equal('Hello World from England');
+  });
+});
+
+describe('FunctionOverloadsWithArgumentsFromCustomDataModel', function () {
+  beforeEach(function () {
+    setup(this, data, [p1]);
+  });
+
+  it('should be able to invoke the correct function based on argument type', function () {
+    let e = this.testValue1.exec(this.ctx);
+    e.should.equal('Encounter http://cqframework.org/3/1');
+    e = this.testValue2.exec(this.ctx);
+    e.should.equal('Condition http://cqframework.org/3/2');
   });
 });

--- a/test/elm/type/data.cql
+++ b/test/elm/type/data.cql
@@ -1,0 +1,29 @@
+// @Test: IsSystemType
+define FiveIsInteger: 5 is Integer
+define FiveIsDecimal: 5 is Decimal
+define FivePointFiveIsInteger: 5.5 is Integer
+define FivePointFiveIsDecimal: 5.5 is Decimal
+
+// @Test: IsListType
+define ListOfIntegersIsListOfIntegers: {1, 2, 3, 4, 5} is List<Integer>
+define ListOfDecimalsIsListOfIntegers: {1.5, 2.5, 3.5, 4.5, 5.5} is List<Integer>
+
+// @Test: IsIntervalType
+define IntervalOfIntegersIsIntervalOfIntegers: Interval[1, 5] is Interval<Integer>
+define IntervalOfDecimalsIsIntervalOfIntegers: Interval[1.5, 5.5] is Interval<Integer>
+
+// @Test: IsTupleType
+define TupleOfIntegersIsTupleOfIntegers: Tuple{ a: 1, b: 2 } is Tuple{a Integer, b Integer}
+define TupleOfDecimalsIsTupleOfIntegers: Tuple{ a: 1.5, b: 2.5 } is Tuple{a Integer, b Integer}
+
+// @Test: IsChoiceType
+define IntegerIsChoiceOfIntegersAndDecimals: 5 is Choice<Integer, Decimal>
+define DecimalIsChoiceOfIntegersAndDecimals: 5.5 is Choice<Integer, Decimal>
+define StringIsChoiceOfIntegersAndDecimals: 'Foo' is Choice<Integer, Decimal>
+
+// @Test: IsCustomDataModelType
+define EncounterIsEncounter: First([Encounter]) is Simple.Encounter
+define EncounterIsRecord: First([Encounter]) is Simple.Record
+define EncounterIsAny: First([Encounter]) is System.Any
+define EncounterIsCondition: First([Encounter]) is Simple.Condition
+define EncounterIsString: First([Encounter]) is System.String

--- a/test/elm/type/data.js
+++ b/test/elm/type/data.js
@@ -1,0 +1,1452 @@
+/*
+   WARNING: This is a GENERATED file.  Do not manually edit!
+
+   To generate this file:
+       - Edit data.cql to add a CQL Snippet
+       - From java dir: ./gradlew :cql-to-elm:generateTestData
+*/
+
+/* eslint-disable */
+
+/* IsSystemType
+library TestSnippet version '1'
+using Simple version '1.0.0'
+context Patient
+define FiveIsInteger: 5 is Integer
+define FiveIsDecimal: 5 is Decimal
+define FivePointFiveIsInteger: 5.5 is Integer
+define FivePointFiveIsDecimal: 5.5 is Decimal
+*/
+
+module.exports['IsSystemType'] = {
+   "library" : {
+      "annotation" : [ {
+         "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
+         "type" : "CqlToElmInfo"
+      } ],
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "1",
+            "localIdentifier" : "Simple",
+            "uri" : "https://github.com/cqframework/cql-execution/simple",
+            "version" : "1.0.0"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "localId" : "5",
+            "name" : "FiveIsInteger",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "value" : [ "define ","FiveIsInteger",": " ]
+                  }, {
+                     "r" : "4",
+                     "s" : [ {
+                        "r" : "2",
+                        "value" : [ "5"," is " ]
+                     }, {
+                        "r" : "3",
+                        "s" : [ {
+                           "value" : [ "Integer" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "4",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "2",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "5",
+                  "type" : "Literal"
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "3",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "localId" : "9",
+            "name" : "FiveIsDecimal",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "9",
+                  "s" : [ {
+                     "value" : [ "define ","FiveIsDecimal",": " ]
+                  }, {
+                     "r" : "8",
+                     "s" : [ {
+                        "r" : "6",
+                        "value" : [ "5"," is " ]
+                     }, {
+                        "r" : "7",
+                        "s" : [ {
+                           "value" : [ "Decimal" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "8",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "6",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "5",
+                  "type" : "Literal"
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "7",
+                  "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "localId" : "13",
+            "name" : "FivePointFiveIsInteger",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "13",
+                  "s" : [ {
+                     "value" : [ "define ","FivePointFiveIsInteger",": " ]
+                  }, {
+                     "r" : "12",
+                     "s" : [ {
+                        "r" : "10",
+                        "value" : [ "5.5"," is " ]
+                     }, {
+                        "r" : "11",
+                        "s" : [ {
+                           "value" : [ "Integer" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "12",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "10",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "value" : "5.5",
+                  "type" : "Literal"
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "11",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "localId" : "17",
+            "name" : "FivePointFiveIsDecimal",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "17",
+                  "s" : [ {
+                     "value" : [ "define ","FivePointFiveIsDecimal",": " ]
+                  }, {
+                     "r" : "16",
+                     "s" : [ {
+                        "r" : "14",
+                        "value" : [ "5.5"," is " ]
+                     }, {
+                        "r" : "15",
+                        "s" : [ {
+                           "value" : [ "Decimal" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "16",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "14",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "value" : "5.5",
+                  "type" : "Literal"
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "15",
+                  "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         } ]
+      }
+   }
+}
+
+/* IsListType
+library TestSnippet version '1'
+using Simple version '1.0.0'
+context Patient
+define ListOfIntegersIsListOfIntegers: {1, 2, 3, 4, 5} is List<Integer>
+define ListOfDecimalsIsListOfIntegers: {1.5, 2.5, 3.5, 4.5, 5.5} is List<Integer>
+*/
+
+module.exports['IsListType'] = {
+   "library" : {
+      "annotation" : [ {
+         "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
+         "type" : "CqlToElmInfo"
+      } ],
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "1",
+            "localIdentifier" : "Simple",
+            "uri" : "https://github.com/cqframework/cql-execution/simple",
+            "version" : "1.0.0"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "localId" : "11",
+            "name" : "ListOfIntegersIsListOfIntegers",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "11",
+                  "s" : [ {
+                     "value" : [ "define ","ListOfIntegersIsListOfIntegers",": " ]
+                  }, {
+                     "r" : "10",
+                     "s" : [ {
+                        "r" : "7",
+                        "s" : [ {
+                           "r" : "2",
+                           "value" : [ "{","1",", ","2",", ","3",", ","4",", ","5","}" ]
+                        } ]
+                     }, {
+                        "value" : [ " is " ]
+                     }, {
+                        "r" : "9",
+                        "s" : [ {
+                           "value" : [ "List<" ]
+                        }, {
+                           "r" : "8",
+                           "s" : [ {
+                              "value" : [ "Integer" ]
+                           } ]
+                        }, {
+                           "value" : [ ">" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "10",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "7",
+                  "type" : "List",
+                  "element" : [ {
+                     "localId" : "2",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "1",
+                     "type" : "Literal"
+                  }, {
+                     "localId" : "3",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "2",
+                     "type" : "Literal"
+                  }, {
+                     "localId" : "4",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "3",
+                     "type" : "Literal"
+                  }, {
+                     "localId" : "5",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "4",
+                     "type" : "Literal"
+                  }, {
+                     "localId" : "6",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "5",
+                     "type" : "Literal"
+                  } ]
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "9",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "8",
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }
+            }
+         }, {
+            "localId" : "21",
+            "name" : "ListOfDecimalsIsListOfIntegers",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "21",
+                  "s" : [ {
+                     "value" : [ "define ","ListOfDecimalsIsListOfIntegers",": " ]
+                  }, {
+                     "r" : "20",
+                     "s" : [ {
+                        "r" : "17",
+                        "s" : [ {
+                           "r" : "12",
+                           "value" : [ "{","1.5",", ","2.5",", ","3.5",", ","4.5",", ","5.5","}" ]
+                        } ]
+                     }, {
+                        "value" : [ " is " ]
+                     }, {
+                        "r" : "19",
+                        "s" : [ {
+                           "value" : [ "List<" ]
+                        }, {
+                           "r" : "18",
+                           "s" : [ {
+                              "value" : [ "Integer" ]
+                           } ]
+                        }, {
+                           "value" : [ ">" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "20",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "17",
+                  "type" : "List",
+                  "element" : [ {
+                     "localId" : "12",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "value" : "1.5",
+                     "type" : "Literal"
+                  }, {
+                     "localId" : "13",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "value" : "2.5",
+                     "type" : "Literal"
+                  }, {
+                     "localId" : "14",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "value" : "3.5",
+                     "type" : "Literal"
+                  }, {
+                     "localId" : "15",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "value" : "4.5",
+                     "type" : "Literal"
+                  }, {
+                     "localId" : "16",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "value" : "5.5",
+                     "type" : "Literal"
+                  } ]
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "19",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "18",
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }
+            }
+         } ]
+      }
+   }
+}
+
+/* IsIntervalType
+library TestSnippet version '1'
+using Simple version '1.0.0'
+context Patient
+define IntervalOfIntegersIsIntervalOfIntegers: Interval[1, 5] is Interval<Integer>
+define IntervalOfDecimalsIsIntervalOfIntegers: Interval[1.5, 5.5] is Interval<Integer>
+*/
+
+module.exports['IsIntervalType'] = {
+   "library" : {
+      "annotation" : [ {
+         "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
+         "type" : "CqlToElmInfo"
+      } ],
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "1",
+            "localIdentifier" : "Simple",
+            "uri" : "https://github.com/cqframework/cql-execution/simple",
+            "version" : "1.0.0"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "localId" : "8",
+            "name" : "IntervalOfIntegersIsIntervalOfIntegers",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "8",
+                  "s" : [ {
+                     "value" : [ "define ","IntervalOfIntegersIsIntervalOfIntegers",": " ]
+                  }, {
+                     "r" : "7",
+                     "s" : [ {
+                        "r" : "4",
+                        "s" : [ {
+                           "r" : "2",
+                           "value" : [ "Interval[","1",", ","5","]" ]
+                        } ]
+                     }, {
+                        "value" : [ " is " ]
+                     }, {
+                        "r" : "6",
+                        "s" : [ {
+                           "value" : [ "Interval<" ]
+                        }, {
+                           "r" : "5",
+                           "s" : [ {
+                              "value" : [ "Integer" ]
+                           } ]
+                        }, {
+                           "value" : [ ">" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "7",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "4",
+                  "lowClosed" : true,
+                  "highClosed" : true,
+                  "type" : "Interval",
+                  "low" : {
+                     "localId" : "2",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "1",
+                     "type" : "Literal"
+                  },
+                  "high" : {
+                     "localId" : "3",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "5",
+                     "type" : "Literal"
+                  }
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "6",
+                  "type" : "IntervalTypeSpecifier",
+                  "pointType" : {
+                     "localId" : "5",
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }
+            }
+         }, {
+            "localId" : "15",
+            "name" : "IntervalOfDecimalsIsIntervalOfIntegers",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "15",
+                  "s" : [ {
+                     "value" : [ "define ","IntervalOfDecimalsIsIntervalOfIntegers",": " ]
+                  }, {
+                     "r" : "14",
+                     "s" : [ {
+                        "r" : "11",
+                        "s" : [ {
+                           "r" : "9",
+                           "value" : [ "Interval[","1.5",", ","5.5","]" ]
+                        } ]
+                     }, {
+                        "value" : [ " is " ]
+                     }, {
+                        "r" : "13",
+                        "s" : [ {
+                           "value" : [ "Interval<" ]
+                        }, {
+                           "r" : "12",
+                           "s" : [ {
+                              "value" : [ "Integer" ]
+                           } ]
+                        }, {
+                           "value" : [ ">" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "14",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "11",
+                  "lowClosed" : true,
+                  "highClosed" : true,
+                  "type" : "Interval",
+                  "low" : {
+                     "localId" : "9",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "value" : "1.5",
+                     "type" : "Literal"
+                  },
+                  "high" : {
+                     "localId" : "10",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "value" : "5.5",
+                     "type" : "Literal"
+                  }
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "13",
+                  "type" : "IntervalTypeSpecifier",
+                  "pointType" : {
+                     "localId" : "12",
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }
+            }
+         } ]
+      }
+   }
+}
+
+/* IsTupleType
+library TestSnippet version '1'
+using Simple version '1.0.0'
+context Patient
+define TupleOfIntegersIsTupleOfIntegers: Tuple{ a: 1, b: 2 } is Tuple{a Integer, b Integer}
+define TupleOfDecimalsIsTupleOfIntegers: Tuple{ a: 1.5, b: 2.5 } is Tuple{a Integer, b Integer}
+*/
+
+module.exports['IsTupleType'] = {
+   "library" : {
+      "annotation" : [ {
+         "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
+         "type" : "CqlToElmInfo"
+      } ],
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "1",
+            "localIdentifier" : "Simple",
+            "uri" : "https://github.com/cqframework/cql-execution/simple",
+            "version" : "1.0.0"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "localId" : "11",
+            "name" : "TupleOfIntegersIsTupleOfIntegers",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "11",
+                  "s" : [ {
+                     "value" : [ "define ","TupleOfIntegersIsTupleOfIntegers",": " ]
+                  }, {
+                     "r" : "10",
+                     "s" : [ {
+                        "r" : "4",
+                        "s" : [ {
+                           "value" : [ "Tuple{ " ]
+                        }, {
+                           "s" : [ {
+                              "r" : "2",
+                              "value" : [ "a",": ","1" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "s" : [ {
+                              "r" : "3",
+                              "value" : [ "b",": ","2" ]
+                           } ]
+                        }, {
+                           "value" : [ " }" ]
+                        } ]
+                     }, {
+                        "value" : [ " is " ]
+                     }, {
+                        "r" : "9",
+                        "s" : [ {
+                           "value" : [ "Tuple{" ]
+                        }, {
+                           "r" : "6",
+                           "s" : [ {
+                              "value" : [ "a"," " ]
+                           }, {
+                              "r" : "5",
+                              "s" : [ {
+                                 "value" : [ "Integer" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "8",
+                           "s" : [ {
+                              "value" : [ "b"," " ]
+                           }, {
+                              "r" : "7",
+                              "s" : [ {
+                                 "value" : [ "Integer" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ "}" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "10",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "4",
+                  "type" : "Tuple",
+                  "element" : [ {
+                     "name" : "a",
+                     "value" : {
+                        "localId" : "2",
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "1",
+                        "type" : "Literal"
+                     }
+                  }, {
+                     "name" : "b",
+                     "value" : {
+                        "localId" : "3",
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "2",
+                        "type" : "Literal"
+                     }
+                  } ]
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "9",
+                  "type" : "TupleTypeSpecifier",
+                  "element" : [ {
+                     "localId" : "6",
+                     "name" : "a",
+                     "elementType" : {
+                        "localId" : "5",
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }, {
+                     "localId" : "8",
+                     "name" : "b",
+                     "elementType" : {
+                        "localId" : "7",
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ]
+               }
+            }
+         }, {
+            "localId" : "21",
+            "name" : "TupleOfDecimalsIsTupleOfIntegers",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "21",
+                  "s" : [ {
+                     "value" : [ "define ","TupleOfDecimalsIsTupleOfIntegers",": " ]
+                  }, {
+                     "r" : "20",
+                     "s" : [ {
+                        "r" : "14",
+                        "s" : [ {
+                           "value" : [ "Tuple{ " ]
+                        }, {
+                           "s" : [ {
+                              "r" : "12",
+                              "value" : [ "a",": ","1.5" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "s" : [ {
+                              "r" : "13",
+                              "value" : [ "b",": ","2.5" ]
+                           } ]
+                        }, {
+                           "value" : [ " }" ]
+                        } ]
+                     }, {
+                        "value" : [ " is " ]
+                     }, {
+                        "r" : "19",
+                        "s" : [ {
+                           "value" : [ "Tuple{" ]
+                        }, {
+                           "r" : "16",
+                           "s" : [ {
+                              "value" : [ "a"," " ]
+                           }, {
+                              "r" : "15",
+                              "s" : [ {
+                                 "value" : [ "Integer" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "18",
+                           "s" : [ {
+                              "value" : [ "b"," " ]
+                           }, {
+                              "r" : "17",
+                              "s" : [ {
+                                 "value" : [ "Integer" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ "}" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "20",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "14",
+                  "type" : "Tuple",
+                  "element" : [ {
+                     "name" : "a",
+                     "value" : {
+                        "localId" : "12",
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "value" : "1.5",
+                        "type" : "Literal"
+                     }
+                  }, {
+                     "name" : "b",
+                     "value" : {
+                        "localId" : "13",
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "value" : "2.5",
+                        "type" : "Literal"
+                     }
+                  } ]
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "19",
+                  "type" : "TupleTypeSpecifier",
+                  "element" : [ {
+                     "localId" : "16",
+                     "name" : "a",
+                     "elementType" : {
+                        "localId" : "15",
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }, {
+                     "localId" : "18",
+                     "name" : "b",
+                     "elementType" : {
+                        "localId" : "17",
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ]
+               }
+            }
+         } ]
+      }
+   }
+}
+
+/* IsChoiceType
+library TestSnippet version '1'
+using Simple version '1.0.0'
+context Patient
+define IntegerIsChoiceOfIntegersAndDecimals: 5 is Choice<Integer, Decimal>
+define DecimalIsChoiceOfIntegersAndDecimals: 5.5 is Choice<Integer, Decimal>
+define StringIsChoiceOfIntegersAndDecimals: 'Foo' is Choice<Integer, Decimal>
+*/
+
+module.exports['IsChoiceType'] = {
+   "library" : {
+      "annotation" : [ {
+         "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
+         "type" : "CqlToElmInfo"
+      } ],
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "1",
+            "localIdentifier" : "Simple",
+            "uri" : "https://github.com/cqframework/cql-execution/simple",
+            "version" : "1.0.0"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "localId" : "7",
+            "name" : "IntegerIsChoiceOfIntegersAndDecimals",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "7",
+                  "s" : [ {
+                     "value" : [ "define ","IntegerIsChoiceOfIntegersAndDecimals",": " ]
+                  }, {
+                     "r" : "6",
+                     "s" : [ {
+                        "r" : "2",
+                        "value" : [ "5"," is " ]
+                     }, {
+                        "r" : "5",
+                        "s" : [ {
+                           "value" : [ "Choice<" ]
+                        }, {
+                           "r" : "3",
+                           "s" : [ {
+                              "value" : [ "Integer" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "4",
+                           "s" : [ {
+                              "value" : [ "Decimal" ]
+                           } ]
+                        }, {
+                           "value" : [ ">" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "6",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "2",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "5",
+                  "type" : "Literal"
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "5",
+                  "type" : "ChoiceTypeSpecifier",
+                  "choice" : [ {
+                     "localId" : "3",
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
+                  }, {
+                     "localId" : "4",
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  } ]
+               }
+            }
+         }, {
+            "localId" : "13",
+            "name" : "DecimalIsChoiceOfIntegersAndDecimals",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "13",
+                  "s" : [ {
+                     "value" : [ "define ","DecimalIsChoiceOfIntegersAndDecimals",": " ]
+                  }, {
+                     "r" : "12",
+                     "s" : [ {
+                        "r" : "8",
+                        "value" : [ "5.5"," is " ]
+                     }, {
+                        "r" : "11",
+                        "s" : [ {
+                           "value" : [ "Choice<" ]
+                        }, {
+                           "r" : "9",
+                           "s" : [ {
+                              "value" : [ "Integer" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "10",
+                           "s" : [ {
+                              "value" : [ "Decimal" ]
+                           } ]
+                        }, {
+                           "value" : [ ">" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "12",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "8",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "value" : "5.5",
+                  "type" : "Literal"
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "11",
+                  "type" : "ChoiceTypeSpecifier",
+                  "choice" : [ {
+                     "localId" : "9",
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
+                  }, {
+                     "localId" : "10",
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  } ]
+               }
+            }
+         }, {
+            "localId" : "19",
+            "name" : "StringIsChoiceOfIntegersAndDecimals",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "19",
+                  "s" : [ {
+                     "value" : [ "define ","StringIsChoiceOfIntegersAndDecimals",": " ]
+                  }, {
+                     "r" : "18",
+                     "s" : [ {
+                        "r" : "14",
+                        "s" : [ {
+                           "value" : [ "'Foo'" ]
+                        } ]
+                     }, {
+                        "value" : [ " is " ]
+                     }, {
+                        "r" : "17",
+                        "s" : [ {
+                           "value" : [ "Choice<" ]
+                        }, {
+                           "r" : "15",
+                           "s" : [ {
+                              "value" : [ "Integer" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "16",
+                           "s" : [ {
+                              "value" : [ "Decimal" ]
+                           } ]
+                        }, {
+                           "value" : [ ">" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "18",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "14",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "Foo",
+                  "type" : "Literal"
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "17",
+                  "type" : "ChoiceTypeSpecifier",
+                  "choice" : [ {
+                     "localId" : "15",
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
+                  }, {
+                     "localId" : "16",
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  } ]
+               }
+            }
+         } ]
+      }
+   }
+}
+
+/* IsCustomDataModelType
+library TestSnippet version '1'
+using Simple version '1.0.0'
+context Patient
+define EncounterIsEncounter: First([Encounter]) is Simple.Encounter
+define EncounterIsRecord: First([Encounter]) is Simple.Record
+define EncounterIsAny: First([Encounter]) is System.Any
+define EncounterIsCondition: First([Encounter]) is Simple.Condition
+define EncounterIsString: First([Encounter]) is System.String
+*/
+
+module.exports['IsCustomDataModelType'] = {
+   "library" : {
+      "annotation" : [ {
+         "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
+         "type" : "CqlToElmInfo"
+      } ],
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "1",
+            "localIdentifier" : "Simple",
+            "uri" : "https://github.com/cqframework/cql-execution/simple",
+            "version" : "1.0.0"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "localId" : "6",
+            "name" : "EncounterIsEncounter",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "6",
+                  "s" : [ {
+                     "value" : [ "define ","EncounterIsEncounter",": " ]
+                  }, {
+                     "r" : "5",
+                     "s" : [ {
+                        "r" : "3",
+                        "s" : [ {
+                           "value" : [ "First","(" ]
+                        }, {
+                           "r" : "2",
+                           "s" : [ {
+                              "value" : [ "[","Encounter","]" ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     }, {
+                        "value" : [ " is " ]
+                     }, {
+                        "r" : "4",
+                        "s" : [ {
+                           "value" : [ "Simple",".","Encounter" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "5",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "3",
+                  "type" : "First",
+                  "source" : {
+                     "localId" : "2",
+                     "dataType" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
+                     "type" : "Retrieve"
+                  }
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "4",
+                  "name" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "localId" : "11",
+            "name" : "EncounterIsRecord",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "11",
+                  "s" : [ {
+                     "value" : [ "define ","EncounterIsRecord",": " ]
+                  }, {
+                     "r" : "10",
+                     "s" : [ {
+                        "r" : "8",
+                        "s" : [ {
+                           "value" : [ "First","(" ]
+                        }, {
+                           "r" : "7",
+                           "s" : [ {
+                              "value" : [ "[","Encounter","]" ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     }, {
+                        "value" : [ " is " ]
+                     }, {
+                        "r" : "9",
+                        "s" : [ {
+                           "value" : [ "Simple",".","Record" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "10",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "8",
+                  "type" : "First",
+                  "source" : {
+                     "localId" : "7",
+                     "dataType" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
+                     "type" : "Retrieve"
+                  }
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "9",
+                  "name" : "{https://github.com/cqframework/cql-execution/simple}Record",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "localId" : "16",
+            "name" : "EncounterIsAny",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "16",
+                  "s" : [ {
+                     "value" : [ "define ","EncounterIsAny",": " ]
+                  }, {
+                     "r" : "15",
+                     "s" : [ {
+                        "r" : "13",
+                        "s" : [ {
+                           "value" : [ "First","(" ]
+                        }, {
+                           "r" : "12",
+                           "s" : [ {
+                              "value" : [ "[","Encounter","]" ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     }, {
+                        "value" : [ " is " ]
+                     }, {
+                        "r" : "14",
+                        "s" : [ {
+                           "value" : [ "System",".","Any" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "15",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "13",
+                  "type" : "First",
+                  "source" : {
+                     "localId" : "12",
+                     "dataType" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
+                     "type" : "Retrieve"
+                  }
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "14",
+                  "name" : "{urn:hl7-org:elm-types:r1}Any",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "localId" : "21",
+            "name" : "EncounterIsCondition",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "21",
+                  "s" : [ {
+                     "value" : [ "define ","EncounterIsCondition",": " ]
+                  }, {
+                     "r" : "20",
+                     "s" : [ {
+                        "r" : "18",
+                        "s" : [ {
+                           "value" : [ "First","(" ]
+                        }, {
+                           "r" : "17",
+                           "s" : [ {
+                              "value" : [ "[","Encounter","]" ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     }, {
+                        "value" : [ " is " ]
+                     }, {
+                        "r" : "19",
+                        "s" : [ {
+                           "value" : [ "Simple",".","Condition" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "20",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "18",
+                  "type" : "First",
+                  "source" : {
+                     "localId" : "17",
+                     "dataType" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
+                     "type" : "Retrieve"
+                  }
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "19",
+                  "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "localId" : "26",
+            "name" : "EncounterIsString",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "26",
+                  "s" : [ {
+                     "value" : [ "define ","EncounterIsString",": " ]
+                  }, {
+                     "r" : "25",
+                     "s" : [ {
+                        "r" : "23",
+                        "s" : [ {
+                           "value" : [ "First","(" ]
+                        }, {
+                           "r" : "22",
+                           "s" : [ {
+                              "value" : [ "[","Encounter","]" ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     }, {
+                        "value" : [ " is " ]
+                     }, {
+                        "r" : "24",
+                        "s" : [ {
+                           "value" : [ "System",".","String" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "25",
+               "type" : "Is",
+               "operand" : {
+                  "localId" : "23",
+                  "type" : "First",
+                  "source" : {
+                     "localId" : "22",
+                     "dataType" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
+                     "type" : "Retrieve"
+                  }
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "24",
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         } ]
+      }
+   }
+}
+

--- a/test/elm/type/patients.js
+++ b/test/elm/type/patients.js
@@ -1,0 +1,66 @@
+const p1 = {
+  recordType: 'Patient',
+  id: '3',
+  name: 'Bob Jones',
+  gender: 'M',
+  birthDate: '1974-07-12T11:15',
+  records: [
+    {
+      recordType: 'Encounter',
+      id: 'http://cqframework.org/3/1',
+      code: {
+        code: '185349003',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: 'Encounter for "check-up" (procedure)'
+      },
+      period: { low: '1978-07-15T10:00', high: '1978-07-15T10:45' }
+    },
+    {
+      recordType: 'Condition',
+      id: 'http://cqframework.org/3/2',
+      code: {
+        code: '1532007',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: 'Viral pharyngitis (disorder)'
+      },
+      period: { low: '1982-03-12', high: '1982-03-26' }
+    },
+    {
+      recordType: 'Encounter',
+      id: 'http://cqframework.org/3/3',
+      code: {
+        code: '406547006',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: 'Urgent follow-up (procedure)'
+      },
+      period: { low: '1982-03-15T15:00', high: '1982-03-15T15:30' }
+    },
+    {
+      recordType: 'Condition',
+      id: 'http://cqframework.org/3/4',
+      code: {
+        code: '109962001',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: "Diffuse non-Hodgkin's lymphoma (disorder)"
+      },
+      period: { low: '2010-10-24', high: '2011-02-01T11:55:00' }
+    },
+    {
+      recordType: 'Encounter',
+      id: 'http://cqframework.org/3/5',
+      code: {
+        code: '185349003',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: 'Encounter for "check-up" (procedure)'
+      },
+      period: { low: '2013-05-23T10:00', high: '2013-05-23T11:00' }
+    }
+  ]
+};
+
+module.exports = { p1 };

--- a/test/elm/type/type-test.js
+++ b/test/elm/type/type-test.js
@@ -1,0 +1,93 @@
+const setup = require('../../setup');
+const data = require('./data');
+const { p1 } = require('./patients');
+
+describe('IsSystemType', () => {
+  beforeEach(function () {
+    setup(this, data);
+  });
+
+  it('should correctly accept matching types', function () {
+    this.fiveIsInteger.exec(this.ctx).should.be.true();
+    this.fiveIsDecimal.exec(this.ctx).should.be.true();
+    this.fivePointFiveIsDecimal.exec(this.ctx).should.be.true();
+  });
+
+  it('should correctly reject non-matching types', function () {
+    this.fivePointFiveIsInteger.exec(this.ctx).should.be.false();
+  });
+});
+
+describe('IsListType', () => {
+  beforeEach(function () {
+    setup(this, data);
+  });
+
+  it('should correctly accept matching types', function () {
+    this.listOfIntegersIsListOfIntegers.exec(this.ctx).should.be.true();
+  });
+
+  it('should correctly reject non-matching types', function () {
+    this.listOfDecimalsIsListOfIntegers.exec(this.ctx).should.be.false();
+  });
+});
+
+describe('IsIntervalType', () => {
+  beforeEach(function () {
+    setup(this, data);
+  });
+
+  it('should correctly accept matching types', function () {
+    this.intervalOfIntegersIsIntervalOfIntegers.exec(this.ctx).should.be.true();
+  });
+
+  it('should correctly reject non-matching types', function () {
+    this.intervalOfDecimalsIsIntervalOfIntegers.exec(this.ctx).should.be.false();
+  });
+});
+
+describe('IsTupleType', () => {
+  beforeEach(function () {
+    setup(this, data);
+  });
+
+  it('should correctly accept matching types', function () {
+    this.tupleOfIntegersIsTupleOfIntegers.exec(this.ctx).should.be.true();
+  });
+
+  it('should correctly reject non-matching types', function () {
+    this.tupleOfDecimalsIsTupleOfIntegers.exec(this.ctx).should.be.false();
+  });
+});
+
+describe('IsChoiceType', () => {
+  beforeEach(function () {
+    setup(this, data);
+  });
+
+  it('should correctly accept matching types', function () {
+    this.integerIsChoiceOfIntegersAndDecimals.exec(this.ctx).should.be.true();
+    this.decimalIsChoiceOfIntegersAndDecimals.exec(this.ctx).should.be.true();
+  });
+
+  it('should correctly reject non-matching types', function () {
+    this.stringIsChoiceOfIntegersAndDecimals.exec(this.ctx).should.be.false();
+  });
+});
+
+describe('IsCustomDataModelType', () => {
+  beforeEach(function () {
+    setup(this, data, [p1]);
+  });
+
+  it('should correctly accept matching types', function () {
+    this.encounterIsEncounter.exec(this.ctx).should.be.true();
+    this.encounterIsRecord.exec(this.ctx).should.be.true();
+    this.encounterIsAny.exec(this.ctx).should.be.true();
+  });
+
+  it('should correctly reject non-matching types', function () {
+    this.encounterIsCondition.exec(this.ctx).should.be.false();
+    this.encounterIsString.exec(this.ctx).should.be.false();
+  });
+});


### PR DESCRIPTION
Support function overloading based on number of arguments, then argument types. There is still a limitation in that it doesn't yet have an algorithm to choose a function when all functions are valid against the argument types (in which case, the function w/ "least conversion" should be used).

In the process of implementing this, I noticed that the Context class already had 95% of what we needed to support the "Is" operator as well, so I refactored "Is" to use the Context functions.

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository. 
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [✔] This pull request describes why these changes were made
- [✔] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [✔] Tests are included and test edge cases
- [✔] Tests have been run locally and pass
- [✔] Code coverage has not gone down and all code touched or added is covered.
- [n/a] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [✔] `cql4browsers.js` built with `yarn run build-everything` if coffeescript source changed.

**Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
