### PR TITLE
Fix unexpected errors

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -2637,7 +2637,7 @@ var Interval = /*#__PURE__*/function () {
       if (this.end() == null || other == null || other.start() == null) {
         return null;
       } else {
-        return this.end().sameOrBefore(other.start(), precision);
+        return cmp.lessThanOrEquals(this.end(), other.start(), precision);
       }
     }
   }, {
@@ -2646,7 +2646,7 @@ var Interval = /*#__PURE__*/function () {
       if (this.start() == null || other == null || other.end() == null) {
         return null;
       } else {
-        return this.start().sameOrAfter(other.end(), precision);
+        return cmp.greaterThanOrEquals(this.start(), other.end(), precision);
       }
     }
   }, {

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -4714,7 +4714,7 @@ var Multiply = /*#__PURE__*/function (_Expression3) {
       if (args == null || args.some(function (x) {
         return x == null;
       })) {
-        null;
+        return null;
       }
 
       var product = args.reduce(function (x, y) {

--- a/src/datatypes/interval.js
+++ b/src/datatypes/interval.js
@@ -320,7 +320,7 @@ class Interval {
     if (this.end() == null || other == null || other.start() == null) {
       return null;
     } else {
-      return this.end().sameOrBefore(other.start(), precision);
+      return cmp.lessThanOrEquals(this.end(), other.start(), precision);
     }
   }
 
@@ -328,7 +328,7 @@ class Interval {
     if (this.start() == null || other == null || other.end() == null) {
       return null;
     } else {
-      return this.start().sameOrAfter(other.end(), precision);
+      return cmp.greaterThanOrEquals(this.start(), other.end(), precision);
     }
   }
 

--- a/src/elm/arithmetic.js
+++ b/src/elm/arithmetic.js
@@ -69,7 +69,7 @@ class Multiply extends Expression {
   exec(ctx) {
     let args = this.execArgs(ctx);
     if (args == null || args.some(x => x == null)) {
-      null;
+      return null;
     }
 
     const product = args.reduce((x, y) => {

--- a/test/elm/interval/interval-test.js
+++ b/test/elm/interval/interval-test.js
@@ -633,6 +633,9 @@ describe('Before', () => {
 });
 
 describe('BeforeOrOn', () => {
+  // NOTE: BeforeOrOn is synonym for SameOrBefore.
+  // NOTE: SameOrBefore for numeric intervals is tests in spec tests
+
   beforeEach(function () {
     setup(this, data);
   });
@@ -696,6 +699,9 @@ describe('BeforeOrOn', () => {
 });
 
 describe('AfterOrOn', () => {
+  // NOTE: AfterOrOn is synonym for SameOrAfter.
+  // NOTE: SameOrAfter for numeric intervals is tests in spec tests
+
   beforeEach(function () {
     setup(this, data);
   });

--- a/test/spec-tests/cql/CqlArithmeticFunctionsTest.cql
+++ b/test/spec-tests/cql/CqlArithmeticFunctionsTest.cql
@@ -411,11 +411,9 @@ define "Modulo": Tuple{
 
 define "Multiply": Tuple{
   "MultiplyNull": Tuple{
-    skipped: 'TypeError: Cannot read property \'isQuantity\' of null'
-    /*
     expression: 1 * null,
     output: null
-    */  },
+  },
   "Multiply1By1": Tuple{
     expression: 1 * 1,
     output: 1

--- a/test/spec-tests/cql/CqlArithmeticFunctionsTest.json
+++ b/test/spec-tests/cql/CqlArithmeticFunctionsTest.json
@@ -2280,11 +2280,25 @@
                   "value" : {
                      "type" : "Tuple",
                      "element" : [ {
-                        "name" : "skipped",
+                        "name" : "expression",
                         "value" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "TypeError: Cannot read property 'isQuantity' of null",
-                           "type" : "Literal"
+                           "type" : "Multiply",
+                           "operand" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                              "value" : "1",
+                              "type" : "Literal"
+                           }, {
+                              "asType" : "{urn:hl7-org:elm-types:r1}Integer",
+                              "type" : "As",
+                              "operand" : {
+                                 "type" : "Null"
+                              }
+                           } ]
+                        }
+                     }, {
+                        "name" : "output",
+                        "value" : {
+                           "type" : "Null"
                         }
                      } ]
                   }

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
@@ -962,11 +962,9 @@ define "NotEqual": Tuple{
 
 define "OnOrAfter": Tuple{
   "TestOnOrAfterNull": Tuple{
-    skipped: 'TypeError: Cannot read property \'execute\' of null'
-    /*
-    expression: Interval[@2012-12-01, @2013-12-01] on or after null,
+    expression: Interval[@2012-12-01, @2013-12-01] on or after (null as Interval<Date>),
     output: null
-    */  },
+  },
   "TestOnOrAfterDateTrue": Tuple{
     expression: Interval[@2012-12-01, @2013-12-01] on or after month of @2012-11-15,
     output: true
@@ -1003,11 +1001,9 @@ define "OnOrAfter": Tuple{
 
 define "OnOrBefore": Tuple{
   "TestOnOrBeforeNull": Tuple{
-    skipped: 'TypeError: Cannot read property \'execute\' of null'
-    /*
-    expression: Interval[@2012-12-01, @2013-12-01] on or before null,
+    expression: Interval[@2012-12-01, @2013-12-01] on or before (null as Interval<Date>),
     output: null
-    */  },
+  },
   "TestOnOrBeforeDateTrue": Tuple{
     expression: Interval[@2012-10-01, @2012-11-01] on or before month of @2012-11-15,
     output: true

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
@@ -982,17 +982,13 @@ define "OnOrAfter": Tuple{
     output: false
   },
   "TestOnOrAfterIntegerTrue": Tuple{
-    skipped: 'TypeError: this.start(...).sameOrAfter is not a function'
-    /*
     expression: Interval[6, 10] on or after 6,
     output: true
-    */  },
+  },
   "TestOnOrAfterDecimalFalse": Tuple{
-    skipped: 'TypeError: this.start(...).sameOrAfter is not a function'
-    /*
     expression: 2.5 on or after Interval[1.666, 2.50000001],
     output: false
-    */  },
+  },
   "TestOnOrAfterQuantityTrue": Tuple{
     expression: 2.5 'mg' on or after Interval[1.666 'mg', 2.50000000 'mg'],
     output: true
@@ -1021,17 +1017,13 @@ define "OnOrBefore": Tuple{
     output: false
   },
   "TestOnOrBeforeIntegerTrue": Tuple{
-    skipped: 'TypeError: this.end(...).sameOrBefore is not a function'
-    /*
     expression: Interval[4, 6] on or before 6,
     output: true
-    */  },
+  },
   "TestOnOrBeforeDecimalFalse": Tuple{
-    skipped: 'TypeError: this.end(...).sameOrBefore is not a function'
-    /*
     expression: 1.6667 on or before Interval[1.666, 2.50000001],
     output: false
-    */  },
+  },
   "TestOnOrBeforeQuantityTrue": Tuple{
     expression: 1.666 'mg' on or before Interval[1.666 'mg', 2.50000000 'mg'],
     output: true

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
@@ -273,17 +273,13 @@ define "Expand": Tuple{
     output: { Interval[10.0, 10.0], Interval[10.1, 10.1], Interval[10.2, 10.2], Interval[10.3, 10.3], Interval[10.4, 10.4], Interval[10.5, 10.5], Interval[10.6, 10.6], Interval[10.7, 10.7], Interval[10.8, 10.8], Interval[10.9, 10.9] }
     */  },
   "ExpandInterval": Tuple{
-    skipped: 'TypeError: intervals is not iterable'
-    /*
     expression: expand Interval[1, 10],
-    output: { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }
-    */  },
+    output: { Interval[1, 1], Interval[2, 2], Interval[3, 3], Interval[4, 4], Interval[5, 5], Interval[6, 6], Interval[7, 7], Interval[8, 8], Interval[9, 9], Interval[10, 10] }
+  },
   "ExpandIntervalPer2": Tuple{
-    skipped: 'TypeError: intervals is not iterable'
-    /*
     expression: expand Interval[1, 10] per 2,
-    output: { 1, 3, 5, 7, 9 }
-    */  }
+    output: { Interval[1, 2], Interval[3, 4], Interval[5, 6], Interval[7, 8], Interval[9, 10] }
+  }
 }
 
 define "Contains": Tuple{

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.json
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.json
@@ -16561,11 +16561,68 @@
                   "value" : {
                      "type" : "Tuple",
                      "element" : [ {
-                        "name" : "skipped",
+                        "name" : "expression",
                         "value" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "TypeError: Cannot read property 'execute' of null",
-                           "type" : "Literal"
+                           "type" : "SameOrAfter",
+                           "operand" : [ {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "type" : "Date",
+                                 "year" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "2012",
+                                    "type" : "Literal"
+                                 },
+                                 "month" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "12",
+                                    "type" : "Literal"
+                                 },
+                                 "day" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "1",
+                                    "type" : "Literal"
+                                 }
+                              },
+                              "high" : {
+                                 "type" : "Date",
+                                 "year" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "2013",
+                                    "type" : "Literal"
+                                 },
+                                 "month" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "12",
+                                    "type" : "Literal"
+                                 },
+                                 "day" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "1",
+                                    "type" : "Literal"
+                                 }
+                              }
+                           }, {
+                              "strict" : false,
+                              "type" : "As",
+                              "operand" : {
+                                 "type" : "Null"
+                              },
+                              "asTypeSpecifier" : {
+                                 "type" : "IntervalTypeSpecifier",
+                                 "pointType" : {
+                                    "name" : "{urn:hl7-org:elm-types:r1}Date",
+                                    "type" : "NamedTypeSpecifier"
+                                 }
+                              }
+                           } ]
+                        }
+                     }, {
+                        "name" : "output",
+                        "value" : {
+                           "type" : "Null"
                         }
                      } ]
                   }
@@ -17095,11 +17152,68 @@
                   "value" : {
                      "type" : "Tuple",
                      "element" : [ {
-                        "name" : "skipped",
+                        "name" : "expression",
                         "value" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "TypeError: Cannot read property 'execute' of null",
-                           "type" : "Literal"
+                           "type" : "SameOrBefore",
+                           "operand" : [ {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "type" : "Date",
+                                 "year" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "2012",
+                                    "type" : "Literal"
+                                 },
+                                 "month" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "12",
+                                    "type" : "Literal"
+                                 },
+                                 "day" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "1",
+                                    "type" : "Literal"
+                                 }
+                              },
+                              "high" : {
+                                 "type" : "Date",
+                                 "year" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "2013",
+                                    "type" : "Literal"
+                                 },
+                                 "month" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "12",
+                                    "type" : "Literal"
+                                 },
+                                 "day" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "1",
+                                    "type" : "Literal"
+                                 }
+                              }
+                           }, {
+                              "strict" : false,
+                              "type" : "As",
+                              "operand" : {
+                                 "type" : "Null"
+                              },
+                              "asTypeSpecifier" : {
+                                 "type" : "IntervalTypeSpecifier",
+                                 "pointType" : {
+                                    "name" : "{urn:hl7-org:elm-types:r1}Date",
+                                    "type" : "NamedTypeSpecifier"
+                                 }
+                              }
+                           } ]
+                        }
+                     }, {
+                        "name" : "output",
+                        "value" : {
+                           "type" : "Null"
                         }
                      } ]
                   }

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.json
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.json
@@ -17071,10 +17071,44 @@
                   "value" : {
                      "type" : "Tuple",
                      "element" : [ {
-                        "name" : "skipped",
+                        "name" : "expression",
                         "value" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "TypeError: this.start(...).sameOrAfter is not a function",
+                           "type" : "SameOrAfter",
+                           "operand" : [ {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "6",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "10",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "6",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "6",
+                                 "type" : "Literal"
+                              }
+                           } ]
+                        }
+                     }, {
+                        "name" : "output",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                           "value" : "true",
                            "type" : "Literal"
                         }
                      } ]
