### PR TITLE
Record evaluated records on a patient-by-patient basis

### DIFF
--- a/src/runtime/executor.js
+++ b/src/runtime/executor.js
@@ -34,7 +34,7 @@ class Executor {
           this.codeService,
           this.parameters
         );
-        r.recordPatientResult(patient_ctx, expression, expr.execute(patient_ctx));
+        r.recordPatientResults(patient_ctx, { [expression]: expr.execute(patient_ctx) });
         patientSource.nextPatient();
       }
     }
@@ -49,12 +49,14 @@ class Executor {
       this.codeService,
       this.parameters
     );
+    const resultMap = {};
     for (let key in this.library.expressions) {
       const expr = this.library.expressions[key];
       if (expr.context === 'Unfiltered') {
-        r.recordUnfilteredResult(key, expr.exec(unfilteredContext));
+        resultMap[key] = expr.exec(unfilteredContext);
       }
     }
+    r.recordUnfilteredResults(resultMap);
     return r;
   }
 
@@ -68,12 +70,14 @@ class Executor {
         this.parameters,
         executionDateTime
       );
+      const resultMap = {};
       for (let key in this.library.expressions) {
         const expr = this.library.expressions[key];
         if (expr.context === 'Patient') {
-          r.recordPatientResult(patient_ctx, key, expr.execute(patient_ctx));
+          resultMap[key] = expr.execute(patient_ctx);
         }
       }
+      r.recordPatientResults(patient_ctx, resultMap);
       patientSource.nextPatient();
     }
     return r;

--- a/test/elm/executor/executor-test.js
+++ b/test/elm/executor/executor-test.js
@@ -2,6 +2,7 @@ const setup = require('../../setup');
 const data = require('./data');
 
 const { p1, p2 } = require('./patients');
+const { Patient } = require('../../../src/cql-patient');
 
 describe('Age', () => {
   beforeEach(function () {
@@ -12,6 +13,15 @@ describe('Age', () => {
   it('should have correct patient results', function () {
     this.results.patientResults['1'].Age.should.equal(32);
     this.results.patientResults['2'].Age.should.equal(5);
+  });
+
+  it('should have correct patientEvaluatedRecords for each patient', function () {
+    this.results.patientEvaluatedRecords['1'].should.eql([new Patient(p1)]);
+    this.results.patientEvaluatedRecords['2'].should.eql([new Patient(p2)]);
+  });
+
+  it('should support older evaluatedRecords array field', function () {
+    this.results.evaluatedRecords.should.eql([new Patient(p1), new Patient(p2)]);
   });
 
   it('should have the correct unfiltered results', function () {


### PR DESCRIPTION
There was a bug that caused the Results.evaluatedRecords array to only contain the evaluated records of the most recently processed patient.

After discussing w/ the abacus team, we decided to switch this to record evaluated records patient by patient.  A new Results.patientEvaluatedRecords property was introduced, which is an object w/ patient ids as keys.

I don't think anyone is using the old Results.evaluatedRecords array, but just in case, I added a getter to provide backward-compatibility.

Surprisingly (and somewhat disturbingly) this did not break any tests.

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository.
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `yarn run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `yarn run build:browserify` if source changed.

**Reviewer:** mgramigna

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
