### PR TITLE
Fix interval handling on null boundaries

### DIFF
--- a/src/elm/arithmetic.js
+++ b/src/elm/arithmetic.js
@@ -21,7 +21,7 @@ class Add extends Expression {
     }
 
     const sum = args.reduce((x, y) => {
-      if (x.isQuantity || x.isDateTime || x.isDate || x.isTime) {
+      if (x.isQuantity || x.isDateTime || x.isDate || (x.isTime && x.isTime())) {
         return doAddition(x, y);
       } else {
         return x + y;

--- a/src/elm/overloaded.js
+++ b/src/elm/overloaded.js
@@ -17,7 +17,7 @@ class Equal extends Expression {
     if (args[0] == null || args[1] == null) {
       return null;
     }
-    return equals(...this.execArgs(ctx));
+    return equals(...args);
   }
 }
 

--- a/src/runtime/context.js
+++ b/src/runtime/context.js
@@ -289,7 +289,7 @@ class Context {
       case '{urn:hl7-org:elm-types:r1}Quantity':
         return val && val.isQuantity;
       case '{urn:hl7-org:elm-types:r1}Time':
-        return val && val.isDateTime && val.isTime();
+        return val && val.isTime && val.isTime();
       default:
         // Use the data model's implementation of _is, if it is available
         if (typeof val._is === 'function') {
@@ -301,34 +301,34 @@ class Context {
   }
 
   matchesInstanceType(val, inst) {
-    switch (false) {
-      case !inst.isBooleanLiteral:
-        return typeof val === 'boolean';
-      case !inst.isDecimalLiteral:
-        return typeof val === 'number';
-      case !inst.isIntegerLiteral:
-        return typeof val === 'number' && Math.floor(val) === val;
-      case !inst.isStringLiteral:
-        return typeof val === 'string';
-      case !inst.isCode:
-        return val && val.isCode;
-      case !inst.isConcept:
-        return val && val.isConcept;
-      case !inst.isDateTime:
-        return val && val.isDateTime;
-      case !inst.isQuantity:
-        return val && val.isQuantity;
-      case !inst.isTime:
-        return val && val.isDateTime && val.isTime();
-      case !inst.isList:
-        return this.matchesListInstanceType(val, inst);
-      case !inst.isTuple:
-        return this.matchesTupleInstanceType(val, inst);
-      case !inst.isInterval:
-        return this.matchesIntervalInstanceType(val, inst);
-      default:
-        return true; // default to true when we don't know for sure
+    if (inst.isBooleanLiteral) {
+      return typeof val === 'boolean';
+    } else if (inst.isDecimalLiteral) {
+      return typeof val === 'number';
+    } else if (inst.isIntegerLiteral) {
+      return typeof val === 'number' && Math.floor(val) === val;
+    } else if (inst.isStringLiteral) {
+      return typeof val === 'string';
+    } else if (inst.isCode) {
+      return val && val.isCode;
+    } else if (inst.isConcept) {
+      return val && val.isConcept;
+    } else if (inst.isTime && inst.isTime()) {
+      return val && val.isTime && val.isTime();
+    } else if (inst.isDate) {
+      return val && val.isDate;
+    } else if (inst.isDateTime) {
+      return val && val.isDateTime;
+    } else if (inst.isQuantity) {
+      return val && val.isQuantity;
+    } else if (inst.isList) {
+      return this.matchesListInstanceType(val, inst);
+    } else if (inst.isTuple) {
+      return this.matchesTupleInstanceType(val, inst);
+    } else if (inst.isInterval) {
+      return this.matchesIntervalInstanceType(val, inst);
     }
+    return true; // default to true when we don't know for sure
   }
 
   matchesListInstanceType(val, list) {

--- a/src/util/comparison.js
+++ b/src/util/comparison.js
@@ -8,7 +8,6 @@ function areDateTimesOrQuantities(a, b) {
   return (
     (a && a.isDateTime && b && b.isDateTime) ||
     (a && a.isDate && b && b.isDate) ||
-    (a && a.isTime && b && b.isTime) ||
     (a && a.isQuantity && b && b.isQuantity)
   );
 }

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
@@ -4,9 +4,11 @@ context Patient
 
 define "After": Tuple{
   "TestAfterNull": Tuple{
+    skipped: 'Converts null to Interval[null,null] instead of Interval(null,null)'
+    /*
     expression: (null as Integer) after Interval[1, 10],
     output: null
-  },
+    */  },
   "IntegerIntervalAfterTrue": Tuple{
     expression: Interval[11, 20] after Interval[1, 10],
     output: true
@@ -99,9 +101,11 @@ define "After": Tuple{
 
 define "Before": Tuple{
   "TestBeforeNull": Tuple{
+    skipped: 'Converts null to Interval[null,null] instead of Interval(null,null)'
+    /*
     expression: (null as Integer) before Interval[1, 10],
     output: null
-  },
+    */  },
   "IntegerIntervalBeforeFalse": Tuple{
     expression: Interval[11, 20] before Interval[1, 10],
     output: false
@@ -1273,12 +1277,10 @@ define "ProperIn": Tuple{
 }
 
 define "ProperlyIncludes": Tuple{
-  "TestProperlyIncludesNull": Tuple{
-    skipped: 'Wrong answer (null vs false)'
-    /*
-    expression: Interval[null, null] properly includes Interval[1, 10],
-    output: false
-    */  },
+  "NullBoundariesProperlyIncludesIntegerInterval": Tuple{
+    expression: Interval[null as Integer, null as Integer] properly includes Interval[1, 10],
+    output: true
+  },
   "IntegerIntervalProperlyIncludesTrue": Tuple{
     expression: Interval[1, 10] properly includes Interval[4, 10],
     output: true
@@ -1322,12 +1324,10 @@ define "ProperlyIncludes": Tuple{
 }
 
 define "ProperlyIncludedIn": Tuple{
-  "TestProperlyIncludedInNull": Tuple{
-    skipped: 'Wrong answer (null vs false)'
-    /*
+  "IntegerIntervalProperlyIncludedInNullBoundaries": Tuple{
     expression: Interval[1, 10] properly included in Interval[null, null],
-    output: false
-    */  },
+    output: true
+  },
   "IntegerIntervalProperlyIncludedInTrue": Tuple{
     expression: Interval[4, 10] properly included in Interval[1, 10],
     output: true

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.json
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.json
@@ -43,55 +43,11 @@
                   "value" : {
                      "type" : "Tuple",
                      "element" : [ {
-                        "name" : "expression",
+                        "name" : "skipped",
                         "value" : {
-                           "type" : "After",
-                           "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "strict" : false,
-                                 "type" : "As",
-                                 "operand" : {
-                                    "type" : "Null"
-                                 },
-                                 "asTypeSpecifier" : {
-                                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "type" : "NamedTypeSpecifier"
-                                 }
-                              },
-                              "high" : {
-                                 "strict" : false,
-                                 "type" : "As",
-                                 "operand" : {
-                                    "type" : "Null"
-                                 },
-                                 "asTypeSpecifier" : {
-                                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "type" : "NamedTypeSpecifier"
-                                 }
-                              }
-                           }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "1",
-                                 "type" : "Literal"
-                              },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "10",
-                                 "type" : "Literal"
-                              }
-                           } ]
-                        }
-                     }, {
-                        "name" : "output",
-                        "value" : {
-                           "type" : "Null"
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Converts null to Interval[null,null] instead of Interval(null,null)",
+                           "type" : "Literal"
                         }
                      } ]
                   }
@@ -1390,55 +1346,11 @@
                   "value" : {
                      "type" : "Tuple",
                      "element" : [ {
-                        "name" : "expression",
+                        "name" : "skipped",
                         "value" : {
-                           "type" : "Before",
-                           "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "strict" : false,
-                                 "type" : "As",
-                                 "operand" : {
-                                    "type" : "Null"
-                                 },
-                                 "asTypeSpecifier" : {
-                                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "type" : "NamedTypeSpecifier"
-                                 }
-                              },
-                              "high" : {
-                                 "strict" : false,
-                                 "type" : "As",
-                                 "operand" : {
-                                    "type" : "Null"
-                                 },
-                                 "asTypeSpecifier" : {
-                                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "type" : "NamedTypeSpecifier"
-                                 }
-                              }
-                           }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "1",
-                                 "type" : "Literal"
-                              },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "10",
-                                 "type" : "Literal"
-                              }
-                           } ]
-                        }
-                     }, {
-                        "name" : "output",
-                        "value" : {
-                           "type" : "Null"
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Converts null to Interval[null,null] instead of Interval(null,null)",
+                           "type" : "Literal"
                         }
                      } ]
                   }
@@ -20510,14 +20422,60 @@
             "expression" : {
                "type" : "Tuple",
                "element" : [ {
-                  "name" : "TestProperlyIncludesNull",
+                  "name" : "NullBoundariesProperlyIncludesIntegerInterval",
                   "value" : {
                      "type" : "Tuple",
                      "element" : [ {
-                        "name" : "skipped",
+                        "name" : "expression",
                         "value" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Wrong answer (null vs false)",
+                           "type" : "ProperIncludes",
+                           "operand" : [ {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "strict" : false,
+                                 "type" : "As",
+                                 "operand" : {
+                                    "type" : "Null"
+                                 },
+                                 "asTypeSpecifier" : {
+                                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "type" : "NamedTypeSpecifier"
+                                 }
+                              },
+                              "high" : {
+                                 "strict" : false,
+                                 "type" : "As",
+                                 "operand" : {
+                                    "type" : "Null"
+                                 },
+                                 "asTypeSpecifier" : {
+                                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "type" : "NamedTypeSpecifier"
+                                 }
+                              }
+                           }, {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "1",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "10",
+                                 "type" : "Literal"
+                              }
+                           } ]
+                        }
+                     }, {
+                        "name" : "output",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                           "value" : "true",
                            "type" : "Literal"
                         }
                      } ]
@@ -21249,14 +21207,104 @@
             "expression" : {
                "type" : "Tuple",
                "element" : [ {
-                  "name" : "TestProperlyIncludedInNull",
+                  "name" : "IntegerIntervalProperlyIncludedInNullBoundaries",
                   "value" : {
                      "type" : "Tuple",
                      "element" : [ {
-                        "name" : "skipped",
+                        "name" : "expression",
                         "value" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Wrong answer (null vs false)",
+                           "type" : "ProperIncludedIn",
+                           "operand" : [ {
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "1",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "10",
+                                 "type" : "Literal"
+                              }
+                           }, {
+                              "type" : "Interval",
+                              "low" : {
+                                 "asType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "type" : "As",
+                                 "operand" : {
+                                    "path" : "low",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "lowClosed" : true,
+                                       "highClosed" : true,
+                                       "type" : "Interval",
+                                       "low" : {
+                                          "type" : "Null"
+                                       },
+                                       "high" : {
+                                          "type" : "Null"
+                                       }
+                                    }
+                                 }
+                              },
+                              "lowClosedExpression" : {
+                                 "path" : "lowClosed",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "lowClosed" : true,
+                                    "highClosed" : true,
+                                    "type" : "Interval",
+                                    "low" : {
+                                       "type" : "Null"
+                                    },
+                                    "high" : {
+                                       "type" : "Null"
+                                    }
+                                 }
+                              },
+                              "high" : {
+                                 "asType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "type" : "As",
+                                 "operand" : {
+                                    "path" : "high",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "lowClosed" : true,
+                                       "highClosed" : true,
+                                       "type" : "Interval",
+                                       "low" : {
+                                          "type" : "Null"
+                                       },
+                                       "high" : {
+                                          "type" : "Null"
+                                       }
+                                    }
+                                 }
+                              },
+                              "highClosedExpression" : {
+                                 "path" : "highClosed",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "lowClosed" : true,
+                                    "highClosed" : true,
+                                    "type" : "Interval",
+                                    "low" : {
+                                       "type" : "Null"
+                                    },
+                                    "high" : {
+                                       "type" : "Null"
+                                    }
+                                 }
+                              }
+                           } ]
+                        }
+                     }, {
+                        "name" : "output",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                           "value" : "true",
                            "type" : "Literal"
                         }
                      } ]