@@ -17084,10 +17118,44 @@
                   "value" : {
                      "type" : "Tuple",
                      "element" : [ {
-                        "name" : "skipped",
+                        "name" : "expression",
                         "value" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "TypeError: this.start(...).sameOrAfter is not a function",
+                           "type" : "SameOrAfter",
+                           "operand" : [ {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                 "value" : "2.5",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                 "value" : "2.5",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                 "value" : "1.666",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                 "value" : "2.50000001",
+                                 "type" : "Literal"
+                              }
+                           } ]
+                        }
+                     }, {
+                        "name" : "output",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                           "value" : "false",
                            "type" : "Literal"
                         }
                      } ]
@@ -17662,10 +17730,44 @@
                   "value" : {
                      "type" : "Tuple",
                      "element" : [ {
-                        "name" : "skipped",
+                        "name" : "expression",
                         "value" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "TypeError: this.end(...).sameOrBefore is not a function",
+                           "type" : "SameOrBefore",
+                           "operand" : [ {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "4",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "6",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "6",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "6",
+                                 "type" : "Literal"
+                              }
+                           } ]
+                        }
+                     }, {
+                        "name" : "output",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                           "value" : "true",
                            "type" : "Literal"
                         }
                      } ]
@@ -17675,10 +17777,44 @@
                   "value" : {
                      "type" : "Tuple",
                      "element" : [ {
-                        "name" : "skipped",
+                        "name" : "expression",
                         "value" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "TypeError: this.end(...).sameOrBefore is not a function",
+                           "type" : "SameOrBefore",
+                           "operand" : [ {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                 "value" : "1.6667",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                 "value" : "1.6667",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                 "value" : "1.666",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                 "value" : "2.50000001",
+                                 "type" : "Literal"
+                              }
+                           } ]
+                        }
+                     }, {
+                        "name" : "output",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                           "value" : "false",
                            "type" : "Literal"
                         }
                      } ]

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.json
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.json
@@ -4637,11 +4637,176 @@
                   "value" : {
                      "type" : "Tuple",
                      "element" : [ {
-                        "name" : "skipped",
+                        "name" : "expression",
                         "value" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "TypeError: intervals is not iterable",
-                           "type" : "Literal"
+                           "type" : "Expand",
+                           "operand" : [ {
+                              "type" : "ToList",
+                              "operand" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "1",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "10",
+                                    "type" : "Literal"
+                                 }
+                              }
+                           }, {
+                              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
+                              "type" : "Null"
+                           } ]
+                        }
+                     }, {
+                        "name" : "output",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "1",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "1",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "2",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "2",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "3",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "3",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "4",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "4",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "5",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "5",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "6",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "6",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "7",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "7",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "8",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "8",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "9",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "9",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "10",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "10",
+                                 "type" : "Literal"
+                              }
+                           } ]
                         }
                      } ]
                   }
