### PR TITLE
Fix 197 and 198 for String Match and Split

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -11481,11 +11481,11 @@ var SplitOnMatches = /*#__PURE__*/function (_Expression4) {
       var stringToSplit = this.stringToSplit.execute(ctx);
       var separatorPattern = this.separatorPattern.execute(ctx);
 
-      if (stringToSplit == null || separatorPattern == null) {
-        return null;
-      } else {
+      if (stringToSplit && separatorPattern) {
         return stringToSplit.split(new RegExp(separatorPattern));
       }
+
+      return stringToSplit ? [stringToSplit] : null;
     }
   }]);
 

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -11637,8 +11637,7 @@ var Matches = /*#__PURE__*/function (_Expression9) {
         return null;
       }
 
-      var match = string.match(new RegExp(pattern));
-      return Boolean(match && match.length > 0 && match[0] === string);
+      return new RegExp('^' + pattern + '$').test(string);
     }
   }]);
 

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -11448,11 +11448,11 @@ var Split = /*#__PURE__*/function (_Expression3) {
       var stringToSplit = this.stringToSplit.execute(ctx);
       var separator = this.separator.execute(ctx);
 
-      if (stringToSplit == null || separator == null) {
-        return null;
-      } else {
+      if (stringToSplit && separator) {
         return stringToSplit.split(separator);
       }
+
+      return stringToSplit ? [stringToSplit] : null;
     }
   }]);
 
@@ -11637,11 +11637,8 @@ var Matches = /*#__PURE__*/function (_Expression9) {
         return null;
       }
 
-      if (string.match(new RegExp(pattern))) {
-        return true;
-      } else {
-        return false;
-      }
+      var match = string.match(new RegExp(pattern));
+      return Boolean(match && match.length > 0 && match[0] === string);
     }
   }]);
 

--- a/src/elm/string.js
+++ b/src/elm/string.js
@@ -49,11 +49,10 @@ class Split extends Expression {
   exec(ctx) {
     const stringToSplit = this.stringToSplit.execute(ctx);
     const separator = this.separator.execute(ctx);
-    if (stringToSplit == null || separator == null) {
-      return null;
-    } else {
+    if (stringToSplit && separator) {
       return stringToSplit.split(separator);
     }
+    return stringToSplit ? [stringToSplit] : null;
   }
 }
 
@@ -155,11 +154,9 @@ class Matches extends Expression {
     if (string == null || pattern == null) {
       return null;
     }
-    if (string.match(new RegExp(pattern))) {
-      return true;
-    } else {
-      return false;
-    }
+
+    const match = string.match(new RegExp(pattern));
+    return Boolean(match && match.length > 0 && match[0] === string);
   }
 }
 

--- a/src/elm/string.js
+++ b/src/elm/string.js
@@ -66,11 +66,10 @@ class SplitOnMatches extends Expression {
   exec(ctx) {
     const stringToSplit = this.stringToSplit.execute(ctx);
     const separatorPattern = this.separatorPattern.execute(ctx);
-    if (stringToSplit == null || separatorPattern == null) {
-      return null;
-    } else {
+    if (stringToSplit && separatorPattern) {
       return stringToSplit.split(new RegExp(separatorPattern));
     }
+    return stringToSplit ? [stringToSplit] : null;
   }
 }
 

--- a/src/elm/string.js
+++ b/src/elm/string.js
@@ -155,8 +155,7 @@ class Matches extends Expression {
       return null;
     }
 
-    const match = string.match(new RegExp(pattern));
-    return Boolean(match && match.length > 0 && match[0] === string);
+    return new RegExp('^' + pattern + '$').test(string);
   }
 }
 

--- a/test/elm/string/string-test.js
+++ b/test/elm/string/string-test.js
@@ -111,8 +111,8 @@ describe('SplitOnMatches', () => {
     should(this.splitOnMatchesIsNullFirst.exec(this.ctx)).be.null();
   });
 
