### PR TITLE
Support for evaluatedRecords from retrieves

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -7003,6 +7003,14 @@ var Retrieve = /*#__PURE__*/function (_Expression) {
         });
       }
 
+      if (Array.isArray(records)) {
+        records.forEach(function (rec) {
+          return ctx.evaluatedRecords.push(rec);
+        });
+      } else {
+        ctx.evaluatedRecords.push(records);
+      }
+
       return records;
     }
   }, {
@@ -12995,7 +13003,8 @@ var Context = /*#__PURE__*/function () {
     this._codeService = _codeService;
     this.context_values = {};
     this.library_context = {};
-    this.localId_context = {}; // TODO: If there is an issue with number of parameters look into cql4browsers fix: 387ea77538182833283af65e6341e7a05192304c
+    this.localId_context = {};
+    this.evaluatedRecords = []; // TODO: If there is an issue with number of parameters look into cql4browsers fix: 387ea77538182833283af65e6341e7a05192304c
 
     this.checkParameters(_parameters); // not crazy about possibly throwing an error in a constructor, but...
 
@@ -13684,6 +13693,18 @@ module.exports = {
 },{"../elm/library":27}],44:[function(require,module,exports){
 "use strict";
 
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
@@ -13697,6 +13718,7 @@ var Results = /*#__PURE__*/function () {
     this.patientResults = {};
     this.unfilteredResults = {};
     this.localIdPatientResultsMap = {};
+    this.evaluatedRecords = [];
   }
 
   _createClass(Results, [{
@@ -13713,7 +13735,14 @@ var Results = /*#__PURE__*/function () {
       }
 
       this.patientResults[patientId][resultName] = result;
-      this.localIdPatientResultsMap[patientId] = patient_ctx.getAllLocalIds();
+      this.localIdPatientResultsMap[patientId] = patient_ctx.getAllLocalIds(); // Merge evaluatedRecords with an aggregated array across all libraries
+
+      var evaluatedRecords = _toConsumableArray(patient_ctx.evaluatedRecords);
+
+      Object.values(patient_ctx.library_context).forEach(function (ctx) {
+        evaluatedRecords.push.apply(evaluatedRecords, _toConsumableArray(ctx.evaluatedRecords));
+      });
+      this.evaluatedRecords = evaluatedRecords;
     }
   }, {
     key: "recordUnfilteredResult",

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -6924,6 +6924,18 @@ for (var _i = 0, _libs = libs; _i < _libs.length; _i++) {
 
 function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
@@ -7004,9 +7016,9 @@ var Retrieve = /*#__PURE__*/function (_Expression) {
       }
 
       if (Array.isArray(records)) {
-        records.forEach(function (rec) {
-          return ctx.evaluatedRecords.push(rec);
-        });
+        var _ctx$evaluatedRecords;
+
+        (_ctx$evaluatedRecords = ctx.evaluatedRecords).push.apply(_ctx$evaluatedRecords, _toConsumableArray(records));
       } else {
         ctx.evaluatedRecords.push(records);
       }
@@ -13724,6 +13736,8 @@ var Results = /*#__PURE__*/function () {
   _createClass(Results, [{
     key: "recordPatientResult",
     value: function recordPatientResult(patient_ctx, resultName, result) {
+      var _this = this;
+
       var p = patient_ctx.patient; // NOTE: From now on prefer getId() over id() because some data models may have an id property
       // that is not a string (e.g., FHIR) -- so reserve getId() for the API (and expect a string
       // representation) but leave id() for data-model specific formats.
@@ -13737,12 +13751,12 @@ var Results = /*#__PURE__*/function () {
       this.patientResults[patientId][resultName] = result;
       this.localIdPatientResultsMap[patientId] = patient_ctx.getAllLocalIds(); // Merge evaluatedRecords with an aggregated array across all libraries
 
-      var evaluatedRecords = _toConsumableArray(patient_ctx.evaluatedRecords);
-
+      this.evaluatedRecords = _toConsumableArray(patient_ctx.evaluatedRecords);
       Object.values(patient_ctx.library_context).forEach(function (ctx) {
-        evaluatedRecords.push.apply(evaluatedRecords, _toConsumableArray(ctx.evaluatedRecords));
+        var _this$evaluatedRecord;
+
+        (_this$evaluatedRecord = _this.evaluatedRecords).push.apply(_this$evaluatedRecord, _toConsumableArray(ctx.evaluatedRecords));
       });
-      this.evaluatedRecords = evaluatedRecords;
     }
   }, {
     key: "recordUnfilteredResult",

--- a/src/elm/external.js
+++ b/src/elm/external.js
@@ -32,7 +32,7 @@ class Retrieve extends Expression {
     }
 
     if (Array.isArray(records)) {
-      records.forEach(rec => ctx.evaluatedRecords.push(rec));
+      ctx.evaluatedRecords.push(...records);
     } else {
       ctx.evaluatedRecords.push(records);
     }

--- a/src/elm/external.js
+++ b/src/elm/external.js
@@ -31,6 +31,11 @@ class Retrieve extends Expression {
       records = records.filter(r => range.includes(r.getDateOrInterval(this.dateProperty)));
     }
 
+    if (Array.isArray(records)) {
+      records.forEach(rec => ctx.evaluatedRecords.push(rec));
+    } else {
+      ctx.evaluatedRecords.push(records);
+    }
     return records;
   }
 

--- a/src/runtime/context.js
+++ b/src/runtime/context.js
@@ -9,6 +9,7 @@ class Context {
     this.context_values = {};
     this.library_context = {};
     this.localId_context = {};
+    this.evaluatedRecords = [];
     // TODO: If there is an issue with number of parameters look into cql4browsers fix: 387ea77538182833283af65e6341e7a05192304c
     this.checkParameters(_parameters); // not crazy about possibly throwing an error in a constructor, but...
     this._parameters = _parameters;

--- a/src/runtime/results.js
+++ b/src/runtime/results.js
@@ -3,6 +3,7 @@ class Results {
     this.patientResults = {};
     this.unfilteredResults = {};
     this.localIdPatientResultsMap = {};
+    this.evaluatedRecords = [];
   }
 
   recordPatientResult(patient_ctx, resultName, result) {
@@ -16,6 +17,14 @@ class Results {
     }
     this.patientResults[patientId][resultName] = result;
     this.localIdPatientResultsMap[patientId] = patient_ctx.getAllLocalIds();
+
+    // Merge evaluatedRecords with an aggregated array across all libraries
+    const evaluatedRecords = [...patient_ctx.evaluatedRecords];
+    Object.values(patient_ctx.library_context).forEach(ctx => {
+      evaluatedRecords.push(...ctx.evaluatedRecords);
+    });
+
+    this.evaluatedRecords = evaluatedRecords;
   }
 
   recordUnfilteredResult(resultName, result) {

--- a/src/runtime/results.js
+++ b/src/runtime/results.js
@@ -19,12 +19,10 @@ class Results {
     this.localIdPatientResultsMap[patientId] = patient_ctx.getAllLocalIds();
 
     // Merge evaluatedRecords with an aggregated array across all libraries
-    const evaluatedRecords = [...patient_ctx.evaluatedRecords];
+    this.evaluatedRecords = [...patient_ctx.evaluatedRecords];
     Object.values(patient_ctx.library_context).forEach(ctx => {
-      evaluatedRecords.push(...ctx.evaluatedRecords);
+      this.evaluatedRecords.push(...ctx.evaluatedRecords);
     });
-
-    this.evaluatedRecords = evaluatedRecords;
   }
 
   recordUnfilteredResult(resultName, result) {

--- a/test/elm/external/external-test.js
+++ b/test/elm/external/external-test.js
@@ -14,6 +14,8 @@ describe('Retrieve', () => {
     c.should.have.length(2);
     c[0].id.should.equal('http://cqframework.org/3/2');
     c[1].id.should.equal('http://cqframework.org/3/4');
+    this.ctx.evaluatedRecords.should.have.length(2);
+    this.ctx.evaluatedRecords.should.containDeep(c);
   });
 
   it('should find encounter performances', function () {
@@ -22,12 +24,16 @@ describe('Retrieve', () => {
     e[0].id.should.equal('http://cqframework.org/3/1');
     e[1].id.should.equal('http://cqframework.org/3/3');
     e[2].id.should.equal('http://cqframework.org/3/5');
+    this.ctx.evaluatedRecords.should.have.length(3);
+    this.ctx.evaluatedRecords.should.containDeep(e);
   });
 
   it('should find observations with a value set from included library', function () {
     const p = this.pharyngitisConditions.exec(this.ctx);
     p.should.have.length(1);
     p[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(p);
   });
 
   it('should find encounter performances with a value set', function () {
@@ -36,6 +42,8 @@ describe('Retrieve', () => {
     a[0].id.should.equal('http://cqframework.org/3/1');
     a[1].id.should.equal('http://cqframework.org/3/3');
     a[2].id.should.equal('http://cqframework.org/3/5');
+    this.ctx.evaluatedRecords.should.have.length(3);
+    this.ctx.evaluatedRecords.should.containDeep(a);
   });
 
   it('should find encounter performances by code', function () {
@@ -44,27 +52,35 @@ describe('Retrieve', () => {
     e[0].id.should.equal('http://cqframework.org/3/1');
     e[1].id.should.equal('http://cqframework.org/3/3');
     e[2].id.should.equal('http://cqframework.org/3/5');
+    this.ctx.evaluatedRecords.should.have.length(3);
+    this.ctx.evaluatedRecords.should.containDeep(e);
   });
 
   it('should not find conditions with wrong valueset', function () {
     const e = this.wrongValueSet.exec(this.ctx);
     e.should.be.empty();
+    this.ctx.evaluatedRecords.should.be.empty;
   });
 
   it('should not find encounter performances using wrong codeProperty', function () {
     const e = this.wrongCodeProperty.exec(this.ctx);
     e.should.be.empty();
+    this.ctx.evaluatedRecords.should.be.empty;
   });
 
   it('should find conditions by specific pharyngitis code', function () {
     const e = this.conditionsByCode.exec(this.ctx);
     e.should.have.length(1);
     e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
   });
 
   it('should find conditions by specific pharyngitis concept', function () {
     const e = this.conditionsByConcept.exec(this.ctx);
     e.should.have.length(1);
     e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
   });
 });


### PR DESCRIPTION
This PR adds the concept of `evaluatedRecords` to the `Context` object and `Results`. `evaluatedRecords` will contain every record that was processed during a retrieve. When a retrieve occurs, the resulting records are added to the `evaluatedRecords` array on the `Context`. When reporting the results, the `evaluatedRecords` for all library contexts are aggregated together into one array and added to the `Results` object.

This functionality will allow eCQM-focused use cases to see which records were processed by the engine, and report those back to the caller

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [X] Tests are included and test edge cases
- [X] Tests have been run locally and pass
- [X] Code coverage has not gone down and all code touched or added is covered.
- [X] Code passes lint and prettier (hint: use `yarn run test:plus` to run tests, lint, and prettier)
- [X] **N/A** All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [X] `cql4browsers.js` built with `yarn run build:browserify` if source changed.

**Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