@@ -4650,11 +4815,110 @@
                   "value" : {
                      "type" : "Tuple",
                      "element" : [ {
-                        "name" : "skipped",
+                        "name" : "expression",
                         "value" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "TypeError: intervals is not iterable",
-                           "type" : "Literal"
+                           "type" : "Expand",
+                           "operand" : [ {
+                              "type" : "ToList",
+                              "operand" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "1",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "10",
+                                    "type" : "Literal"
+                                 }
+                              }
+                           }, {
+                              "type" : "ToQuantity",
+                              "operand" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "2",
+                                 "type" : "Literal"
+                              }
+                           } ]
+                        }
+                     }, {
+                        "name" : "output",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "1",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "2",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "3",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "4",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "5",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "6",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "7",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "8",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "9",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "10",
+                                 "type" : "Literal"
+                              }
+                           } ]
                         }
                      } ]
                   }

--- a/test/spec-tests/skip-list.txt
+++ b/test/spec-tests/skip-list.txt
@@ -97,10 +97,6 @@ ValueLiteralsAndSelectors.Decimal.DecimalNeg2Pow31ToInf1    Underflows because i
 # Unexpected error
 
 CqlArithmeticFunctionsTest.Multiply.MultiplyNull    TypeError: Cannot read property 'isQuantity' of null