-  it('should return null when separatorPattern is null', function () {
-    should(this.splitOnMatchesIsNullSecond.exec(this.ctx)).be.null();
+  it('should return list with original string when separatorPattern is null', function () {
+    this.splitOnMatchesIsNullSecond.exec(this.ctx).should.eql(['12three']);
   });
 
   it('should return null when both parameters are null', function () {

--- a/test/elm/string/string-test.js
+++ b/test/elm/string/string-test.js
@@ -84,11 +84,6 @@ describe('Split', () => {
   it('should return null when separating null', function () {
     should(this.separateNull.exec(this.ctx)).be.null();
   });
-
-  // TODO: Verify this assumption
-  it('should return null when the separator is null', function () {
-    should(this.separateUsingNull.exec(this.ctx)).be.null();
-  });
 });
 
 describe('SplitOnMatches', () => {

--- a/test/elm/string/string-test.js
+++ b/test/elm/string/string-test.js
@@ -84,6 +84,10 @@ describe('Split', () => {
   it('should return null when separating null', function () {
     should(this.separateNull.exec(this.ctx)).be.null();
   });
+
+  it('should return list with original string when the separator is null', function () {
+    this.separateUsingNull.exec(this.ctx).should.eql(['a,b,c']);
+  });
 });
 
 describe('SplitOnMatches', () => {

--- a/test/spec-tests/cql/CqlStringOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlStringOperatorsTest.cql
@@ -177,11 +177,9 @@ define "Matches": Tuple{
     output: true
   },
   "MatchesWordsAndSpacesFalse": Tuple{
-    skipped: 'Wrong answer (true vs false - engine is probably not looking for FULL match)'
-    /*
     expression: Matches('Not all who wander are lost - circa 2017', '[\\w]+'),
     output: false
-    */  },
+  },
   "MatchesNotWords": Tuple{
     expression: Matches('   ', '\\W+'),
     output: true
@@ -256,11 +254,9 @@ define "Split": Tuple{
     output: null
   },
   "SplitABNull": Tuple{
-    skipped: 'Wrong answer (null vs {\'a,b\'})'
-    /*
     expression: Split('a,b', null),
     output: {'a,b'}
-    */  },
+  },
   "SplitABDash": Tuple{
     expression: Split('a,b', '-'),
     output: {'a,b'}

--- a/test/spec-tests/cql/CqlStringOperatorsTest.json
+++ b/test/spec-tests/cql/CqlStringOperatorsTest.json
@@ -1143,10 +1143,24 @@
                   "value" : {
                      "type" : "Tuple",
                      "element" : [ {
-                        "name" : "skipped",
+                        "name" : "expression",
                         "value" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Wrong answer (true vs false - engine is probably not looking for FULL match)",
+                           "type" : "Matches",
+                           "operand" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "Not all who wander are lost - circa 2017",
+                              "type" : "Literal"
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "[\\w]+",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     }, {
+                        "name" : "output",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                           "value" : "false",
                            "type" : "Literal"
                         }
                      } ]
@@ -1517,11 +1531,31 @@
                   "value" : {
                      "type" : "Tuple",
                      "element" : [ {
-                        "name" : "skipped",
+                        "name" : "expression",
                         "value" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Wrong answer (null vs {'a,b'})",
-                           "type" : "Literal"
+                           "type" : "Split",
+                           "stringToSplit" : {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "a,b",
+                              "type" : "Literal"
+                           },
+                           "separator" : {
+                              "asType" : "{urn:hl7-org:elm-types:r1}String",
+                              "type" : "As",
+                              "operand" : {
+                                 "type" : "Null"
+                              }
+                           }
+                        }
+                     }, {
+                        "name" : "output",
+                        "value" : {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "a,b",
+                              "type" : "Literal"
+                           } ]
                         }
                      } ]
                   }

--- a/test/spec-tests/skip-list.txt
+++ b/test/spec-tests/skip-list.txt
@@ -45,8 +45,6 @@ CqlListOperatorsTest.Distinct.DistinctANullANull                 Wrong answer ({
 CqlListOperatorsTest.Except.ExceptNullRight                     Wrong answer (null vs {1, 4})
 CqlListOperatorsTest.In.In1Null                                 Wrong answer (null vs false)
 CqlListOperatorsTest.Length.LengthNullList                      Wrong answer (null vs 0)
-CqlStringOperatorsTest.Matches.MatchesWordsAndSpacesFalse       Wrong answer (true vs false - engine is probably not looking for FULL match)
-CqlStringOperatorsTest.Split.SplitABNull                        Wrong answer (null vs {'a,b'})
 ValueLiteralsAndSelectors.Decimal.Decimal10Pow28ToZeroOneStepDecimalMaxValue    Wrong answer (null vs big number)
 ValueLiteralsAndSelectors.Decimal.DecimalPos10Pow28ToZeroOneStepDecimalMaxValue Wrong answer (null vs big number)
 ValueLiteralsAndSelectors.Decimal.DecimalNeg10Pow28ToZeroOneStepDecimalMinValue Wrong answer (null vs big number)


### PR DESCRIPTION
Various fixes to tests and/or logic to address the following test failures:

| **Test** | **Error** |
| --- | --- |
|CqlStringOperatorsTest.Matches.MatchesWordsAndSpacesFalse | Wrong answer (true vs false - engine is probably not looking for FULL match) |
| CqlStringOperatorsTest.Split.SplitABNull | Wrong answer (null vs {'a,b'}) |

Fixes #197
Fixes #198

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository.
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `yarn run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `yarn run build:browserify` if source changed.

**Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
