### PR TITLE
Update README to reflect Java 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ the unit tests) before expecting it to work! For a working example, see `example
 There are several steps involved to execute CQL.  First, you must create a JSON representation of
 the ELM. For the easiest integration, we will generate a JSON file using cql-to-elm:
 
-1. Install the [Java 11 SDK](https://github.com/AdoptOpenJDK/homebrew-openjdk)
+1. Install the [Java 11 SDK](https://adoptopenjdk.net/)
 2. Clone the [clinical_quality_language](https://github.com/cqframework/clinical_quality_language)
    repository to a location of your choice
 3. `cd ${path_to_clinical_quality_language}/Src/java` (replacing

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ the unit tests) before expecting it to work! For a working example, see `example
 There are several steps involved to execute CQL.  First, you must create a JSON representation of
 the ELM. For the easiest integration, we will generate a JSON file using cql-to-elm:
 
-1. Install the [Java 8 SDK](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+1. Install the [Java 11 SDK](https://github.com/AdoptOpenJDK/homebrew-openjdk)
 2. Clone the [clinical_quality_language](https://github.com/cqframework/clinical_quality_language)
    repository to a location of your choice
 3. `cd ${path_to_clinical_quality_language}/Src/java` (replacing


### PR DESCRIPTION
This updates the README to reflect that we use AdoptOpenJDK Java 11, rather than Oracle Java 8. If the link should be changed from the Homebrew link to another download link, I can do that.

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository.
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `yarn run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `yarn run build:browserify` if source changed.

**Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