-CqlIntervalOperatorsTest.OnOrAfter.TestOnOrAfterIntegerTrue       TypeError: this.start(...).sameOrAfter is not a function
-CqlIntervalOperatorsTest.OnOrAfter.TestOnOrAfterDecimalFalse      TypeError: this.start(...).sameOrAfter is not a function
-CqlIntervalOperatorsTest.OnOrBefore.TestOnOrBeforeIntegerTrue     TypeError: this.end(...).sameOrBefore is not a function
-CqlIntervalOperatorsTest.OnOrBefore.TestOnOrBeforeDecimalFalse    TypeError: this.end(...).sameOrBefore is not a function
 
 # Test Expectation not parsed correctly
 

--- a/test/spec-tests/skip-list.txt
+++ b/test/spec-tests/skip-list.txt
@@ -97,8 +97,6 @@ ValueLiteralsAndSelectors.Decimal.DecimalNeg2Pow31ToInf1    Underflows because i
 # Unexpected error
 
 CqlArithmeticFunctionsTest.Multiply.MultiplyNull    TypeError: Cannot read property 'isQuantity' of null
-CqlIntervalOperatorsTest.Expand.ExpandInterval      TypeError: intervals is not iterable
-CqlIntervalOperatorsTest.Expand.ExpandIntervalPer2  TypeError: intervals is not iterable
 CqlIntervalOperatorsTest.OnOrAfter.TestOnOrAfterNull              TypeError: Cannot read property 'execute' of null
 CqlIntervalOperatorsTest.OnOrAfter.TestOnOrAfterIntegerTrue       TypeError: this.start(...).sameOrAfter is not a function
 CqlIntervalOperatorsTest.OnOrAfter.TestOnOrAfterDecimalFalse      TypeError: this.start(...).sameOrAfter is not a function

