### PR TITLE
Update _is operator argument to take the type specifier from CQL

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -13260,11 +13260,7 @@ var Context = /*#__PURE__*/function () {
         default:
           // Use the data model's implementation of _is, if it is available
           if (typeof val._is === 'function') {
-            var matches = /^\{(.+)\}(.+)$/.exec(spec.name);
-
-            if (matches) {
-              return val._is(matches[1], matches[2]);
-            }
+            return val._is(spec);
           } // otherwise just default to true
 
 

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -151,23 +151,23 @@ var Record = /*#__PURE__*/function () {
 
   _createClass(Record, [{
     key: "_is",
-    value: function _is(namespace, name) {
+    value: function _is(typeSpecifier) {
       return this._typeHierarchy().some(function (t) {
-        return t.namespace === namespace && t.name === name;
+        return t.type === typeSpecifier.type && t.name == typeSpecifier.name;
       });
     }
   }, {
     key: "_typeHierarchy",
     value: function _typeHierarchy() {
       return [{
-        namespace: 'https://github.com/cqframework/cql-execution/simple',
-        name: this.json.recordType
+        name: "{https://github.com/cqframework/cql-execution/simple}".concat(this.json.recordType),
+        type: 'NamedTypeSpecifier'
       }, {
-        namespace: 'https://github.com/cqframework/cql-execution/simple',
-        name: 'Record'
+        name: '{https://github.com/cqframework/cql-execution/simple}Record',
+        type: 'NamedTypeSpecifier'
       }, {
-        namespace: 'urn:hl7-org:elm-types:r1',
-        name: 'Any'
+        name: '{urn:hl7-org:elm-types:r1}Any',
+        type: 'NamedTypeSpecifier'
       }];
     }
   }, {

--- a/src/cql-patient.js
+++ b/src/cql-patient.js
@@ -6,18 +6,23 @@ class Record {
     this.id = this.json.id;
   }
 
-  _is(namespace, name) {
-    return this._typeHierarchy().some(t => t.namespace === namespace && t.name === name);
+  _is(typeSpecifier) {
+    return this._typeHierarchy().some(
+      t => t.type === typeSpecifier.type && t.name == typeSpecifier.name
+    );
   }
 
   _typeHierarchy() {
     return [
       {
-        namespace: 'https://github.com/cqframework/cql-execution/simple',
-        name: this.json.recordType
+        name: `{https://github.com/cqframework/cql-execution/simple}${this.json.recordType}`,
+        type: 'NamedTypeSpecifier'
       },
-      { namespace: 'https://github.com/cqframework/cql-execution/simple', name: 'Record' },
-      { namespace: 'urn:hl7-org:elm-types:r1', name: 'Any' }
+      {
+        name: '{https://github.com/cqframework/cql-execution/simple}Record',
+        type: 'NamedTypeSpecifier'
+      },
+      { name: '{urn:hl7-org:elm-types:r1}Any', type: 'NamedTypeSpecifier' }
     ];
   }
 

--- a/src/elm/reusable.js
+++ b/src/elm/reusable.js
@@ -69,7 +69,9 @@ class FunctionRef extends Expression {
       functionDefs = functionDefs.filter(f => {
         let match = true;
         for (let i = 0; i < args.length && match; i++) {
-          match = ctx.matchesTypeSpecifier(args[i], f.parameters[i].operandTypeSpecifier);
+          if (args[i] !== null) {
+            match = ctx.matchesTypeSpecifier(args[i], f.parameters[i].operandTypeSpecifier);
+          }
         }
         return match;
       });

--- a/src/runtime/context.js
+++ b/src/runtime/context.js
@@ -289,10 +289,7 @@ class Context {
       default:
         // Use the data model's implementation of _is, if it is available
         if (typeof val._is === 'function') {
-          const matches = /^\{(.+)\}(.+)$/.exec(spec.name);
-          if (matches) {
-            return val._is(matches[1], matches[2]);
-          }
+          return val._is(spec);
         }
         // otherwise just default to true
         return true;

--- a/src/runtime/context.js
+++ b/src/runtime/context.js
@@ -265,6 +265,9 @@ class Context {
   }
 
   matchesNamedTypeSpecifier(val, spec) {
+    if (val == null) {
+      return true;
+    }
     switch (spec.name) {
       case '{urn:hl7-org:elm-types:r1}Boolean':
         return typeof val === 'boolean';


### PR DESCRIPTION
As requested by @cmoesel, this PR refactors the `_is` operator call to take the whole type specifier from CQL. This PR works in conjunction with https://github.com/cqframework/cql-exec-fhir/pull/13

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository. 
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `yarn run build-everything` if coffeescript source changed.

**Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
