### PR TITLE
ToQuantity: Fix Decimal/Integer Overloads & add Ratio Overload

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -11771,6 +11771,7 @@ var _require3 = require('../datatypes/clinical'),
     Concept = _require3.Concept;
 
 var _require4 = require('../datatypes/quantity'),
+    Quantity = _require4.Quantity,
     parseQuantity = _require4.parseQuantity;
 
 var _require5 = require('../util/math'),
@@ -12039,12 +12040,23 @@ var ToQuantity = /*#__PURE__*/function (_Expression8) {
   _createClass(ToQuantity, [{
     key: "exec",
     value: function exec(ctx) {
-      var arg = this.execArgs(ctx);
-
-      if (arg != null) {
-        return parseQuantity(arg.toString());
-      } else {
+      return this.convertValue(this.execArgs(ctx));
+    }
+  }, {
+    key: "convertValue",
+    value: function convertValue(val) {
+      if (val == null) {
         return null;
+      } else if (typeof val === 'number') {
+        return new Quantity(val, '1');
+      } else if (val.isRatio) {
+        // numerator and denominator are guaranteed non-null
+        return val.numerator.dividedBy(val.denominator);
+      } else if (val.isUncertainty) {
+        return new Uncertainty(this.convertValue(val.low), this.convertValue(val.high));
+      } else {
+        // it's a string or something else we'll try to parse as a string
+        return parseQuantity(val.toString());
       }
     }
   }]);

--- a/test/elm/convert/convert-test.js
+++ b/test/elm/convert/convert-test.js
@@ -4,6 +4,7 @@ const data = require('./data');
 const { isNull } = require('../../../src/util/util');
 const { DateTime } = require('../../../src/datatypes/datetime');
 const { Quantity } = require('../../../src/datatypes/quantity');
+const { Uncertainty } = require('../../../src/datatypes/uncertainty');
 
 describe('FromString', () => {
   beforeEach(function () {
@@ -361,6 +362,28 @@ describe('ToInteger', () => {
 describe('ToQuantity', () => {
   beforeEach(function () {
     setup(this, data);
+  });
+
+  it('should convert a decimal to a quantity with unit 1', function () {
+    this.decimalOverload.exec(this.ctx).should.eql(new Quantity(0.1, '1'));
+  });
+
+  it('should convert an integer to a quantity with unit 1', function () {
+    this.integerOverload.exec(this.ctx).should.eql(new Quantity(13, '1'));
+  });
+
+  it('should convert an integer uncertainty to a quantity uncertainty', function () {
+    this.uncertaintyOverload
+      .exec(this.ctx)
+      .should.eql(new Uncertainty(new Quantity(6, '1'), new Quantity(18, '1')));
+  });
+
+  it('should convert a string to a quantity with the specified unit', function () {
+    this.stringOverload.exec(this.ctx).should.eql(new Quantity(-0.1, 'mg'));
+  });
+
+  it('should convert a ratio to a quantity by dividing numerator by denominator', function () {
+    this.ratioOverload.exec(this.ctx).should.eql(new Quantity(0.5, 'mg/mL'));
   });
 
   it('should be null if string is not formatted properly', function () {

--- a/test/elm/convert/data.cql
+++ b/test/elm/convert/data.cql
@@ -79,6 +79,12 @@ define TooLargeInt: ToInteger('2147483648')
 define TooSmallInt: ToInteger('-2147483649')
 
 // @Test: ToQuantity
+define DecimalOverload: ToQuantity(0.1)
+define IntegerOverload: ToQuantity(13)
+define UncertaintySixToEighteen: months between DateTime(2005) and DateTime(2006, 7)
+define UncertaintyOverload: ToQuantity(UncertaintySixToEighteen)
+define StringOverload: ToQuantity('-0.1 \'mg\'')
+define RatioOverload: ToQuantity(5 'mg':10 'mL')
 define WrongFormatQuantity: ToQuantity('abc')
 define TooLargeQuantity: ToQuantity('444444444444444444444444444444 \'\'')
 define TooSmallQuantity: ToQuantity('-444444444444444444444444444444 \'\'')

--- a/test/elm/convert/data.js
+++ b/test/elm/convert/data.js
@@ -2902,6 +2902,12 @@ module.exports['ToInteger'] = {
 library TestSnippet version '1'
 using Simple version '1.0.0'
 context Patient
+define DecimalOverload: ToQuantity(0.1)
+define IntegerOverload: ToQuantity(13)
+define UncertaintySixToEighteen: months between DateTime(2005) and DateTime(2006, 7)
+define UncertaintyOverload: ToQuantity(UncertaintySixToEighteen)
+define StringOverload: ToQuantity('-0.1 \'mg\'')
+define RatioOverload: ToQuantity(5 'mg':10 'mL')
 define WrongFormatQuantity: ToQuantity('abc')
 define TooLargeQuantity: ToQuantity('444444444444444444444444444444 \'\'')
 define TooSmallQuantity: ToQuantity('-444444444444444444444444444444 \'\'')
@@ -2946,7 +2952,7 @@ module.exports['ToQuantity'] = {
             }
          }, {
             "localId" : "4",
-            "name" : "WrongFormatQuantity",
+            "name" : "DecimalOverload",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
@@ -2954,13 +2960,261 @@ module.exports['ToQuantity'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","WrongFormatQuantity",": " ]
+                     "value" : [ "define ","DecimalOverload",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
+                        "r" : "2",
+                        "value" : [ "ToQuantity","(","0.1",")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "3",
+               "type" : "ToQuantity",
+               "operand" : {
+                  "localId" : "2",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "value" : "0.1",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "7",
+            "name" : "IntegerOverload",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "7",
+                  "s" : [ {
+                     "value" : [ "define ","IntegerOverload",": " ]
+                  }, {
+                     "r" : "6",
+                     "s" : [ {
+                        "r" : "5",
+                        "value" : [ "ToQuantity","(","13",")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "6",
+               "type" : "ToQuantity",
+               "operand" : {
+                  "localId" : "5",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "13",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "14",
+            "name" : "UncertaintySixToEighteen",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "14",
+                  "s" : [ {
+                     "value" : [ "define ","UncertaintySixToEighteen",": " ]
+                  }, {
+                     "r" : "13",
+                     "s" : [ {
+                        "value" : [ "months between " ]
+                     }, {
+                        "r" : "9",
+                        "s" : [ {
+                           "r" : "8",
+                           "value" : [ "DateTime","(","2005",")" ]
+                        } ]
+                     }, {
+                        "value" : [ " and " ]
+                     }, {
+                        "r" : "12",
+                        "s" : [ {
+                           "r" : "10",
+                           "value" : [ "DateTime","(","2006",", ","7",")" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "13",
+               "precision" : "Month",
+               "type" : "DurationBetween",
+               "operand" : [ {
+                  "localId" : "9",
+                  "type" : "DateTime",
+                  "year" : {
+                     "localId" : "8",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "2005",
+                     "type" : "Literal"
+                  }
+               }, {
+                  "localId" : "12",
+                  "type" : "DateTime",
+                  "year" : {
+                     "localId" : "10",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "2006",
+                     "type" : "Literal"
+                  },
+                  "month" : {
+                     "localId" : "11",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "7",
+                     "type" : "Literal"
+                  }
+               } ]
+            }
+         }, {
+            "localId" : "17",
+            "name" : "UncertaintyOverload",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "17",
+                  "s" : [ {
+                     "value" : [ "define ","UncertaintyOverload",": " ]
+                  }, {
+                     "r" : "16",
+                     "s" : [ {
                         "value" : [ "ToQuantity","(" ]
                      }, {
-                        "r" : "2",
+                        "r" : "15",
+                        "s" : [ {
+                           "value" : [ "UncertaintySixToEighteen" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "16",
+               "type" : "ToQuantity",
+               "operand" : {
+                  "localId" : "15",
+                  "name" : "UncertaintySixToEighteen",
+                  "type" : "ExpressionRef"
+               }
+            }
+         }, {
+            "localId" : "20",
+            "name" : "StringOverload",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "20",
+                  "s" : [ {
+                     "value" : [ "define ","StringOverload",": " ]
+                  }, {
+                     "r" : "19",
+                     "s" : [ {
+                        "value" : [ "ToQuantity","(" ]
+                     }, {
+                        "r" : "18",
+                        "s" : [ {
+                           "value" : [ "'-0.1 \\'mg\\''" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "19",
+               "type" : "ToQuantity",
+               "operand" : {
+                  "localId" : "18",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "-0.1 'mg'",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "localId" : "25",
+            "name" : "RatioOverload",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "25",
+                  "s" : [ {
+                     "value" : [ "define ","RatioOverload",": " ]
+                  }, {
+                     "r" : "24",
+                     "s" : [ {
+                        "value" : [ "ToQuantity","(" ]
+                     }, {
+                        "r" : "23",
+                        "s" : [ {
+                           "r" : "21",
+                           "s" : [ {
+                              "value" : [ "5 ","'mg'" ]
+                           } ]
+                        }, {
+                           "value" : [ ":" ]
+                        }, {
+                           "r" : "22",
+                           "s" : [ {
+                              "value" : [ "10 ","'mL'" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "24",
+               "type" : "ToQuantity",
+               "operand" : {
+                  "localId" : "23",
+                  "type" : "Ratio",
+                  "numerator" : {
+                     "localId" : "21",
+                     "value" : 5,
+                     "unit" : "mg"
+                  },
+                  "denominator" : {
+                     "localId" : "22",
+                     "value" : 10,
+                     "unit" : "mL"
+                  }
+               }
+            }
+         }, {
+            "localId" : "28",
+            "name" : "WrongFormatQuantity",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "28",
+                  "s" : [ {
+                     "value" : [ "define ","WrongFormatQuantity",": " ]
+                  }, {
+                     "r" : "27",
+                     "s" : [ {
+                        "value" : [ "ToQuantity","(" ]
+                     }, {
+                        "r" : "26",
                         "s" : [ {
                            "value" : [ "'abc'" ]
                         } ]
@@ -2971,32 +3225,32 @@ module.exports['ToQuantity'] = {
                }
             } ],
             "expression" : {
-               "localId" : "3",
+               "localId" : "27",
                "type" : "ToQuantity",
                "operand" : {
-                  "localId" : "2",
+                  "localId" : "26",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "abc",
                   "type" : "Literal"
                }
             }
          }, {
-            "localId" : "7",
+            "localId" : "31",
             "name" : "TooLargeQuantity",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "7",
+                  "r" : "31",
                   "s" : [ {
                      "value" : [ "define ","TooLargeQuantity",": " ]
                   }, {
-                     "r" : "6",
+                     "r" : "30",
                      "s" : [ {
                         "value" : [ "ToQuantity","(" ]
                      }, {
-                        "r" : "5",
+                        "r" : "29",
                         "s" : [ {
                            "value" : [ "'444444444444444444444444444444 \\'\\''" ]
                         } ]
@@ -3007,32 +3261,32 @@ module.exports['ToQuantity'] = {
                }
             } ],
             "expression" : {
-               "localId" : "6",
+               "localId" : "30",
                "type" : "ToQuantity",
                "operand" : {
-                  "localId" : "5",
+                  "localId" : "29",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "444444444444444444444444444444 ''",
                   "type" : "Literal"
                }
             }
          }, {
-            "localId" : "10",
+            "localId" : "34",
             "name" : "TooSmallQuantity",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "10",
+                  "r" : "34",
                   "s" : [ {
                      "value" : [ "define ","TooSmallQuantity",": " ]
                   }, {
-                     "r" : "9",
+                     "r" : "33",
                      "s" : [ {
                         "value" : [ "ToQuantity","(" ]
                      }, {
-                        "r" : "8",
+                        "r" : "32",
                         "s" : [ {
                            "value" : [ "'-444444444444444444444444444444 \\'\\''" ]
                         } ]
@@ -3043,41 +3297,41 @@ module.exports['ToQuantity'] = {
                }
             } ],
             "expression" : {
-               "localId" : "9",
+               "localId" : "33",
                "type" : "ToQuantity",
                "operand" : {
-                  "localId" : "8",
+                  "localId" : "32",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "-444444444444444444444444444444 ''",
                   "type" : "Literal"
                }
             }
          }, {
-            "localId" : "15",
+            "localId" : "39",
             "name" : "NullArg",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "15",
+                  "r" : "39",
                   "s" : [ {
                      "value" : [ "define ","NullArg",": " ]
                   }, {
-                     "r" : "14",
+                     "r" : "38",
                      "s" : [ {
                         "value" : [ "ToQuantity","(" ]
                      }, {
-                        "r" : "13",
+                        "r" : "37",
                         "s" : [ {
                            "value" : [ "(" ]
                         }, {
-                           "r" : "13",
+                           "r" : "37",
                            "s" : [ {
-                              "r" : "11",
+                              "r" : "35",
                               "value" : [ "null"," as " ]
                            }, {
-                              "r" : "12",
+                              "r" : "36",
                               "s" : [ {
                                  "value" : [ "String" ]
                               } ]
@@ -3092,18 +3346,18 @@ module.exports['ToQuantity'] = {
                }
             } ],
             "expression" : {
-               "localId" : "14",
+               "localId" : "38",
                "type" : "ToQuantity",
                "operand" : {
-                  "localId" : "13",
+                  "localId" : "37",
                   "strict" : false,
                   "type" : "As",
                   "operand" : {
-                     "localId" : "11",
+                     "localId" : "35",
                      "type" : "Null"
                   },
                   "asTypeSpecifier" : {
-                     "localId" : "12",
+                     "localId" : "36",
                      "name" : "{urn:hl7-org:elm-types:r1}String",
                      "type" : "NamedTypeSpecifier"
                   }


### PR DESCRIPTION
This PR contains fixes and enhancements to `ToQuantity`:
* Decimal and Integer overloads now properly set units to `1`
* Ratio overload is now supported (divides ratio numerator by denominator)

Fixes #175 

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [ ] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `yarn run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `yarn run build:browserify` if source changed.

**Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