--- a/test/spec-tests/skip-list.txt
+++ b/test/spec-tests/skip-list.txt
@@ -97,10 +97,8 @@ ValueLiteralsAndSelectors.Decimal.DecimalNeg2Pow31ToInf1    Underflows because i
 # Unexpected error
 
 CqlArithmeticFunctionsTest.Multiply.MultiplyNull    TypeError: Cannot read property 'isQuantity' of null
-CqlIntervalOperatorsTest.OnOrAfter.TestOnOrAfterNull              TypeError: Cannot read property 'execute' of null
 CqlIntervalOperatorsTest.OnOrAfter.TestOnOrAfterIntegerTrue       TypeError: this.start(...).sameOrAfter is not a function
 CqlIntervalOperatorsTest.OnOrAfter.TestOnOrAfterDecimalFalse      TypeError: this.start(...).sameOrAfter is not a function
-CqlIntervalOperatorsTest.OnOrBefore.TestOnOrBeforeNull            TypeError: Cannot read property 'execute' of null
 CqlIntervalOperatorsTest.OnOrBefore.TestOnOrBeforeIntegerTrue     TypeError: this.end(...).sameOrBefore is not a function
 CqlIntervalOperatorsTest.OnOrBefore.TestOnOrBeforeDecimalFalse    TypeError: this.end(...).sameOrBefore is not a function
 

--- a/test/spec-tests/skip-list.txt
+++ b/test/spec-tests/skip-list.txt
@@ -94,10 +94,6 @@ ValueLiteralsAndSelectors.Decimal.DecimalNeg2Pow31ToInf1    Underflows because i
 "CqlDateTimeOperatorsTest.Uncertainty tests.DateTimeDurationBetweenUncertainSubtract" Subtracting Uncertainties not supported
 "CqlDateTimeOperatorsTest.Uncertainty tests.DateTimeDurationBetweenUncertainMultiply" Multiplying Uncertainties not supported
 
-# Unexpected error
-
-CqlArithmeticFunctionsTest.Multiply.MultiplyNull    TypeError: Cannot read property 'isQuantity' of null
-
 # Test Expectation not parsed correctly
 
 CqlTypeOperatorsTest.ToDateTime.ToDateTime4 @2014-01-01T12:05:05.955+01:30 Parsed with offset 1 (should be 1.5)

--- a/test/spec-tests/xml/CqlIntervalOperatorsTest.xml
+++ b/test/spec-tests/xml/CqlIntervalOperatorsTest.xml
@@ -926,7 +926,7 @@
 	</group>
 	<group name="OnOrAfter">
 		<test name="TestOnOrAfterNull">