--- a/test/spec-tests/skip-list.txt
+++ b/test/spec-tests/skip-list.txt
@@ -19,6 +19,10 @@ CqlIntervalOperatorsTest.Expand.ExpandPer0D1        Translation Error: Could not
 CqlTypeOperatorsTest.ToDateTime.ToDateTime4         @2014-01-01T12:05:05.955+01:30 Parsed with offset 1 (should be 1.5)
 CqlTypeOperatorsTest.ToDateTime.ToDateTime5         @2014-01-01T12:05:05.955-01:15 Parsed with offset -1 (should be -1.25)
 
+# Invalid Translation (translates, but translates wrong)
+CqlIntervalOperatorsTest.After.TestAfterNull        Converts null to Interval[null,null] instead of Interval(null,null)
+CqlIntervalOperatorsTest.Before.TestBeforeNull      Converts null to Interval[null,null] instead of Interval(null,null)
+
 # Incorrect answer
 
 CqlAggregateFunctionsTest.Max.MaxTestString                     Wrong answer (just returning first item?)
@@ -30,8 +34,6 @@ CqlComparisonOperatorsTest.Equal.DateTimeEqNull                 Wrong answer (tr
 CqlIntervalOperatorsTest.Collapse.TestCollapseNull              Wrong answer (Interval(null, null) vs null)
 CqlIntervalOperatorsTest.Expand.ExpandPer2Days                  Wrong answer (null vs { Interval[@2018-01-01, @2018-01-02], Interval[@2018-01-03, @2018-01-04] })
 CqlIntervalOperatorsTest.Except.NullInterval                    Wrong answer (Interval(null, null) vs null)
-CqlIntervalOperatorsTest.ProperlyIncludes.TestProperlyIncludesNull      Wrong answer (null vs false)
-CqlIntervalOperatorsTest.ProperlyIncludedIn.TestProperlyIncludedInNull  Wrong answer (null vs false)
 ValueLiteralsAndSelectors.Decimal.Decimal10Pow28ToZeroOneStepDecimalMaxValue    Wrong answer (null vs big number)
 ValueLiteralsAndSelectors.Decimal.DecimalPos10Pow28ToZeroOneStepDecimalMaxValue Wrong answer (null vs big number)
 ValueLiteralsAndSelectors.Decimal.DecimalNeg10Pow28ToZeroOneStepDecimalMinValue Wrong answer (null vs big number)

--- a/test/spec-tests/xml/CqlIntervalOperatorsTest.xml
+++ b/test/spec-tests/xml/CqlIntervalOperatorsTest.xml
@@ -1201,9 +1201,9 @@
 		</test>
 	</group>
 	<group name="ProperlyIncludes">
-		<test name="TestProperlyIncludesNull">
-			<expression>Interval[null, null] properly includes Interval[1, 10]</expression>
-			<output>false</output>
+		<test name="NullBoundariesProperlyIncludesIntegerInterval">
+			<expression>Interval[null as Integer, null as Integer] properly includes Interval[1, 10]</expression>
+			<output>true</output>
 		</test>
 		<test name="IntegerIntervalProperlyIncludesTrue">
 			<expression>Interval[1, 10] properly includes Interval[4, 10]</expression>
@@ -1247,9 +1247,9 @@
 		</test>
 	</group>
 	<group name="ProperlyIncludedIn">
-		<test name="TestProperlyIncludedInNull">
+		<test name="IntegerIntervalProperlyIncludedInNullBoundaries">
 			<expression>Interval[1, 10] properly included in Interval[null, null]</expression>
-			<output>false</output>
+			<output>true</output>
 		</test>
 		<test name="IntegerIntervalProperlyIncludedInTrue">
 			<expression>Interval[4, 10] properly included in Interval[1, 10]</expression>


### PR DESCRIPTION
Various changes to address handling of intervals with null boundaries, especially with double-null boundaries.  Also cleans up a few other things related to `isTime()` that I stumbled upon along the way.  Changes:
- maintain the interval point type, considering casts when necessary
- use point type in calculations when necessary
- toClosed() function should not close null endpoints since that changes their meaning
- support interval construction when isLowExpression or isHighExpression properties are used
- fix incorrect uses of isTime to isTime()
- remove unnecessary uses of isTime()
- since Time is represented using a DateTime class, always check isTime() first when determining exact type

This fixes the following two test cases:
| **Test** | **Error** |
| --- | --- |
| CqlIntervalOperatorsTest.ProperlyIncludes.TestProperlyIncludesNull | Wrong answer (null vs false) |
| CqlIntervalOperatorsTest.ProperlyIncludedIn.TestProperlyIncludedInNull | Wrong answer (null vs false) |

_NOTE: The tests above were also renamed to better indicate what they are testing.  The new names are `NullBoundariesProperlyIncludesIntegerInterval` and `IntegerIntervalProperlyIncludedInNullBoundaries`.  In addition, after consulting w/ Bryn, I confirmed that the test cases themselves were actually wrong and the expected output should be `true`._

The following two test cases were not ignored before, but need to be ignored now.  This is because the CQL to ELM translator translates them wrong.  I've filed a bug for this (cqframework/clinical_quality_language#596), but until it is fixed, these test cases must be ignored:
| **Test** | **Error** |
| --- | --- |
| CqlIntervalOperatorsTest.After.TestAfterNull | Converts null to Interval[null,null] instead of Interval(null,null) |
| CqlIntervalOperatorsTest.Before.TestBeforeNull | Converts null to Interval[null,null] instead of Interval(null,null) |

Fixes #196 

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository.
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [ ] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `yarn run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `yarn run build:browserify` if source changed.

**Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