-			<expression>Interval[@2012-12-01, @2013-12-01] on or after null</expression>
+			<expression>Interval[@2012-12-01, @2013-12-01] on or after (null as Interval&lt;Date&gt;)</expression>
 			<output>null</output>
 		</test>
 		<test name="TestOnOrAfterDateTrue">
@@ -960,7 +960,7 @@
 	</group>
 	<group name="OnOrBefore">
 		<test name="TestOnOrBeforeNull">
-			<expression>Interval[@2012-12-01, @2013-12-01] on or before null</expression>
+			<expression>Interval[@2012-12-01, @2013-12-01] on or before (null as Interval&lt;Date&gt;)</expression>
 			<output>null</output>
 		</test>
 		<test name="TestOnOrBeforeDateTrue">

--- a/test/spec-tests/xml/CqlIntervalOperatorsTest.xml
+++ b/test/spec-tests/xml/CqlIntervalOperatorsTest.xml
@@ -264,11 +264,11 @@
 		</test>
 		<test name="ExpandInterval">
 			<expression>expand Interval[1, 10]</expression>
-			<output>{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }</output>
+			<output>{ Interval[1, 1], Interval[2, 2], Interval[3, 3], Interval[4, 4], Interval[5, 5], Interval[6, 6], Interval[7, 7], Interval[8, 8], Interval[9, 9], Interval[10, 10] }</output>
 		</test>
 		<test name="ExpandIntervalPer2">
 			<expression>expand Interval[1, 10] per 2</expression>
-			<output>{ 1, 3, 5, 7, 9 }</output>
+			<output>{ Interval[1, 2], Interval[3, 4], Interval[5, 6], Interval[7, 8], Interval[9, 10] }</output>
 		</test>
 	</group>
 	<group name="Contains">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1543,9 +1543,9 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001093:
-  version "1.0.30001099"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001099.tgz#540118fcc6842d1fde62f4ee5521d1ec6afdb40e"
-  integrity sha512-sdS9A+sQTk7wKoeuZBN/YMAHVztUfVnjDi4/UV3sDE8xoh7YR12hKW+pIdB3oqKGwr9XaFL2ovfzt9w8eUI5CA==
+  version "1.0.30001177"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001177.tgz"
+  integrity sha512-6Ld7t3ifCL02jTj3MxPMM5wAYjbo4h/TAQGFTgv1inihP1tWnWp8mxxT4ut4JBEHLbpFXEXJJQ119JCJTBkYDw==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
Various fixes to tests and or logic to address the following test failures due to unexpected errors:
| Test | Error |
| ---- | ----- |
| CqlArithmeticFunctionsTest.Multiply.MultiplyNull | TypeError: Cannot read property 'isQuantity' of null |
| CqlIntervalOperatorsTest.Expand.ExpandInterval | TypeError: intervals is not iterable |
| CqlIntervalOperatorsTest.Expand.ExpandIntervalPer2 | TypeError: intervals is not iterable |
| CqlIntervalOperatorsTest.OnOrAfter.TestOnOrAfterNull | TypeError: Cannot read property 'execute' of null |
| CqlIntervalOperatorsTest.OnOrAfter.TestOnOrAfterIntegerTrue | TypeError: this.start(...).sameOrAfter is not a function |
| CqlIntervalOperatorsTest.OnOrAfter.TestOnOrAfterDecimalFalse | TypeError: this.start(...).sameOrAfter is not a function |
| CqlIntervalOperatorsTest.OnOrBefore.TestOnOrBeforeNull | TypeError: Cannot read property 'execute' of null |
| CqlIntervalOperatorsTest.OnOrBefore.TestOnOrBeforeIntegerTrue | TypeError: this.end(...).sameOrBefore is not a function |
| CqlIntervalOperatorsTest.OnOrBefore.TestOnOrBeforeDecimalFalse | TypeError: this.end(...).sameOrBefore is not a function |

Fixes #205 

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `yarn run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `yarn run build:browserify` if source changed.

**Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
