### PR TITLE
bumping cql-to-elm to version 1.5.2. s

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -7516,7 +7516,12 @@ var Expand = /*#__PURE__*/function (_Expression14) {
       var _this$execArgs17 = this.execArgs(ctx),
           _this$execArgs18 = _slicedToArray(_this$execArgs17, 2),
           intervals = _this$execArgs18[0],
-          per = _this$execArgs18[1];
+          per = _this$execArgs18[1]; // CQL 1.5 introduced an overload to allow singular intervals; make it a list so we can use the same logic for either overload
+
+
+      if (!Array.isArray(intervals)) {
+        intervals = [intervals];
+      }
 
       var type = intervalListType(intervals);
 

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -115,7 +115,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -405,6 +405,11 @@ var Code = /*#__PURE__*/function () {
   }
 
   _createClass(Code, [{
+    key: "isCode",
+    get: function get() {
+      return true;
+    }
+  }, {
     key: "hasMatch",
     value: function hasMatch(code) {
       if (typeof code === 'string') {
@@ -413,11 +418,6 @@ var Code = /*#__PURE__*/function () {
       } else {
         return codesInList(toCodeList(code), [this]);
       }
-    }
-  }, {
-    key: "isCode",
-    get: function get() {
-      return true;
     }
   }]);
 
@@ -433,14 +433,14 @@ var Concept = /*#__PURE__*/function () {
   }
 
   _createClass(Concept, [{
-    key: "hasMatch",
-    value: function hasMatch(code) {
-      return codesInList(toCodeList(code), this.codes);
-    }
-  }, {
     key: "isConcept",
     get: function get() {
       return true;
+    }
+  }, {
+    key: "hasMatch",
+    value: function hasMatch(code) {
+      return codesInList(toCodeList(code), this.codes);
     }
   }]);
 
@@ -457,6 +457,11 @@ var ValueSet = /*#__PURE__*/function () {
   }
 
   _createClass(ValueSet, [{
+    key: "isValueSet",
+    get: function get() {
+      return true;
+    }
+  }, {
     key: "hasMatch",
     value: function hasMatch(code) {
       var codesList = toCodeList(code); // InValueSet String Overload
@@ -495,11 +500,6 @@ var ValueSet = /*#__PURE__*/function () {
       } else {
         return codesInList(codesList, this.codes);
       }
-    }
-  }, {
-    key: "isValueSet",
-    get: function get() {
-      return true;
     }
   }]);
 
@@ -599,11 +599,9 @@ for (var _i = 0, _libs = libs; _i < _libs.length; _i++) {
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = o[Symbol.iterator](); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-
 function _construct(Parent, args, Class) { if (_isNativeReflectConstruct()) { _construct = Reflect.construct; } else { _construct = function _construct(Parent, args, Class) { var a = [null]; a.push.apply(a, args); var Constructor = Function.bind.apply(Parent, a); var instance = new Constructor(); if (Class) _setPrototypeOf(instance, Class.prototype); return instance; }; } return _construct.apply(null, arguments); }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
@@ -611,11 +609,13 @@ function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableTo
 
 function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
 function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter); }
 
 function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
+
+function _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = o[Symbol.iterator](); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
 
@@ -703,79 +703,6 @@ function truncateLuxonDateTime(luxonDT, unit) {
 }
 
 var DateTime = /*#__PURE__*/function () {
-  _createClass(DateTime, null, [{
-    key: "parse",
-    value: function parse(string) {
-      if (string === null) {
-        return null;
-      }
-
-      var matches = /(\d{4})(-(\d{2}))?(-(\d{2}))?(T((\d{2})(:(\d{2})(:(\d{2})(\.(\d+))?)?)?)?(Z|(([+-])(\d{2})(:?(\d{2}))?))?)?/.exec(string);
-
-      if (matches == null) {
-        return null;
-      }
-
-      var years = matches[1];
-      var months = matches[3];
-      var days = matches[5];
-      var hours = matches[8];
-      var minutes = matches[10];
-      var seconds = matches[12];
-      var milliseconds = matches[14];
-
-      if (milliseconds != null) {
-        milliseconds = normalizeMillisecondsField(milliseconds);
-      }
-
-      if (milliseconds != null) {
-        string = normalizeMillisecondsFieldInString(string, matches[14]);
-      }
-
-      if (!isValidDateTimeStringFormat(string)) {
-        return null;
-      } // convert the args to integers
-
-
-      var args = [years, months, days, hours, minutes, seconds, milliseconds].map(function (arg) {
-        return arg != null ? parseInt(arg) : arg;
-      }); // convert timezone offset to decimal and add it to arguments
-
-      if (matches[18] != null) {
-        var num = parseInt(matches[18]) + (matches[20] != null ? parseInt(matches[20]) / 60 : 0);
-        args.push(matches[17] === '+' ? num : num * -1);
-      } else if (matches[15] === 'Z') {
-        args.push(0);
-      }
-
-      return _construct(DateTime, _toConsumableArray(args));
-    }
-  }, {
-    key: "fromJSDate",
-    value: function fromJSDate(date, timezoneOffset) {
-      //This is from a JS Date, not a CQL Date
-      if (date instanceof DateTime) {
-        return date;
-      }
-
-      if (timezoneOffset != null) {
-        date = new jsDate(date.getTime() + timezoneOffset * 60 * 60 * 1000);
-        return new DateTime(date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate(), date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds(), date.getUTCMilliseconds(), timezoneOffset);
-      } else {
-        return new DateTime(date.getFullYear(), date.getMonth() + 1, date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds(), date.getMilliseconds());
-      }
-    }
-  }, {
-    key: "fromLuxonDateTime",
-    value: function fromLuxonDateTime(luxonDT) {
-      if (luxonDT instanceof DateTime) {
-        return luxonDT;
-      }
-
-      return new DateTime(luxonDT.year, luxonDT.month, luxonDT.day, luxonDT.hour, luxonDT.minute, luxonDT.second, luxonDT.millisecond, luxonDT.offset / 60);
-    }
-  }]);
-
   function DateTime() {
     var year = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : null;
     var month = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
@@ -806,6 +733,11 @@ var DateTime = /*#__PURE__*/function () {
   }
 
   _createClass(DateTime, [{
+    key: "isDateTime",
+    get: function get() {
+      return true;
+    }
+  }, {
     key: "copy",
     value: function copy() {
       return new DateTime(this.year, this.month, this.day, this.hour, this.minute, this.second, this.millisecond, this.timezoneOffset);
@@ -1095,7 +1027,7 @@ var DateTime = /*#__PURE__*/function () {
   }, {
     key: "getDate",
     value: function getDate() {
-      return new _Date(this.year, this.month, this.day);
+      return new Date(this.year, this.month, this.day);
     }
   }, {
     key: "getTime",
@@ -1144,10 +1076,76 @@ var DateTime = /*#__PURE__*/function () {
 
       return reduced;
     }
+  }], [{
+    key: "parse",
+    value: function parse(string) {
+      if (string === null) {
+        return null;
+      }
+
+      var matches = /(\d{4})(-(\d{2}))?(-(\d{2}))?(T((\d{2})(:(\d{2})(:(\d{2})(\.(\d+))?)?)?)?(Z|(([+-])(\d{2})(:?(\d{2}))?))?)?/.exec(string);
+
+      if (matches == null) {
+        return null;
+      }
+
+      var years = matches[1];
+      var months = matches[3];
+      var days = matches[5];
+      var hours = matches[8];
+      var minutes = matches[10];
+      var seconds = matches[12];
+      var milliseconds = matches[14];
+
+      if (milliseconds != null) {
+        milliseconds = normalizeMillisecondsField(milliseconds);
+      }
+
+      if (milliseconds != null) {
+        string = normalizeMillisecondsFieldInString(string, matches[14]);
+      }
+
+      if (!isValidDateTimeStringFormat(string)) {
+        return null;
+      } // convert the args to integers
+
+
+      var args = [years, months, days, hours, minutes, seconds, milliseconds].map(function (arg) {
+        return arg != null ? parseInt(arg) : arg;
+      }); // convert timezone offset to decimal and add it to arguments
+
+      if (matches[18] != null) {
+        var num = parseInt(matches[18]) + (matches[20] != null ? parseInt(matches[20]) / 60 : 0);
+        args.push(matches[17] === '+' ? num : num * -1);
+      } else if (matches[15] === 'Z') {
+        args.push(0);
+      }
+
+      return _construct(DateTime, _toConsumableArray(args));
+    }
   }, {
-    key: "isDateTime",
-    get: function get() {
-      return true;
+    key: "fromJSDate",
+    value: function fromJSDate(date, timezoneOffset) {
+      //This is from a JS Date, not a CQL Date
+      if (date instanceof DateTime) {
+        return date;
+      }
+
+      if (timezoneOffset != null) {
+        date = new jsDate(date.getTime() + timezoneOffset * 60 * 60 * 1000);
+        return new DateTime(date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate(), date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds(), date.getUTCMilliseconds(), timezoneOffset);
+      } else {
+        return new DateTime(date.getFullYear(), date.getMonth() + 1, date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds(), date.getMilliseconds());
+      }
+    }
+  }, {
+    key: "fromLuxonDateTime",
+    value: function fromLuxonDateTime(luxonDT) {
+      if (luxonDT instanceof DateTime) {
+        return luxonDT;
+      }
+
+      return new DateTime(luxonDT.year, luxonDT.month, luxonDT.day, luxonDT.hour, luxonDT.minute, luxonDT.second, luxonDT.millisecond, luxonDT.offset / 60);
     }
   }]);
 
@@ -1166,73 +1164,49 @@ DateTime.Unit = {
 };
 DateTime.FIELDS = [DateTime.Unit.YEAR, DateTime.Unit.MONTH, DateTime.Unit.DAY, DateTime.Unit.HOUR, DateTime.Unit.MINUTE, DateTime.Unit.SECOND, DateTime.Unit.MILLISECOND];
 
-var _Date = /*#__PURE__*/function () {
-  _createClass(_Date, null, [{
-    key: "parse",
-    value: function parse(string) {
-      if (string === null) {
-        return null;
-      }
-
-      var matches = /(\d{4})(-(\d{2}))?(-(\d{2}))?/.exec(string);
-
-      if (matches == null) {
-        return null;
-      }
-
-      var years = matches[1];
-      var months = matches[3];
-      var days = matches[5];
-
-      if (!isValidDateStringFormat(string)) {
-        return null;
-      } // convert args to integers
-
-
-      var args = [years, months, days].map(function (arg) {
-        return arg != null ? parseInt(arg) : arg;
-      });
-      return _construct(_Date, _toConsumableArray(args));
-    }
-  }]);
-
-  function _Date() {
+var Date = /*#__PURE__*/function () {
+  function Date() {
     var year = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : null;
     var month = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
     var day = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
 
-    _classCallCheck(this, _Date);
+    _classCallCheck(this, Date);
 
     this.year = year;
     this.month = month;
     this.day = day;
   }
 
-  _createClass(_Date, [{
+  _createClass(Date, [{
+    key: "isDate",
+    get: function get() {
+      return true;
+    }
+  }, {
     key: "copy",
     value: function copy() {
-      return new _Date(this.year, this.month, this.day);
+      return new Date(this.year, this.month, this.day);
     }
   }, {
     key: "successor",
     value: function successor() {
       if (this.day != null) {
-        return this.add(1, _Date.Unit.DAY);
+        return this.add(1, Date.Unit.DAY);
       } else if (this.month != null) {
-        return this.add(1, _Date.Unit.MONTH);
+        return this.add(1, Date.Unit.MONTH);
       } else if (this.year != null) {
-        return this.add(1, _Date.Unit.YEAR);
+        return this.add(1, Date.Unit.YEAR);
       }
     }
   }, {
     key: "predecessor",
     value: function predecessor() {
       if (this.day != null) {
-        return this.add(-1, _Date.Unit.DAY);
+        return this.add(-1, Date.Unit.DAY);
       } else if (this.month != null) {
-        return this.add(-1, _Date.Unit.MONTH);
+        return this.add(-1, Date.Unit.MONTH);
       } else if (this.year != null) {
-        return this.add(-1, _Date.Unit.YEAR);
+        return this.add(-1, Date.Unit.YEAR);
       }
     }
   }, {
@@ -1280,19 +1254,19 @@ var _Date = /*#__PURE__*/function () {
       var result = null;
 
       if (this.year != null) {
-        result = _Date.Unit.YEAR;
+        result = Date.Unit.YEAR;
       } else {
         return result;
       }
 
       if (this.month != null) {
-        result = _Date.Unit.MONTH;
+        result = Date.Unit.MONTH;
       } else {
         return result;
       }
 
       if (this.day != null) {
-        result = _Date.Unit.DAY;
+        result = Date.Unit.DAY;
       } else {
         return result;
       }
@@ -1366,13 +1340,12 @@ var _Date = /*#__PURE__*/function () {
   }, {
     key: "reducedPrecision",
     value: function reducedPrecision() {
-      var unitField = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _Date.Unit.DAY;
+      var unitField = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : Date.Unit.DAY;
       var reduced = this.copy();
 
-      if (unitField !== _Date.Unit.DAY) {
-        var fieldIndex = _Date.FIELDS.indexOf(unitField);
-
-        var fieldsToRemove = _Date.FIELDS.slice(fieldIndex + 1);
+      if (unitField !== Date.Unit.DAY) {
+        var fieldIndex = Date.FIELDS.indexOf(unitField);
+        var fieldsToRemove = Date.FIELDS.slice(fieldIndex + 1);
 
         var _iterator2 = _createForOfIteratorHelper(fieldsToRemove),
             _step2;
@@ -1391,52 +1364,71 @@ var _Date = /*#__PURE__*/function () {
 
       return reduced;
     }
-  }, {
-    key: "isDate",
-    get: function get() {
-      return true;
-    }
   }], [{
+    key: "parse",
+    value: function parse(string) {
+      if (string === null) {
+        return null;
+      }
+
+      var matches = /(\d{4})(-(\d{2}))?(-(\d{2}))?/.exec(string);
+
+      if (matches == null) {
+        return null;
+      }
+
+      var years = matches[1];
+      var months = matches[3];
+      var days = matches[5];
+
+      if (!isValidDateStringFormat(string)) {
+        return null;
+      } // convert args to integers
+
+
+      var args = [years, months, days].map(function (arg) {
+        return arg != null ? parseInt(arg) : arg;
+      });
+      return _construct(Date, _toConsumableArray(args));
+    }
+  }, {
     key: "fromJSDate",
     value: function fromJSDate(date) {
-      if (date instanceof _Date) {
+      if (date instanceof Date) {
         return date;
       }
 
-      return new _Date(date.getFullYear(), date.getMonth() + 1, date.getDate());
+      return new Date(date.getFullYear(), date.getMonth() + 1, date.getDate());
     }
   }, {
     key: "fromLuxonDateTime",
     value: function fromLuxonDateTime(luxonDT) {
-      if (luxonDT instanceof _Date) {
+      if (luxonDT instanceof Date) {
         return luxonDT;
       }
 
-      return new _Date(luxonDT.year, luxonDT.month, luxonDT.day);
+      return new Date(luxonDT.year, luxonDT.month, luxonDT.day);
     }
   }]);
 
-  return _Date;
+  return Date;
 }();
 
 var MIN_DATETIME_VALUE = DateTime.parse('0001-01-01T00:00:00.000');
 var MAX_DATETIME_VALUE = DateTime.parse('9999-12-31T23:59:59.999');
-
-var MIN_DATE_VALUE = _Date.parse('0001-01-01');
-
-var MAX_DATE_VALUE = _Date.parse('9999-12-31');
-
+var MIN_DATE_VALUE = Date.parse('0001-01-01');
+var MAX_DATE_VALUE = Date.parse('9999-12-31');
 var MIN_TIME_VALUE = DateTime.parse('0000-01-01T00:00:00.000').getTime();
 var MAX_TIME_VALUE = DateTime.parse('0000-01-01T23:59:59.999').getTime();
-_Date.Unit = {
+Date.Unit = {
   YEAR: 'year',
   MONTH: 'month',
   WEEK: 'week',
   DAY: 'day'
 };
-_Date.FIELDS = [_Date.Unit.YEAR, _Date.Unit.MONTH, _Date.Unit.DAY]; // Shared Funtions For Date and DateTime
+Date.FIELDS = [Date.Unit.YEAR, Date.Unit.MONTH, Date.Unit.DAY]; // Shared Funtions For Date and DateTime
 
-DateTime.prototype.isPrecise = _Date.prototype.isPrecise = function () {
+DateTime.prototype.isPrecise = Date.prototype.isPrecise = function () {
   var _this = this;
 
   return this.constructor.FIELDS.every(function (field) {
@@ -1444,12 +1436,12 @@ DateTime.prototype.isPrecise = _Date.prototype.isPrecise = function () {
   });
 };
 
-DateTime.prototype.isImprecise = _Date.prototype.isImprecise = function () {
+DateTime.prototype.isImprecise = Date.prototype.isImprecise = function () {
   return !this.isPrecise();
 }; // This function can take another Date-ish object, or a precision string (e.g. 'month')
 
 
-DateTime.prototype.isMorePrecise = _Date.prototype.isMorePrecise = function (other) {
+DateTime.prototype.isMorePrecise = Date.prototype.isMorePrecise = function (other) {
   if (typeof other === 'string' && this.constructor.FIELDS.includes(other)) {
     if (this[other] == null) {
       return false;
@@ -1477,12 +1469,12 @@ DateTime.prototype.isMorePrecise = _Date.prototype.isMorePrecise = function (oth
 }; // This function can take another Date-ish object, or a precision string (e.g. 'month')
 
 
-DateTime.prototype.isLessPrecise = _Date.prototype.isLessPrecise = function (other) {
+DateTime.prototype.isLessPrecise = Date.prototype.isLessPrecise = function (other) {
   return !this.isSamePrecision(other) && !this.isMorePrecise(other);
 }; // This function can take another Date-ish object, or a precision string (e.g. 'month')
 
 
-DateTime.prototype.isSamePrecision = _Date.prototype.isSamePrecision = function (other) {
+DateTime.prototype.isSamePrecision = Date.prototype.isSamePrecision = function (other) {
   if (typeof other === 'string' && this.constructor.FIELDS.includes(other)) {
     return other === this.getPrecision();
   }
@@ -1511,15 +1503,15 @@ DateTime.prototype.isSamePrecision = _Date.prototype.isSamePrecision = function 
   return true;
 };
 
-DateTime.prototype.equals = _Date.prototype.equals = function (other) {
+DateTime.prototype.equals = Date.prototype.equals = function (other) {
   return compareWithDefaultResult(this, other, null);
 };
 
-DateTime.prototype.equivalent = _Date.prototype.equivalent = function (other) {
+DateTime.prototype.equivalent = Date.prototype.equivalent = function (other) {
   return compareWithDefaultResult(this, other, false);
 };
 
-DateTime.prototype.sameAs = _Date.prototype.sameAs = function (other, precision) {
+DateTime.prototype.sameAs = Date.prototype.sameAs = function (other, precision) {
   if (!(other.isDate || other.isDateTime)) {
     return null;
   } else if (this.isDate && other.isDateTime) {
@@ -1578,7 +1570,7 @@ DateTime.prototype.sameAs = _Date.prototype.sameAs = function (other, precision)
   return true;
 };
 
-DateTime.prototype.sameOrBefore = _Date.prototype.sameOrBefore = function (other, precision) {
+DateTime.prototype.sameOrBefore = Date.prototype.sameOrBefore = function (other, precision) {
   if (!(other.isDate || other.isDateTime)) {
     return null;
   } else if (this.isDate && other.isDateTime) {
@@ -1640,7 +1632,7 @@ DateTime.prototype.sameOrBefore = _Date.prototype.sameOrBefore = function (other
   return true;
 };
 
-DateTime.prototype.sameOrAfter = _Date.prototype.sameOrAfter = function (other, precision) {
+DateTime.prototype.sameOrAfter = Date.prototype.sameOrAfter = function (other, precision) {
   if (!(other.isDate || other.isDateTime)) {
     return null;
   } else if (this.isDate && other.isDateTime) {
@@ -1702,7 +1694,7 @@ DateTime.prototype.sameOrAfter = _Date.prototype.sameOrAfter = function (other, 
   return true;
 };
 
-DateTime.prototype.before = _Date.prototype.before = function (other, precision) {
+DateTime.prototype.before = Date.prototype.before = function (other, precision) {
   if (!(other.isDate || other.isDateTime)) {
     return null;
   } else if (this.isDate && other.isDateTime) {
@@ -1764,7 +1756,7 @@ DateTime.prototype.before = _Date.prototype.before = function (other, precision)
   return false;
 };
 
-DateTime.prototype.after = _Date.prototype.after = function (other, precision) {
+DateTime.prototype.after = Date.prototype.after = function (other, precision) {
   if (!(other.isDate || other.isDateTime)) {
     return null;
   } else if (this.isDate && other.isDateTime) {
@@ -1826,7 +1818,7 @@ DateTime.prototype.after = _Date.prototype.after = function (other, precision) {
   return false;
 };
 
-DateTime.prototype.add = _Date.prototype.add = function (offset, field) {
+DateTime.prototype.add = Date.prototype.add = function (offset, field) {
   if (offset === 0 || this.year == null) {
     return this.copy();
   } // Use luxon to do the date math because it honors DST and it has the leap-year/end-of-month semantics we want.
@@ -1862,7 +1854,7 @@ DateTime.prototype.add = _Date.prototype.add = function (offset, field) {
   }
 };
 
-DateTime.prototype.getFieldFloor = _Date.prototype.getFieldFloor = function (field) {
+DateTime.prototype.getFieldFloor = Date.prototype.getFieldFloor = function (field) {
   switch (field) {
     case 'month':
       return 1;
@@ -1887,7 +1879,7 @@ DateTime.prototype.getFieldFloor = _Date.prototype.getFieldFloor = function (fie
   }
 };
 
-DateTime.prototype.getFieldCieling = _Date.prototype.getFieldCieling = function (field) {
+DateTime.prototype.getFieldCieling = Date.prototype.getFieldCieling = function (field) {
   switch (field) {
     case 'month':
       return 12;
@@ -2012,7 +2004,7 @@ function isValidDateTimeStringFormat(string) {
 
 module.exports = {
   DateTime: DateTime,
-  Date: _Date,
+  Date: Date,
   MIN_DATETIME_VALUE: MIN_DATETIME_VALUE,
   MAX_DATETIME_VALUE: MAX_DATETIME_VALUE,
   MIN_DATE_VALUE: MIN_DATE_VALUE,
@@ -2091,6 +2083,37 @@ var Interval = /*#__PURE__*/function () {
   }
 
   _createClass(Interval, [{
+    key: "isInterval",
+    get: function get() {
+      return true;
+    }
+  }, {
+    key: "pointType",
+    get: function get() {
+      var pointType = null;
+      var point = this.low != null ? this.low : this.high;
+
+      if (point != null) {
+        if (typeof point === 'number') {
+          pointType = parseInt(point) === point ? '{urn:hl7-org:elm-types:r1}Integer' : '{urn:hl7-org:elm-types:r1}Decimal';
+        } else if (point.isTime && point.isTime()) {
+          pointType = '{urn:hl7-org:elm-types:r1}Time';
+        } else if (point.isDate) {
+          pointType = '{urn:hl7-org:elm-types:r1}Date';
+        } else if (point.isDateTime) {
+          pointType = '{urn:hl7-org:elm-types:r1}DateTime';
+        } else if (point.isQuantity) {
+          pointType = '{urn:hl7-org:elm-types:r1}Quantity';
+        }
+      }
+
+      if (pointType == null && this.defaultPointType != null) {
+        pointType = this.defaultPointType;
+      }
+
+      return pointType;
+    }
+  }, {
     key: "copy",
     value: function copy() {
       var newLow = this.low;
@@ -2700,37 +2723,6 @@ var Interval = /*#__PURE__*/function () {
       var end = this.highClosed ? ']' : ')';
       return start + this.low.toString() + ', ' + this.high.toString() + end;
     }
-  }, {
-    key: "isInterval",
-    get: function get() {
-      return true;
-    }
-  }, {
-    key: "pointType",
-    get: function get() {
-      var pointType = null;
-      var point = this.low != null ? this.low : this.high;
-
-      if (point != null) {
-        if (typeof point === 'number') {
-          pointType = parseInt(point) === point ? '{urn:hl7-org:elm-types:r1}Integer' : '{urn:hl7-org:elm-types:r1}Decimal';
-        } else if (point.isTime && point.isTime()) {
-          pointType = '{urn:hl7-org:elm-types:r1}Time';
-        } else if (point.isDate) {
-          pointType = '{urn:hl7-org:elm-types:r1}Date';
-        } else if (point.isDateTime) {
-          pointType = '{urn:hl7-org:elm-types:r1}DateTime';
-        } else if (point.isQuantity) {
-          pointType = '{urn:hl7-org:elm-types:r1}Quantity';
-        }
-      }
-
-      if (pointType == null && this.defaultPointType != null) {
-        pointType = this.defaultPointType;
-      }
-
-      return pointType;
-    }
   }]);
 
   return Interval;
@@ -2923,6 +2915,11 @@ var Quantity = /*#__PURE__*/function () {
   }
 
   _createClass(Quantity, [{
+    key: "isQuantity",
+    get: function get() {
+      return true;
+    }
+  }, {
     key: "clone",
     value: function clone() {
       return new Quantity(this.value, this.unit);
@@ -3063,11 +3060,6 @@ var Quantity = /*#__PURE__*/function () {
 
       return new Quantity(decimalAdjust('round', resultValue, -8), resultUnit);
     }
-  }, {
-    key: "isQuantity",
-    get: function get() {
-      return true;
-    }
   }]);
 
   return Quantity;
@@ -3183,6 +3175,11 @@ var Ratio = /*#__PURE__*/function () {
   }
 
   _createClass(Ratio, [{
+    key: "isRatio",
+    get: function get() {
+      return true;
+    }
+  }, {
     key: "clone",
     value: function clone() {
       return new Ratio(this.numerator.clone(), this.denominator.clone());
@@ -3209,11 +3206,6 @@ var Ratio = /*#__PURE__*/function () {
       var equal = this.equals(other);
       return equal != null ? equal : false;
     }
-  }, {
-    key: "isRatio",
-    get: function get() {
-      return true;
-    }
   }]);
 
   return Ratio;
@@ -3237,17 +3229,6 @@ var _require = require('./logic'),
     ThreeValuedLogic = _require.ThreeValuedLogic;
 
 var Uncertainty = /*#__PURE__*/function () {
-  _createClass(Uncertainty, null, [{
-    key: "from",
-    value: function from(obj) {
-      if (obj != null && obj.isUncertainty) {
-        return obj;
-      } else {
-        return new Uncertainty(obj);
-      }
-    }
-  }]);
-
   function Uncertainty() {
     var low = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : null;
     var high = arguments.length > 1 ? arguments[1] : undefined;
@@ -3291,6 +3272,11 @@ var Uncertainty = /*#__PURE__*/function () {
   }
 
   _createClass(Uncertainty, [{
+    key: "isUncertainty",
+    get: function get() {
+      return true;
+    }
+  }, {
     key: "copy",
     value: function copy() {
       var newLow = this.low;
@@ -3383,10 +3369,14 @@ var Uncertainty = /*#__PURE__*/function () {
     value: function greaterThanOrEquals(other) {
       return ThreeValuedLogic.not(this.lessThan(Uncertainty.from(other)));
     }
-  }, {
-    key: "isUncertainty",
-    get: function get() {
-      return true;
+  }], [{
+    key: "from",
+    value: function from(obj) {
+      if (obj != null && obj.isUncertainty) {
+        return obj;
+      } else {
+        return new Uncertainty(obj);
+      }
     }
   }]);
 
@@ -3399,6 +3389,8 @@ module.exports = {
 },{"./logic":10}],14:[function(require,module,exports){
 "use strict";
 
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
 function _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = o[Symbol.iterator](); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
 
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
@@ -3408,8 +3400,6 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -3423,7 +3413,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -4215,7 +4205,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -5057,6 +5047,8 @@ module.exports = {
 },{"../util/util":48,"./expressions":23}],17:[function(require,module,exports){
 "use strict";
 
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
 function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
@@ -5068,8 +5060,6 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
 function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -5087,7 +5077,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -5350,15 +5340,15 @@ var Code = /*#__PURE__*/function (_Expression8) {
 
 
   _createClass(Code, [{
+    key: "isCode",
+    get: function get() {
+      return true;
+    }
+  }, {
     key: "exec",
     value: function exec(ctx) {
       var system = ctx.getCodeSystem(this.systemName) || {};
       return new dt.Code(this.code, system.id, this.version, this.display);
-    }
-  }, {
-    key: "isCode",
-    get: function get() {
-      return true;
     }
   }]);
 
@@ -5441,6 +5431,11 @@ var Concept = /*#__PURE__*/function (_Expression11) {
 
 
   _createClass(Concept, [{
+    key: "isConcept",
+    get: function get() {
+      return true;
+    }
+  }, {
     key: "toCode",
     value: function toCode(ctx, code) {
       var system = ctx.getCodeSystem(code.system.name) || {};
@@ -5455,11 +5450,6 @@ var Concept = /*#__PURE__*/function (_Expression11) {
         return _this12.toCode(ctx, code);
       });
       return new dt.Concept(codes, this.display);
-    }
-  }, {
-    key: "isConcept",
-    get: function get() {
-      return true;
     }
   }]);
 
@@ -5580,7 +5570,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -5717,13 +5707,13 @@ module.exports = {
 },{"../datatypes/datatypes":6,"./expression":22}],19:[function(require,module,exports){
 "use strict";
 
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
 function _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = o[Symbol.iterator](); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
 
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
-
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -5741,7 +5731,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -5914,7 +5904,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -5985,27 +5975,27 @@ var DateTime = /*#__PURE__*/function (_Expression) {
 
 DateTime.PROPERTIES = ['year', 'month', 'day', 'hour', 'minute', 'second', 'millisecond', 'timezoneOffset'];
 
-var _Date = /*#__PURE__*/function (_Expression2) {
-  _inherits(_Date, _Expression2);
+var Date = /*#__PURE__*/function (_Expression2) {
+  _inherits(Date, _Expression2);
 
-  var _super2 = _createSuper(_Date);
+  var _super2 = _createSuper(Date);
 
-  function _Date(json) {
+  function Date(json) {
     var _this3;
 
-    _classCallCheck(this, _Date);
+    _classCallCheck(this, Date);
 
     _this3 = _super2.call(this, json);
     _this3.json = json;
     return _this3;
   }
 
-  _createClass(_Date, [{
+  _createClass(Date, [{
     key: "exec",
     value: function exec(ctx) {
       var _this4 = this;
 
-      var _iterator2 = _createForOfIteratorHelper(_Date.PROPERTIES),
+      var _iterator2 = _createForOfIteratorHelper(Date.PROPERTIES),
           _step2;
 
       try {
@@ -6022,18 +6012,17 @@ var _Date = /*#__PURE__*/function (_Expression2) {
         _iterator2.f();
       }
 
-      var args = _Date.PROPERTIES.map(function (p) {
+      var args = Date.PROPERTIES.map(function (p) {
         return _this4[p] != null ? _this4[p].execute(ctx) : undefined;
       });
-
       return _construct(DT.Date, _toConsumableArray(args));
     }
   }]);
 
-  return _Date;
+  return Date;
 }(Expression);
 
-_Date.PROPERTIES = ['year', 'month', 'day'];
+Date.PROPERTIES = ['year', 'month', 'day'];
 
 var Time = /*#__PURE__*/function (_Expression3) {
   _inherits(Time, _Expression3);
@@ -6344,7 +6333,7 @@ var DurationBetween = /*#__PURE__*/function (_Expression12) {
 }(Expression);
 
 module.exports = {
-  Date: _Date,
+  Date: Date,
   DateFrom: DateFrom,
   DateTime: DateTime,
   DateTimeComponentFrom: DateTimeComponentFrom,
@@ -6376,7 +6365,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -6445,7 +6434,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -6641,7 +6630,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -6756,7 +6745,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -6859,6 +6848,8 @@ module.exports = {
 },{"../datatypes/datatypes":6,"../datatypes/quantity":11,"./builder":16,"./expression":22}],26:[function(require,module,exports){
 "use strict";
 
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
 function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
 
 function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
@@ -6881,8 +6872,6 @@ function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
@@ -6899,7 +6888,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -6949,6 +6938,11 @@ var Interval = /*#__PURE__*/function (_Expression) {
 
 
   _createClass(Interval, [{
+    key: "isInterval",
+    get: function get() {
+      return true;
+    }
+  }, {
     key: "exec",
     value: function exec(ctx) {
       var lowValue = this.low.execute(ctx);
@@ -6967,11 +6961,6 @@ var Interval = /*#__PURE__*/function (_Expression) {
       }
 
       return new dtivl.Interval(lowValue, highValue, lowClosed, highClosed, defaultPointType);
-    }
-  }, {
-    key: "isInterval",
-    get: function get() {
-      return true;
     }
   }]);
 
@@ -8212,13 +8201,13 @@ module.exports = {
 },{"./expressions":23}],28:[function(require,module,exports){
 "use strict";
 
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
 function _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = o[Symbol.iterator](); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
 
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
-
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -8236,7 +8225,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -8269,16 +8258,16 @@ var List = /*#__PURE__*/function (_Expression) {
   }
 
   _createClass(List, [{
+    key: "isList",
+    get: function get() {
+      return true;
+    }
+  }, {
     key: "exec",
     value: function exec(ctx) {
       return this.elements.map(function (item) {
         return item.execute(ctx);
       });
-    }
-  }, {
-    key: "isList",
-    get: function get() {
-      return true;
     }
   }]);
 
@@ -8772,7 +8761,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -8784,7 +8773,23 @@ var Literal = /*#__PURE__*/function (_Expression) {
 
   var _super = _createSuper(Literal);
 
-  _createClass(Literal, null, [{
+  function Literal(json) {
+    var _this;
+
+    _classCallCheck(this, Literal);
+
+    _this = _super.call(this, json);
+    _this.valueType = json.valueType;
+    _this.value = json.value;
+    return _this;
+  }
+
+  _createClass(Literal, [{
+    key: "exec",
+    value: function exec(ctx) {
+      return this.value;
+    }
+  }], [{
     key: "from",
     value: function from(json) {
       switch (json.valueType) {
@@ -8803,24 +8808,6 @@ var Literal = /*#__PURE__*/function (_Expression) {
         default:
           return new Literal(json);
       }
-    }
-  }]);
-
-  function Literal(json) {
-    var _this;
-
-    _classCallCheck(this, Literal);
-
-    _this = _super.call(this, json);
-    _this.valueType = json.valueType;
-    _this.value = json.value;
-    return _this;
-  }
-
-  _createClass(Literal, [{
-    key: "exec",
-    value: function exec(ctx) {
-      return this.value;
     }
   }]);
 
@@ -8846,14 +8833,14 @@ var BooleanLiteral = /*#__PURE__*/function (_Literal) {
 
 
   _createClass(BooleanLiteral, [{
-    key: "exec",
-    value: function exec(ctx) {
-      return this.value;
-    }
-  }, {
     key: "isBooleanLiteral",
     get: function get() {
       return true;
+    }
+  }, {
+    key: "exec",
+    value: function exec(ctx) {
+      return this.value;
     }
   }]);
 
@@ -8878,14 +8865,14 @@ var IntegerLiteral = /*#__PURE__*/function (_Literal2) {
 
 
   _createClass(IntegerLiteral, [{
-    key: "exec",
-    value: function exec(ctx) {
-      return this.value;
-    }
-  }, {
     key: "isIntegerLiteral",
     get: function get() {
       return true;
+    }
+  }, {
+    key: "exec",
+    value: function exec(ctx) {
+      return this.value;
     }
   }]);
 
@@ -8910,14 +8897,14 @@ var DecimalLiteral = /*#__PURE__*/function (_Literal3) {
 
 
   _createClass(DecimalLiteral, [{
-    key: "exec",
-    value: function exec(ctx) {
-      return this.value;
-    }
-  }, {
     key: "isDecimalLiteral",
     get: function get() {
       return true;
+    }
+  }, {
+    key: "exec",
+    value: function exec(ctx) {
+      return this.value;
     }
   }]);
 
@@ -8938,15 +8925,15 @@ var StringLiteral = /*#__PURE__*/function (_Literal4) {
 
 
   _createClass(StringLiteral, [{
+    key: "isStringLiteral",
+    get: function get() {
+      return true;
+    }
+  }, {
     key: "exec",
     value: function exec(ctx) {
       // TODO: Remove these replacements when CQL-to-ELM fixes bug: https://github.com/cqframework/clinical_quality_language/issues/82
       return this.value.replace(/\\'/g, "'").replace(/\\"/g, '"');
-    }
-  }, {
-    key: "isStringLiteral",
-    get: function get() {
-      return true;
     }
   }]);
 
@@ -8993,7 +8980,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -9140,13 +9127,13 @@ module.exports = {
 },{"../datatypes/datatypes":6,"./expression":22}],31:[function(require,module,exports){
 "use strict";
 
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
 function _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = o[Symbol.iterator](); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
 
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
-
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -9164,7 +9151,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -9270,6 +9257,8 @@ module.exports = {
 },{"./expression":22}],32:[function(require,module,exports){
 "use strict";
 
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
 function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
@@ -9277,8 +9266,6 @@ function _nonIterableRest() { throw new TypeError("Invalid attempt to destructur
 function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
 
@@ -9308,7 +9295,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -10012,7 +9999,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -10110,7 +10097,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -10153,6 +10140,8 @@ module.exports = {
 },{"../datatypes/datatypes":6,"./expression":22}],35:[function(require,module,exports){
 "use strict";
 
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
 function _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = o[Symbol.iterator](); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
 
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
@@ -10162,8 +10151,6 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
 function _get(target, property, receiver) { if (typeof Reflect !== "undefined" && Reflect.get) { _get = Reflect.get; } else { _get = function _get(target, property, receiver) { var base = _superPropBase(target, property); if (!base) return; var desc = Object.getOwnPropertyDescriptor(base, property); if (desc.get) { return desc.get.call(receiver); } return desc.value; }; } return _get(target, property, receiver || target); }
 
 function _superPropBase(object, property) { while (!Object.prototype.hasOwnProperty.call(object, property)) { object = _getPrototypeOf(object); if (object === null) break; } return object; }
-
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
@@ -10179,7 +10166,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -10680,7 +10667,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -10735,13 +10722,13 @@ module.exports = {
 },{"../datatypes/datatypes":6,"../datatypes/quantity":11,"./expression":22}],37:[function(require,module,exports){
 "use strict";
 
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
 function _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = o[Symbol.iterator](); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
 
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
-
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -10759,7 +10746,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -11052,6 +11039,8 @@ module.exports = {
 },{"./builder":16,"./expression":22}],38:[function(require,module,exports){
 "use strict";
 
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
 function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
@@ -11063,8 +11052,6 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
 function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -11082,7 +11069,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -11548,7 +11535,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -11658,6 +11645,11 @@ var Tuple = /*#__PURE__*/function (_Expression2) {
   }
 
   _createClass(Tuple, [{
+    key: "isTuple",
+    get: function get() {
+      return true;
+    }
+  }, {
     key: "exec",
     value: function exec(ctx) {
       var val = {};
@@ -11677,11 +11669,6 @@ var Tuple = /*#__PURE__*/function (_Expression2) {
       }
 
       return val;
-    }
-  }, {
-    key: "isTuple",
-    get: function get() {
-      return true;
     }
   }]);
 
@@ -11725,6 +11712,8 @@ module.exports = {
 },{"./builder":16,"./expression":22}],40:[function(require,module,exports){
 "use strict";
 
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
 function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
@@ -11736,8 +11725,6 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
 function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -11755,7 +11742,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -11765,7 +11752,7 @@ var _require = require('./expression'),
 
 var _require2 = require('../datatypes/datetime'),
     DateTime = _require2.DateTime,
-    _Date = _require2.Date;
+    Date = _require2.Date;
 
 var _require3 = require('../datatypes/clinical'),
     Concept = _require3.Concept;
@@ -11921,7 +11908,7 @@ var ToDate = /*#__PURE__*/function (_Expression4) {
       } else if (arg.isDateTime) {
         return arg.getDate();
       } else {
-        return _Date.parse(arg.toString());
+        return Date.parse(arg.toString());
       }
     }
   }]);
@@ -12958,7 +12945,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -12999,6 +12986,23 @@ var Context = /*#__PURE__*/function () {
   }
 
   _createClass(Context, [{
+    key: "parameters",
+    get: function get() {
+      return this._parameters || this.parent && this.parent.parameters;
+    },
+    set: function set(params) {
+      this.checkParameters(params);
+      this._parameters = params;
+    }
+  }, {
+    key: "codeService",
+    get: function get() {
+      return this._codeService || this.parent && this.parent.codeService;
+    },
+    set: function set(cs) {
+      this._codeService = cs;
+    }
+  }, {
     key: "withParameters",
     value: function withParameters(params) {
       this.parameters = params || {};
@@ -13382,23 +13386,6 @@ var Context = /*#__PURE__*/function () {
       var pointType = ivl.low != null ? ivl.low : ivl.high;
       return val.isInterval && (val.low == null || this.matchesInstanceType(val.low, pointType)) && (val.high == null || this.matchesInstanceType(val.high, pointType));
     }
-  }, {
-    key: "parameters",
-    get: function get() {
-      return this._parameters || this.parent && this.parent.parameters;
-    },
-    set: function set(params) {
-      this.checkParameters(params);
-      this._parameters = params;
-    }
-  }, {
-    key: "codeService",
-    get: function get() {
-      return this._codeService || this.parent && this.parent.codeService;
-    },
-    set: function set(cs) {
-      this._codeService = cs;
-    }
   }]);
 
   return Context;
@@ -13720,6 +13707,13 @@ var Results = /*#__PURE__*/function () {
 
 
   _createClass(Results, [{
+    key: "evaluatedRecords",
+    get: function get() {
+      var _ref;
+
+      return (_ref = []).concat.apply(_ref, _toConsumableArray(Object.values(this.patientEvaluatedRecords)));
+    }
+  }, {
     key: "recordPatientResults",
     value: function recordPatientResults(patient_ctx, resultMap) {
       var _this = this;
@@ -13745,13 +13739,6 @@ var Results = /*#__PURE__*/function () {
     key: "recordUnfilteredResults",
     value: function recordUnfilteredResults(resultMap) {
       this.unfilteredResults = resultMap;
-    }
-  }, {
-    key: "evaluatedRecords",
-    get: function get() {
-      var _ref;
-
-      return (_ref = []).concat.apply(_ref, _toConsumableArray(Object.values(this.patientEvaluatedRecords)));
     }
   }]);
 
@@ -14079,7 +14066,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -20613,11 +20600,17 @@ function padStart(input, n) {
     n = 2;
   }
 
-  if (input.toString().length < n) {
-    return ("0".repeat(n) + input).slice(-n);
+  var minus = input < 0 ? "-" : "";
+  var target = minus ? input * -1 : input;
+  var result;
+
+  if (target.toString().length < n) {
+    result = ("0".repeat(n) + target).slice(-n);
   } else {
-    return input.toString();
+    result = target.toString();
   }
+
+  return "" + minus + result;
 }
 function parseInteger(string) {
   if (isUndefined(string) || string === null || string === "") {
@@ -21205,7 +21198,7 @@ var Formatter = /*#__PURE__*/function () {
       }, "era");
     },
         tokenToString = function tokenToString(token) {
-      // Where possible: http://cldr.unicode.org/translation/date-time#TOC-Stand-Alone-vs.-Format-Styles
+      // Where possible: http://cldr.unicode.org/translation/date-time-1/date-time#TOC-Standalone-vs.-Format-Styles
       switch (token) {
         // ms
         case "S":
@@ -21646,7 +21639,7 @@ var Zone = /*#__PURE__*/function () {
 
 var singleton = null;
 /**
- * Represents the local zone for this Javascript environment.
+ * Represents the local zone for this JavaScript environment.
  * @implements {Zone}
  */
 
@@ -22562,21 +22555,30 @@ var PolyDateFormatter = /*#__PURE__*/function () {
     var z;
 
     if (dt.zone.universal && this.hasIntl) {
-      // Chromium doesn't support fixed-offset zones like Etc/GMT+8 in its formatter,
-      // See https://bugs.chromium.org/p/chromium/issues/detail?id=364374.
-      // So we have to make do. Two cases:
-      // 1. The format options tell us to show the zone. We can't do that, so the best
-      // we can do is format the date in UTC.
-      // 2. The format options don't tell us to show the zone. Then we can adjust them
-      // the time and tell the formatter to show it to us in UTC, so that the time is right
-      // and the bad zone doesn't show up.
-      // We can clean all this up when Chrome fixes this.
-      z = "UTC";
+      // UTC-8 or Etc/UTC-8 are not part of tzdata, only Etc/GMT+8 and the like.
+      // That is why fixed-offset TZ is set to that unless it is:
+      // 1. Outside of the supported range Etc/GMT-14 to Etc/GMT+12.
+      // 2. Not a whole hour, e.g. UTC+4:30.
+      var gmtOffset = -1 * (dt.offset / 60);
 
-      if (opts.timeZoneName) {
+      if (gmtOffset >= -14 && gmtOffset <= 12 && gmtOffset % 1 === 0) {
+        z = gmtOffset >= 0 ? "Etc/GMT+" + gmtOffset : "Etc/GMT" + gmtOffset;
         this.dt = dt;
       } else {
-        this.dt = dt.offset === 0 ? dt : DateTime.fromMillis(dt.ts + dt.offset * 60 * 1000);
+        // Not all fixed-offset zones like Etc/+4:30 are present in tzdata.
+        // So we have to make do. Two cases:
+        // 1. The format options tell us to show the zone. We can't do that, so the best
+        // we can do is format the date in UTC.
+        // 2. The format options don't tell us to show the zone. Then we can adjust them
+        // the time and tell the formatter to show it to us in UTC, so that the time is right
+        // and the bad zone doesn't show up.
+        z = "UTC";
+
+        if (opts.timeZoneName) {
+          this.dt = dt;
+        } else {
+          this.dt = dt.offset === 0 ? dt : DateTime.fromMillis(dt.ts + dt.offset * 60 * 1000);
+        }
       }
     } else if (dt.zone.type === "local") {
       this.dt = dt;
@@ -22878,7 +22880,7 @@ var Locale = /*#__PURE__*/function () {
     return listStuff(this, length, defaultOK, eras, function () {
       var intl = {
         era: length
-      }; // This is utter bullshit. Different calendars are going to define eras totally differently. What I need is the minimum set of dates
+      }; // This is problematic. Different calendars are going to define eras totally differently. What I need is the minimum set of dates
       // to definitely enumerate them.
 
       if (!_this4.eraCache[length]) {
@@ -23061,10 +23063,10 @@ function extractISOYmd(match, cursor) {
 
 function extractISOTime(match, cursor) {
   var item = {
-    hour: int(match, cursor, 0),
-    minute: int(match, cursor + 1, 0),
-    second: int(match, cursor + 2, 0),
-    millisecond: parseMillis(match[cursor + 3])
+    hours: int(match, cursor, 0),
+    minutes: int(match, cursor + 1, 0),
+    seconds: int(match, cursor + 2, 0),
+    milliseconds: parseMillis(match[cursor + 3])
   };
   return [item, null, cursor + 4];
 }
@@ -23079,8 +23081,10 @@ function extractISOOffset(match, cursor) {
 function extractIANAZone(match, cursor) {
   var zone = match[cursor] ? IANAZone.create(match[cursor]) : null;
   return [{}, zone, cursor + 1];
-} // ISO duration parsing
+} // ISO time parsing
 
+
+var isoTimeOnly = RegExp("^T?" + isoTimeBaseRegex.source + "$"); // ISO duration parsing
 
 var isoDuration = /^-?P(?:(?:(-?\d{1,9})Y)?(?:(-?\d{1,9})M)?(?:(-?\d{1,9})W)?(?:(-?\d{1,9})D)?(?:T(?:(-?\d{1,9})H)?(?:(-?\d{1,9})M)?(?:(-?\d{1,20})(?:[.,](-?\d{1,9}))?S)?)?)$/;
 
@@ -23230,6 +23234,10 @@ function parseHTTPDate(s) {
 }
 function parseISODuration(s) {
   return parse(s, [isoDuration, extractISODuration]);
+}
+var extractISOTimeOnly = combineExtractors(extractISOTime);
+function parseISOTimeOnly(s) {
+  return parse(s, [isoTimeOnly, extractISOTimeOnly]);
 }
 var sqlYmdWithTimeExtensionRegex = combineRegexes(sqlYmdRegex, sqlTimeExtensionRegex);
 var sqlTimeCombinedRegex = combineRegexes(sqlTimeRegex);
@@ -23444,7 +23452,7 @@ var Duration = /*#__PURE__*/function () {
     }, opts));
   }
   /**
-   * Create a Duration from a Javascript object with keys like 'years' and 'hours.
+   * Create a Duration from a JavaScript object with keys like 'years' and 'hours.
    * If this object is empty then a zero milliseconds duration is returned.
    * @param {Object} obj - the object to create the DateTime from
    * @param {number} obj.years
@@ -23493,6 +23501,34 @@ var Duration = /*#__PURE__*/function () {
   Duration.fromISO = function fromISO(text, opts) {
     var _parseISODuration = parseISODuration(text),
         parsed = _parseISODuration[0];
+
+    if (parsed) {
+      var obj = Object.assign(parsed, opts);
+      return Duration.fromObject(obj);
+    } else {
+      return Duration.invalid("unparsable", "the input \"" + text + "\" can't be parsed as ISO 8601");
+    }
+  }
+  /**
+   * Create a Duration from an ISO 8601 time string.
+   * @param {string} text - text to parse
+   * @param {Object} opts - options for parsing
+   * @param {string} [opts.locale='en-US'] - the locale to use
+   * @param {string} opts.numberingSystem - the numbering system to use
+   * @param {string} [opts.conversionAccuracy='casual'] - the conversion system to use
+   * @see https://en.wikipedia.org/wiki/ISO_8601#Times
+   * @example Duration.fromISOTime('11:22:33.444').toObject() //=> { hours: 11, minutes: 22, seconds: 33, milliseconds: 444 }
+   * @example Duration.fromISOTime('11:00').toObject() //=> { hours: 11, minutes: 0, seconds: 0 }
+   * @example Duration.fromISOTime('T11:00').toObject() //=> { hours: 11, minutes: 0, seconds: 0 }
+   * @example Duration.fromISOTime('1100').toObject() //=> { hours: 11, minutes: 0, seconds: 0 }
+   * @example Duration.fromISOTime('T1100').toObject() //=> { hours: 11, minutes: 0, seconds: 0 }
+   * @return {Duration}
+   */
+  ;
+
+  Duration.fromISOTime = function fromISOTime(text, opts) {
+    var _parseISOTimeOnly = parseISOTimeOnly(text),
+        parsed = _parseISOTimeOnly[0];
 
     if (parsed) {
       var obj = Object.assign(parsed, opts);
@@ -23607,7 +23643,7 @@ var Duration = /*#__PURE__*/function () {
     return this.isValid ? Formatter.create(this.loc, fmtOpts).formatDurationFromString(this, fmt) : INVALID;
   }
   /**
-   * Returns a Javascript object with this Duration's values.
+   * Returns a JavaScript object with this Duration's values.
    * @param opts - options for generating the object
    * @param {boolean} [opts.includeConfig=false] - include configuration attributes in the output
    * @example Duration.fromObject({ years: 1, days: 6, seconds: 2 }).toObject() //=> { years: 1, days: 6, seconds: 2 }
@@ -23661,6 +23697,57 @@ var Duration = /*#__PURE__*/function () {
     return s;
   }
   /**
+   * Returns an ISO 8601-compliant string representation of this Duration, formatted as a time of day.
+   * Note that this will return null if the duration is invalid, negative, or equal to or greater than 24 hours.
+   * @see https://en.wikipedia.org/wiki/ISO_8601#Times
+   * @param {Object} opts - options
+   * @param {boolean} [opts.suppressMilliseconds=false] - exclude milliseconds from the format if they're 0
+   * @param {boolean} [opts.suppressSeconds=false] - exclude seconds from the format if they're 0
+   * @param {boolean} [opts.includePrefix=false] - include the `T` prefix
+   * @param {string} [opts.format='extended'] - choose between the basic and extended format
+   * @example Duration.fromObject({ hours: 11 }).toISOTime() //=> '11:00:00.000'
+   * @example Duration.fromObject({ hours: 11 }).toISOTime({ suppressMilliseconds: true }) //=> '11:00:00'
+   * @example Duration.fromObject({ hours: 11 }).toISOTime({ suppressSeconds: true }) //=> '11:00'
+   * @example Duration.fromObject({ hours: 11 }).toISOTime({ includePrefix: true }) //=> 'T11:00:00.000'
+   * @example Duration.fromObject({ hours: 11 }).toISOTime({ format: 'basic' }) //=> '110000.000'
+   * @return {string}
+   */
+  ;
+
+  _proto.toISOTime = function toISOTime(opts) {
+    if (opts === void 0) {
+      opts = {};
+    }
+
+    if (!this.isValid) return null;
+    var millis = this.toMillis();
+    if (millis < 0 || millis >= 86400000) return null;
+    opts = Object.assign({
+      suppressMilliseconds: false,
+      suppressSeconds: false,
+      includePrefix: false,
+      format: "extended"
+    }, opts);
+    var value = this.shiftTo("hours", "minutes", "seconds", "milliseconds");
+    var fmt = opts.format === "basic" ? "hhmm" : "hh:mm";
+
+    if (!opts.suppressSeconds || value.seconds !== 0 || value.milliseconds !== 0) {
+      fmt += opts.format === "basic" ? "ss" : ":ss";
+
+      if (!opts.suppressMilliseconds || value.milliseconds !== 0) {
+        fmt += ".SSS";
+      }
+    }
+
+    var str = value.toFormat(fmt);
+
+    if (opts.includePrefix) {
+      str = "T" + str;
+    }
+
+    return str;
+  }
+  /**
    * Returns an ISO 8601 representation of this Duration appropriate for use in JSON.
    * @return {string}
    */
@@ -23684,8 +23771,17 @@ var Duration = /*#__PURE__*/function () {
    */
   ;
 
-  _proto.valueOf = function valueOf() {
+  _proto.toMillis = function toMillis() {
     return this.as("milliseconds");
+  }
+  /**
+   * Returns an milliseconds value of this Duration. Alias of {@link toMillis}
+   * @return {number}
+   */
+  ;
+
+  _proto.valueOf = function valueOf() {
+    return this.toMillis();
   }
   /**
    * Make this Duration longer by the specified amount. Return a newly-constructed Duration.
@@ -23942,10 +24038,16 @@ var Duration = /*#__PURE__*/function () {
       return false;
     }
 
+    function eq(v1, v2) {
+      // Consider 0 and undefined as equal
+      if (v1 === undefined || v1 === 0) return v2 === undefined || v2 === 0;
+      return v1 === v2;
+    }
+
     for (var _iterator3 = _createForOfIteratorHelperLoose(orderedUnits), _step3; !(_step3 = _iterator3()).done;) {
       var u = _step3.value;
 
-      if (this.values[u] !== other.values[u]) {
+      if (!eq(this.values[u], other.values[u])) {
         return false;
       }
     }
@@ -24827,7 +24929,7 @@ var Info = /*#__PURE__*/function () {
       zone = Settings.defaultZone;
     }
 
-    var proto = DateTime.local().setZone(zone).set({
+    var proto = DateTime.now().setZone(zone).set({
       month: 12
     });
     return !zone.universal && proto.offset !== proto.set({
@@ -25077,6 +25179,8 @@ function dayDiff(earlier, later) {
 function highOrderDiffs(cursor, later, units) {
   var differs = [["years", function (a, b) {
     return b.year - a.year;
+  }], ["quarters", function (a, b) {
+    return b.quarter - a.quarter;
   }], ["months", function (a, b) {
     return b.month - a.month + (b.year - a.year) * 12;
   }], ["weeks", function (a, b) {
@@ -26107,6 +26211,8 @@ function toTechTimeFormat(dt, _ref) {
       _ref$suppressMillisec = _ref.suppressMilliseconds,
       suppressMilliseconds = _ref$suppressMillisec === void 0 ? false : _ref$suppressMillisec,
       includeOffset = _ref.includeOffset,
+      _ref$includePrefix = _ref.includePrefix,
+      includePrefix = _ref$includePrefix === void 0 ? false : _ref$includePrefix,
       _ref$includeZone = _ref.includeZone,
       includeZone = _ref$includeZone === void 0 ? false : _ref$includeZone,
       _ref$spaceZone = _ref.spaceZone,
@@ -26133,7 +26239,13 @@ function toTechTimeFormat(dt, _ref) {
     fmt += format === "basic" ? "ZZZ" : "ZZ";
   }
 
-  return toTechFormat(dt, fmt);
+  var str = toTechFormat(dt, fmt);
+
+  if (includePrefix) {
+    str = "T" + str;
+  }
+
+  return str;
 } // defaults for unspecified units in the supported calendars
 
 
@@ -26351,10 +26463,22 @@ var DateTime = /*#__PURE__*/function () {
   } // CONSTRUCT
 
   /**
+   * Create a DateTime for the current instant, in the system's time zone.
+   *
+   * Use Settings to override these default values if needed.
+   * @example DateTime.now().toISO() //~> now in the ISO format
+   * @return {DateTime}
+   */
+
+
+  DateTime.now = function now() {
+    return new DateTime({});
+  }
+  /**
    * Create a local DateTime
    * @param {number} [year] - The calendar year. If omitted (as in, call `local()` with no arguments), the current time will be used
    * @param {number} [month=1] - The month, 1-indexed
-   * @param {number} [day=1] - The day of the month
+   * @param {number} [day=1] - The day of the month, 1-indexed
    * @param {number} [hour=0] - The hour of the day, in 24-hour time
    * @param {number} [minute=0] - The minute of the hour, meaning a number between 0 and 59
    * @param {number} [second=0] - The second of the minute, meaning a number between 0 and 59
@@ -26369,13 +26493,11 @@ var DateTime = /*#__PURE__*/function () {
    * @example DateTime.local(2017, 3, 12, 5, 45, 10, 765) //~> 2017-03-12T05:45:10.765
    * @return {DateTime}
    */
-
+  ;
 
   DateTime.local = function local(year, month, day, hour, minute, second, millisecond) {
     if (isUndefined(year)) {
-      return new DateTime({
-        ts: Settings.now()
-      });
+      return new DateTime({});
     } else {
       return quickDT({
         year: year,
@@ -26428,8 +26550,8 @@ var DateTime = /*#__PURE__*/function () {
     }
   }
   /**
-   * Create a DateTime from a Javascript Date object. Uses the default zone.
-   * @param {Date} date - a Javascript Date object
+   * Create a DateTime from a JavaScript Date object. Uses the default zone.
+   * @param {Date} date - a JavaScript Date object
    * @param {Object} options - configuration options for the DateTime
    * @param {string|Zone} [options.zone='local'] - the zone to place the DateTime into
    * @return {DateTime}
@@ -26517,7 +26639,7 @@ var DateTime = /*#__PURE__*/function () {
     }
   }
   /**
-   * Create a DateTime from a Javascript object with keys like 'year' and 'hour' with reasonable defaults.
+   * Create a DateTime from a JavaScript object with keys like 'year' and 'hour' with reasonable defaults.
    * @param {Object} obj - the object to create the DateTime from
    * @param {number} obj.year - a year, such as 1987
    * @param {number} obj.month - a month, 1-12
@@ -27049,12 +27171,12 @@ var DateTime = /*#__PURE__*/function () {
    *
    * Adding hours, minutes, seconds, or milliseconds increases the timestamp by the right number of milliseconds. Adding days, months, or years shifts the calendar, accounting for DSTs and leap years along the way. Thus, `dt.plus({ hours: 24 })` may result in a different time than `dt.plus({ days: 1 })` if there's a DST shift in between.
    * @param {Duration|Object|number} duration - The amount to add. Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
-   * @example DateTime.local().plus(123) //~> in 123 milliseconds
-   * @example DateTime.local().plus({ minutes: 15 }) //~> in 15 minutes
-   * @example DateTime.local().plus({ days: 1 }) //~> this time tomorrow
-   * @example DateTime.local().plus({ days: -1 }) //~> this time yesterday
-   * @example DateTime.local().plus({ hours: 3, minutes: 13 }) //~> in 3 hr, 13 min
-   * @example DateTime.local().plus(Duration.fromObject({ hours: 3, minutes: 13 })) //~> in 3 hr, 13 min
+   * @example DateTime.now().plus(123) //~> in 123 milliseconds
+   * @example DateTime.now().plus({ minutes: 15 }) //~> in 15 minutes
+   * @example DateTime.now().plus({ days: 1 }) //~> this time tomorrow
+   * @example DateTime.now().plus({ days: -1 }) //~> this time yesterday
+   * @example DateTime.now().plus({ hours: 3, minutes: 13 }) //~> in 3 hr, 13 min
+   * @example DateTime.now().plus(Duration.fromObject({ hours: 3, minutes: 13 })) //~> in 3 hr, 13 min
    * @return {DateTime}
    */
   ;
@@ -27082,6 +27204,7 @@ var DateTime = /*#__PURE__*/function () {
    * @param {string} unit - The unit to go to the beginning of. Can be 'year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second', or 'millisecond'.
    * @example DateTime.local(2014, 3, 3).startOf('month').toISODate(); //=> '2014-03-01'
    * @example DateTime.local(2014, 3, 3).startOf('year').toISODate(); //=> '2014-01-01'
+   * @example DateTime.local(2014, 3, 3).startOf('week').toISODate(); //=> '2014-03-03', weeks always start on Mondays
    * @example DateTime.local(2014, 3, 3, 5, 30).startOf('day').toISOTime(); //=> '00:00.000-05:00'
    * @example DateTime.local(2014, 3, 3, 5, 30).startOf('hour').toISOTime(); //=> '05:00:00.000-05:00'
    * @return {DateTime}
@@ -27135,9 +27258,10 @@ var DateTime = /*#__PURE__*/function () {
   }
   /**
    * "Set" this DateTime to the end (meaning the last millisecond) of a unit of time
-   * @param {string} unit - The unit to go to the end of. Can be 'year', 'month', 'day', 'hour', 'minute', 'second', or 'millisecond'.
+   * @param {string} unit - The unit to go to the end of. Can be 'year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second', or 'millisecond'.
    * @example DateTime.local(2014, 3, 3).endOf('month').toISO(); //=> '2014-03-31T23:59:59.999-05:00'
    * @example DateTime.local(2014, 3, 3).endOf('year').toISO(); //=> '2014-12-31T23:59:59.999-05:00'
+   * @example DateTime.local(2014, 3, 3).endOf('week').toISO(); // => '2014-03-09T23:59:59.999-05:00', weeks start on Mondays
    * @example DateTime.local(2014, 3, 3, 5, 30).endOf('day').toISO(); //=> '2014-03-03T23:59:59.999-05:00'
    * @example DateTime.local(2014, 3, 3, 5, 30).endOf('hour').toISO(); //=> '2014-03-03T05:59:59.999-05:00'
    * @return {DateTime}
@@ -27157,10 +27281,10 @@ var DateTime = /*#__PURE__*/function () {
    * @see https://moment.github.io/luxon/docs/manual/formatting.html#table-of-tokens
    * @param {string} fmt - the format string
    * @param {Object} opts - opts to override the configuration options
-   * @example DateTime.local().toFormat('yyyy LLL dd') //=> '2017 Apr 22'
-   * @example DateTime.local().setLocale('fr').toFormat('yyyy LLL dd') //=> '2017 avr. 22'
-   * @example DateTime.local().toFormat('yyyy LLL dd', { locale: "fr" }) //=> '2017 avr. 22'
-   * @example DateTime.local().toFormat("HH 'hours and' mm 'minutes'") //=> '20 hours and 55 minutes'
+   * @example DateTime.now().toFormat('yyyy LLL dd') //=> '2017 Apr 22'
+   * @example DateTime.now().setLocale('fr').toFormat('yyyy LLL dd') //=> '2017 avr. 22'
+   * @example DateTime.now().toFormat('yyyy LLL dd', { locale: "fr" }) //=> '2017 avr. 22'
+   * @example DateTime.now().toFormat("HH 'hours and' mm 'minutes'") //=> '20 hours and 55 minutes'
    * @return {string}
    */
   ;
@@ -27179,15 +27303,15 @@ var DateTime = /*#__PURE__*/function () {
    * Defaults to the system's locale if no locale has been specified
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
    * @param opts {Object} - Intl.DateTimeFormat constructor options and configuration options
-   * @example DateTime.local().toLocaleString(); //=> 4/20/2017
-   * @example DateTime.local().setLocale('en-gb').toLocaleString(); //=> '20/04/2017'
-   * @example DateTime.local().toLocaleString({ locale: 'en-gb' }); //=> '20/04/2017'
-   * @example DateTime.local().toLocaleString(DateTime.DATE_FULL); //=> 'April 20, 2017'
-   * @example DateTime.local().toLocaleString(DateTime.TIME_SIMPLE); //=> '11:32 AM'
-   * @example DateTime.local().toLocaleString(DateTime.DATETIME_SHORT); //=> '4/20/2017, 11:32 AM'
-   * @example DateTime.local().toLocaleString({ weekday: 'long', month: 'long', day: '2-digit' }); //=> 'Thursday, April 20'
-   * @example DateTime.local().toLocaleString({ weekday: 'short', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }); //=> 'Thu, Apr 20, 11:27 AM'
-   * @example DateTime.local().toLocaleString({ hour: '2-digit', minute: '2-digit', hour12: false }); //=> '11:32'
+   * @example DateTime.now().toLocaleString(); //=> 4/20/2017
+   * @example DateTime.now().setLocale('en-gb').toLocaleString(); //=> '20/04/2017'
+   * @example DateTime.now().toLocaleString({ locale: 'en-gb' }); //=> '20/04/2017'
+   * @example DateTime.now().toLocaleString(DateTime.DATE_FULL); //=> 'April 20, 2017'
+   * @example DateTime.now().toLocaleString(DateTime.TIME_SIMPLE); //=> '11:32 AM'
+   * @example DateTime.now().toLocaleString(DateTime.DATETIME_SHORT); //=> '4/20/2017, 11:32 AM'
+   * @example DateTime.now().toLocaleString({ weekday: 'long', month: 'long', day: '2-digit' }); //=> 'Thursday, April 20'
+   * @example DateTime.now().toLocaleString({ weekday: 'short', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }); //=> 'Thu, Apr 20, 11:27 AM'
+   * @example DateTime.now().toLocaleString({ hour: '2-digit', minute: '2-digit', hour12: false }); //=> '11:32'
    * @return {string}
    */
   ;
@@ -27204,7 +27328,7 @@ var DateTime = /*#__PURE__*/function () {
    * Defaults to the system's locale if no locale has been specified
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatToParts
    * @param opts {Object} - Intl.DateTimeFormat constructor options, same as `toLocaleString`.
-   * @example DateTime.local().toLocaleParts(); //=> [
+   * @example DateTime.now().toLocaleParts(); //=> [
    *                                   //=>   { type: 'day', value: '25' },
    *                                   //=>   { type: 'literal', value: '/' },
    *                                   //=>   { type: 'month', value: '05' },
@@ -27229,9 +27353,9 @@ var DateTime = /*#__PURE__*/function () {
    * @param {boolean} [opts.includeOffset=true] - include the offset, such as 'Z' or '-04:00'
    * @param {string} [opts.format='extended'] - choose between the basic and extended format
    * @example DateTime.utc(1982, 5, 25).toISO() //=> '1982-05-25T00:00:00.000Z'
-   * @example DateTime.local().toISO() //=> '2017-04-22T20:47:05.335-04:00'
-   * @example DateTime.local().toISO({ includeOffset: false }) //=> '2017-04-22T20:47:05.335'
-   * @example DateTime.local().toISO({ format: 'basic' }) //=> '20170422T204705.335-0400'
+   * @example DateTime.now().toISO() //=> '2017-04-22T20:47:05.335-04:00'
+   * @example DateTime.now().toISO({ includeOffset: false }) //=> '2017-04-22T20:47:05.335'
+   * @example DateTime.now().toISO({ format: 'basic' }) //=> '20170422T204705.335-0400'
    * @return {string}
    */
   ;
@@ -27286,10 +27410,12 @@ var DateTime = /*#__PURE__*/function () {
    * @param {boolean} [opts.suppressMilliseconds=false] - exclude milliseconds from the format if they're 0
    * @param {boolean} [opts.suppressSeconds=false] - exclude seconds from the format if they're 0
    * @param {boolean} [opts.includeOffset=true] - include the offset, such as 'Z' or '-04:00'
+   * @param {boolean} [opts.includePrefix=false] - include the `T` prefix
    * @param {string} [opts.format='extended'] - choose between the basic and extended format
    * @example DateTime.utc().set({ hour: 7, minute: 34 }).toISOTime() //=> '07:34:19.361Z'
    * @example DateTime.utc().set({ hour: 7, minute: 34, seconds: 0, milliseconds: 0 }).toISOTime({ suppressSeconds: true }) //=> '07:34Z'
    * @example DateTime.utc().set({ hour: 7, minute: 34 }).toISOTime({ format: 'basic' }) //=> '073419.361Z'
+   * @example DateTime.utc().set({ hour: 7, minute: 34 }).toISOTime({ includePrefix: true }) //=> 'T07:34:19.361Z'
    * @return {string}
    */
   ;
@@ -27302,6 +27428,8 @@ var DateTime = /*#__PURE__*/function () {
         suppressSeconds = _ref6$suppressSeconds === void 0 ? false : _ref6$suppressSeconds,
         _ref6$includeOffset = _ref6.includeOffset,
         includeOffset = _ref6$includeOffset === void 0 ? true : _ref6$includeOffset,
+        _ref6$includePrefix = _ref6.includePrefix,
+        includePrefix = _ref6$includePrefix === void 0 ? false : _ref6$includePrefix,
         _ref6$format = _ref6.format,
         format = _ref6$format === void 0 ? "extended" : _ref6$format;
 
@@ -27309,6 +27437,7 @@ var DateTime = /*#__PURE__*/function () {
       suppressSeconds: suppressSeconds,
       suppressMilliseconds: suppressMilliseconds,
       includeOffset: includeOffset,
+      includePrefix: includePrefix,
       format: format
     });
   }
@@ -27352,9 +27481,9 @@ var DateTime = /*#__PURE__*/function () {
    * @param {boolean} [opts.includeZone=false] - include the zone, such as 'America/New_York'. Overrides includeOffset.
    * @param {boolean} [opts.includeOffset=true] - include the offset, such as 'Z' or '-04:00'
    * @example DateTime.utc().toSQL() //=> '05:15:16.345'
-   * @example DateTime.local().toSQL() //=> '05:15:16.345 -04:00'
-   * @example DateTime.local().toSQL({ includeOffset: false }) //=> '05:15:16.345'
-   * @example DateTime.local().toSQL({ includeZone: false }) //=> '05:15:16.345 America/New_York'
+   * @example DateTime.now().toSQL() //=> '05:15:16.345 -04:00'
+   * @example DateTime.now().toSQL({ includeOffset: false }) //=> '05:15:16.345'
+   * @example DateTime.now().toSQL({ includeZone: false }) //=> '05:15:16.345 America/New_York'
    * @return {string}
    */
   ;
@@ -27451,10 +27580,10 @@ var DateTime = /*#__PURE__*/function () {
     return this.toJSDate();
   }
   /**
-   * Returns a Javascript object with this DateTime's year, month, day, and so on.
+   * Returns a JavaScript object with this DateTime's year, month, day, and so on.
    * @param opts - options for generating the object
    * @param {boolean} [opts.includeConfig=false] - include configuration attributes in the output
-   * @example DateTime.local().toObject() //=> { year: 2017, month: 4, day: 22, hour: 20, minute: 49, second: 42, millisecond: 268 }
+   * @example DateTime.now().toObject() //=> { year: 2017, month: 4, day: 22, hour: 20, minute: 49, second: 42, millisecond: 268 }
    * @return {Object}
    */
   ;
@@ -27476,7 +27605,7 @@ var DateTime = /*#__PURE__*/function () {
     return base;
   }
   /**
-   * Returns a Javascript Date equivalent to this DateTime.
+   * Returns a JavaScript Date equivalent to this DateTime.
    * @return {Date}
    */
   ;
@@ -27547,7 +27676,7 @@ var DateTime = /*#__PURE__*/function () {
       opts = {};
     }
 
-    return this.diff(DateTime.local(), unit, opts);
+    return this.diff(DateTime.now(), unit, opts);
   }
   /**
    * Return an Interval spanning between this DateTime and another DateTime
@@ -27560,23 +27689,23 @@ var DateTime = /*#__PURE__*/function () {
     return this.isValid ? Interval.fromDateTimes(this, otherDateTime) : this;
   }
   /**
-   * Return whether this DateTime is in the same unit of time as another DateTime
+   * Return whether this DateTime is in the same unit of time as another DateTime.
+   * Higher-order units must also be identical for this function to return `true`.
+   * Note that time zones are **ignored** in this comparison, which compares the **local** calendar time. Use {@link setZone} to convert one of the dates if needed.
    * @param {DateTime} otherDateTime - the other DateTime
    * @param {string} unit - the unit of time to check sameness on
-   * @example DateTime.local().hasSame(otherDT, 'day'); //~> true if both the same calendar day
+   * @example DateTime.now().hasSame(otherDT, 'day'); //~> true if otherDT is in the same current calendar day
    * @return {boolean}
    */
   ;
 
   _proto.hasSame = function hasSame(otherDateTime, unit) {
     if (!this.isValid) return false;
-
-    if (unit === "millisecond") {
-      return this.valueOf() === otherDateTime.valueOf();
-    } else {
-      var inputMs = otherDateTime.valueOf();
-      return this.startOf(unit) <= inputMs && inputMs <= this.endOf(unit);
-    }
+    var inputMs = otherDateTime.valueOf();
+    var otherZoneDateTime = this.setZone(otherDateTime.zone, {
+      keepLocalTime: true
+    });
+    return otherZoneDateTime.startOf(unit) <= inputMs && inputMs <= otherZoneDateTime.endOf(unit);
   }
   /**
    * Equality check
@@ -27594,19 +27723,19 @@ var DateTime = /*#__PURE__*/function () {
    * Returns a string representation of a this time relative to now, such as "in two days". Can only internationalize if your
    * platform supports Intl.RelativeTimeFormat. Rounds down by default.
    * @param {Object} options - options that affect the output
-   * @param {DateTime} [options.base=DateTime.local()] - the DateTime to use as the basis to which this time is compared. Defaults to now.
+   * @param {DateTime} [options.base=DateTime.now()] - the DateTime to use as the basis to which this time is compared. Defaults to now.
    * @param {string} [options.style="long"] - the style of units, must be "long", "short", or "narrow"
    * @param {string} options.unit - use a specific unit; if omitted, the method will pick the unit. Use one of "years", "quarters", "months", "weeks", "days", "hours", "minutes", or "seconds"
    * @param {boolean} [options.round=true] - whether to round the numbers in the output.
-   * @param {boolean} [options.padding=0] - padding in milliseconds. This allows you to round up the result if it fits inside the threshold. Don't use in combination with {round: false} because the decimal output will include the padding.
+   * @param {number} [options.padding=0] - padding in milliseconds. This allows you to round up the result if it fits inside the threshold. Don't use in combination with {round: false} because the decimal output will include the padding.
    * @param {string} options.locale - override the locale of this DateTime
    * @param {string} options.numberingSystem - override the numberingSystem of this DateTime. The Intl system may choose not to honor this
-   * @example DateTime.local().plus({ days: 1 }).toRelative() //=> "in 1 day"
-   * @example DateTime.local().setLocale("es").toRelative({ days: 1 }) //=> "dentro de 1 día"
-   * @example DateTime.local().plus({ days: 1 }).toRelative({ locale: "fr" }) //=> "dans 23 heures"
-   * @example DateTime.local().minus({ days: 2 }).toRelative() //=> "2 days ago"
-   * @example DateTime.local().minus({ days: 2 }).toRelative({ unit: "hours" }) //=> "48 hours ago"
-   * @example DateTime.local().minus({ hours: 36 }).toRelative({ round: false }) //=> "1.5 days ago"
+   * @example DateTime.now().plus({ days: 1 }).toRelative() //=> "in 1 day"
+   * @example DateTime.now().setLocale("es").toRelative({ days: 1 }) //=> "dentro de 1 día"
+   * @example DateTime.now().plus({ days: 1 }).toRelative({ locale: "fr" }) //=> "dans 23 heures"
+   * @example DateTime.now().minus({ days: 2 }).toRelative() //=> "2 days ago"
+   * @example DateTime.now().minus({ days: 2 }).toRelative({ unit: "hours" }) //=> "48 hours ago"
+   * @example DateTime.now().minus({ hours: 36 }).toRelative({ round: false }) //=> "1.5 days ago"
    */
   ;
 
@@ -27629,14 +27758,14 @@ var DateTime = /*#__PURE__*/function () {
    * Returns a string representation of this date relative to today, such as "yesterday" or "next month".
    * Only internationalizes on platforms that supports Intl.RelativeTimeFormat.
    * @param {Object} options - options that affect the output
-   * @param {DateTime} [options.base=DateTime.local()] - the DateTime to use as the basis to which this time is compared. Defaults to now.
+   * @param {DateTime} [options.base=DateTime.now()] - the DateTime to use as the basis to which this time is compared. Defaults to now.
    * @param {string} options.locale - override the locale of this DateTime
    * @param {string} options.unit - use a specific unit; if omitted, the method will pick the unit. Use one of "years", "quarters", "months", "weeks", or "days"
    * @param {string} options.numberingSystem - override the numberingSystem of this DateTime. The Intl system may choose not to honor this
-   * @example DateTime.local().plus({ days: 1 }).toRelativeCalendar() //=> "tomorrow"
-   * @example DateTime.local().setLocale("es").plus({ days: 1 }).toRelative() //=> ""mañana"
-   * @example DateTime.local().plus({ days: 1 }).toRelativeCalendar({ locale: "fr" }) //=> "demain"
-   * @example DateTime.local().minus({ days: 2 }).toRelativeCalendar() //=> "2 days ago"
+   * @example DateTime.now().plus({ days: 1 }).toRelativeCalendar() //=> "tomorrow"
+   * @example DateTime.now().setLocale("es").plus({ days: 1 }).toRelative() //=> ""mañana"
+   * @example DateTime.now().plus({ days: 1 }).toRelativeCalendar({ locale: "fr" }) //=> "demain"
+   * @example DateTime.now().minus({ days: 2 }).toRelativeCalendar() //=> "2 days ago"
    */
   ;
 
@@ -28012,7 +28141,7 @@ var DateTime = /*#__PURE__*/function () {
     }
     /**
      * Get the UTC offset of this DateTime in minutes
-     * @example DateTime.local().offset //=> -240
+     * @example DateTime.now().offset //=> -240
      * @example DateTime.utc().offset //=> 0
      * @type {number}
      */
@@ -28366,6 +28495,8 @@ function friendlyDateTime(dateTimeish) {
   }
 }
 
+var VERSION = "1.26.0";
+
 exports.DateTime = DateTime;
 exports.Duration = Duration;
 exports.FixedOffsetZone = FixedOffsetZone;
@@ -28375,6 +28506,7 @@ exports.Interval = Interval;
 exports.InvalidZone = InvalidZone;
 exports.LocalZone = LocalZone;
 exports.Settings = Settings;
+exports.VERSION = VERSION;
 exports.Zone = Zone;
 
 

--- a/src/elm/interval.js
+++ b/src/elm/interval.js
@@ -385,6 +385,10 @@ class Expand extends Expression {
     // expand(argument List<Interval<T>>, per Quantity) List<Interval<T>>
     let defaultPer, expandFunction;
     let [intervals, per] = this.execArgs(ctx);
+    // CQL 1.5 introduced an overload to allow singular intervals; make it a list so we can use the same logic for either overload
+    if (!Array.isArray(intervals)) {
+      intervals = [intervals];
+    }
     const type = intervalListType(intervals);
     if (type === 'mismatch') {
       throw new Error('List of intervals contains mismatched types.');

--- a/test/elm/aggregate/data.js
+++ b/test/elm/aggregate/data.js
@@ -23,6 +23,14 @@ module.exports['Count'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "26",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -40,7 +48,27 @@ module.exports['Count'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -64,7 +92,7 @@ module.exports['Count'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","not_null",": " ]
+                     "value" : [ "","define ","not_null",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -125,7 +153,7 @@ module.exports['Count'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","has_null",": " ]
+                     "value" : [ "","define ","has_null",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -192,7 +220,7 @@ module.exports['Count'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","empty",": " ]
+                     "value" : [ "","define ","empty",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -220,7 +248,7 @@ module.exports['Count'] = {
                "s" : {
                   "r" : "26",
                   "s" : [ {
-                     "value" : [ "define ","is_null",": " ]
+                     "value" : [ "","define ","is_null",": " ]
                   }, {
                      "r" : "25",
                      "s" : [ {
@@ -296,6 +324,14 @@ module.exports['Sum'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "68",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -313,7 +349,27 @@ module.exports['Sum'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -337,7 +393,7 @@ module.exports['Sum'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","not_null",": " ]
+                     "value" : [ "","define ","not_null",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -398,7 +454,7 @@ module.exports['Sum'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","has_null",": " ]
+                     "value" : [ "","define ","has_null",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -465,7 +521,7 @@ module.exports['Sum'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","not_null_q",": " ]
+                     "value" : [ "","define ","not_null_q",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -560,7 +616,7 @@ module.exports['Sum'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","has_null_q",": " ]
+                     "value" : [ "","define ","has_null_q",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -641,7 +697,7 @@ module.exports['Sum'] = {
                "s" : {
                   "r" : "42",
                   "s" : [ {
-                     "value" : [ "define ","unmatched_units_q",": " ]
+                     "value" : [ "","define ","unmatched_units_q",": " ]
                   }, {
                      "r" : "41",
                      "s" : [ {
@@ -748,7 +804,7 @@ module.exports['Sum'] = {
                "s" : {
                   "r" : "46",
                   "s" : [ {
-                     "value" : [ "define ","empty",": " ]
+                     "value" : [ "","define ","empty",": " ]
                   }, {
                      "r" : "45",
                      "s" : [ {
@@ -789,7 +845,7 @@ module.exports['Sum'] = {
                "s" : {
                   "r" : "54",
                   "s" : [ {
-                     "value" : [ "define ","q_diff_units",": " ]
+                     "value" : [ "","define ","q_diff_units",": " ]
                   }, {
                      "r" : "53",
                      "s" : [ {
@@ -884,7 +940,7 @@ module.exports['Sum'] = {
                "s" : {
                   "r" : "63",
                   "s" : [ {
-                     "value" : [ "define ","NumbersAndQuantities",": " ]
+                     "value" : [ "","define ","NumbersAndQuantities",": " ]
                   }, {
                      "r" : "62",
                      "s" : [ {
@@ -988,7 +1044,7 @@ module.exports['Sum'] = {
                "s" : {
                   "r" : "68",
                   "s" : [ {
-                     "value" : [ "define ","IncompatibleUnitsNull",": " ]
+                     "value" : [ "","define ","IncompatibleUnitsNull",": " ]
                   }, {
                      "r" : "67",
                      "s" : [ {
@@ -1069,6 +1125,14 @@ module.exports['Min'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "136",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1086,7 +1150,27 @@ module.exports['Min'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1110,7 +1194,7 @@ module.exports['Min'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","not_null",": " ]
+                     "value" : [ "","define ","not_null",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -1176,7 +1260,7 @@ module.exports['Min'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","has_null",": " ]
+                     "value" : [ "","define ","has_null",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -1254,7 +1338,7 @@ module.exports['Min'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","empty",": " ]
+                     "value" : [ "","define ","empty",": " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -1295,7 +1379,7 @@ module.exports['Min'] = {
                "s" : {
                   "r" : "32",
                   "s" : [ {
-                     "value" : [ "define ","not_null_q",": " ]
+                     "value" : [ "","define ","not_null_q",": " ]
                   }, {
                      "r" : "31",
                      "s" : [ {
@@ -1402,7 +1486,7 @@ module.exports['Min'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","has_null_q",": " ]
+                     "value" : [ "","define ","has_null_q",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -1498,7 +1582,7 @@ module.exports['Min'] = {
                "s" : {
                   "r" : "50",
                   "s" : [ {
-                     "value" : [ "define ","q_diff_units",": " ]
+                     "value" : [ "","define ","q_diff_units",": " ]
                   }, {
                      "r" : "49",
                      "s" : [ {
@@ -1605,7 +1689,7 @@ module.exports['Min'] = {
                "s" : {
                   "r" : "59",
                   "s" : [ {
-                     "value" : [ "define ","NumbersAndQuantities",": " ]
+                     "value" : [ "","define ","NumbersAndQuantities",": " ]
                   }, {
                      "r" : "58",
                      "s" : [ {
@@ -1709,7 +1793,7 @@ module.exports['Min'] = {
                "s" : {
                   "r" : "66",
                   "s" : [ {
-                     "value" : [ "define ","IntegerMin",": " ]
+                     "value" : [ "","define ","IntegerMin",": " ]
                   }, {
                      "r" : "65",
                      "s" : [ {
@@ -1765,7 +1849,7 @@ module.exports['Min'] = {
                "s" : {
                   "r" : "74",
                   "s" : [ {
-                     "value" : [ "define ","DecimalMin",": " ]
+                     "value" : [ "","define ","DecimalMin",": " ]
                   }, {
                      "r" : "73",
                      "s" : [ {
@@ -1833,7 +1917,7 @@ module.exports['Min'] = {
                "s" : {
                   "r" : "80",
                   "s" : [ {
-                     "value" : [ "define ","DateMin",": " ]
+                     "value" : [ "","define ","DateMin",": " ]
                   }, {
                      "r" : "79",
                      "s" : [ {
@@ -1923,7 +2007,7 @@ module.exports['Min'] = {
                "s" : {
                   "r" : "91",
                   "s" : [ {
-                     "value" : [ "define ","DateTimeMin",": " ]
+                     "value" : [ "","define ","DateTimeMin",": " ]
                   }, {
                      "r" : "90",
                      "s" : [ {
@@ -2016,7 +2100,7 @@ module.exports['Min'] = {
                "s" : {
                   "r" : "106",
                   "s" : [ {
-                     "value" : [ "define ","TimeMin",": " ]
+                     "value" : [ "","define ","TimeMin",": " ]
                   }, {
                      "r" : "105",
                      "s" : [ {
@@ -2138,7 +2222,7 @@ module.exports['Min'] = {
                "s" : {
                   "r" : "113",
                   "s" : [ {
-                     "value" : [ "define ","StringMin",": " ]
+                     "value" : [ "","define ","StringMin",": " ]
                   }, {
                      "r" : "112",
                      "s" : [ {
@@ -2221,7 +2305,7 @@ module.exports['Min'] = {
                "s" : {
                   "r" : "125",
                   "s" : [ {
-                     "value" : [ "define ","MinIsNull",": " ]
+                     "value" : [ "","define ","MinIsNull",": " ]
                   }, {
                      "r" : "124",
                      "s" : [ {
@@ -2334,7 +2418,7 @@ module.exports['Min'] = {
                "s" : {
                   "r" : "131",
                   "s" : [ {
-                     "value" : [ "define ","MinIsAlsoNull",": " ]
+                     "value" : [ "","define ","MinIsAlsoNull",": " ]
                   }, {
                      "r" : "130",
                      "s" : [ {
@@ -2395,7 +2479,7 @@ module.exports['Min'] = {
                "s" : {
                   "r" : "136",
                   "s" : [ {
-                     "value" : [ "define ","IncompatibleUnitsNull",": " ]
+                     "value" : [ "","define ","IncompatibleUnitsNull",": " ]
                   }, {
                      "r" : "135",
                      "s" : [ {
@@ -2478,6 +2562,14 @@ module.exports['Max'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "132",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2495,7 +2587,27 @@ module.exports['Max'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2519,7 +2631,7 @@ module.exports['Max'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","not_null",": " ]
+                     "value" : [ "","define ","not_null",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -2585,7 +2697,7 @@ module.exports['Max'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","has_null",": " ]
+                     "value" : [ "","define ","has_null",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -2645,7 +2757,7 @@ module.exports['Max'] = {
                "s" : {
                   "r" : "26",
                   "s" : [ {
-                     "value" : [ "define ","not_null_q",": " ]
+                     "value" : [ "","define ","not_null_q",": " ]
                   }, {
                      "r" : "25",
                      "s" : [ {
@@ -2752,7 +2864,7 @@ module.exports['Max'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","has_null_q",": " ]
+                     "value" : [ "","define ","has_null_q",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -2826,7 +2938,7 @@ module.exports['Max'] = {
                "s" : {
                   "r" : "42",
                   "s" : [ {
-                     "value" : [ "define ","q_diff_units",": " ]
+                     "value" : [ "","define ","q_diff_units",": " ]
                   }, {
                      "r" : "41",
                      "s" : [ {
@@ -2933,7 +3045,7 @@ module.exports['Max'] = {
                "s" : {
                   "r" : "51",
                   "s" : [ {
-                     "value" : [ "define ","NumbersAndQuantities",": " ]
+                     "value" : [ "","define ","NumbersAndQuantities",": " ]
                   }, {
                      "r" : "50",
                      "s" : [ {
@@ -3037,7 +3149,7 @@ module.exports['Max'] = {
                "s" : {
                   "r" : "56",
                   "s" : [ {
-                     "value" : [ "define ","IncompatibleUnitsNull",": " ]
+                     "value" : [ "","define ","IncompatibleUnitsNull",": " ]
                   }, {
                      "r" : "55",
                      "s" : [ {
@@ -3096,7 +3208,7 @@ module.exports['Max'] = {
                "s" : {
                   "r" : "60",
                   "s" : [ {
-                     "value" : [ "define ","empty",": " ]
+                     "value" : [ "","define ","empty",": " ]
                   }, {
                      "r" : "59",
                      "s" : [ {
@@ -3137,7 +3249,7 @@ module.exports['Max'] = {
                "s" : {
                   "r" : "67",
                   "s" : [ {
-                     "value" : [ "define ","IntegerMax",": " ]
+                     "value" : [ "","define ","IntegerMax",": " ]
                   }, {
                      "r" : "66",
                      "s" : [ {
@@ -3193,7 +3305,7 @@ module.exports['Max'] = {
                "s" : {
                   "r" : "75",
                   "s" : [ {
-                     "value" : [ "define ","DecimalMax",": " ]
+                     "value" : [ "","define ","DecimalMax",": " ]
                   }, {
                      "r" : "74",
                      "s" : [ {
@@ -3261,7 +3373,7 @@ module.exports['Max'] = {
                "s" : {
                   "r" : "81",
                   "s" : [ {
-                     "value" : [ "define ","DateMax",": " ]
+                     "value" : [ "","define ","DateMax",": " ]
                   }, {
                      "r" : "80",
                      "s" : [ {
@@ -3351,7 +3463,7 @@ module.exports['Max'] = {
                "s" : {
                   "r" : "92",
                   "s" : [ {
-                     "value" : [ "define ","DateTimeMax",": " ]
+                     "value" : [ "","define ","DateTimeMax",": " ]
                   }, {
                      "r" : "91",
                      "s" : [ {
@@ -3444,7 +3556,7 @@ module.exports['Max'] = {
                "s" : {
                   "r" : "107",
                   "s" : [ {
-                     "value" : [ "define ","TimeMax",": " ]
+                     "value" : [ "","define ","TimeMax",": " ]
                   }, {
                      "r" : "106",
                      "s" : [ {
@@ -3566,7 +3678,7 @@ module.exports['Max'] = {
                "s" : {
                   "r" : "114",
                   "s" : [ {
-                     "value" : [ "define ","StringMax",": " ]
+                     "value" : [ "","define ","StringMax",": " ]
                   }, {
                      "r" : "113",
                      "s" : [ {
@@ -3649,7 +3761,7 @@ module.exports['Max'] = {
                "s" : {
                   "r" : "126",
                   "s" : [ {
-                     "value" : [ "define ","MaxIsNull",": " ]
+                     "value" : [ "","define ","MaxIsNull",": " ]
                   }, {
                      "r" : "125",
                      "s" : [ {
@@ -3762,7 +3874,7 @@ module.exports['Max'] = {
                "s" : {
                   "r" : "132",
                   "s" : [ {
-                     "value" : [ "define ","MaxIsAlsoNull",": " ]
+                     "value" : [ "","define ","MaxIsAlsoNull",": " ]
                   }, {
                      "r" : "131",
                      "s" : [ {
@@ -3837,6 +3949,14 @@ module.exports['Avg'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "57",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3854,7 +3974,27 @@ module.exports['Avg'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3878,7 +4018,7 @@ module.exports['Avg'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","not_null",": " ]
+                     "value" : [ "","define ","not_null",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -3955,7 +4095,7 @@ module.exports['Avg'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","has_null",": " ]
+                     "value" : [ "","define ","has_null",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -4031,7 +4171,7 @@ module.exports['Avg'] = {
                "s" : {
                   "r" : "24",
                   "s" : [ {
-                     "value" : [ "define ","not_null_q",": " ]
+                     "value" : [ "","define ","not_null_q",": " ]
                   }, {
                      "r" : "23",
                      "s" : [ {
@@ -4126,7 +4266,7 @@ module.exports['Avg'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","has_null_q",": " ]
+                     "value" : [ "","define ","has_null_q",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -4200,7 +4340,7 @@ module.exports['Avg'] = {
                "s" : {
                   "r" : "35",
                   "s" : [ {
-                     "value" : [ "define ","empty",": " ]
+                     "value" : [ "","define ","empty",": " ]
                   }, {
                      "r" : "34",
                      "s" : [ {
@@ -4257,7 +4397,7 @@ module.exports['Avg'] = {
                "s" : {
                   "r" : "43",
                   "s" : [ {
-                     "value" : [ "define ","q_diff_units",": " ]
+                     "value" : [ "","define ","q_diff_units",": " ]
                   }, {
                      "r" : "42",
                      "s" : [ {
@@ -4352,7 +4492,7 @@ module.exports['Avg'] = {
                "s" : {
                   "r" : "52",
                   "s" : [ {
-                     "value" : [ "define ","NumbersAndQuantities",": " ]
+                     "value" : [ "","define ","NumbersAndQuantities",": " ]
                   }, {
                      "r" : "51",
                      "s" : [ {
@@ -4456,7 +4596,7 @@ module.exports['Avg'] = {
                "s" : {
                   "r" : "57",
                   "s" : [ {
-                     "value" : [ "define ","IncompatibleUnitsNull",": " ]
+                     "value" : [ "","define ","IncompatibleUnitsNull",": " ]
                   }, {
                      "r" : "56",
                      "s" : [ {
@@ -4536,6 +4676,14 @@ module.exports['Median'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "122",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -4553,7 +4701,27 @@ module.exports['Median'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -4577,7 +4745,7 @@ module.exports['Median'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","odd",": " ]
+                     "value" : [ "","define ","odd",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -4654,7 +4822,7 @@ module.exports['Median'] = {
                "s" : {
                   "r" : "18",
                   "s" : [ {
-                     "value" : [ "define ","even",": " ]
+                     "value" : [ "","define ","even",": " ]
                   }, {
                      "r" : "17",
                      "s" : [ {
@@ -4736,7 +4904,7 @@ module.exports['Median'] = {
                "s" : {
                   "r" : "26",
                   "s" : [ {
-                     "value" : [ "define ","odd_q",": " ]
+                     "value" : [ "","define ","odd_q",": " ]
                   }, {
                      "r" : "25",
                      "s" : [ {
@@ -4831,7 +4999,7 @@ module.exports['Median'] = {
                "s" : {
                   "r" : "35",
                   "s" : [ {
-                     "value" : [ "define ","even_q",": " ]
+                     "value" : [ "","define ","even_q",": " ]
                   }, {
                      "r" : "34",
                      "s" : [ {
@@ -4938,7 +5106,7 @@ module.exports['Median'] = {
                "s" : {
                   "r" : "44",
                   "s" : [ {
-                     "value" : [ "define ","q_diff_units",": " ]
+                     "value" : [ "","define ","q_diff_units",": " ]
                   }, {
                      "r" : "43",
                      "s" : [ {
@@ -5045,7 +5213,7 @@ module.exports['Median'] = {
                "s" : {
                   "r" : "53",
                   "s" : [ {
-                     "value" : [ "define ","NumbersAndQuantities",": " ]
+                     "value" : [ "","define ","NumbersAndQuantities",": " ]
                   }, {
                      "r" : "52",
                      "s" : [ {
@@ -5137,7 +5305,7 @@ module.exports['Median'] = {
                "s" : {
                   "r" : "57",
                   "s" : [ {
-                     "value" : [ "define ","empty",": " ]
+                     "value" : [ "","define ","empty",": " ]
                   }, {
                      "r" : "56",
                      "s" : [ {
@@ -5194,7 +5362,7 @@ module.exports['Median'] = {
                "s" : {
                   "r" : "64",
                   "s" : [ {
-                     "value" : [ "define ","has_null",": " ]
+                     "value" : [ "","define ","has_null",": " ]
                   }, {
                      "r" : "63",
                      "s" : [ {
@@ -5270,7 +5438,7 @@ module.exports['Median'] = {
                "s" : {
                   "r" : "75",
                   "s" : [ {
-                     "value" : [ "define ","dup_vals_even",": " ]
+                     "value" : [ "","define ","dup_vals_even",": " ]
                   }, {
                      "r" : "74",
                      "s" : [ {
@@ -5362,7 +5530,7 @@ module.exports['Median'] = {
                "s" : {
                   "r" : "87",
                   "s" : [ {
-                     "value" : [ "define ","dup_vals_odd",":  " ]
+                     "value" : [ "","define ","dup_vals_odd",":  " ]
                   }, {
                      "r" : "86",
                      "s" : [ {
@@ -5459,7 +5627,7 @@ module.exports['Median'] = {
                "s" : {
                   "r" : "94",
                   "s" : [ {
-                     "value" : [ "define ","has_null_q",": " ]
+                     "value" : [ "","define ","has_null_q",": " ]
                   }, {
                      "r" : "93",
                      "s" : [ {
@@ -5533,7 +5701,7 @@ module.exports['Median'] = {
                "s" : {
                   "r" : "105",
                   "s" : [ {
-                     "value" : [ "define ","dup_vals_even_q",": " ]
+                     "value" : [ "","define ","dup_vals_even_q",": " ]
                   }, {
                      "r" : "104",
                      "s" : [ {
@@ -5664,7 +5832,7 @@ module.exports['Median'] = {
                "s" : {
                   "r" : "117",
                   "s" : [ {
-                     "value" : [ "define ","dup_vals_odd_q",":  " ]
+                     "value" : [ "","define ","dup_vals_odd_q",":  " ]
                   }, {
                      "r" : "116",
                      "s" : [ {
@@ -5807,7 +5975,7 @@ module.exports['Median'] = {
                "s" : {
                   "r" : "122",
                   "s" : [ {
-                     "value" : [ "define ","IncompatibleUnitsNull",": " ]
+                     "value" : [ "","define ","IncompatibleUnitsNull",": " ]
                   }, {
                      "r" : "121",
                      "s" : [ {
@@ -5879,6 +6047,14 @@ module.exports['Mode'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "48",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -5896,7 +6072,27 @@ module.exports['Mode'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -5920,7 +6116,7 @@ module.exports['Mode'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","not_null",": " ]
+                     "value" : [ "","define ","not_null",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -5991,7 +6187,7 @@ module.exports['Mode'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","has_null",": " ]
+                     "value" : [ "","define ","has_null",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -6056,7 +6252,7 @@ module.exports['Mode'] = {
                "s" : {
                   "r" : "22",
                   "s" : [ {
-                     "value" : [ "define ","empty",": " ]
+                     "value" : [ "","define ","empty",": " ]
                   }, {
                      "r" : "21",
                      "s" : [ {
@@ -6084,7 +6280,7 @@ module.exports['Mode'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","bi_modal",": " ]
+                     "value" : [ "","define ","bi_modal",": " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -6165,7 +6361,7 @@ module.exports['Mode'] = {
                "s" : {
                   "r" : "43",
                   "s" : [ {
-                     "value" : [ "define ","NumbersAndQuantities",": " ]
+                     "value" : [ "","define ","NumbersAndQuantities",": " ]
                   }, {
                      "r" : "42",
                      "s" : [ {
@@ -6269,7 +6465,7 @@ module.exports['Mode'] = {
                "s" : {
                   "r" : "48",
                   "s" : [ {
-                     "value" : [ "define ","IncompatibleUnitsNull",": " ]
+                     "value" : [ "","define ","IncompatibleUnitsNull",": " ]
                   }, {
                      "r" : "47",
                      "s" : [ {
@@ -6339,6 +6535,14 @@ module.exports['Variance'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "38",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -6356,7 +6560,27 @@ module.exports['Variance'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -6380,7 +6604,7 @@ module.exports['Variance'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","v",": " ]
+                     "value" : [ "","define ","v",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -6457,7 +6681,7 @@ module.exports['Variance'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","v_q",": " ]
+                     "value" : [ "","define ","v_q",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -6552,7 +6776,7 @@ module.exports['Variance'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","q_diff_units",": " ]
+                     "value" : [ "","define ","q_diff_units",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -6647,7 +6871,7 @@ module.exports['Variance'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","NumbersAndQuantities",": " ]
+                     "value" : [ "","define ","NumbersAndQuantities",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -6731,7 +6955,7 @@ module.exports['Variance'] = {
                "s" : {
                   "r" : "38",
                   "s" : [ {
-                     "value" : [ "define ","IncompatibleUnitsNull",": " ]
+                     "value" : [ "","define ","IncompatibleUnitsNull",": " ]
                   }, {
                      "r" : "37",
                      "s" : [ {
@@ -6801,6 +7025,14 @@ module.exports['PopulationVariance'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "38",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -6818,7 +7050,27 @@ module.exports['PopulationVariance'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -6842,7 +7094,7 @@ module.exports['PopulationVariance'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","v",": " ]
+                     "value" : [ "","define ","v",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -6903,7 +7155,7 @@ module.exports['PopulationVariance'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","v_q",": " ]
+                     "value" : [ "","define ","v_q",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -6998,7 +7250,7 @@ module.exports['PopulationVariance'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","q_diff_units",": " ]
+                     "value" : [ "","define ","q_diff_units",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -7093,7 +7345,7 @@ module.exports['PopulationVariance'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","NumbersAndQuantities",": " ]
+                     "value" : [ "","define ","NumbersAndQuantities",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -7177,7 +7429,7 @@ module.exports['PopulationVariance'] = {
                "s" : {
                   "r" : "38",
                   "s" : [ {
-                     "value" : [ "define ","IncompatibleUnitsNull",": " ]
+                     "value" : [ "","define ","IncompatibleUnitsNull",": " ]
                   }, {
                      "r" : "37",
                      "s" : [ {
@@ -7248,6 +7500,14 @@ module.exports['StdDev'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "46",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -7265,7 +7525,27 @@ module.exports['StdDev'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -7289,7 +7569,7 @@ module.exports['StdDev'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","std",": " ]
+                     "value" : [ "","define ","std",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -7366,7 +7646,7 @@ module.exports['StdDev'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","std_q",": " ]
+                     "value" : [ "","define ","std_q",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -7461,7 +7741,7 @@ module.exports['StdDev'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","q_diff_units",": " ]
+                     "value" : [ "","define ","q_diff_units",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -7556,7 +7836,7 @@ module.exports['StdDev'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","sq_throw1",": " ]
+                     "value" : [ "","define ","sq_throw1",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -7651,7 +7931,7 @@ module.exports['StdDev'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","NumbersAndQuantities",": " ]
+                     "value" : [ "","define ","NumbersAndQuantities",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -7732,7 +8012,7 @@ module.exports['StdDev'] = {
                "s" : {
                   "r" : "46",
                   "s" : [ {
-                     "value" : [ "define ","IncompatibleUnitsNull",": " ]
+                     "value" : [ "","define ","IncompatibleUnitsNull",": " ]
                   }, {
                      "r" : "45",
                      "s" : [ {
@@ -7802,6 +8082,14 @@ module.exports['PopulationStdDev'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "38",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -7819,7 +8107,27 @@ module.exports['PopulationStdDev'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -7843,7 +8151,7 @@ module.exports['PopulationStdDev'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","dev",": " ]
+                     "value" : [ "","define ","dev",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -7920,7 +8228,7 @@ module.exports['PopulationStdDev'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","dev_q",": " ]
+                     "value" : [ "","define ","dev_q",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -8015,7 +8323,7 @@ module.exports['PopulationStdDev'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","q_diff_units",": " ]
+                     "value" : [ "","define ","q_diff_units",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -8110,7 +8418,7 @@ module.exports['PopulationStdDev'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","NumbersAndQuantities",": " ]
+                     "value" : [ "","define ","NumbersAndQuantities",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -8191,7 +8499,7 @@ module.exports['PopulationStdDev'] = {
                "s" : {
                   "r" : "38",
                   "s" : [ {
-                     "value" : [ "define ","IncompatibleUnitsNull",": " ]
+                     "value" : [ "","define ","IncompatibleUnitsNull",": " ]
                   }, {
                      "r" : "37",
                      "s" : [ {
@@ -8267,6 +8575,14 @@ module.exports['Product'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "79",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -8284,7 +8600,27 @@ module.exports['Product'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -8308,7 +8644,7 @@ module.exports['Product'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","decimal_product",": " ]
+                     "value" : [ "","define ","decimal_product",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -8364,7 +8700,7 @@ module.exports['Product'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","integer_product",": " ]
+                     "value" : [ "","define ","integer_product",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -8415,7 +8751,7 @@ module.exports['Product'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","zero_product",": " ]
+                     "value" : [ "","define ","zero_product",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -8466,7 +8802,7 @@ module.exports['Product'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","quantity_product",": " ]
+                     "value" : [ "","define ","quantity_product",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -8549,7 +8885,7 @@ module.exports['Product'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","quantity_zero_product",": " ]
+                     "value" : [ "","define ","quantity_zero_product",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -8620,7 +8956,7 @@ module.exports['Product'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","product_with_null",": " ]
+                     "value" : [ "","define ","product_with_null",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -8673,7 +9009,7 @@ module.exports['Product'] = {
                "s" : {
                   "r" : "47",
                   "s" : [ {
-                     "value" : [ "define ","product_of_nulls",": " ]
+                     "value" : [ "","define ","product_of_nulls",": " ]
                   }, {
                      "r" : "46",
                      "s" : [ {
@@ -8749,7 +9085,7 @@ module.exports['Product'] = {
                "s" : {
                   "r" : "53",
                   "s" : [ {
-                     "value" : [ "define ","product_null",": " ]
+                     "value" : [ "","define ","product_null",": " ]
                   }, {
                      "r" : "52",
                      "s" : [ {
@@ -8810,7 +9146,7 @@ module.exports['Product'] = {
                "s" : {
                   "r" : "65",
                   "s" : [ {
-                     "value" : [ "define ","product_quantity_null",": " ]
+                     "value" : [ "","define ","product_quantity_null",": " ]
                   }, {
                      "r" : "64",
                      "s" : [ {
@@ -8923,7 +9259,7 @@ module.exports['Product'] = {
                "s" : {
                   "r" : "74",
                   "s" : [ {
-                     "value" : [ "define ","NumbersAndQuantities",": " ]
+                     "value" : [ "","define ","NumbersAndQuantities",": " ]
                   }, {
                      "r" : "73",
                      "s" : [ {
@@ -9027,7 +9363,7 @@ module.exports['Product'] = {
                "s" : {
                   "r" : "79",
                   "s" : [ {
-                     "value" : [ "define ","IncompatibleUnitsNull",": " ]
+                     "value" : [ "","define ","IncompatibleUnitsNull",": " ]
                   }, {
                      "r" : "78",
                      "s" : [ {
@@ -9097,6 +9433,14 @@ module.exports['GeometricMean'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "31",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -9114,7 +9458,27 @@ module.exports['GeometricMean'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -9138,7 +9502,7 @@ module.exports['GeometricMean'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","decimal_geometric_mean",": " ]
+                     "value" : [ "","define ","decimal_geometric_mean",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -9191,7 +9555,7 @@ module.exports['GeometricMean'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","zero_geometric_mean",": " ]
+                     "value" : [ "","define ","zero_geometric_mean",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -9245,7 +9609,7 @@ module.exports['GeometricMean'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","null_geometric_mean",": " ]
+                     "value" : [ "","define ","null_geometric_mean",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -9314,7 +9678,7 @@ module.exports['GeometricMean'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","all_nulls",": " ]
+                     "value" : [ "","define ","all_nulls",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -9376,7 +9740,7 @@ module.exports['GeometricMean'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","also_null_geometric_mean",": " ]
+                     "value" : [ "","define ","also_null_geometric_mean",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -9448,6 +9812,14 @@ module.exports['AllTrue'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "33",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -9465,7 +9837,27 @@ module.exports['AllTrue'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -9489,7 +9881,7 @@ module.exports['AllTrue'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","at",": " ]
+                     "value" : [ "","define ","at",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -9545,7 +9937,7 @@ module.exports['AllTrue'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","atwn",": " ]
+                     "value" : [ "","define ","atwn",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -9615,7 +10007,7 @@ module.exports['AllTrue'] = {
                "s" : {
                   "r" : "24",
                   "s" : [ {
-                     "value" : [ "define ","atf",": " ]
+                     "value" : [ "","define ","atf",": " ]
                   }, {
                      "r" : "23",
                      "s" : [ {
@@ -9671,7 +10063,7 @@ module.exports['AllTrue'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","atfwn",": " ]
+                     "value" : [ "","define ","atfwn",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -9752,6 +10144,14 @@ module.exports['AnyTrue'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "33",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -9769,7 +10169,27 @@ module.exports['AnyTrue'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -9793,7 +10213,7 @@ module.exports['AnyTrue'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","at",": " ]
+                     "value" : [ "","define ","at",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -9849,7 +10269,7 @@ module.exports['AnyTrue'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","atwn",": " ]
+                     "value" : [ "","define ","atwn",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -9919,7 +10339,7 @@ module.exports['AnyTrue'] = {
                "s" : {
                   "r" : "24",
                   "s" : [ {
-                     "value" : [ "define ","atf",": " ]
+                     "value" : [ "","define ","atf",": " ]
                   }, {
                      "r" : "23",
                      "s" : [ {
@@ -9975,7 +10395,7 @@ module.exports['AnyTrue'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","atfwn",": " ]
+                     "value" : [ "","define ","atfwn",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {

--- a/test/elm/arithmetic/data.js
+++ b/test/elm/arithmetic/data.js
@@ -30,6 +30,14 @@ module.exports['Add'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "64",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -47,7 +55,27 @@ module.exports['Add'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -72,7 +100,7 @@ module.exports['Add'] = {
                   "r" : "3",
                   "s" : [ {
                      "r" : "2",
-                     "value" : [ "define ","Ten",": ","10" ]
+                     "value" : [ "","define ","Ten",": ","10" ]
                   } ]
                }
             } ],
@@ -93,7 +121,7 @@ module.exports['Add'] = {
                   "r" : "5",
                   "s" : [ {
                      "r" : "4",
-                     "value" : [ "define ","Eleven",": ","11" ]
+                     "value" : [ "","define ","Eleven",": ","11" ]
                   } ]
                }
             } ],
@@ -113,7 +141,7 @@ module.exports['Add'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","OnePlusTwo",": " ]
+                     "value" : [ "","define ","OnePlusTwo",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -148,7 +176,7 @@ module.exports['Add'] = {
                "s" : {
                   "r" : "29",
                   "s" : [ {
-                     "value" : [ "define ","AddMultiple",": " ]
+                     "value" : [ "","define ","AddMultiple",": " ]
                   }, {
                      "r" : "28",
                      "s" : [ {
@@ -303,7 +331,7 @@ module.exports['Add'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","AddVariables",": " ]
+                     "value" : [ "","define ","AddVariables",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -345,7 +373,7 @@ module.exports['Add'] = {
                "s" : {
                   "r" : "38",
                   "s" : [ {
-                     "value" : [ "define ","AddTime",": " ]
+                     "value" : [ "","define ","AddTime",": " ]
                   }, {
                      "r" : "37",
                      "s" : [ {
@@ -394,7 +422,7 @@ module.exports['Add'] = {
                "s" : {
                   "r" : "45",
                   "s" : [ {
-                     "value" : [ "define ","UncertaintyZeroToTwelve",": " ]
+                     "value" : [ "","define ","UncertaintyZeroToTwelve",": " ]
                   }, {
                      "r" : "44",
                      "s" : [ {
@@ -457,7 +485,7 @@ module.exports['Add'] = {
                "s" : {
                   "r" : "52",
                   "s" : [ {
-                     "value" : [ "define ","UncertaintySixToEighteen",": " ]
+                     "value" : [ "","define ","UncertaintySixToEighteen",": " ]
                   }, {
                      "r" : "51",
                      "s" : [ {
@@ -520,7 +548,7 @@ module.exports['Add'] = {
                "s" : {
                   "r" : "56",
                   "s" : [ {
-                     "value" : [ "define ","AddUncertainties",": " ]
+                     "value" : [ "","define ","AddUncertainties",": " ]
                   }, {
                      "r" : "55",
                      "s" : [ {
@@ -562,7 +590,7 @@ module.exports['Add'] = {
                "s" : {
                   "r" : "60",
                   "s" : [ {
-                     "value" : [ "define ","AddUncertaintyAndNumber",": " ]
+                     "value" : [ "","define ","AddUncertaintyAndNumber",": " ]
                   }, {
                      "r" : "59",
                      "s" : [ {
@@ -601,7 +629,7 @@ module.exports['Add'] = {
                "s" : {
                   "r" : "64",
                   "s" : [ {
-                     "value" : [ "define ","AddNumberAndUncertainty",": " ]
+                     "value" : [ "","define ","AddNumberAndUncertainty",": " ]
                   }, {
                      "r" : "63",
                      "s" : [ {
@@ -656,6 +684,14 @@ module.exports['Subtract'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "47",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -673,7 +709,27 @@ module.exports['Subtract'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -698,7 +754,7 @@ module.exports['Subtract'] = {
                   "r" : "3",
                   "s" : [ {
                      "r" : "2",
-                     "value" : [ "define ","Ten",": ","10" ]
+                     "value" : [ "","define ","Ten",": ","10" ]
                   } ]
                }
             } ],
@@ -719,7 +775,7 @@ module.exports['Subtract'] = {
                   "r" : "5",
                   "s" : [ {
                      "r" : "4",
-                     "value" : [ "define ","Eleven",": ","11" ]
+                     "value" : [ "","define ","Eleven",": ","11" ]
                   } ]
                }
             } ],
@@ -739,7 +795,7 @@ module.exports['Subtract'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","FiveMinusTwo",": " ]
+                     "value" : [ "","define ","FiveMinusTwo",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -774,7 +830,7 @@ module.exports['Subtract'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","SubtractMultiple",": " ]
+                     "value" : [ "","define ","SubtractMultiple",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -839,7 +895,7 @@ module.exports['Subtract'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","SubtractVariables",": " ]
+                     "value" : [ "","define ","SubtractVariables",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -881,7 +937,7 @@ module.exports['Subtract'] = {
                "s" : {
                   "r" : "28",
                   "s" : [ {
-                     "value" : [ "define ","UncertaintyZeroToTwelve",": " ]
+                     "value" : [ "","define ","UncertaintyZeroToTwelve",": " ]
                   }, {
                      "r" : "27",
                      "s" : [ {
@@ -944,7 +1000,7 @@ module.exports['Subtract'] = {
                "s" : {
                   "r" : "35",
                   "s" : [ {
-                     "value" : [ "define ","UncertaintySixToEighteen",": " ]
+                     "value" : [ "","define ","UncertaintySixToEighteen",": " ]
                   }, {
                      "r" : "34",
                      "s" : [ {
@@ -1007,7 +1063,7 @@ module.exports['Subtract'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","SubtractUncertainties",": " ]
+                     "value" : [ "","define ","SubtractUncertainties",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -1049,7 +1105,7 @@ module.exports['Subtract'] = {
                "s" : {
                   "r" : "43",
                   "s" : [ {
-                     "value" : [ "define ","SubtractNumberFromUncertainty",": " ]
+                     "value" : [ "","define ","SubtractNumberFromUncertainty",": " ]
                   }, {
                      "r" : "42",
                      "s" : [ {
@@ -1088,7 +1144,7 @@ module.exports['Subtract'] = {
                "s" : {
                   "r" : "47",
                   "s" : [ {
-                     "value" : [ "define ","SubtractUncertaintyFromNumber",": " ]
+                     "value" : [ "","define ","SubtractUncertaintyFromNumber",": " ]
                   }, {
                      "r" : "46",
                      "s" : [ {
@@ -1143,6 +1199,14 @@ module.exports['Multiply'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "49",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1160,7 +1224,27 @@ module.exports['Multiply'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1185,7 +1269,7 @@ module.exports['Multiply'] = {
                   "r" : "3",
                   "s" : [ {
                      "r" : "2",
-                     "value" : [ "define ","Ten",": ","10" ]
+                     "value" : [ "","define ","Ten",": ","10" ]
                   } ]
                }
             } ],
@@ -1206,7 +1290,7 @@ module.exports['Multiply'] = {
                   "r" : "5",
                   "s" : [ {
                      "r" : "4",
-                     "value" : [ "define ","Eleven",": ","11" ]
+                     "value" : [ "","define ","Eleven",": ","11" ]
                   } ]
                }
             } ],
@@ -1226,7 +1310,7 @@ module.exports['Multiply'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","FiveTimesTwo",": " ]
+                     "value" : [ "","define ","FiveTimesTwo",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -1261,7 +1345,7 @@ module.exports['Multiply'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","MultiplyMultiple",": " ]
+                     "value" : [ "","define ","MultiplyMultiple",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -1341,7 +1425,7 @@ module.exports['Multiply'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","MultiplyVariables",": " ]
+                     "value" : [ "","define ","MultiplyVariables",": " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -1383,7 +1467,7 @@ module.exports['Multiply'] = {
                "s" : {
                   "r" : "30",
                   "s" : [ {
-                     "value" : [ "define ","UncertaintyTwoToFourteen",": " ]
+                     "value" : [ "","define ","UncertaintyTwoToFourteen",": " ]
                   }, {
                      "r" : "29",
                      "s" : [ {
@@ -1446,7 +1530,7 @@ module.exports['Multiply'] = {
                "s" : {
                   "r" : "37",
                   "s" : [ {
-                     "value" : [ "define ","UncertaintySixToEighteen",": " ]
+                     "value" : [ "","define ","UncertaintySixToEighteen",": " ]
                   }, {
                      "r" : "36",
                      "s" : [ {
@@ -1509,7 +1593,7 @@ module.exports['Multiply'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","MultiplyUncertainties",": " ]
+                     "value" : [ "","define ","MultiplyUncertainties",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -1551,7 +1635,7 @@ module.exports['Multiply'] = {
                "s" : {
                   "r" : "45",
                   "s" : [ {
-                     "value" : [ "define ","MultiplyUncertaintyAndNumber",": " ]
+                     "value" : [ "","define ","MultiplyUncertaintyAndNumber",": " ]
                   }, {
                      "r" : "44",
                      "s" : [ {
@@ -1590,7 +1674,7 @@ module.exports['Multiply'] = {
                "s" : {
                   "r" : "49",
                   "s" : [ {
-                     "value" : [ "define ","MultiplyNumberAndUncertainty",": " ]
+                     "value" : [ "","define ","MultiplyNumberAndUncertainty",": " ]
                   }, {
                      "r" : "48",
                      "s" : [ {
@@ -1646,6 +1730,14 @@ module.exports['Divide'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "51",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1663,7 +1755,27 @@ module.exports['Divide'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1688,7 +1800,7 @@ module.exports['Divide'] = {
                   "r" : "3",
                   "s" : [ {
                      "r" : "2",
-                     "value" : [ "define ","Hundred",": ","100" ]
+                     "value" : [ "","define ","Hundred",": ","100" ]
                   } ]
                }
             } ],
@@ -1709,7 +1821,7 @@ module.exports['Divide'] = {
                   "r" : "5",
                   "s" : [ {
                      "r" : "4",
-                     "value" : [ "define ","Four",": ","4" ]
+                     "value" : [ "","define ","Four",": ","4" ]
                   } ]
                }
             } ],
@@ -1729,7 +1841,7 @@ module.exports['Divide'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","TenDividedByTwo",": " ]
+                     "value" : [ "","define ","TenDividedByTwo",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -1770,7 +1882,7 @@ module.exports['Divide'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","TenDividedByFour",": " ]
+                     "value" : [ "","define ","TenDividedByFour",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -1811,7 +1923,7 @@ module.exports['Divide'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","DivideMultiple",": " ]
+                     "value" : [ "","define ","DivideMultiple",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -1888,7 +2000,7 @@ module.exports['Divide'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","DivideVariables",": " ]
+                     "value" : [ "","define ","DivideVariables",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -1936,7 +2048,7 @@ module.exports['Divide'] = {
                "s" : {
                   "r" : "32",
                   "s" : [ {
-                     "value" : [ "define ","UncertaintyTwoToFourteen",": " ]
+                     "value" : [ "","define ","UncertaintyTwoToFourteen",": " ]
                   }, {
                      "r" : "31",
                      "s" : [ {
@@ -1999,7 +2111,7 @@ module.exports['Divide'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","UncertaintySixToEighteen",": " ]
+                     "value" : [ "","define ","UncertaintySixToEighteen",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -2062,7 +2174,7 @@ module.exports['Divide'] = {
                "s" : {
                   "r" : "43",
                   "s" : [ {
-                     "value" : [ "define ","DivideUncertainties",": " ]
+                     "value" : [ "","define ","DivideUncertainties",": " ]
                   }, {
                      "r" : "42",
                      "s" : [ {
@@ -2110,7 +2222,7 @@ module.exports['Divide'] = {
                "s" : {
                   "r" : "47",
                   "s" : [ {
-                     "value" : [ "define ","DivideUncertaintyByNumber",": " ]
+                     "value" : [ "","define ","DivideUncertaintyByNumber",": " ]
                   }, {
                      "r" : "46",
                      "s" : [ {
@@ -2155,7 +2267,7 @@ module.exports['Divide'] = {
                "s" : {
                   "r" : "51",
                   "s" : [ {
-                     "value" : [ "define ","DivideNumberByUncertainty",": " ]
+                     "value" : [ "","define ","DivideNumberByUncertainty",": " ]
                   }, {
                      "r" : "50",
                      "s" : [ {
@@ -2207,6 +2319,14 @@ module.exports['Negate'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "4",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2224,7 +2344,27 @@ module.exports['Negate'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2248,7 +2388,7 @@ module.exports['Negate'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","NegativeOne",": " ]
+                     "value" : [ "","define ","NegativeOne",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -2286,6 +2426,14 @@ module.exports['MathPrecedence'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "21",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2303,7 +2451,27 @@ module.exports['MathPrecedence'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2327,7 +2495,7 @@ module.exports['MathPrecedence'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","Mixed",": " ]
+                     "value" : [ "","define ","Mixed",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -2415,7 +2583,7 @@ module.exports['MathPrecedence'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","Parenthetical",": " ]
+                     "value" : [ "","define ","Parenthetical",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -2521,6 +2689,14 @@ module.exports['Power'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "5",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2538,7 +2714,27 @@ module.exports['Power'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2562,7 +2758,7 @@ module.exports['Power'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","Pow",": " ]
+                     "value" : [ "","define ","Pow",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -2608,6 +2804,14 @@ module.exports['MinValue'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "16",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2625,7 +2829,27 @@ module.exports['MinValue'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2649,7 +2873,7 @@ module.exports['MinValue'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","MinInteger",": " ]
+                     "value" : [ "","define ","MinInteger",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -2678,7 +2902,7 @@ module.exports['MinValue'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","MinDecimal",": " ]
+                     "value" : [ "","define ","MinDecimal",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -2707,7 +2931,7 @@ module.exports['MinValue'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","MinDateTime",": " ]
+                     "value" : [ "","define ","MinDateTime",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -2736,7 +2960,7 @@ module.exports['MinValue'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","MinTime",": " ]
+                     "value" : [ "","define ","MinTime",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -2765,7 +2989,7 @@ module.exports['MinValue'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","MinWrongType",": " ]
+                     "value" : [ "","define ","MinWrongType",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -2805,6 +3029,14 @@ module.exports['MaxValue'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "16",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2822,7 +3054,27 @@ module.exports['MaxValue'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2846,7 +3098,7 @@ module.exports['MaxValue'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","MaxInteger",": " ]
+                     "value" : [ "","define ","MaxInteger",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -2875,7 +3127,7 @@ module.exports['MaxValue'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","MaxDecimal",": " ]
+                     "value" : [ "","define ","MaxDecimal",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -2904,7 +3156,7 @@ module.exports['MaxValue'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","MaxDateTime",": " ]
+                     "value" : [ "","define ","MaxDateTime",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -2933,7 +3185,7 @@ module.exports['MaxValue'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","MaxTime",": " ]
+                     "value" : [ "","define ","MaxTime",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -2962,7 +3214,7 @@ module.exports['MaxValue'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","MaxWrongType",": " ]
+                     "value" : [ "","define ","MaxWrongType",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -2999,6 +3251,14 @@ module.exports['TruncatedDivide'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "9",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3016,7 +3276,27 @@ module.exports['TruncatedDivide'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3040,7 +3320,7 @@ module.exports['TruncatedDivide'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","Trunc",": " ]
+                     "value" : [ "","define ","Trunc",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -3075,7 +3355,7 @@ module.exports['TruncatedDivide'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","Even",": " ]
+                     "value" : [ "","define ","Even",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -3117,6 +3397,14 @@ module.exports['Modulo'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "5",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3134,7 +3422,27 @@ module.exports['Modulo'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3158,7 +3466,7 @@ module.exports['Modulo'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","Mod",": " ]
+                     "value" : [ "","define ","Mod",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -3201,6 +3509,14 @@ module.exports['Ceiling'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "7",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3218,7 +3534,27 @@ module.exports['Ceiling'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3242,7 +3578,7 @@ module.exports['Ceiling'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","Ceil",": " ]
+                     "value" : [ "","define ","Ceil",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -3272,7 +3608,7 @@ module.exports['Ceiling'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","Even",": " ]
+                     "value" : [ "","define ","Even",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -3313,6 +3649,14 @@ module.exports['Floor'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "7",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3330,7 +3674,27 @@ module.exports['Floor'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3354,7 +3718,7 @@ module.exports['Floor'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","flr",": " ]
+                     "value" : [ "","define ","flr",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -3384,7 +3748,7 @@ module.exports['Floor'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","Even",": " ]
+                     "value" : [ "","define ","Even",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -3425,6 +3789,14 @@ module.exports['Truncate'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "7",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3442,7 +3814,27 @@ module.exports['Truncate'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3466,7 +3858,7 @@ module.exports['Truncate'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","Trunc",": " ]
+                     "value" : [ "","define ","Trunc",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -3496,7 +3888,7 @@ module.exports['Truncate'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","Even",": " ]
+                     "value" : [ "","define ","Even",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -3538,6 +3930,14 @@ module.exports['Abs'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "11",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3555,7 +3955,27 @@ module.exports['Abs'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3579,7 +3999,7 @@ module.exports['Abs'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","Pos",": " ]
+                     "value" : [ "","define ","Pos",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -3609,7 +4029,7 @@ module.exports['Abs'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","Neg",": " ]
+                     "value" : [ "","define ","Neg",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -3650,7 +4070,7 @@ module.exports['Abs'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","Zero",": " ]
+                     "value" : [ "","define ","Zero",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -3690,6 +4110,14 @@ module.exports['Round'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "15",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3707,7 +4135,27 @@ module.exports['Round'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3731,7 +4179,7 @@ module.exports['Round'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","Up",": " ]
+                     "value" : [ "","define ","Up",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -3761,7 +4209,7 @@ module.exports['Round'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","Up_percent",": " ]
+                     "value" : [ "","define ","Up_percent",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -3797,7 +4245,7 @@ module.exports['Round'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","Down",": " ]
+                     "value" : [ "","define ","Down",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -3827,7 +4275,7 @@ module.exports['Round'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","Down_percent",": " ]
+                     "value" : [ "","define ","Down_percent",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -3870,6 +4318,14 @@ module.exports['Ln'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "4",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3887,7 +4343,27 @@ module.exports['Ln'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3911,7 +4387,7 @@ module.exports['Ln'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","ln",": " ]
+                     "value" : [ "","define ","ln",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -3951,6 +4427,14 @@ module.exports['Log'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "5",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3968,7 +4452,27 @@ module.exports['Log'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3992,7 +4496,7 @@ module.exports['Log'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","log",": " ]
+                     "value" : [ "","define ","log",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -4050,6 +4554,14 @@ module.exports['Successor'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "69",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -4067,7 +4579,27 @@ module.exports['Successor'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -4091,7 +4623,7 @@ module.exports['Successor'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","Is",": " ]
+                     "value" : [ "","define ","Is",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -4121,7 +4653,7 @@ module.exports['Successor'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","Rs",": " ]
+                     "value" : [ "","define ","Rs",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -4151,7 +4683,7 @@ module.exports['Successor'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","ofr",": " ]
+                     "value" : [ "","define ","ofr",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -4181,7 +4713,7 @@ module.exports['Successor'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","y_date",": " ]
+                     "value" : [ "","define ","y_date",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -4220,7 +4752,7 @@ module.exports['Successor'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","ym_date",": " ]
+                     "value" : [ "","define ","ym_date",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -4265,7 +4797,7 @@ module.exports['Successor'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","ymd_date",": " ]
+                     "value" : [ "","define ","ymd_date",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -4316,7 +4848,7 @@ module.exports['Successor'] = {
                "s" : {
                   "r" : "32",
                   "s" : [ {
-                     "value" : [ "define ","ymdh_date",": " ]
+                     "value" : [ "","define ","ymdh_date",": " ]
                   }, {
                      "r" : "31",
                      "s" : [ {
@@ -4373,7 +4905,7 @@ module.exports['Successor'] = {
                "s" : {
                   "r" : "40",
                   "s" : [ {
-                     "value" : [ "define ","ymdhm_date",": " ]
+                     "value" : [ "","define ","ymdhm_date",": " ]
                   }, {
                      "r" : "39",
                      "s" : [ {
@@ -4436,7 +4968,7 @@ module.exports['Successor'] = {
                "s" : {
                   "r" : "49",
                   "s" : [ {
-                     "value" : [ "define ","ymdhms_date",": " ]
+                     "value" : [ "","define ","ymdhms_date",": " ]
                   }, {
                      "r" : "48",
                      "s" : [ {
@@ -4505,7 +5037,7 @@ module.exports['Successor'] = {
                "s" : {
                   "r" : "59",
                   "s" : [ {
-                     "value" : [ "define ","ymdhmsm_date",": " ]
+                     "value" : [ "","define ","ymdhmsm_date",": " ]
                   }, {
                      "r" : "58",
                      "s" : [ {
@@ -4580,7 +5112,7 @@ module.exports['Successor'] = {
                "s" : {
                   "r" : "69",
                   "s" : [ {
-                     "value" : [ "define ","max_date",": " ]
+                     "value" : [ "","define ","max_date",": " ]
                   }, {
                      "r" : "68",
                      "s" : [ {
@@ -4672,6 +5204,14 @@ module.exports['Predecessor'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "70",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -4689,7 +5229,27 @@ module.exports['Predecessor'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -4713,7 +5273,7 @@ module.exports['Predecessor'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","Is",": " ]
+                     "value" : [ "","define ","Is",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -4743,7 +5303,7 @@ module.exports['Predecessor'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","Rs",": " ]
+                     "value" : [ "","define ","Rs",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -4773,7 +5333,7 @@ module.exports['Predecessor'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","ufr",": " ]
+                     "value" : [ "","define ","ufr",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -4812,7 +5372,7 @@ module.exports['Predecessor'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","y_date",": " ]
+                     "value" : [ "","define ","y_date",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -4851,7 +5411,7 @@ module.exports['Predecessor'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","ym_date",": " ]
+                     "value" : [ "","define ","ym_date",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -4896,7 +5456,7 @@ module.exports['Predecessor'] = {
                "s" : {
                   "r" : "26",
                   "s" : [ {
-                     "value" : [ "define ","ymd_date",": " ]
+                     "value" : [ "","define ","ymd_date",": " ]
                   }, {
                      "r" : "25",
                      "s" : [ {
@@ -4947,7 +5507,7 @@ module.exports['Predecessor'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","ymdh_date",": " ]
+                     "value" : [ "","define ","ymdh_date",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -5004,7 +5564,7 @@ module.exports['Predecessor'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","ymdhm_date",": " ]
+                     "value" : [ "","define ","ymdhm_date",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -5067,7 +5627,7 @@ module.exports['Predecessor'] = {
                "s" : {
                   "r" : "50",
                   "s" : [ {
-                     "value" : [ "define ","ymdhms_date",": " ]
+                     "value" : [ "","define ","ymdhms_date",": " ]
                   }, {
                      "r" : "49",
                      "s" : [ {
@@ -5136,7 +5696,7 @@ module.exports['Predecessor'] = {
                "s" : {
                   "r" : "60",
                   "s" : [ {
-                     "value" : [ "define ","ymdhmsm_date",": " ]
+                     "value" : [ "","define ","ymdhmsm_date",": " ]
                   }, {
                      "r" : "59",
                      "s" : [ {
@@ -5211,7 +5771,7 @@ module.exports['Predecessor'] = {
                "s" : {
                   "r" : "70",
                   "s" : [ {
-                     "value" : [ "define ","min_date",": " ]
+                     "value" : [ "","define ","min_date",": " ]
                   }, {
                      "r" : "69",
                      "s" : [ {
@@ -5315,6 +5875,14 @@ module.exports['Quantity'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "94",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -5332,7 +5900,27 @@ module.exports['Quantity'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -5356,7 +5944,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "3",
                   "s" : [ {
-                     "value" : [ "define ","days_10",": " ]
+                     "value" : [ "","define ","days_10",": " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -5381,7 +5969,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","QL10Days",": " ]
+                     "value" : [ "","define ","QL10Days",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -5443,7 +6031,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","QL10Min"," : " ]
+                     "value" : [ "","define ","QL10Min"," : " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -5505,7 +6093,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","Jan1_2000",": " ]
+                     "value" : [ "","define ","Jan1_2000",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -5547,7 +6135,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","add_q_q"," : " ]
+                     "value" : [ "","define ","add_q_q"," : " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -5589,7 +6177,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "24",
                   "s" : [ {
-                     "value" : [ "define ","add_d_q"," : " ]
+                     "value" : [ "","define ","add_d_q"," : " ]
                   }, {
                      "r" : "23",
                      "s" : [ {
@@ -5631,7 +6219,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "28",
                   "s" : [ {
-                     "value" : [ "define ","sub_q_q"," : " ]
+                     "value" : [ "","define ","sub_q_q"," : " ]
                   }, {
                      "r" : "27",
                      "s" : [ {
@@ -5673,7 +6261,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "32",
                   "s" : [ {
-                     "value" : [ "define ","sub_d_q"," : " ]
+                     "value" : [ "","define ","sub_d_q"," : " ]
                   }, {
                      "r" : "31",
                      "s" : [ {
@@ -5715,7 +6303,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "36",
                   "s" : [ {
-                     "value" : [ "define ","add_q_q_diff"," : " ]
+                     "value" : [ "","define ","add_q_q_diff"," : " ]
                   }, {
                      "r" : "35",
                      "s" : [ {
@@ -5757,7 +6345,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "40",
                   "s" : [ {
-                     "value" : [ "define ","sub_q_q_diff"," : " ]
+                     "value" : [ "","define ","sub_q_q_diff"," : " ]
                   }, {
                      "r" : "39",
                      "s" : [ {
@@ -5799,7 +6387,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "44",
                   "s" : [ {
-                     "value" : [ "define ","div_q_d"," : " ]
+                     "value" : [ "","define ","div_q_d"," : " ]
                   }, {
                      "r" : "43",
                      "s" : [ {
@@ -5841,7 +6429,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "48",
                   "s" : [ {
-                     "value" : [ "define ","div_q_q"," : " ]
+                     "value" : [ "","define ","div_q_q"," : " ]
                   }, {
                      "r" : "47",
                      "s" : [ {
@@ -5883,7 +6471,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "52",
                   "s" : [ {
-                     "value" : [ "define ","mul_q_d"," : " ]
+                     "value" : [ "","define ","mul_q_d"," : " ]
                   }, {
                      "r" : "51",
                      "s" : [ {
@@ -5925,7 +6513,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "56",
                   "s" : [ {
-                     "value" : [ "define ","mul_d_q"," : " ]
+                     "value" : [ "","define ","mul_d_q"," : " ]
                   }, {
                      "r" : "55",
                      "s" : [ {
@@ -5967,7 +6555,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "60",
                   "s" : [ {
-                     "value" : [ "define ","mul_q_q"," : " ]
+                     "value" : [ "","define ","mul_q_q"," : " ]
                   }, {
                      "r" : "59",
                      "s" : [ {
@@ -6011,7 +6599,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "64",
                   "s" : [ {
-                     "value" : [ "define ","mul_q_q_diff"," : " ]
+                     "value" : [ "","define ","mul_q_q_diff"," : " ]
                   }, {
                      "r" : "63",
                      "s" : [ {
@@ -6055,7 +6643,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "67",
                   "s" : [ {
-                     "value" : [ "define ","neg"," : " ]
+                     "value" : [ "","define ","neg"," : " ]
                   }, {
                      "r" : "66",
                      "s" : [ {
@@ -6088,7 +6676,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "70",
                   "s" : [ {
-                     "value" : [ "define ","abs"," : " ]
+                     "value" : [ "","define ","abs"," : " ]
                   }, {
                      "r" : "69",
                      "s" : [ {
@@ -6123,7 +6711,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "76",
                   "s" : [ {
-                     "value" : [ "define ","MultiplyUcum",": " ]
+                     "value" : [ "","define ","MultiplyUcum",": " ]
                   }, {
                      "r" : "75",
                      "s" : [ {
@@ -6193,7 +6781,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "82",
                   "s" : [ {
-                     "value" : [ "define ","DivideUcum",": " ]
+                     "value" : [ "","define ","DivideUcum",": " ]
                   }, {
                      "r" : "81",
                      "s" : [ {
@@ -6263,7 +6851,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "88",
                   "s" : [ {
-                     "value" : [ "define ","AddUcum",": " ]
+                     "value" : [ "","define ","AddUcum",": " ]
                   }, {
                      "r" : "87",
                      "s" : [ {
@@ -6333,7 +6921,7 @@ module.exports['Quantity'] = {
                "s" : {
                   "r" : "94",
                   "s" : [ {
-                     "value" : [ "define ","SubtractUcum",": " ]
+                     "value" : [ "","define ","SubtractUcum",": " ]
                   }, {
                      "r" : "93",
                      "s" : [ {
@@ -6473,6 +7061,14 @@ module.exports['OutOfBounds'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "282",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -6490,7 +7086,27 @@ module.exports['OutOfBounds'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -6514,7 +7130,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define ","IntegerAddOverflow",": " ]
+                     "value" : [ "","define ","IntegerAddOverflow",": " ]
                   }, {
                      "r" : "5",
                      "s" : [ {
@@ -6558,7 +7174,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","IntegerAddUnderflow",": " ]
+                     "value" : [ "","define ","IntegerAddUnderflow",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -6611,7 +7227,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "18",
                   "s" : [ {
-                     "value" : [ "define ","IntegerSubtractOverflow",": " ]
+                     "value" : [ "","define ","IntegerSubtractOverflow",": " ]
                   }, {
                      "r" : "17",
                      "s" : [ {
@@ -6664,7 +7280,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","IntegerSubtractUnderflow",": " ]
+                     "value" : [ "","define ","IntegerSubtractUnderflow",": " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -6708,7 +7324,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "28",
                   "s" : [ {
-                     "value" : [ "define ","IntegerMultiplyOverflow",": " ]
+                     "value" : [ "","define ","IntegerMultiplyOverflow",": " ]
                   }, {
                      "r" : "27",
                      "s" : [ {
@@ -6752,7 +7368,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","IntegerMultiplyUnderflow",": " ]
+                     "value" : [ "","define ","IntegerMultiplyUnderflow",": " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -6805,7 +7421,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","IntegerDivideOverflow",": " ]
+                     "value" : [ "","define ","IntegerDivideOverflow",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -6857,7 +7473,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "45",
                   "s" : [ {
-                     "value" : [ "define ","IntegerDivideUnderflow",": " ]
+                     "value" : [ "","define ","IntegerDivideUnderflow",": " ]
                   }, {
                      "r" : "44",
                      "s" : [ {
@@ -6920,7 +7536,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "49",
                   "s" : [ {
-                     "value" : [ "define ","IntegerDivideByZero",": " ]
+                     "value" : [ "","define ","IntegerDivideByZero",": " ]
                   }, {
                      "r" : "48",
                      "s" : [ {
@@ -6961,7 +7577,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "54",
                   "s" : [ {
-                     "value" : [ "define ","IntegerPowerOverflow",": " ]
+                     "value" : [ "","define ","IntegerPowerOverflow",": " ]
                   }, {
                      "r" : "53",
                      "s" : [ {
@@ -7012,7 +7628,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "59",
                   "s" : [ {
-                     "value" : [ "define ","IntegerPowerUnderflow",": " ]
+                     "value" : [ "","define ","IntegerPowerUnderflow",": " ]
                   }, {
                      "r" : "58",
                      "s" : [ {
@@ -7063,7 +7679,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "63",
                   "s" : [ {
-                     "value" : [ "define ","IntegerSuccessorOverflow",": " ]
+                     "value" : [ "","define ","IntegerSuccessorOverflow",": " ]
                   }, {
                      "r" : "62",
                      "s" : [ {
@@ -7101,7 +7717,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "67",
                   "s" : [ {
-                     "value" : [ "define ","IntegerPredecessorUnderflow",": " ]
+                     "value" : [ "","define ","IntegerPredecessorUnderflow",": " ]
                   }, {
                      "r" : "66",
                      "s" : [ {
@@ -7139,7 +7755,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "72",
                   "s" : [ {
-                     "value" : [ "define ","DecimalAddOverflow",": " ]
+                     "value" : [ "","define ","DecimalAddOverflow",": " ]
                   }, {
                      "r" : "71",
                      "s" : [ {
@@ -7183,7 +7799,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "78",
                   "s" : [ {
-                     "value" : [ "define ","DecimalAddUnderflow",": " ]
+                     "value" : [ "","define ","DecimalAddUnderflow",": " ]
                   }, {
                      "r" : "77",
                      "s" : [ {
@@ -7236,7 +7852,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "84",
                   "s" : [ {
-                     "value" : [ "define ","DecimalSubtractOverflow",": " ]
+                     "value" : [ "","define ","DecimalSubtractOverflow",": " ]
                   }, {
                      "r" : "83",
                      "s" : [ {
@@ -7289,7 +7905,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "89",
                   "s" : [ {
-                     "value" : [ "define ","DecimalSubtractUnderflow",": " ]
+                     "value" : [ "","define ","DecimalSubtractUnderflow",": " ]
                   }, {
                      "r" : "88",
                      "s" : [ {
@@ -7333,7 +7949,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "94",
                   "s" : [ {
-                     "value" : [ "define ","DecimalMultiplyOverflow",": " ]
+                     "value" : [ "","define ","DecimalMultiplyOverflow",": " ]
                   }, {
                      "r" : "93",
                      "s" : [ {
@@ -7380,7 +7996,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "100",
                   "s" : [ {
-                     "value" : [ "define ","DecimalMultiplyUnderflow",": " ]
+                     "value" : [ "","define ","DecimalMultiplyUnderflow",": " ]
                   }, {
                      "r" : "99",
                      "s" : [ {
@@ -7436,7 +8052,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "105",
                   "s" : [ {
-                     "value" : [ "define ","DecimalDivideOverflow",": " ]
+                     "value" : [ "","define ","DecimalDivideOverflow",": " ]
                   }, {
                      "r" : "104",
                      "s" : [ {
@@ -7485,7 +8101,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "111",
                   "s" : [ {
-                     "value" : [ "define ","DecimalDivideUnderflow",": " ]
+                     "value" : [ "","define ","DecimalDivideUnderflow",": " ]
                   }, {
                      "r" : "110",
                      "s" : [ {
@@ -7545,7 +8161,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "115",
                   "s" : [ {
-                     "value" : [ "define ","DecimalDivideByZero",": " ]
+                     "value" : [ "","define ","DecimalDivideByZero",": " ]
                   }, {
                      "r" : "114",
                      "s" : [ {
@@ -7583,7 +8199,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "120",
                   "s" : [ {
-                     "value" : [ "define ","DecimalPowerOverflow",": " ]
+                     "value" : [ "","define ","DecimalPowerOverflow",": " ]
                   }, {
                      "r" : "119",
                      "s" : [ {
@@ -7637,7 +8253,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "125",
                   "s" : [ {
-                     "value" : [ "define ","DecimalPowerUnderflow",": " ]
+                     "value" : [ "","define ","DecimalPowerUnderflow",": " ]
                   }, {
                      "r" : "124",
                      "s" : [ {
@@ -7691,7 +8307,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "129",
                   "s" : [ {
-                     "value" : [ "define ","DecimalSuccessorOverflow",": " ]
+                     "value" : [ "","define ","DecimalSuccessorOverflow",": " ]
                   }, {
                      "r" : "128",
                      "s" : [ {
@@ -7729,7 +8345,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "133",
                   "s" : [ {
-                     "value" : [ "define ","DecimalPredecessorUnderflow",": " ]
+                     "value" : [ "","define ","DecimalPredecessorUnderflow",": " ]
                   }, {
                      "r" : "132",
                      "s" : [ {
@@ -7767,7 +8383,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "138",
                   "s" : [ {
-                     "value" : [ "define ","MaxQuantity",": " ]
+                     "value" : [ "","define ","MaxQuantity",": " ]
                   }, {
                      "r" : "137",
                      "s" : [ {
@@ -7834,7 +8450,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "143",
                   "s" : [ {
-                     "value" : [ "define ","MinQuantity",": " ]
+                     "value" : [ "","define ","MinQuantity",": " ]
                   }, {
                      "r" : "142",
                      "s" : [ {
@@ -7901,7 +8517,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "147",
                   "s" : [ {
-                     "value" : [ "define ","QuantityAddOverflow",": " ]
+                     "value" : [ "","define ","QuantityAddOverflow",": " ]
                   }, {
                      "r" : "146",
                      "s" : [ {
@@ -7944,7 +8560,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "152",
                   "s" : [ {
-                     "value" : [ "define ","QuantityAddUnderflow",": " ]
+                     "value" : [ "","define ","QuantityAddUnderflow",": " ]
                   }, {
                      "r" : "151",
                      "s" : [ {
@@ -8003,7 +8619,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "157",
                   "s" : [ {
-                     "value" : [ "define ","QuantitySubtractOverflow",": " ]
+                     "value" : [ "","define ","QuantitySubtractOverflow",": " ]
                   }, {
                      "r" : "156",
                      "s" : [ {
@@ -8062,7 +8678,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "161",
                   "s" : [ {
-                     "value" : [ "define ","QuantitySubtractUnderflow",": " ]
+                     "value" : [ "","define ","QuantitySubtractUnderflow",": " ]
                   }, {
                      "r" : "160",
                      "s" : [ {
@@ -8105,7 +8721,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "165",
                   "s" : [ {
-                     "value" : [ "define ","QuantityMultiplyOverflow",": " ]
+                     "value" : [ "","define ","QuantityMultiplyOverflow",": " ]
                   }, {
                      "r" : "164",
                      "s" : [ {
@@ -8148,7 +8764,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "169",
                   "s" : [ {
-                     "value" : [ "define ","QuantityMultiplyUnderflow",": " ]
+                     "value" : [ "","define ","QuantityMultiplyUnderflow",": " ]
                   }, {
                      "r" : "168",
                      "s" : [ {
@@ -8191,7 +8807,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "173",
                   "s" : [ {
-                     "value" : [ "define ","QuantityDivideOverflow",": " ]
+                     "value" : [ "","define ","QuantityDivideOverflow",": " ]
                   }, {
                      "r" : "172",
                      "s" : [ {
@@ -8234,7 +8850,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "178",
                   "s" : [ {
-                     "value" : [ "define ","QuantityDivideUnderflow",": " ]
+                     "value" : [ "","define ","QuantityDivideUnderflow",": " ]
                   }, {
                      "r" : "177",
                      "s" : [ {
@@ -8293,7 +8909,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "182",
                   "s" : [ {
-                     "value" : [ "define ","QuantityDivideByZero",": " ]
+                     "value" : [ "","define ","QuantityDivideByZero",": " ]
                   }, {
                      "r" : "181",
                      "s" : [ {
@@ -8337,7 +8953,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "185",
                   "s" : [ {
-                     "value" : [ "define ","QuantitySuccessorOverflow",": " ]
+                     "value" : [ "","define ","QuantitySuccessorOverflow",": " ]
                   }, {
                      "r" : "184",
                      "s" : [ {
@@ -8370,7 +8986,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "188",
                   "s" : [ {
-                     "value" : [ "define ","QuantityPredecessorUnderflow",": " ]
+                     "value" : [ "","define ","QuantityPredecessorUnderflow",": " ]
                   }, {
                      "r" : "187",
                      "s" : [ {
@@ -8403,7 +9019,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "193",
                   "s" : [ {
-                     "value" : [ "define ","DateTimeAddOverflow",": " ]
+                     "value" : [ "","define ","DateTimeAddOverflow",": " ]
                   }, {
                      "r" : "192",
                      "s" : [ {
@@ -8451,7 +9067,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "199",
                   "s" : [ {
-                     "value" : [ "define ","DateTimeAddUnderflow",": " ]
+                     "value" : [ "","define ","DateTimeAddUnderflow",": " ]
                   }, {
                      "r" : "198",
                      "s" : [ {
@@ -8515,7 +9131,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "205",
                   "s" : [ {
-                     "value" : [ "define ","DateTimeSubtractOverflow",": " ]
+                     "value" : [ "","define ","DateTimeSubtractOverflow",": " ]
                   }, {
                      "r" : "204",
                      "s" : [ {
@@ -8579,7 +9195,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "210",
                   "s" : [ {
-                     "value" : [ "define ","DateTimeSubtractUnderflow",": " ]
+                     "value" : [ "","define ","DateTimeSubtractUnderflow",": " ]
                   }, {
                      "r" : "209",
                      "s" : [ {
@@ -8627,7 +9243,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "214",
                   "s" : [ {
-                     "value" : [ "define ","DateTimeSuccessorOverflow",": " ]
+                     "value" : [ "","define ","DateTimeSuccessorOverflow",": " ]
                   }, {
                      "r" : "213",
                      "s" : [ {
@@ -8665,7 +9281,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "218",
                   "s" : [ {
-                     "value" : [ "define ","DateTimePredecessorUnderflow",": " ]
+                     "value" : [ "","define ","DateTimePredecessorUnderflow",": " ]
                   }, {
                      "r" : "217",
                      "s" : [ {
@@ -8703,7 +9319,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "223",
                   "s" : [ {
-                     "value" : [ "define ","DateAddOverflow",": " ]
+                     "value" : [ "","define ","DateAddOverflow",": " ]
                   }, {
                      "r" : "222",
                      "s" : [ {
@@ -8751,7 +9367,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "229",
                   "s" : [ {
-                     "value" : [ "define ","DateAddUnderflow",": " ]
+                     "value" : [ "","define ","DateAddUnderflow",": " ]
                   }, {
                      "r" : "228",
                      "s" : [ {
@@ -8815,7 +9431,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "235",
                   "s" : [ {
-                     "value" : [ "define ","DateSubtractOverflow",": " ]
+                     "value" : [ "","define ","DateSubtractOverflow",": " ]
                   }, {
                      "r" : "234",
                      "s" : [ {
@@ -8879,7 +9495,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "240",
                   "s" : [ {
-                     "value" : [ "define ","DateSubtractUnderflow",": " ]
+                     "value" : [ "","define ","DateSubtractUnderflow",": " ]
                   }, {
                      "r" : "239",
                      "s" : [ {
@@ -8927,7 +9543,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "244",
                   "s" : [ {
-                     "value" : [ "define ","DateSuccessorOverflow",": " ]
+                     "value" : [ "","define ","DateSuccessorOverflow",": " ]
                   }, {
                      "r" : "243",
                      "s" : [ {
@@ -8965,7 +9581,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "248",
                   "s" : [ {
-                     "value" : [ "define ","DatePredecessorUnderflow",": " ]
+                     "value" : [ "","define ","DatePredecessorUnderflow",": " ]
                   }, {
                      "r" : "247",
                      "s" : [ {
@@ -9003,7 +9619,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "253",
                   "s" : [ {
-                     "value" : [ "define ","TimeAddOverflow",": " ]
+                     "value" : [ "","define ","TimeAddOverflow",": " ]
                   }, {
                      "r" : "252",
                      "s" : [ {
@@ -9051,7 +9667,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "259",
                   "s" : [ {
-                     "value" : [ "define ","TimeAddUnderflow",": " ]
+                     "value" : [ "","define ","TimeAddUnderflow",": " ]
                   }, {
                      "r" : "258",
                      "s" : [ {
@@ -9115,7 +9731,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "265",
                   "s" : [ {
-                     "value" : [ "define ","TimeSubtractOverflow",": " ]
+                     "value" : [ "","define ","TimeSubtractOverflow",": " ]
                   }, {
                      "r" : "264",
                      "s" : [ {
@@ -9179,7 +9795,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "270",
                   "s" : [ {
-                     "value" : [ "define ","TimeSubtractUnderflow",": " ]
+                     "value" : [ "","define ","TimeSubtractUnderflow",": " ]
                   }, {
                      "r" : "269",
                      "s" : [ {
@@ -9227,7 +9843,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "274",
                   "s" : [ {
-                     "value" : [ "define ","TimeSuccessorOverflow",": " ]
+                     "value" : [ "","define ","TimeSuccessorOverflow",": " ]
                   }, {
                      "r" : "273",
                      "s" : [ {
@@ -9265,7 +9881,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "278",
                   "s" : [ {
-                     "value" : [ "define ","TimePredecessorUnderflow",": " ]
+                     "value" : [ "","define ","TimePredecessorUnderflow",": " ]
                   }, {
                      "r" : "277",
                      "s" : [ {
@@ -9303,7 +9919,7 @@ module.exports['OutOfBounds'] = {
                "s" : {
                   "r" : "282",
                   "s" : [ {
-                     "value" : [ "define ","ExpOverflow",": " ]
+                     "value" : [ "","define ","ExpOverflow",": " ]
                   }, {
                      "r" : "281",
                      "s" : [ {

--- a/test/elm/clinical/data.js
+++ b/test/elm/clinical/data.js
@@ -23,6 +23,14 @@ module.exports['ValueSetDef'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "6",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -40,7 +48,22 @@ module.exports['ValueSetDef'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "valueSets" : {
@@ -48,18 +71,50 @@ module.exports['ValueSetDef'] = {
             "localId" : "2",
             "name" : "Known",
             "id" : "2.16.840.1.113883.3.464.1003.101.12.1061",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"Known\"",": ","'2.16.840.1.113883.3.464.1003.101.12.1061'" ]
+                  } ]
+               }
+            } ]
          }, {
             "localId" : "3",
             "name" : "Unknown One Arg",
             "id" : "1.2.3.4.5.6.7.8.9",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"Unknown One Arg\"",": ","'1.2.3.4.5.6.7.8.9'" ]
+                  } ]
+               }
+            } ]
          }, {
             "localId" : "4",
             "name" : "Unknown Two Arg",
             "id" : "1.2.3.4.5.6.7.8.9",
             "version" : "1",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "4",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"Unknown Two Arg\"",": ","'1.2.3.4.5.6.7.8.9'"," version ","'1'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -83,7 +138,7 @@ module.exports['ValueSetDef'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "5",
                      "s" : [ {
@@ -116,6 +171,14 @@ module.exports['ValueSetRef'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "4",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -133,7 +196,22 @@ module.exports['ValueSetRef'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "valueSets" : {
@@ -141,7 +219,21 @@ module.exports['ValueSetRef'] = {
             "localId" : "2",
             "name" : "Acute Pharyngitis",
             "id" : "2.16.840.1.113883.3.464.1003.101.12.1001",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"Acute Pharyngitis\"",": ","'2.16.840.1.113883.3.464.1003.101.12.1001'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -165,7 +257,7 @@ module.exports['ValueSetRef'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -220,6 +312,14 @@ module.exports['InValueSet'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "128",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -237,7 +337,22 @@ module.exports['InValueSet'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "valueSets" : {
@@ -245,23 +360,64 @@ module.exports['InValueSet'] = {
             "localId" : "2",
             "name" : "Female",
             "id" : "2.16.840.1.113883.3.560.100.2",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"Female\"",": ","'2.16.840.1.113883.3.560.100.2'" ]
+                  } ]
+               }
+            } ]
          }, {
             "localId" : "3",
             "name" : "Versioned Female",
             "id" : "2.16.840.1.113883.3.560.100.2",
             "version" : "20121025",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"Versioned Female\"",": ","'2.16.840.1.113883.3.560.100.2'"," version ","'20121025'" ]
+                  } ]
+               }
+            } ]
          }, {
             "localId" : "4",
             "name" : "SharedCodes",
             "id" : "2.16.840.1.113883.3.000.000.0",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "4",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"SharedCodes\"",": ","'2.16.840.1.113883.3.000.000.0'" ]
+                  } ]
+               }
+            } ]
          }, {
             "localId" : "5",
             "name" : "ImproperSharedCodes",
             "id" : "2.16.840.1.113883.3.000.000.1",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"ImproperSharedCodes\"",": ","'2.16.840.1.113883.3.000.000.1'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -285,7 +441,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","String",": " ]
+                     "value" : [ "","define ","String",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -315,7 +471,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "7",
-                  "name" : "Female"
+                  "name" : "Female",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -328,7 +485,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","SharedCodesFoo",": " ]
+                     "value" : [ "","define ","SharedCodesFoo",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -358,7 +515,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "11",
-                  "name" : "SharedCodes"
+                  "name" : "SharedCodes",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -371,7 +529,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","SharedCodesNoMatch",": " ]
+                     "value" : [ "","define ","SharedCodesNoMatch",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -401,7 +559,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "15",
-                  "name" : "SharedCodes"
+                  "name" : "SharedCodes",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -414,7 +573,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","ImproperSharedCodesCodeValue",": " ]
+                     "value" : [ "","define ","ImproperSharedCodesCodeValue",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -444,7 +603,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "19",
-                  "name" : "ImproperSharedCodes"
+                  "name" : "ImproperSharedCodes",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -457,7 +617,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","StringInVersionedValueSet",": " ]
+                     "value" : [ "","define ","StringInVersionedValueSet",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -487,7 +647,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "23",
-                  "name" : "Versioned Female"
+                  "name" : "Versioned Female",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -500,7 +661,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "30",
                   "s" : [ {
-                     "value" : [ "define ","ShortCode",": " ]
+                     "value" : [ "","define ","ShortCode",": " ]
                   }, {
                      "r" : "29",
                      "s" : [ {
@@ -549,7 +710,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "28",
-                  "name" : "Female"
+                  "name" : "Female",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -562,7 +724,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "36",
                   "s" : [ {
-                     "value" : [ "define ","MediumCode",": " ]
+                     "value" : [ "","define ","MediumCode",": " ]
                   }, {
                      "r" : "35",
                      "s" : [ {
@@ -630,7 +792,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "34",
-                  "name" : "Female"
+                  "name" : "Female",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -643,7 +806,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "43",
                   "s" : [ {
-                     "value" : [ "define ","LongCode",": " ]
+                     "value" : [ "","define ","LongCode",": " ]
                   }, {
                      "r" : "42",
                      "s" : [ {
@@ -730,7 +893,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "41",
-                  "name" : "Female"
+                  "name" : "Female",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -743,7 +907,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "47",
                   "s" : [ {
-                     "value" : [ "define ","WrongString",": " ]
+                     "value" : [ "","define ","WrongString",": " ]
                   }, {
                      "r" : "46",
                      "s" : [ {
@@ -773,7 +937,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "45",
-                  "name" : "Female"
+                  "name" : "Female",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -786,7 +951,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "51",
                   "s" : [ {
-                     "value" : [ "define ","WrongStringInVersionedValueSet",": " ]
+                     "value" : [ "","define ","WrongStringInVersionedValueSet",": " ]
                   }, {
                      "r" : "50",
                      "s" : [ {
@@ -816,7 +981,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "49",
-                  "name" : "Versioned Female"
+                  "name" : "Versioned Female",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -829,7 +995,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "56",
                   "s" : [ {
-                     "value" : [ "define ","WrongShortCode",": " ]
+                     "value" : [ "","define ","WrongShortCode",": " ]
                   }, {
                      "r" : "55",
                      "s" : [ {
@@ -878,7 +1044,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "54",
-                  "name" : "Female"
+                  "name" : "Female",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -891,7 +1058,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "62",
                   "s" : [ {
-                     "value" : [ "define ","WrongMediumCode",": " ]
+                     "value" : [ "","define ","WrongMediumCode",": " ]
                   }, {
                      "r" : "61",
                      "s" : [ {
@@ -959,7 +1126,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "60",
-                  "name" : "Female"
+                  "name" : "Female",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -972,7 +1140,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "69",
                   "s" : [ {
-                     "value" : [ "define ","LongCodeDifferentVersion",": " ]
+                     "value" : [ "","define ","LongCodeDifferentVersion",": " ]
                   }, {
                      "r" : "68",
                      "s" : [ {
@@ -1059,7 +1227,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "67",
-                  "name" : "Female"
+                  "name" : "Female",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -1072,7 +1241,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "76",
                   "s" : [ {
-                     "value" : [ "define ","NullCode",": " ]
+                     "value" : [ "","define ","NullCode",": " ]
                   }, {
                      "r" : "75",
                      "s" : [ {
@@ -1157,7 +1326,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "74",
-                  "name" : "Female"
+                  "name" : "Female",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -1170,7 +1340,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "86",
                   "s" : [ {
-                     "value" : [ "define ","InListOfCodes",": " ]
+                     "value" : [ "","define ","InListOfCodes",": " ]
                   }, {
                      "r" : "85",
                      "s" : [ {
@@ -1299,7 +1469,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "84",
-                  "name" : "Female"
+                  "name" : "Female",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -1312,7 +1483,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "94",
                   "s" : [ {
-                     "value" : [ "define ","ListOfCodes",": " ]
+                     "value" : [ "","define ","ListOfCodes",": " ]
                   }, {
                      "r" : "93",
                      "s" : [ {
@@ -1436,7 +1607,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "101",
                   "s" : [ {
-                     "value" : [ "define ","WrongListOfCodes",": " ]
+                     "value" : [ "","define ","WrongListOfCodes",": " ]
                   }, {
                      "r" : "100",
                      "s" : [ {
@@ -1541,7 +1712,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "105",
                   "s" : [ {
-                     "value" : [ "define ","InListOfCodesExpressionRef",": " ]
+                     "value" : [ "","define ","InListOfCodesExpressionRef",": " ]
                   }, {
                      "r" : "104",
                      "s" : [ {
@@ -1570,7 +1741,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "103",
-                  "name" : "Female"
+                  "name" : "Female",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -1583,7 +1755,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "109",
                   "s" : [ {
-                     "value" : [ "define ","InWrongListOfCodes",": " ]
+                     "value" : [ "","define ","InWrongListOfCodes",": " ]
                   }, {
                      "r" : "108",
                      "s" : [ {
@@ -1612,7 +1784,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "107",
-                  "name" : "Female"
+                  "name" : "Female",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -1625,7 +1798,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "121",
                   "s" : [ {
-                     "value" : [ "define ","ListOfCodesWithNull",": " ]
+                     "value" : [ "","define ","ListOfCodesWithNull",": " ]
                   }, {
                      "r" : "120",
                      "s" : [ {
@@ -1768,7 +1941,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "119",
-                  "name" : "Female"
+                  "name" : "Female",
+                  "type" : "ValueSetRef"
                }
             }
          }, {
@@ -1781,7 +1955,7 @@ module.exports['InValueSet'] = {
                "s" : {
                   "r" : "128",
                   "s" : [ {
-                     "value" : [ "define ","ListOfCodesNull",": " ]
+                     "value" : [ "","define ","ListOfCodesNull",": " ]
                   }, {
                      "r" : "127",
                      "s" : [ {
@@ -1843,7 +2017,8 @@ module.exports['InValueSet'] = {
                },
                "valueset" : {
                   "localId" : "126",
-                  "name" : "Female"
+                  "name" : "Female",
+                  "type" : "ValueSetRef"
                }
             }
          } ]
@@ -1864,6 +2039,14 @@ module.exports['Patient Property In ValueSet'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "7",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1881,7 +2064,22 @@ module.exports['Patient Property In ValueSet'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "valueSets" : {
@@ -1889,7 +2087,21 @@ module.exports['Patient Property In ValueSet'] = {
             "localId" : "2",
             "name" : "Female",
             "id" : "2.16.840.1.113883.3.560.100.2",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"Female\"",": ","'2.16.840.1.113883.3.560.100.2'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1913,7 +2125,7 @@ module.exports['Patient Property In ValueSet'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","IsFemale",": " ]
+                     "value" : [ "","define ","IsFemale",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -1957,7 +2169,8 @@ module.exports['Patient Property In ValueSet'] = {
                },
                "valueset" : {
                   "localId" : "5",
-                  "name" : "Female"
+                  "name" : "Female",
+                  "type" : "ValueSetRef"
                }
             }
          } ]
@@ -1979,6 +2192,14 @@ module.exports['CodeDef'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "6",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1996,7 +2217,22 @@ module.exports['CodeDef'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "codeSystems" : {
@@ -2004,7 +2240,16 @@ module.exports['CodeDef'] = {
             "localId" : "2",
             "name" : "LOINC",
             "id" : "http://loinc.org",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","codesystem ","\"LOINC\"",": ","'http://loinc.org'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "codes" : {
@@ -2014,10 +2259,31 @@ module.exports['CodeDef'] = {
             "id" : "72166-2",
             "display" : "Tobacco smoking status",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "4",
+                  "s" : [ {
+                     "value" : [ "","code ","\"Tobacco smoking status code\"",": ","'72166-2'"," from " ]
+                  }, {
+                     "r" : "3",
+                     "s" : [ {
+                        "value" : [ "\"LOINC\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " display ","'Tobacco smoking status'" ]
+                  } ]
+               }
+            } ],
             "codeSystem" : {
                "localId" : "3",
                "name" : "LOINC"
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2041,7 +2307,7 @@ module.exports['CodeDef'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "5",
                      "s" : [ {
@@ -2075,6 +2341,14 @@ module.exports['CodeRef'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "6",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2092,7 +2366,22 @@ module.exports['CodeRef'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "codeSystems" : {
@@ -2100,7 +2389,16 @@ module.exports['CodeRef'] = {
             "localId" : "2",
             "name" : "LOINC",
             "id" : "http://loinc.org",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","codesystem ","\"LOINC\"",": ","'http://loinc.org'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "codes" : {
@@ -2110,10 +2408,31 @@ module.exports['CodeRef'] = {
             "id" : "72166-2",
             "display" : "Tobacco smoking status",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "4",
+                  "s" : [ {
+                     "value" : [ "","code ","\"Tobacco smoking status code\"",": ","'72166-2'"," from " ]
+                  }, {
+                     "r" : "3",
+                     "s" : [ {
+                        "value" : [ "\"LOINC\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " display ","'Tobacco smoking status'" ]
+                  } ]
+               }
+            } ],
             "codeSystem" : {
                "localId" : "3",
                "name" : "LOINC"
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2137,7 +2456,7 @@ module.exports['CodeRef'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "5",
                      "s" : [ {
@@ -2171,6 +2490,14 @@ module.exports['ConceptDef'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "8",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2188,7 +2515,22 @@ module.exports['ConceptDef'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "codeSystems" : {
@@ -2196,7 +2538,16 @@ module.exports['ConceptDef'] = {
             "localId" : "2",
             "name" : "LOINC",
             "id" : "http://loinc.org",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","codesystem ","\"LOINC\"",": ","'http://loinc.org'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "codes" : {
@@ -2206,6 +2557,22 @@ module.exports['ConceptDef'] = {
             "id" : "72166-2",
             "display" : "Tobacco smoking status",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "4",
+                  "s" : [ {
+                     "value" : [ "","code ","\"Tobacco smoking status code\"",": ","'72166-2'"," from " ]
+                  }, {
+                     "r" : "3",
+                     "s" : [ {
+                        "value" : [ "\"LOINC\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " display ","'Tobacco smoking status'" ]
+                  } ]
+               }
+            } ],
             "codeSystem" : {
                "localId" : "3",
                "name" : "LOINC"
@@ -2218,10 +2585,31 @@ module.exports['ConceptDef'] = {
             "name" : "Tobacco smoking status",
             "display" : "Tobacco smoking status",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "6",
+                  "s" : [ {
+                     "value" : [ "","concept ","\"Tobacco smoking status\"",": { " ]
+                  }, {
+                     "r" : "5",
+                     "s" : [ {
+                        "value" : [ "\"Tobacco smoking status code\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " } display ","'Tobacco smoking status'" ]
+                  } ]
+               }
+            } ],
             "code" : [ {
                "localId" : "5",
                "name" : "Tobacco smoking status code"
             } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2245,7 +2633,7 @@ module.exports['ConceptDef'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -2280,6 +2668,14 @@ module.exports['ConceptRef'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "8",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2297,7 +2693,22 @@ module.exports['ConceptRef'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "codeSystems" : {
@@ -2305,7 +2716,16 @@ module.exports['ConceptRef'] = {
             "localId" : "2",
             "name" : "LOINC",
             "id" : "http://loinc.org",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","codesystem ","\"LOINC\"",": ","'http://loinc.org'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "codes" : {
@@ -2315,6 +2735,22 @@ module.exports['ConceptRef'] = {
             "id" : "72166-2",
             "display" : "Tobacco smoking status",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "4",
+                  "s" : [ {
+                     "value" : [ "","code ","\"Tobacco smoking status code\"",": ","'72166-2'"," from " ]
+                  }, {
+                     "r" : "3",
+                     "s" : [ {
+                        "value" : [ "\"LOINC\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " display ","'Tobacco smoking status'" ]
+                  } ]
+               }
+            } ],
             "codeSystem" : {
                "localId" : "3",
                "name" : "LOINC"
@@ -2327,10 +2763,31 @@ module.exports['ConceptRef'] = {
             "name" : "Tobacco smoking status",
             "display" : "Tobacco smoking status",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "6",
+                  "s" : [ {
+                     "value" : [ "","concept ","\"Tobacco smoking status\"",": { " ]
+                  }, {
+                     "r" : "5",
+                     "s" : [ {
+                        "value" : [ "\"Tobacco smoking status code\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " } display ","'Tobacco smoking status'" ]
+                  } ]
+               }
+            } ],
             "code" : [ {
                "localId" : "5",
                "name" : "Tobacco smoking status code"
             } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2354,7 +2811,7 @@ module.exports['ConceptRef'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -2391,6 +2848,14 @@ module.exports['CalculateAge'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "15",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2408,7 +2873,27 @@ module.exports['CalculateAge'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2432,7 +2917,7 @@ module.exports['CalculateAge'] = {
                "s" : {
                   "r" : "3",
                   "s" : [ {
-                     "value" : [ "define ","Years",": " ]
+                     "value" : [ "","define ","Years",": " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -2467,7 +2952,7 @@ module.exports['CalculateAge'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","Months",": " ]
+                     "value" : [ "","define ","Months",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -2502,7 +2987,7 @@ module.exports['CalculateAge'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","Weeks",": " ]
+                     "value" : [ "","define ","Weeks",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -2534,7 +3019,7 @@ module.exports['CalculateAge'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","Days",": " ]
+                     "value" : [ "","define ","Days",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -2566,7 +3051,7 @@ module.exports['CalculateAge'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","Hours",": " ]
+                     "value" : [ "","define ","Hours",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -2598,7 +3083,7 @@ module.exports['CalculateAge'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","Minutes",": " ]
+                     "value" : [ "","define ","Minutes",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -2630,7 +3115,7 @@ module.exports['CalculateAge'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","Seconds",": " ]
+                     "value" : [ "","define ","Seconds",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -2675,6 +3160,14 @@ module.exports['CalculateAgeAt'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "41",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2692,7 +3185,27 @@ module.exports['CalculateAgeAt'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2716,7 +3229,7 @@ module.exports['CalculateAgeAt'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","AgeAt2012",": " ]
+                     "value" : [ "","define ","AgeAt2012",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -2765,7 +3278,7 @@ module.exports['CalculateAgeAt'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","AgeAt19810216",": " ]
+                     "value" : [ "","define ","AgeAt19810216",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -2826,7 +3339,7 @@ module.exports['CalculateAgeAt'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","AgeAt1975",": " ]
+                     "value" : [ "","define ","AgeAt1975",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -2875,7 +3388,7 @@ module.exports['CalculateAgeAt'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","AgeInYearsDateTimeArg",": " ]
+                     "value" : [ "","define ","AgeInYearsDateTimeArg",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -2936,7 +3449,7 @@ module.exports['CalculateAgeAt'] = {
                "s" : {
                   "r" : "28",
                   "s" : [ {
-                     "value" : [ "define ","CalculateAgeInYearsDateTimeArg",": " ]
+                     "value" : [ "","define ","CalculateAgeInYearsDateTimeArg",": " ]
                   }, {
                      "r" : "27",
                      "s" : [ {
@@ -3034,7 +3547,7 @@ module.exports['CalculateAgeAt'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","AgeInYearsDateArg",": " ]
+                     "value" : [ "","define ","AgeInYearsDateArg",": " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -3098,7 +3611,7 @@ module.exports['CalculateAgeAt'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","CalculateAgeInYearsDateArg",": " ]
+                     "value" : [ "","define ","CalculateAgeInYearsDateArg",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {

--- a/test/elm/comparison/data.js
+++ b/test/elm/comparison/data.js
@@ -56,6 +56,14 @@ module.exports['Equal'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "353",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -73,7 +81,27 @@ module.exports['Equal'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -97,7 +125,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Int",": " ]
+                     "value" : [ "","define ","AGtB_Int",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -132,7 +160,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Int",": " ]
+                     "value" : [ "","define ","AEqB_Int",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -167,7 +195,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Int",": " ]
+                     "value" : [ "","define ","ALtB_Int",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -202,7 +230,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","EqTuples",": " ]
+                     "value" : [ "","define ","EqTuples",": " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -340,7 +368,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","UneqTuples",": " ]
+                     "value" : [ "","define ","UneqTuples",": " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -487,7 +515,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "42",
                   "s" : [ {
-                     "value" : [ "define ","EqTuplesWithNullFields",": " ]
+                     "value" : [ "","define ","EqTuplesWithNullFields",": " ]
                   }, {
                      "r" : "41",
                      "s" : [ {
@@ -593,7 +621,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "50",
                   "s" : [ {
-                     "value" : [ "define ","UneqTuplesWithNullFields",": " ]
+                     "value" : [ "","define ","UneqTuplesWithNullFields",": " ]
                   }, {
                      "r" : "49",
                      "s" : [ {
@@ -699,7 +727,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "58",
                   "s" : [ {
-                     "value" : [ "define ","UncertTuplesWithNullFieldOnOne",": " ]
+                     "value" : [ "","define ","UncertTuplesWithNullFieldOnOne",": " ]
                   }, {
                      "r" : "57",
                      "s" : [ {
@@ -811,7 +839,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "78",
                   "s" : [ {
-                     "value" : [ "define ","EqDateTimes",": " ]
+                     "value" : [ "","define ","EqDateTimes",": " ]
                   }, {
                      "r" : "77",
                      "s" : [ {
@@ -965,7 +993,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "98",
                   "s" : [ {
-                     "value" : [ "define ","UneqDateTimes",": " ]
+                     "value" : [ "","define ","UneqDateTimes",": " ]
                   }, {
                      "r" : "97",
                      "s" : [ {
@@ -1119,7 +1147,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "118",
                   "s" : [ {
-                     "value" : [ "define ","EqDateTimesTZ",": " ]
+                     "value" : [ "","define ","EqDateTimesTZ",": " ]
                   }, {
                      "r" : "117",
                      "s" : [ {
@@ -1273,7 +1301,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "138",
                   "s" : [ {
-                     "value" : [ "define ","UneqDateTimesTZ",": " ]
+                     "value" : [ "","define ","UneqDateTimesTZ",": " ]
                   }, {
                      "r" : "137",
                      "s" : [ {
@@ -1427,7 +1455,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "155",
                   "s" : [ {
-                     "value" : [ "define ","EqDateTimesNullMs",": " ]
+                     "value" : [ "","define ","EqDateTimesNullMs",": " ]
                   }, {
                      "r" : "154",
                      "s" : [ {
@@ -1547,7 +1575,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "172",
                   "s" : [ {
-                     "value" : [ "define ","EqDateTimesNullOtherMs",": " ]
+                     "value" : [ "","define ","EqDateTimesNullOtherMs",": " ]
                   }, {
                      "r" : "171",
                      "s" : [ {
@@ -1667,7 +1695,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "182",
                   "s" : [ {
-                     "value" : [ "define ","EqDateTimesOnlyDate",": " ]
+                     "value" : [ "","define ","EqDateTimesOnlyDate",": " ]
                   }, {
                      "r" : "181",
                      "s" : [ {
@@ -1745,7 +1773,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "192",
                   "s" : [ {
-                     "value" : [ "define ","UneqDateTimesOnlyDate",": " ]
+                     "value" : [ "","define ","UneqDateTimesOnlyDate",": " ]
                   }, {
                      "r" : "191",
                      "s" : [ {
@@ -1823,7 +1851,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "205",
                   "s" : [ {
-                     "value" : [ "define ","PossiblyEqDateTimesOnlyDateOnOne",": " ]
+                     "value" : [ "","define ","PossiblyEqDateTimesOnlyDateOnOne",": " ]
                   }, {
                      "r" : "204",
                      "s" : [ {
@@ -1919,7 +1947,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "218",
                   "s" : [ {
-                     "value" : [ "define ","UneqDateTimesOnlyDateOnOne",": " ]
+                     "value" : [ "","define ","UneqDateTimesOnlyDateOnOne",": " ]
                   }, {
                      "r" : "217",
                      "s" : [ {
@@ -2015,7 +2043,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "226",
                   "s" : [ {
-                     "value" : [ "define ","PossiblyEqualDateTimes",": " ]
+                     "value" : [ "","define ","PossiblyEqualDateTimes",": " ]
                   }, {
                      "r" : "225",
                      "s" : [ {
@@ -2081,7 +2109,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "235",
                   "s" : [ {
-                     "value" : [ "define ","ImpossiblyEqualDateTimes",": " ]
+                     "value" : [ "","define ","ImpossiblyEqualDateTimes",": " ]
                   }, {
                      "r" : "234",
                      "s" : [ {
@@ -2153,7 +2181,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "245",
                   "s" : [ {
-                     "value" : [ "define ","DateAndDateTimeNull",": " ]
+                     "value" : [ "","define ","DateAndDateTimeNull",": " ]
                   }, {
                      "r" : "244",
                      "s" : [ {
@@ -2234,7 +2262,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "255",
                   "s" : [ {
-                     "value" : [ "define ","DateAndDateTimeNotEqual",": " ]
+                     "value" : [ "","define ","DateAndDateTimeNotEqual",": " ]
                   }, {
                      "r" : "254",
                      "s" : [ {
@@ -2315,7 +2343,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "268",
                   "s" : [ {
-                     "value" : [ "define ","DateAndDateTimeUncertainFalse",": " ]
+                     "value" : [ "","define ","DateAndDateTimeUncertainFalse",": " ]
                   }, {
                      "r" : "267",
                      "s" : [ {
@@ -2414,7 +2442,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "278",
                   "s" : [ {
-                     "value" : [ "define ","DateTimeAndDateNull",": " ]
+                     "value" : [ "","define ","DateTimeAndDateNull",": " ]
                   }, {
                      "r" : "277",
                      "s" : [ {
@@ -2495,7 +2523,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "288",
                   "s" : [ {
-                     "value" : [ "define ","DateTimeAndDateNotEqual",": " ]
+                     "value" : [ "","define ","DateTimeAndDateNotEqual",": " ]
                   }, {
                      "r" : "287",
                      "s" : [ {
@@ -2576,7 +2604,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "301",
                   "s" : [ {
-                     "value" : [ "define ","DateTimeAndDateUncertainFalse",": " ]
+                     "value" : [ "","define ","DateTimeAndDateUncertainFalse",": " ]
                   }, {
                      "r" : "300",
                      "s" : [ {
@@ -2675,7 +2703,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "305",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity",": " ]
+                     "value" : [ "","define ","AGtB_Quantity",": " ]
                   }, {
                      "r" : "304",
                      "s" : [ {
@@ -2719,7 +2747,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "309",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity",": " ]
+                     "value" : [ "","define ","AEqB_Quantity",": " ]
                   }, {
                      "r" : "308",
                      "s" : [ {
@@ -2763,7 +2791,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "313",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity",": " ]
+                     "value" : [ "","define ","ALtB_Quantity",": " ]
                   }, {
                      "r" : "312",
                      "s" : [ {
@@ -2807,7 +2835,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "317",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity_diff",": " ]
+                     "value" : [ "","define ","AGtB_Quantity_diff",": " ]
                   }, {
                      "r" : "316",
                      "s" : [ {
@@ -2851,7 +2879,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "321",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity_diff",": " ]
+                     "value" : [ "","define ","AEqB_Quantity_diff",": " ]
                   }, {
                      "r" : "320",
                      "s" : [ {
@@ -2895,7 +2923,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "325",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity_diff",": " ]
+                     "value" : [ "","define ","ALtB_Quantity_diff",": " ]
                   }, {
                      "r" : "324",
                      "s" : [ {
@@ -2939,7 +2967,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "329",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","AGtB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "328",
                      "s" : [ {
@@ -2983,7 +3011,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "333",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","AEqB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "332",
                      "s" : [ {
@@ -3027,7 +3055,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "337",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","ALtB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "336",
                      "s" : [ {
@@ -3071,7 +3099,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "345",
                   "s" : [ {
-                     "value" : [ "define ","EqRatios",": " ]
+                     "value" : [ "","define ","EqRatios",": " ]
                   }, {
                      "r" : "344",
                      "s" : [ {
@@ -3151,7 +3179,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "353",
                   "s" : [ {
-                     "value" : [ "define ","UneqRatios",": " ]
+                     "value" : [ "","define ","UneqRatios",": " ]
                   }, {
                      "r" : "352",
                      "s" : [ {
@@ -3272,6 +3300,14 @@ module.exports['NotEqual'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "337",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3289,7 +3325,27 @@ module.exports['NotEqual'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3313,7 +3369,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Int",": " ]
+                     "value" : [ "","define ","AGtB_Int",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -3351,7 +3407,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Int",": " ]
+                     "value" : [ "","define ","AEqB_Int",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -3389,7 +3445,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Int",": " ]
+                     "value" : [ "","define ","ALtB_Int",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -3427,7 +3483,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","EqTuples",": " ]
+                     "value" : [ "","define ","EqTuples",": " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -3568,7 +3624,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","UneqTuples",": " ]
+                     "value" : [ "","define ","UneqTuples",": " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -3718,7 +3774,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "42",
                   "s" : [ {
-                     "value" : [ "define ","EqTuplesWithNullFields",": " ]
+                     "value" : [ "","define ","EqTuplesWithNullFields",": " ]
                   }, {
                      "r" : "41",
                      "s" : [ {
@@ -3827,7 +3883,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "50",
                   "s" : [ {
-                     "value" : [ "define ","UneqTuplesWithNullFields",": " ]
+                     "value" : [ "","define ","UneqTuplesWithNullFields",": " ]
                   }, {
                      "r" : "49",
                      "s" : [ {
@@ -3936,7 +3992,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "58",
                   "s" : [ {
-                     "value" : [ "define ","UncertTuplesWithNullFieldOnOne",": " ]
+                     "value" : [ "","define ","UncertTuplesWithNullFieldOnOne",": " ]
                   }, {
                      "r" : "57",
                      "s" : [ {
@@ -4051,7 +4107,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "78",
                   "s" : [ {
-                     "value" : [ "define ","EqDateTimes",": " ]
+                     "value" : [ "","define ","EqDateTimes",": " ]
                   }, {
                      "r" : "77",
                      "s" : [ {
@@ -4208,7 +4264,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "98",
                   "s" : [ {
-                     "value" : [ "define ","UneqDateTimes",": " ]
+                     "value" : [ "","define ","UneqDateTimes",": " ]
                   }, {
                      "r" : "97",
                      "s" : [ {
@@ -4365,7 +4421,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "118",
                   "s" : [ {
-                     "value" : [ "define ","EqDateTimesTZ",": " ]
+                     "value" : [ "","define ","EqDateTimesTZ",": " ]
                   }, {
                      "r" : "117",
                      "s" : [ {
@@ -4522,7 +4578,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "138",
                   "s" : [ {
-                     "value" : [ "define ","UneqDateTimesTZ",": " ]
+                     "value" : [ "","define ","UneqDateTimesTZ",": " ]
                   }, {
                      "r" : "137",
                      "s" : [ {
@@ -4679,7 +4735,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "155",
                   "s" : [ {
-                     "value" : [ "define ","EqDateTimesNullMs",": " ]
+                     "value" : [ "","define ","EqDateTimesNullMs",": " ]
                   }, {
                      "r" : "154",
                      "s" : [ {
@@ -4802,7 +4858,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "172",
                   "s" : [ {
-                     "value" : [ "define ","EqDateTimesNullOtherMs",": " ]
+                     "value" : [ "","define ","EqDateTimesNullOtherMs",": " ]
                   }, {
                      "r" : "171",
                      "s" : [ {
@@ -4925,7 +4981,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "182",
                   "s" : [ {
-                     "value" : [ "define ","EqDateTimesOnlyDate",": " ]
+                     "value" : [ "","define ","EqDateTimesOnlyDate",": " ]
                   }, {
                      "r" : "181",
                      "s" : [ {
@@ -5006,7 +5062,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "192",
                   "s" : [ {
-                     "value" : [ "define ","UneqDateTimesOnlyDate",": " ]
+                     "value" : [ "","define ","UneqDateTimesOnlyDate",": " ]
                   }, {
                      "r" : "191",
                      "s" : [ {
@@ -5087,7 +5143,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "205",
                   "s" : [ {
-                     "value" : [ "define ","PossiblyEqDateTimesOnlyDateOnOne",": " ]
+                     "value" : [ "","define ","PossiblyEqDateTimesOnlyDateOnOne",": " ]
                   }, {
                      "r" : "204",
                      "s" : [ {
@@ -5186,7 +5242,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "218",
                   "s" : [ {
-                     "value" : [ "define ","UneqDateTimesOnlyDateOnOne",": " ]
+                     "value" : [ "","define ","UneqDateTimesOnlyDateOnOne",": " ]
                   }, {
                      "r" : "217",
                      "s" : [ {
@@ -5285,7 +5341,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "226",
                   "s" : [ {
-                     "value" : [ "define ","PossiblyEqualDateTimes",": " ]
+                     "value" : [ "","define ","PossiblyEqualDateTimes",": " ]
                   }, {
                      "r" : "225",
                      "s" : [ {
@@ -5354,7 +5410,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "235",
                   "s" : [ {
-                     "value" : [ "define ","ImpossiblyEqualDateTimes",": " ]
+                     "value" : [ "","define ","ImpossiblyEqualDateTimes",": " ]
                   }, {
                      "r" : "234",
                      "s" : [ {
@@ -5429,7 +5485,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "245",
                   "s" : [ {
-                     "value" : [ "define ","DateAndDateTimeNull",": " ]
+                     "value" : [ "","define ","DateAndDateTimeNull",": " ]
                   }, {
                      "r" : "244",
                      "s" : [ {
@@ -5513,7 +5569,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "255",
                   "s" : [ {
-                     "value" : [ "define ","DateAndDateTimeNotEqual",": " ]
+                     "value" : [ "","define ","DateAndDateTimeNotEqual",": " ]
                   }, {
                      "r" : "254",
                      "s" : [ {
@@ -5597,7 +5653,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "268",
                   "s" : [ {
-                     "value" : [ "define ","DateAndDateTimeUncertainTrue",": " ]
+                     "value" : [ "","define ","DateAndDateTimeUncertainTrue",": " ]
                   }, {
                      "r" : "267",
                      "s" : [ {
@@ -5699,7 +5755,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "278",
                   "s" : [ {
-                     "value" : [ "define ","DateTimeAndDateNull",": " ]
+                     "value" : [ "","define ","DateTimeAndDateNull",": " ]
                   }, {
                      "r" : "277",
                      "s" : [ {
@@ -5783,7 +5839,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "288",
                   "s" : [ {
-                     "value" : [ "define ","DateTimeAndDateNotEqual",": " ]
+                     "value" : [ "","define ","DateTimeAndDateNotEqual",": " ]
                   }, {
                      "r" : "287",
                      "s" : [ {
@@ -5867,7 +5923,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "301",
                   "s" : [ {
-                     "value" : [ "define ","DateTimeAndDateUncertainTrue",": " ]
+                     "value" : [ "","define ","DateTimeAndDateUncertainTrue",": " ]
                   }, {
                      "r" : "300",
                      "s" : [ {
@@ -5969,7 +6025,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "305",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity",": " ]
+                     "value" : [ "","define ","AGtB_Quantity",": " ]
                   }, {
                      "r" : "304",
                      "s" : [ {
@@ -6016,7 +6072,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "309",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity",": " ]
+                     "value" : [ "","define ","AEqB_Quantity",": " ]
                   }, {
                      "r" : "308",
                      "s" : [ {
@@ -6063,7 +6119,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "313",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity",": " ]
+                     "value" : [ "","define ","ALtB_Quantity",": " ]
                   }, {
                      "r" : "312",
                      "s" : [ {
@@ -6110,7 +6166,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "317",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity_diff",": " ]
+                     "value" : [ "","define ","AGtB_Quantity_diff",": " ]
                   }, {
                      "r" : "316",
                      "s" : [ {
@@ -6157,7 +6213,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "321",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity_diff",": " ]
+                     "value" : [ "","define ","AEqB_Quantity_diff",": " ]
                   }, {
                      "r" : "320",
                      "s" : [ {
@@ -6204,7 +6260,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "325",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity_diff",": " ]
+                     "value" : [ "","define ","ALtB_Quantity_diff",": " ]
                   }, {
                      "r" : "324",
                      "s" : [ {
@@ -6251,7 +6307,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "329",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","AGtB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "328",
                      "s" : [ {
@@ -6298,7 +6354,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "333",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","AEqB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "332",
                      "s" : [ {
@@ -6345,7 +6401,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "337",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","ALtB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "336",
                      "s" : [ {
@@ -6496,6 +6552,14 @@ module.exports['Equivalent'] = {
          "errorType" : "semantic",
          "errorSeverity" : "warning",
          "type" : "CqlToElmError"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "544",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -6513,7 +6577,22 @@ module.exports['Equivalent'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "codeSystems" : {
@@ -6521,7 +6600,16 @@ module.exports['Equivalent'] = {
             "localId" : "2",
             "name" : "LOINC",
             "id" : "http://loinc.org",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","codesystem ","\"LOINC\"",": ","'http://loinc.org'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "codes" : {
@@ -6531,6 +6619,22 @@ module.exports['Equivalent'] = {
             "id" : "72166-2",
             "display" : "Tobacco smoking status code",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "4",
+                  "s" : [ {
+                     "value" : [ "","code ","\"Tobacco smoking status code\"",": ","'72166-2'"," from " ]
+                  }, {
+                     "r" : "3",
+                     "s" : [ {
+                        "value" : [ "\"LOINC\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " display ","'Tobacco smoking status code'" ]
+                  } ]
+               }
+            } ],
             "codeSystem" : {
                "localId" : "3",
                "name" : "LOINC"
@@ -6541,6 +6645,22 @@ module.exports['Equivalent'] = {
             "id" : "72166-2",
             "display" : "Tobacco smoking status code clone",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "6",
+                  "s" : [ {
+                     "value" : [ "","code ","\"Tobacco smoking status code clone\"",": ","'72166-2'"," from " ]
+                  }, {
+                     "r" : "5",
+                     "s" : [ {
+                        "value" : [ "\"LOINC\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " display ","'Tobacco smoking status code clone'" ]
+                  } ]
+               }
+            } ],
             "codeSystem" : {
                "localId" : "5",
                "name" : "LOINC"
@@ -6551,6 +6671,22 @@ module.exports['Equivalent'] = {
             "id" : "75626-2",
             "display" : "Total Score [Audit-C] code",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "8",
+                  "s" : [ {
+                     "value" : [ "","code ","\"Total Score [AUDIT-C] code\"",": ","'75626-2'"," from " ]
+                  }, {
+                     "r" : "7",
+                     "s" : [ {
+                        "value" : [ "\"LOINC\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " display ","'Total Score [Audit-C] code'" ]
+                  } ]
+               }
+            } ],
             "codeSystem" : {
                "localId" : "7",
                "name" : "LOINC"
@@ -6563,6 +6699,22 @@ module.exports['Equivalent'] = {
             "name" : "Tobacco smoking status",
             "display" : "Tobacco smoking status",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "10",
+                  "s" : [ {
+                     "value" : [ "","concept ","\"Tobacco smoking status\"",": { " ]
+                  }, {
+                     "r" : "9",
+                     "s" : [ {
+                        "value" : [ "\"Tobacco smoking status code\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " } display ","'Tobacco smoking status'" ]
+                  } ]
+               }
+            } ],
             "code" : [ {
                "localId" : "9",
                "name" : "Tobacco smoking status code"
@@ -6572,6 +6724,22 @@ module.exports['Equivalent'] = {
             "name" : "Tobacco smoking status clone",
             "display" : "Tobacco smoking status",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "12",
+                  "s" : [ {
+                     "value" : [ "","concept ","\"Tobacco smoking status clone\"",": { " ]
+                  }, {
+                     "r" : "11",
+                     "s" : [ {
+                        "value" : [ "\"Tobacco smoking status code clone\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " } display ","'Tobacco smoking status'" ]
+                  } ]
+               }
+            } ],
             "code" : [ {
                "localId" : "11",
                "name" : "Tobacco smoking status code clone"
@@ -6581,10 +6749,31 @@ module.exports['Equivalent'] = {
             "name" : "Total Score [AUDIT-C]",
             "display" : "Total Score [Audit-C]",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "14",
+                  "s" : [ {
+                     "value" : [ "","concept ","\"Total Score [AUDIT-C]\"",": { " ]
+                  }, {
+                     "r" : "13",
+                     "s" : [ {
+                        "value" : [ "\"Total Score [AUDIT-C] code\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " } display ","'Total Score [Audit-C]'" ]
+                  } ]
+               }
+            } ],
             "code" : [ {
                "localId" : "13",
                "name" : "Total Score [AUDIT-C] code"
             } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -6608,7 +6797,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "18",
                   "s" : [ {
-                     "value" : [ "define ","ANull_BDefined",": " ]
+                     "value" : [ "","define ","ANull_BDefined",": " ]
                   }, {
                      "r" : "17",
                      "s" : [ {
@@ -6645,7 +6834,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "22",
                   "s" : [ {
-                     "value" : [ "define ","ADefined_BNull",": " ]
+                     "value" : [ "","define ","ADefined_BNull",": " ]
                   }, {
                      "r" : "21",
                      "s" : [ {
@@ -6682,7 +6871,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "30",
                   "s" : [ {
-                     "value" : [ "define ","ANull_BNull",": " ]
+                     "value" : [ "","define ","ANull_BNull",": " ]
                   }, {
                      "r" : "29",
                      "s" : [ {
@@ -6768,7 +6957,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","ADefined_BDefined",": " ]
+                     "value" : [ "","define ","ADefined_BDefined",": " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -6803,7 +6992,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "38",
                   "s" : [ {
-                     "value" : [ "define ","CaseInsensitiveStrings",": " ]
+                     "value" : [ "","define ","CaseInsensitiveStrings",": " ]
                   }, {
                      "r" : "37",
                      "s" : [ {
@@ -6847,7 +7036,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "42",
                   "s" : [ {
-                     "value" : [ "define ","WhiteSpaceTabTrue",": " ]
+                     "value" : [ "","define ","WhiteSpaceTabTrue",": " ]
                   }, {
                      "r" : "41",
                      "s" : [ {
@@ -6891,7 +7080,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "46",
                   "s" : [ {
-                     "value" : [ "define ","WhiteSpaceTabReturnTrue",": " ]
+                     "value" : [ "","define ","WhiteSpaceTabReturnTrue",": " ]
                   }, {
                      "r" : "45",
                      "s" : [ {
@@ -6935,7 +7124,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "50",
                   "s" : [ {
-                     "value" : [ "define ","WhiteSpaceIncorrectSpaceFalse",": " ]
+                     "value" : [ "","define ","WhiteSpaceIncorrectSpaceFalse",": " ]
                   }, {
                      "r" : "49",
                      "s" : [ {
@@ -6979,7 +7168,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "54",
                   "s" : [ {
-                     "value" : [ "define ","WhiteSpaceIncorrectNumberTabsFalse",": " ]
+                     "value" : [ "","define ","WhiteSpaceIncorrectNumberTabsFalse",": " ]
                   }, {
                      "r" : "53",
                      "s" : [ {
@@ -7023,7 +7212,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "58",
                   "s" : [ {
-                     "value" : [ "define ","WhiteSpaceNoSpaceFalse",": " ]
+                     "value" : [ "","define ","WhiteSpaceNoSpaceFalse",": " ]
                   }, {
                      "r" : "57",
                      "s" : [ {
@@ -7067,7 +7256,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "66",
                   "s" : [ {
-                     "value" : [ "define ","EqRatios",": " ]
+                     "value" : [ "","define ","EqRatios",": " ]
                   }, {
                      "r" : "65",
                      "s" : [ {
@@ -7147,7 +7336,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "74",
                   "s" : [ {
-                     "value" : [ "define ","UneqRatios",": " ]
+                     "value" : [ "","define ","UneqRatios",": " ]
                   }, {
                      "r" : "73",
                      "s" : [ {
@@ -7227,7 +7416,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "86",
                   "s" : [ {
-                     "value" : [ "define ","UneqRatioTypes",": " ]
+                     "value" : [ "","define ","UneqRatioTypes",": " ]
                   }, {
                      "r" : "85",
                      "s" : [ {
@@ -7330,7 +7519,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "94",
                   "s" : [ {
-                     "value" : [ "define ","SameTuples",": " ]
+                     "value" : [ "// define EmptyTuples: { : } ~ { : } // TODO: We don't seem to support this format","define ","SameTuples",": " ]
                   }, {
                      "r" : "93",
                      "s" : [ {
@@ -7448,7 +7637,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "100",
                   "s" : [ {
-                     "value" : [ "define ","SameTuplesNull",": " ]
+                     "value" : [ "","define ","SameTuplesNull",": " ]
                   }, {
                      "r" : "99",
                      "s" : [ {
@@ -7516,7 +7705,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "108",
                   "s" : [ {
-                     "value" : [ "define ","DifferentTuples",": " ]
+                     "value" : [ "","define ","DifferentTuples",": " ]
                   }, {
                      "r" : "107",
                      "s" : [ {
@@ -7634,7 +7823,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "118",
                   "s" : [ {
-                     "value" : [ "define ","SameNestedTuples",": " ]
+                     "value" : [ "","define ","SameNestedTuples",": " ]
                   }, {
                      "r" : "117",
                      "s" : [ {
@@ -7788,7 +7977,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "128",
                   "s" : [ {
-                     "value" : [ "define ","SameNestedTuplesNull",": " ]
+                     "value" : [ "","define ","SameNestedTuplesNull",": " ]
                   }, {
                      "r" : "127",
                      "s" : [ {
@@ -7930,7 +8119,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "132",
                   "s" : [ {
-                     "value" : [ "define ","EmptyLists",": " ]
+                     "value" : [ "","define ","EmptyLists",": " ]
                   }, {
                      "r" : "131",
                      "s" : [ {
@@ -7961,7 +8150,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "142",
                   "s" : [ {
-                     "value" : [ "define ","DifferentTypesLists",": " ]
+                     "value" : [ "","define ","DifferentTypesLists",": " ]
                   }, {
                      "r" : "141",
                      "s" : [ {
@@ -8055,7 +8244,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "149",
                   "s" : [ {
-                     "value" : [ "define ","DifferentLengthLists",": " ]
+                     "value" : [ "","define ","DifferentLengthLists",": " ]
                   }, {
                      "r" : "148",
                      "s" : [ {
@@ -8133,7 +8322,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "157",
                   "s" : [ {
-                     "value" : [ "define ","DifferentOrderLists",": " ]
+                     "value" : [ "","define ","DifferentOrderLists",": " ]
                   }, {
                      "r" : "156",
                      "s" : [ {
@@ -8223,7 +8412,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "167",
                   "s" : [ {
-                     "value" : [ "define ","SameLists",": " ]
+                     "value" : [ "","define ","SameLists",": " ]
                   }, {
                      "r" : "166",
                      "s" : [ {
@@ -8337,7 +8526,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "177",
                   "s" : [ {
-                     "value" : [ "define ","SameListsNull",": " ]
+                     "value" : [ "","define ","SameListsNull",": " ]
                   }, {
                      "r" : "176",
                      "s" : [ {
@@ -8399,7 +8588,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "193",
                   "s" : [ {
-                     "value" : [ "define ","SameNestedLists",": " ]
+                     "value" : [ "","define ","SameNestedLists",": " ]
                   }, {
                      "r" : "192",
                      "s" : [ {
@@ -8581,7 +8770,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "205",
                   "s" : [ {
-                     "value" : [ "define ","SameNestedListsNull",": " ]
+                     "value" : [ "","define ","SameNestedListsNull",": " ]
                   }, {
                      "r" : "204",
                      "s" : [ {
@@ -8687,7 +8876,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "213",
                   "s" : [ {
-                     "value" : [ "define ","EmptyInterval",": " ]
+                     "value" : [ "","define ","EmptyInterval",": " ]
                   }, {
                      "r" : "212",
                      "s" : [ {
@@ -8749,7 +8938,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "221",
                   "s" : [ {
-                     "value" : [ "define ","IntervalDifferentPointTypes",":  " ]
+                     "value" : [ "","define ","IntervalDifferentPointTypes",":  " ]
                   }, {
                      "r" : "220",
                      "s" : [ {
@@ -8832,7 +9021,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "229",
                   "s" : [ {
-                     "value" : [ "define ","IntervalDifferentStarts",": " ]
+                     "value" : [ "","define ","IntervalDifferentStarts",": " ]
                   }, {
                      "r" : "228",
                      "s" : [ {
@@ -8902,7 +9091,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "237",
                   "s" : [ {
-                     "value" : [ "define ","IntervalDifferentEndings",": " ]
+                     "value" : [ "","define ","IntervalDifferentEndings",": " ]
                   }, {
                      "r" : "236",
                      "s" : [ {
@@ -8972,7 +9161,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "245",
                   "s" : [ {
-                     "value" : [ "define ","SameIntervals",": " ]
+                     "value" : [ "","define ","SameIntervals",": " ]
                   }, {
                      "r" : "244",
                      "s" : [ {
@@ -9042,7 +9231,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "251",
                   "s" : [ {
-                     "value" : [ "define ","TupleAndList",": " ]
+                     "value" : [ "","define ","TupleAndList",": " ]
                   }, {
                      "r" : "250",
                      "s" : [ {
@@ -9137,7 +9326,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "257",
                   "s" : [ {
-                     "value" : [ "define ","ListAndTuple",": " ]
+                     "value" : [ "","define ","ListAndTuple",": " ]
                   }, {
                      "r" : "256",
                      "s" : [ {
@@ -9232,7 +9421,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "263",
                   "s" : [ {
-                     "value" : [ "define ","TupleAndNullList",": " ]
+                     "value" : [ "","define ","TupleAndNullList",": " ]
                   }, {
                      "r" : "262",
                      "s" : [ {
@@ -9295,7 +9484,7 @@ module.exports['Equivalent'] = {
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
                         "name" : "a",
-                        "type" : {
+                        "elementType" : {
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -9313,7 +9502,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "269",
                   "s" : [ {
-                     "value" : [ "define ","NullListAndTuple",": " ]
+                     "value" : [ "","define ","NullListAndTuple",": " ]
                   }, {
                      "r" : "268",
                      "s" : [ {
@@ -9364,7 +9553,7 @@ module.exports['Equivalent'] = {
                      "type" : "TupleTypeSpecifier",
                      "element" : [ {
                         "name" : "a",
-                        "type" : {
+                        "elementType" : {
                            "name" : "{urn:hl7-org:elm-types:r1}String",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -9394,7 +9583,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "273",
                   "s" : [ {
-                     "value" : [ "define ","SameCodeAndCode",": " ]
+                     "value" : [ "","define ","SameCodeAndCode",": " ]
                   }, {
                      "r" : "272",
                      "s" : [ {
@@ -9436,7 +9625,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "277",
                   "s" : [ {
-                     "value" : [ "define ","SameCodeAndConcept",": " ]
+                     "value" : [ "","define ","SameCodeAndConcept",": " ]
                   }, {
                      "r" : "276",
                      "s" : [ {
@@ -9481,7 +9670,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "281",
                   "s" : [ {
-                     "value" : [ "define ","SameConceptAndCode",": " ]
+                     "value" : [ "","define ","SameConceptAndCode",": " ]
                   }, {
                      "r" : "280",
                      "s" : [ {
@@ -9526,7 +9715,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "285",
                   "s" : [ {
-                     "value" : [ "define ","SameConceptAndConcept",": " ]
+                     "value" : [ "","define ","SameConceptAndConcept",": " ]
                   }, {
                      "r" : "284",
                      "s" : [ {
@@ -9568,7 +9757,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "289",
                   "s" : [ {
-                     "value" : [ "define ","DiffCodeAndCode",": " ]
+                     "value" : [ "","define ","DiffCodeAndCode",": " ]
                   }, {
                      "r" : "288",
                      "s" : [ {
@@ -9610,7 +9799,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "293",
                   "s" : [ {
-                     "value" : [ "define ","DiffCodeAndConcept",": " ]
+                     "value" : [ "","define ","DiffCodeAndConcept",": " ]
                   }, {
                      "r" : "292",
                      "s" : [ {
@@ -9655,7 +9844,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "297",
                   "s" : [ {
-                     "value" : [ "define ","DiffConceptAndCode",": " ]
+                     "value" : [ "","define ","DiffConceptAndCode",": " ]
                   }, {
                      "r" : "296",
                      "s" : [ {
@@ -9700,7 +9889,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "301",
                   "s" : [ {
-                     "value" : [ "define ","DiffConceptAndConcept",": " ]
+                     "value" : [ "","define ","DiffConceptAndConcept",": " ]
                   }, {
                      "r" : "300",
                      "s" : [ {
@@ -9742,7 +9931,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "321",
                   "s" : [ {
-                     "value" : [ "define ","EqDateTimes",": " ]
+                     "value" : [ "","define ","EqDateTimes",": " ]
                   }, {
                      "r" : "320",
                      "s" : [ {
@@ -9896,7 +10085,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "341",
                   "s" : [ {
-                     "value" : [ "define ","UneqDateTimes",": " ]
+                     "value" : [ "","define ","UneqDateTimes",": " ]
                   }, {
                      "r" : "340",
                      "s" : [ {
@@ -10050,7 +10239,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "361",
                   "s" : [ {
-                     "value" : [ "define ","EqDateTimesTZ",": " ]
+                     "value" : [ "","define ","EqDateTimesTZ",": " ]
                   }, {
                      "r" : "360",
                      "s" : [ {
@@ -10204,7 +10393,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "381",
                   "s" : [ {
-                     "value" : [ "define ","UneqDateTimesTZ",": " ]
+                     "value" : [ "","define ","UneqDateTimesTZ",": " ]
                   }, {
                      "r" : "380",
                      "s" : [ {
@@ -10358,7 +10547,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "398",
                   "s" : [ {
-                     "value" : [ "define ","EqDateTimesNullMs",": " ]
+                     "value" : [ "","define ","EqDateTimesNullMs",": " ]
                   }, {
                      "r" : "397",
                      "s" : [ {
@@ -10478,7 +10667,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "415",
                   "s" : [ {
-                     "value" : [ "define ","EqDateTimesNullOtherMs",": " ]
+                     "value" : [ "","define ","EqDateTimesNullOtherMs",": " ]
                   }, {
                      "r" : "414",
                      "s" : [ {
@@ -10598,7 +10787,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "425",
                   "s" : [ {
-                     "value" : [ "define ","EqDateTimesOnlyDate",": " ]
+                     "value" : [ "","define ","EqDateTimesOnlyDate",": " ]
                   }, {
                      "r" : "424",
                      "s" : [ {
@@ -10676,7 +10865,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "435",
                   "s" : [ {
-                     "value" : [ "define ","UneqDateTimesOnlyDate",": " ]
+                     "value" : [ "","define ","UneqDateTimesOnlyDate",": " ]
                   }, {
                      "r" : "434",
                      "s" : [ {
@@ -10754,7 +10943,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "448",
                   "s" : [ {
-                     "value" : [ "define ","PossiblyEqDateTimesOnlyDateOnOne",": " ]
+                     "value" : [ "","define ","PossiblyEqDateTimesOnlyDateOnOne",": " ]
                   }, {
                      "r" : "447",
                      "s" : [ {
@@ -10850,7 +11039,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "461",
                   "s" : [ {
-                     "value" : [ "define ","UneqDateTimesOnlyDateOnOne",": " ]
+                     "value" : [ "","define ","UneqDateTimesOnlyDateOnOne",": " ]
                   }, {
                      "r" : "460",
                      "s" : [ {
@@ -10946,7 +11135,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "469",
                   "s" : [ {
-                     "value" : [ "define ","PossiblyEqualDateTimes",": " ]
+                     "value" : [ "","define ","PossiblyEqualDateTimes",": " ]
                   }, {
                      "r" : "468",
                      "s" : [ {
@@ -11012,7 +11201,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "478",
                   "s" : [ {
-                     "value" : [ "define ","ImpossiblyEqualDateTimes",": " ]
+                     "value" : [ "","define ","ImpossiblyEqualDateTimes",": " ]
                   }, {
                      "r" : "477",
                      "s" : [ {
@@ -11084,7 +11273,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "488",
                   "s" : [ {
-                     "value" : [ "define ","DateAndDateTimeNull",": " ]
+                     "value" : [ "","define ","DateAndDateTimeNull",": " ]
                   }, {
                      "r" : "487",
                      "s" : [ {
@@ -11165,7 +11354,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "498",
                   "s" : [ {
-                     "value" : [ "define ","DateAndDateTimeNotEqual",": " ]
+                     "value" : [ "","define ","DateAndDateTimeNotEqual",": " ]
                   }, {
                      "r" : "497",
                      "s" : [ {
@@ -11246,7 +11435,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "511",
                   "s" : [ {
-                     "value" : [ "define ","DateAndDateTimeUncertainFalse",": " ]
+                     "value" : [ "","define ","DateAndDateTimeUncertainFalse",": " ]
                   }, {
                      "r" : "510",
                      "s" : [ {
@@ -11345,7 +11534,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "521",
                   "s" : [ {
-                     "value" : [ "define ","DateTimeAndDateNull",": " ]
+                     "value" : [ "","define ","DateTimeAndDateNull",": " ]
                   }, {
                      "r" : "520",
                      "s" : [ {
@@ -11426,7 +11615,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "531",
                   "s" : [ {
-                     "value" : [ "define ","DateTimeAndDateNotEqual",": " ]
+                     "value" : [ "","define ","DateTimeAndDateNotEqual",": " ]
                   }, {
                      "r" : "530",
                      "s" : [ {
@@ -11507,7 +11696,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "544",
                   "s" : [ {
-                     "value" : [ "define ","DateTimeAndDateUncertainFalse",": " ]
+                     "value" : [ "","define ","DateTimeAndDateUncertainFalse",": " ]
                   }, {
                      "r" : "543",
                      "s" : [ {
@@ -11624,6 +11813,14 @@ module.exports['Less'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "49",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -11641,7 +11838,27 @@ module.exports['Less'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -11665,7 +11882,7 @@ module.exports['Less'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Int",": " ]
+                     "value" : [ "","define ","AGtB_Int",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -11700,7 +11917,7 @@ module.exports['Less'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Int",": " ]
+                     "value" : [ "","define ","AEqB_Int",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -11735,7 +11952,7 @@ module.exports['Less'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Int",": " ]
+                     "value" : [ "","define ","ALtB_Int",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -11770,7 +11987,7 @@ module.exports['Less'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity",": " ]
+                     "value" : [ "","define ","AGtB_Quantity",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -11814,7 +12031,7 @@ module.exports['Less'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity",": " ]
+                     "value" : [ "","define ","AEqB_Quantity",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -11858,7 +12075,7 @@ module.exports['Less'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity",": " ]
+                     "value" : [ "","define ","ALtB_Quantity",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -11902,7 +12119,7 @@ module.exports['Less'] = {
                "s" : {
                   "r" : "29",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity_diff",": " ]
+                     "value" : [ "","define ","AGtB_Quantity_diff",": " ]
                   }, {
                      "r" : "28",
                      "s" : [ {
@@ -11946,7 +12163,7 @@ module.exports['Less'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity_diff",": " ]
+                     "value" : [ "","define ","AEqB_Quantity_diff",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -11990,7 +12207,7 @@ module.exports['Less'] = {
                "s" : {
                   "r" : "37",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity_diff",": " ]
+                     "value" : [ "","define ","ALtB_Quantity_diff",": " ]
                   }, {
                      "r" : "36",
                      "s" : [ {
@@ -12034,7 +12251,7 @@ module.exports['Less'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","AGtB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -12078,7 +12295,7 @@ module.exports['Less'] = {
                "s" : {
                   "r" : "45",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","AEqB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "44",
                      "s" : [ {
@@ -12122,7 +12339,7 @@ module.exports['Less'] = {
                "s" : {
                   "r" : "49",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","ALtB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "48",
                      "s" : [ {
@@ -12184,6 +12401,14 @@ module.exports['LessOrEqual'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "49",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -12201,7 +12426,27 @@ module.exports['LessOrEqual'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -12225,7 +12470,7 @@ module.exports['LessOrEqual'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Int",": " ]
+                     "value" : [ "","define ","AGtB_Int",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -12260,7 +12505,7 @@ module.exports['LessOrEqual'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Int",": " ]
+                     "value" : [ "","define ","AEqB_Int",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -12295,7 +12540,7 @@ module.exports['LessOrEqual'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Int",": " ]
+                     "value" : [ "","define ","ALtB_Int",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -12330,7 +12575,7 @@ module.exports['LessOrEqual'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity",": " ]
+                     "value" : [ "","define ","AGtB_Quantity",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -12374,7 +12619,7 @@ module.exports['LessOrEqual'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity",": " ]
+                     "value" : [ "","define ","AEqB_Quantity",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -12418,7 +12663,7 @@ module.exports['LessOrEqual'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity",": " ]
+                     "value" : [ "","define ","ALtB_Quantity",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -12462,7 +12707,7 @@ module.exports['LessOrEqual'] = {
                "s" : {
                   "r" : "29",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity_diff",": " ]
+                     "value" : [ "","define ","AGtB_Quantity_diff",": " ]
                   }, {
                      "r" : "28",
                      "s" : [ {
@@ -12506,7 +12751,7 @@ module.exports['LessOrEqual'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity_diff",": " ]
+                     "value" : [ "","define ","AEqB_Quantity_diff",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -12550,7 +12795,7 @@ module.exports['LessOrEqual'] = {
                "s" : {
                   "r" : "37",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity_diff",": " ]
+                     "value" : [ "","define ","ALtB_Quantity_diff",": " ]
                   }, {
                      "r" : "36",
                      "s" : [ {
@@ -12594,7 +12839,7 @@ module.exports['LessOrEqual'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","AGtB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -12638,7 +12883,7 @@ module.exports['LessOrEqual'] = {
                "s" : {
                   "r" : "45",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","AEqB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "44",
                      "s" : [ {
@@ -12682,7 +12927,7 @@ module.exports['LessOrEqual'] = {
                "s" : {
                   "r" : "49",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","ALtB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "48",
                      "s" : [ {
@@ -12744,6 +12989,14 @@ module.exports['Greater'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "49",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -12761,7 +13014,27 @@ module.exports['Greater'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -12785,7 +13058,7 @@ module.exports['Greater'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Int",": " ]
+                     "value" : [ "","define ","AGtB_Int",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -12820,7 +13093,7 @@ module.exports['Greater'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Int",": " ]
+                     "value" : [ "","define ","AEqB_Int",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -12855,7 +13128,7 @@ module.exports['Greater'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Int",": " ]
+                     "value" : [ "","define ","ALtB_Int",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -12890,7 +13163,7 @@ module.exports['Greater'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity",": " ]
+                     "value" : [ "","define ","AGtB_Quantity",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -12934,7 +13207,7 @@ module.exports['Greater'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity",": " ]
+                     "value" : [ "","define ","AEqB_Quantity",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -12978,7 +13251,7 @@ module.exports['Greater'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity",": " ]
+                     "value" : [ "","define ","ALtB_Quantity",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -13022,7 +13295,7 @@ module.exports['Greater'] = {
                "s" : {
                   "r" : "29",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity_diff",": " ]
+                     "value" : [ "","define ","AGtB_Quantity_diff",": " ]
                   }, {
                      "r" : "28",
                      "s" : [ {
@@ -13066,7 +13339,7 @@ module.exports['Greater'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity_diff",": " ]
+                     "value" : [ "","define ","AEqB_Quantity_diff",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -13110,7 +13383,7 @@ module.exports['Greater'] = {
                "s" : {
                   "r" : "37",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity_diff",": " ]
+                     "value" : [ "","define ","ALtB_Quantity_diff",": " ]
                   }, {
                      "r" : "36",
                      "s" : [ {
@@ -13154,7 +13427,7 @@ module.exports['Greater'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","AGtB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -13198,7 +13471,7 @@ module.exports['Greater'] = {
                "s" : {
                   "r" : "45",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","AEqB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "44",
                      "s" : [ {
@@ -13242,7 +13515,7 @@ module.exports['Greater'] = {
                "s" : {
                   "r" : "49",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","ALtB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "48",
                      "s" : [ {
@@ -13306,6 +13579,14 @@ module.exports['GreaterOrEqual'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "61",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -13323,7 +13604,27 @@ module.exports['GreaterOrEqual'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -13347,7 +13648,7 @@ module.exports['GreaterOrEqual'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Int",": " ]
+                     "value" : [ "","define ","AGtB_Int",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -13382,7 +13683,7 @@ module.exports['GreaterOrEqual'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Int",": " ]
+                     "value" : [ "","define ","AEqB_Int",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -13417,7 +13718,7 @@ module.exports['GreaterOrEqual'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Int",": " ]
+                     "value" : [ "","define ","ALtB_Int",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -13452,7 +13753,7 @@ module.exports['GreaterOrEqual'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity",": " ]
+                     "value" : [ "","define ","AGtB_Quantity",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -13496,7 +13797,7 @@ module.exports['GreaterOrEqual'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity",": " ]
+                     "value" : [ "","define ","AEqB_Quantity",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -13540,7 +13841,7 @@ module.exports['GreaterOrEqual'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity",": " ]
+                     "value" : [ "","define ","ALtB_Quantity",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -13584,7 +13885,7 @@ module.exports['GreaterOrEqual'] = {
                "s" : {
                   "r" : "29",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity_diff",": " ]
+                     "value" : [ "","define ","AGtB_Quantity_diff",": " ]
                   }, {
                      "r" : "28",
                      "s" : [ {
@@ -13628,7 +13929,7 @@ module.exports['GreaterOrEqual'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity_diff",": " ]
+                     "value" : [ "","define ","AEqB_Quantity_diff",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -13672,7 +13973,7 @@ module.exports['GreaterOrEqual'] = {
                "s" : {
                   "r" : "37",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity_diff",": " ]
+                     "value" : [ "","define ","ALtB_Quantity_diff",": " ]
                   }, {
                      "r" : "36",
                      "s" : [ {
@@ -13716,7 +14017,7 @@ module.exports['GreaterOrEqual'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","AGtB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","AGtB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -13760,7 +14061,7 @@ module.exports['GreaterOrEqual'] = {
                "s" : {
                   "r" : "45",
                   "s" : [ {
-                     "value" : [ "define ","AEqB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","AEqB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "44",
                      "s" : [ {
@@ -13804,7 +14105,7 @@ module.exports['GreaterOrEqual'] = {
                "s" : {
                   "r" : "49",
                   "s" : [ {
-                     "value" : [ "define ","ALtB_Quantity_incompatible",": " ]
+                     "value" : [ "","define ","ALtB_Quantity_incompatible",": " ]
                   }, {
                      "r" : "48",
                      "s" : [ {
@@ -13848,7 +14149,7 @@ module.exports['GreaterOrEqual'] = {
                "s" : {
                   "r" : "55",
                   "s" : [ {
-                     "value" : [ "define ","DivideUcum_incompatible",": " ]
+                     "value" : [ "","define ","DivideUcum_incompatible",": " ]
                   }, {
                      "r" : "54",
                      "s" : [ {
@@ -13918,7 +14219,7 @@ module.exports['GreaterOrEqual'] = {
                "s" : {
                   "r" : "61",
                   "s" : [ {
-                     "value" : [ "define ","DivideUcum",": " ]
+                     "value" : [ "","define ","DivideUcum",": " ]
                   }, {
                      "r" : "60",
                      "s" : [ {

--- a/test/elm/conditional/data.js
+++ b/test/elm/conditional/data.js
@@ -21,6 +21,14 @@ module.exports['If'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "8",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -38,7 +46,22 @@ module.exports['If'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -46,11 +69,30 @@ module.exports['If'] = {
             "localId" : "3",
             "name" : "var",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","parameter ","var"," " ]
+                  }, {
+                     "r" : "2",
+                     "s" : [ {
+                        "value" : [ "Boolean" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "2",
                "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "NamedTypeSpecifier"
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -74,7 +116,7 @@ module.exports['If'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","exp",": " ]
+                     "value" : [ "","define ","exp",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -106,13 +148,9 @@ module.exports['If'] = {
                "localId" : "7",
                "type" : "If",
                "condition" : {
-                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                  "type" : "As",
-                  "operand" : {
-                     "localId" : "4",
-                     "name" : "var",
-                     "type" : "ParameterRef"
-                  }
+                  "localId" : "4",
+                  "name" : "var",
+                  "type" : "ParameterRef"
                },
                "then" : {
                   "localId" : "5",
@@ -161,6 +199,14 @@ module.exports['Case'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "30",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -178,7 +224,22 @@ module.exports['Case'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -186,6 +247,20 @@ module.exports['Case'] = {
             "localId" : "3",
             "name" : "var",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","parameter ","var"," " ]
+                  }, {
+                     "r" : "2",
+                     "s" : [ {
+                        "value" : [ "Integer" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "2",
                "name" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -195,6 +270,20 @@ module.exports['Case'] = {
             "localId" : "5",
             "name" : "X",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "value" : [ "","parameter ","X"," " ]
+                  }, {
+                     "r" : "4",
+                     "s" : [ {
+                        "value" : [ "Integer" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "4",
                "name" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -204,11 +293,30 @@ module.exports['Case'] = {
             "localId" : "7",
             "name" : "Y",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "7",
+                  "s" : [ {
+                     "value" : [ "","parameter ","Y"," " ]
+                  }, {
+                     "r" : "6",
+                     "s" : [ {
+                        "value" : [ "Integer" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "6",
                "name" : "{urn:hl7-org:elm-types:r1}Integer",
                "type" : "NamedTypeSpecifier"
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -232,7 +340,7 @@ module.exports['Case'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","selected",":\n  " ]
+                     "value" : [ "","define ","selected",":\n  " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -335,7 +443,7 @@ module.exports['Case'] = {
                "s" : {
                   "r" : "30",
                   "s" : [ {
-                     "value" : [ "define ","standard",":\n  " ]
+                     "value" : [ "","define ","standard",":\n  " ]
                   }, {
                      "r" : "29",
                      "s" : [ {

--- a/test/elm/convert/data.js
+++ b/test/elm/convert/data.js
@@ -38,6 +38,14 @@ module.exports['FromString'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "76",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -55,7 +63,27 @@ module.exports['FromString'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -79,7 +107,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","stringStr",": " ]
+                     "value" : [ "","define ","stringStr",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -116,7 +144,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","stringNull",": " ]
+                     "value" : [ "","define ","stringNull",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -150,7 +178,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","boolTrue",": " ]
+                     "value" : [ "","define ","boolTrue",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -191,7 +219,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","boolFalse",": " ]
+                     "value" : [ "","define ","boolFalse",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -232,7 +260,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","decimalValid",": " ]
+                     "value" : [ "","define ","decimalValid",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -273,7 +301,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "24",
                   "s" : [ {
-                     "value" : [ "define ","decimalInvalid",": " ]
+                     "value" : [ "","define ","decimalInvalid",": " ]
                   }, {
                      "r" : "23",
                      "s" : [ {
@@ -314,7 +342,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "28",
                   "s" : [ {
-                     "value" : [ "define ","integerValid",": " ]
+                     "value" : [ "","define ","integerValid",": " ]
                   }, {
                      "r" : "27",
                      "s" : [ {
@@ -355,7 +383,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "32",
                   "s" : [ {
-                     "value" : [ "define ","integerDropDecimal",": " ]
+                     "value" : [ "","define ","integerDropDecimal",": " ]
                   }, {
                      "r" : "31",
                      "s" : [ {
@@ -396,7 +424,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "36",
                   "s" : [ {
-                     "value" : [ "define ","integerInvalid",": " ]
+                     "value" : [ "","define ","integerInvalid",": " ]
                   }, {
                      "r" : "35",
                      "s" : [ {
@@ -437,7 +465,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "40",
                   "s" : [ {
-                     "value" : [ "define ","quantityStr",": " ]
+                     "value" : [ "","define ","quantityStr",": " ]
                   }, {
                      "r" : "39",
                      "s" : [ {
@@ -478,7 +506,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "44",
                   "s" : [ {
-                     "value" : [ "define ","posQuantityStr",": " ]
+                     "value" : [ "","define ","posQuantityStr",": " ]
                   }, {
                      "r" : "43",
                      "s" : [ {
@@ -519,7 +547,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "48",
                   "s" : [ {
-                     "value" : [ "define ","negQuantityStr",": " ]
+                     "value" : [ "","define ","negQuantityStr",": " ]
                   }, {
                      "r" : "47",
                      "s" : [ {
@@ -560,7 +588,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "52",
                   "s" : [ {
-                     "value" : [ "define ","quantityStrDecimal",": " ]
+                     "value" : [ "","define ","quantityStrDecimal",": " ]
                   }, {
                      "r" : "51",
                      "s" : [ {
@@ -601,7 +629,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "56",
                   "s" : [ {
-                     "value" : [ "define ","dateTimeStr",": " ]
+                     "value" : [ "","define ","dateTimeStr",": " ]
                   }, {
                      "r" : "55",
                      "s" : [ {
@@ -642,7 +670,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "60",
                   "s" : [ {
-                     "value" : [ "define ","dateStr",": " ]
+                     "value" : [ "","define ","dateStr",": " ]
                   }, {
                      "r" : "59",
                      "s" : [ {
@@ -683,7 +711,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "64",
                   "s" : [ {
-                     "value" : [ "define ","NullConvert",": " ]
+                     "value" : [ "","define ","NullConvert",": " ]
                   }, {
                      "r" : "63",
                      "s" : [ {
@@ -724,7 +752,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "68",
                   "s" : [ {
-                     "value" : [ "define ","ZDateTime",": " ]
+                     "value" : [ "","define ","ZDateTime",": " ]
                   }, {
                      "r" : "67",
                      "s" : [ {
@@ -765,7 +793,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "72",
                   "s" : [ {
-                     "value" : [ "define ","TimezoneDateTime",": " ]
+                     "value" : [ "// January 1st, 2014, 2:30PM UTC","define ","TimezoneDateTime",": " ]
                   }, {
                      "r" : "71",
                      "s" : [ {
@@ -806,7 +834,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "76",
                   "s" : [ {
-                     "value" : [ "define ","TimezoneTime",": " ]
+                     "value" : [ "// January 1st, 2014, 2:30PM Mountain Standard (GMT-7:00)","define ","TimezoneTime",": " ]
                   }, {
                      "r" : "75",
                      "s" : [ {
@@ -857,6 +885,14 @@ module.exports['FromInteger'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "16",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -874,7 +910,27 @@ module.exports['FromInteger'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -898,7 +954,7 @@ module.exports['FromInteger'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","string10",": " ]
+                     "value" : [ "","define ","string10",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -933,7 +989,7 @@ module.exports['FromInteger'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","decimal10",": " ]
+                     "value" : [ "","define ","decimal10",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -968,7 +1024,7 @@ module.exports['FromInteger'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","intNull",": " ]
+                     "value" : [ "","define ","intNull",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -1002,7 +1058,7 @@ module.exports['FromInteger'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","intInt",": " ]
+                     "value" : [ "","define ","intInt",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -1043,6 +1099,14 @@ module.exports['FromQuantity'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "17",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1060,7 +1124,27 @@ module.exports['FromQuantity'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1084,7 +1168,7 @@ module.exports['FromQuantity'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","quantityStr",": " ]
+                     "value" : [ "","define ","quantityStr",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -1125,7 +1209,7 @@ module.exports['FromQuantity'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","negQuantityStr",": " ]
+                     "value" : [ "","define ","negQuantityStr",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -1175,7 +1259,7 @@ module.exports['FromQuantity'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","posQuantityStr",": " ]
+                     "value" : [ "","define ","posQuantityStr",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -1221,7 +1305,7 @@ module.exports['FromQuantity'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","quantityQuantity",": " ]
+                     "value" : [ "","define ","quantityQuantity",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -1268,6 +1352,14 @@ module.exports['FromBoolean'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "15",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1285,7 +1377,27 @@ module.exports['FromBoolean'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1309,7 +1421,7 @@ module.exports['FromBoolean'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","booleanTrueStr",": " ]
+                     "value" : [ "","define ","booleanTrueStr",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -1344,7 +1456,7 @@ module.exports['FromBoolean'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","booleanFalseStr",": " ]
+                     "value" : [ "","define ","booleanFalseStr",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -1379,7 +1491,7 @@ module.exports['FromBoolean'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","booleanTrueBool",": " ]
+                     "value" : [ "","define ","booleanTrueBool",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -1410,7 +1522,7 @@ module.exports['FromBoolean'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","booleanFalseBool",": " ]
+                     "value" : [ "","define ","booleanFalseBool",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -1450,6 +1562,14 @@ module.exports['FromDateTime'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "12",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1467,7 +1587,27 @@ module.exports['FromDateTime'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1491,7 +1631,7 @@ module.exports['FromDateTime'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","dateTimeToStr",": " ]
+                     "value" : [ "","define ","dateTimeToStr",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -1564,7 +1704,7 @@ module.exports['FromDateTime'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","dateTimeToDate",": " ]
+                     "value" : [ "","define ","dateTimeToDate",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -1637,7 +1777,7 @@ module.exports['FromDateTime'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","dateTimeToDateTime",": " ]
+                     "value" : [ "","define ","dateTimeToDateTime",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -1717,6 +1857,14 @@ module.exports['FromDate'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "20",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1734,7 +1882,27 @@ module.exports['FromDate'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1758,7 +1926,7 @@ module.exports['FromDate'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","dateYMDToDateTime",": " ]
+                     "value" : [ "","define ","dateYMDToDateTime",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -1806,7 +1974,7 @@ module.exports['FromDate'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","dateYMToDateTime",": " ]
+                     "value" : [ "","define ","dateYMToDateTime",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -1849,7 +2017,7 @@ module.exports['FromDate'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","dateYToDateTime",": " ]
+                     "value" : [ "","define ","dateYToDateTime",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -1887,7 +2055,7 @@ module.exports['FromDate'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","dateToDate",": " ]
+                     "value" : [ "","define ","dateToDate",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -1931,7 +2099,7 @@ module.exports['FromDate'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","dateToStr",": " ]
+                     "value" : [ "","define ","dateToStr",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -1987,6 +2155,14 @@ module.exports['FromTime'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "8",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2004,7 +2180,27 @@ module.exports['FromTime'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2028,7 +2224,7 @@ module.exports['FromTime'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","timeStr",": " ]
+                     "value" : [ "","define ","timeStr",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -2071,7 +2267,7 @@ module.exports['FromTime'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","timeTime",": " ]
+                     "value" : [ "","define ","timeTime",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -2121,6 +2317,14 @@ module.exports['FromCode'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "14",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2138,7 +2342,22 @@ module.exports['FromCode'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "codeSystems" : {
@@ -2146,7 +2365,21 @@ module.exports['FromCode'] = {
             "localId" : "2",
             "name" : "SNOMED-CT",
             "id" : "2.16.840.1.113883.6.96",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","codesystem ","\"SNOMED-CT\"",": ","'2.16.840.1.113883.6.96'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2170,7 +2403,7 @@ module.exports['FromCode'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","hepB",": " ]
+                     "value" : [ "","define ","hepB",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -2206,7 +2439,7 @@ module.exports['FromCode'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","codeConcept",": " ]
+                     "value" : [ "","define ","codeConcept",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -2246,7 +2479,7 @@ module.exports['FromCode'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","codeCode",": " ]
+                     "value" : [ "","define ","codeCode",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -2282,7 +2515,7 @@ module.exports['FromCode'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","foo",": " ]
+                     "value" : [ "","define ","foo",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -2321,6 +2554,14 @@ module.exports['ToDecimal'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "27",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2338,7 +2579,27 @@ module.exports['ToDecimal'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2362,7 +2623,7 @@ module.exports['ToDecimal'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","NoSign",": " ]
+                     "value" : [ "","define ","NoSign",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -2398,7 +2659,7 @@ module.exports['ToDecimal'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","PositiveSign",": " ]
+                     "value" : [ "","define ","PositiveSign",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -2434,7 +2695,7 @@ module.exports['ToDecimal'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","NegativeSign",": " ]
+                     "value" : [ "","define ","NegativeSign",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -2470,7 +2731,7 @@ module.exports['ToDecimal'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","TooPrecise",": " ]
+                     "value" : [ "","define ","TooPrecise",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -2506,7 +2767,7 @@ module.exports['ToDecimal'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","TooLargeDec",": " ]
+                     "value" : [ "","define ","TooLargeDec",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -2542,7 +2803,7 @@ module.exports['ToDecimal'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","TooSmallDec",": " ]
+                     "value" : [ "","define ","TooSmallDec",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -2578,7 +2839,7 @@ module.exports['ToDecimal'] = {
                "s" : {
                   "r" : "24",
                   "s" : [ {
-                     "value" : [ "define ","NullDecimal",": " ]
+                     "value" : [ "","define ","NullDecimal",": " ]
                   }, {
                      "r" : "23",
                      "s" : [ {
@@ -2635,7 +2896,7 @@ module.exports['ToDecimal'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","WrongFormat",": " ]
+                     "value" : [ "","define ","WrongFormat",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -2682,6 +2943,14 @@ module.exports['ToInteger'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "16",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2699,7 +2968,27 @@ module.exports['ToInteger'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2723,7 +3012,7 @@ module.exports['ToInteger'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","NoSign",": " ]
+                     "value" : [ "","define ","NoSign",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -2759,7 +3048,7 @@ module.exports['ToInteger'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","PositiveSign",": " ]
+                     "value" : [ "","define ","PositiveSign",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -2795,7 +3084,7 @@ module.exports['ToInteger'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","NegativeSign",": " ]
+                     "value" : [ "","define ","NegativeSign",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -2831,7 +3120,7 @@ module.exports['ToInteger'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","TooLargeInt",": " ]
+                     "value" : [ "","define ","TooLargeInt",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -2867,7 +3156,7 @@ module.exports['ToInteger'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","TooSmallInt",": " ]
+                     "value" : [ "","define ","TooSmallInt",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -2919,6 +3208,14 @@ module.exports['ToQuantity'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "39",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2936,7 +3233,27 @@ module.exports['ToQuantity'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2960,7 +3277,7 @@ module.exports['ToQuantity'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","DecimalOverload",": " ]
+                     "value" : [ "","define ","DecimalOverload",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -2990,7 +3307,7 @@ module.exports['ToQuantity'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","IntegerOverload",": " ]
+                     "value" : [ "","define ","IntegerOverload",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -3020,7 +3337,7 @@ module.exports['ToQuantity'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","UncertaintySixToEighteen",": " ]
+                     "value" : [ "","define ","UncertaintySixToEighteen",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -3083,7 +3400,7 @@ module.exports['ToQuantity'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","UncertaintyOverload",": " ]
+                     "value" : [ "","define ","UncertaintyOverload",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -3118,7 +3435,7 @@ module.exports['ToQuantity'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","StringOverload",": " ]
+                     "value" : [ "","define ","StringOverload",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -3154,7 +3471,7 @@ module.exports['ToQuantity'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","RatioOverload",": " ]
+                     "value" : [ "","define ","RatioOverload",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -3208,7 +3525,7 @@ module.exports['ToQuantity'] = {
                "s" : {
                   "r" : "28",
                   "s" : [ {
-                     "value" : [ "define ","WrongFormatQuantity",": " ]
+                     "value" : [ "","define ","WrongFormatQuantity",": " ]
                   }, {
                      "r" : "27",
                      "s" : [ {
@@ -3244,7 +3561,7 @@ module.exports['ToQuantity'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","TooLargeQuantity",": " ]
+                     "value" : [ "","define ","TooLargeQuantity",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -3280,7 +3597,7 @@ module.exports['ToQuantity'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","TooSmallQuantity",": " ]
+                     "value" : [ "","define ","TooSmallQuantity",": " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -3316,7 +3633,7 @@ module.exports['ToQuantity'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","NullArg",": " ]
+                     "value" : [ "","define ","NullArg",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -3385,6 +3702,14 @@ module.exports['ToRatio'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "21",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3402,7 +3727,27 @@ module.exports['ToRatio'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3426,7 +3771,7 @@ module.exports['ToRatio'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define ","NullArg",": " ]
+                     "value" : [ "","define ","NullArg",": " ]
                   }, {
                      "r" : "5",
                      "s" : [ {
@@ -3483,7 +3828,7 @@ module.exports['ToRatio'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","IsValid",": " ]
+                     "value" : [ "","define ","IsValid",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -3519,7 +3864,7 @@ module.exports['ToRatio'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","IsValidWithCustomUCUM",": " ]
+                     "value" : [ "","define ","IsValidWithCustomUCUM",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -3555,7 +3900,7 @@ module.exports['ToRatio'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","InvalidSeparator",": " ]
+                     "value" : [ "","define ","InvalidSeparator",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -3591,7 +3936,7 @@ module.exports['ToRatio'] = {
                "s" : {
                   "r" : "18",
                   "s" : [ {
-                     "value" : [ "define ","InvalidNumerator",": " ]
+                     "value" : [ "","define ","InvalidNumerator",": " ]
                   }, {
                      "r" : "17",
                      "s" : [ {
@@ -3627,7 +3972,7 @@ module.exports['ToRatio'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","InvalidDenominator",": " ]
+                     "value" : [ "","define ","InvalidDenominator",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -3679,6 +4024,14 @@ module.exports['ToTime'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "33",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3696,7 +4049,27 @@ module.exports['ToTime'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3720,7 +4093,7 @@ module.exports['ToTime'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define ","NullArgTime",": " ]
+                     "value" : [ "","define ","NullArgTime",": " ]
                   }, {
                      "r" : "5",
                      "s" : [ {
@@ -3777,7 +4150,7 @@ module.exports['ToTime'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","IncorrectFormatTime",": " ]
+                     "value" : [ "","define ","IncorrectFormatTime",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -3813,7 +4186,7 @@ module.exports['ToTime'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","InvalidTime",": " ]
+                     "value" : [ "","define ","InvalidTime",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -3849,7 +4222,7 @@ module.exports['ToTime'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","TimeH",": " ]
+                     "value" : [ "","define ","TimeH",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -3885,7 +4258,7 @@ module.exports['ToTime'] = {
                "s" : {
                   "r" : "18",
                   "s" : [ {
-                     "value" : [ "define ","TimeHM",": " ]
+                     "value" : [ "","define ","TimeHM",": " ]
                   }, {
                      "r" : "17",
                      "s" : [ {
@@ -3921,7 +4294,7 @@ module.exports['ToTime'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","TimeHMS",": " ]
+                     "value" : [ "","define ","TimeHMS",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -3957,7 +4330,7 @@ module.exports['ToTime'] = {
                "s" : {
                   "r" : "24",
                   "s" : [ {
-                     "value" : [ "define ","TimeHMSMs",": " ]
+                     "value" : [ "","define ","TimeHMSMs",": " ]
                   }, {
                      "r" : "23",
                      "s" : [ {
@@ -3993,7 +4366,7 @@ module.exports['ToTime'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","HourTooHigh",": " ]
+                     "value" : [ "","define ","HourTooHigh",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -4029,7 +4402,7 @@ module.exports['ToTime'] = {
                "s" : {
                   "r" : "30",
                   "s" : [ {
-                     "value" : [ "define ","MinuteTooHigh",": " ]
+                     "value" : [ "","define ","MinuteTooHigh",": " ]
                   }, {
                      "r" : "29",
                      "s" : [ {
@@ -4065,7 +4438,7 @@ module.exports['ToTime'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","SecondTooHigh",": " ]
+                     "value" : [ "","define ","SecondTooHigh",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -4118,6 +4491,14 @@ module.exports['ToBoolean'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "34",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -4135,7 +4516,27 @@ module.exports['ToBoolean'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -4159,7 +4560,7 @@ module.exports['ToBoolean'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","UpperCaseTrue",": " ]
+                     "value" : [ "","define ","UpperCaseTrue",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -4195,7 +4596,7 @@ module.exports['ToBoolean'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","UpperCaseFalse",": " ]
+                     "value" : [ "","define ","UpperCaseFalse",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -4231,7 +4632,7 @@ module.exports['ToBoolean'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","LowerCaseTrue",": " ]
+                     "value" : [ "","define ","LowerCaseTrue",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -4267,7 +4668,7 @@ module.exports['ToBoolean'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","LowerCaseFalse",": " ]
+                     "value" : [ "","define ","LowerCaseFalse",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -4303,7 +4704,7 @@ module.exports['ToBoolean'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","UpperCaseT",": " ]
+                     "value" : [ "","define ","UpperCaseT",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -4339,7 +4740,7 @@ module.exports['ToBoolean'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","UpperCaseF",": " ]
+                     "value" : [ "","define ","UpperCaseF",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -4375,7 +4776,7 @@ module.exports['ToBoolean'] = {
                "s" : {
                   "r" : "22",
                   "s" : [ {
-                     "value" : [ "define ","LowerCaseT",": " ]
+                     "value" : [ "","define ","LowerCaseT",": " ]
                   }, {
                      "r" : "21",
                      "s" : [ {
@@ -4411,7 +4812,7 @@ module.exports['ToBoolean'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","LowerCaseF",": " ]
+                     "value" : [ "","define ","LowerCaseF",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -4447,7 +4848,7 @@ module.exports['ToBoolean'] = {
                "s" : {
                   "r" : "28",
                   "s" : [ {
-                     "value" : [ "define ","IsTrue",": " ]
+                     "value" : [ "","define ","IsTrue",": " ]
                   }, {
                      "r" : "27",
                      "s" : [ {
@@ -4483,7 +4884,7 @@ module.exports['ToBoolean'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","IsFalse",": " ]
+                     "value" : [ "","define ","IsFalse",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -4519,7 +4920,7 @@ module.exports['ToBoolean'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","IsNull",": " ]
+                     "value" : [ "","define ","IsNull",": " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -4563,6 +4964,14 @@ module.exports['ToConcept'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "11",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -4580,7 +4989,27 @@ module.exports['ToConcept'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -4604,7 +5033,7 @@ module.exports['ToConcept'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define ","IsValid",": " ]
+                     "value" : [ "","define ","IsValid",": " ]
                   }, {
                      "r" : "5",
                      "s" : [ {
@@ -4678,7 +5107,7 @@ module.exports['ToConcept'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","IsNull",": " ]
+                     "value" : [ "// Concept { codes: { Code { system: 'http://loinc.org', code: '8480-6' } } }","define ","IsNull",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -4738,6 +5167,14 @@ module.exports['ToDate'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "22",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -4755,7 +5192,27 @@ module.exports['ToDate'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -4779,7 +5236,7 @@ module.exports['ToDate'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","ToDateString",": " ]
+                     "value" : [ "","define ","ToDateString",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -4815,7 +5272,7 @@ module.exports['ToDate'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","ToDateDateTime",": " ]
+                     "value" : [ "","define ","ToDateDateTime",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -4892,7 +5349,7 @@ module.exports['ToDate'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","ToDateNull",": " ]
+                     "value" : [ "","define ","ToDateNull",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -4942,7 +5399,7 @@ module.exports['ToDate'] = {
                "s" : {
                   "r" : "22",
                   "s" : [ {
-                     "value" : [ "define ","ToDateDateTimeString",": " ]
+                     "value" : [ "","define ","ToDateDateTimeString",": " ]
                   }, {
                      "r" : "21",
                      "s" : [ {
@@ -5010,6 +5467,14 @@ module.exports['ConvertsToBoolean'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "15",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -5027,7 +5492,27 @@ module.exports['ConvertsToBoolean'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -5051,7 +5536,7 @@ module.exports['ConvertsToBoolean'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","IsTrueWithTrueValue",": " ]
+                     "value" : [ "","define ","IsTrueWithTrueValue",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -5087,7 +5572,7 @@ module.exports['ConvertsToBoolean'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","IsTrueWithFalseValue",": " ]
+                     "value" : [ "","define ","IsTrueWithFalseValue",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -5123,7 +5608,7 @@ module.exports['ConvertsToBoolean'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","IsFalse",": " ]
+                     "value" : [ "","define ","IsFalse",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -5159,7 +5644,7 @@ module.exports['ConvertsToBoolean'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","IsNull",": " ]
+                     "value" : [ "","define ","IsNull",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -5218,6 +5703,14 @@ module.exports['ConvertsToDate'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "12",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -5235,7 +5728,27 @@ module.exports['ConvertsToDate'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -5259,7 +5772,7 @@ module.exports['ConvertsToDate'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","IsTrue",": " ]
+                     "value" : [ "","define ","IsTrue",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -5295,7 +5808,7 @@ module.exports['ConvertsToDate'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","IsFalse",": " ]
+                     "value" : [ "","define ","IsFalse",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -5331,7 +5844,7 @@ module.exports['ConvertsToDate'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","IsNull",": " ]
+                     "value" : [ "","define ","IsNull",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -5391,6 +5904,14 @@ module.exports['ConvertsToDateTime'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "15",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -5408,7 +5929,27 @@ module.exports['ConvertsToDateTime'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -5432,7 +5973,7 @@ module.exports['ConvertsToDateTime'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","IsTrue",": " ]
+                     "value" : [ "","define ","IsTrue",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -5468,7 +6009,7 @@ module.exports['ConvertsToDateTime'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","IsTrueWithDateValue",": " ]
+                     "value" : [ "","define ","IsTrueWithDateValue",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -5511,7 +6052,7 @@ module.exports['ConvertsToDateTime'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","IsFalse",": " ]
+                     "value" : [ "","define ","IsFalse",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -5547,7 +6088,7 @@ module.exports['ConvertsToDateTime'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","IsNull",": " ]
+                     "value" : [ "","define ","IsNull",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -5606,6 +6147,14 @@ module.exports['ConvertsToDecimal'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "12",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -5623,7 +6172,27 @@ module.exports['ConvertsToDecimal'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -5647,7 +6216,7 @@ module.exports['ConvertsToDecimal'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","IsTrue",": " ]
+                     "value" : [ "","define ","IsTrue",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -5683,7 +6252,7 @@ module.exports['ConvertsToDecimal'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","IsFalse",": " ]
+                     "value" : [ "","define ","IsFalse",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -5719,7 +6288,7 @@ module.exports['ConvertsToDecimal'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","IsNull",": " ]
+                     "value" : [ "","define ","IsNull",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -5778,6 +6347,14 @@ module.exports['ConvertsToInteger'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "12",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -5795,7 +6372,27 @@ module.exports['ConvertsToInteger'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -5819,7 +6416,7 @@ module.exports['ConvertsToInteger'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","IsTrue",": " ]
+                     "value" : [ "","define ","IsTrue",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -5855,7 +6452,7 @@ module.exports['ConvertsToInteger'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","IsFalse",": " ]
+                     "value" : [ "","define ","IsFalse",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -5891,7 +6488,7 @@ module.exports['ConvertsToInteger'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","IsNull",": " ]
+                     "value" : [ "","define ","IsNull",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -5953,6 +6550,14 @@ module.exports['ConvertsToQuantity'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "21",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -5970,7 +6575,27 @@ module.exports['ConvertsToQuantity'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -5994,7 +6619,7 @@ module.exports['ConvertsToQuantity'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","IsTrueWithDecimal",": " ]
+                     "value" : [ "","define ","IsTrueWithDecimal",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -6024,7 +6649,7 @@ module.exports['ConvertsToQuantity'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","IsTrueWithInteger",": " ]
+                     "value" : [ "","define ","IsTrueWithInteger",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -6054,7 +6679,7 @@ module.exports['ConvertsToQuantity'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","IsTrueWithString",": " ]
+                     "value" : [ "","define ","IsTrueWithString",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -6090,7 +6715,7 @@ module.exports['ConvertsToQuantity'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","IsFalse",": " ]
+                     "value" : [ "","define ","IsFalse",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -6126,7 +6751,7 @@ module.exports['ConvertsToQuantity'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","IsFalseWithInvalidUcum",": " ]
+                     "value" : [ "","define ","IsFalseWithInvalidUcum",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -6162,7 +6787,7 @@ module.exports['ConvertsToQuantity'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","IsNull",": " ]
+                     "value" : [ "","define ","IsNull",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -6222,6 +6847,14 @@ module.exports['ConvertsToRatio'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "15",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -6239,7 +6872,27 @@ module.exports['ConvertsToRatio'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -6263,7 +6916,7 @@ module.exports['ConvertsToRatio'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","IsTrue",": " ]
+                     "value" : [ "","define ","IsTrue",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -6299,7 +6952,7 @@ module.exports['ConvertsToRatio'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","IsFalse",": " ]
+                     "value" : [ "","define ","IsFalse",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -6335,7 +6988,7 @@ module.exports['ConvertsToRatio'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","IsFalseWithInvalidUcum",": " ]
+                     "value" : [ "","define ","IsFalseWithInvalidUcum",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -6371,7 +7024,7 @@ module.exports['ConvertsToRatio'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","IsNull",": " ]
+                     "value" : [ "","define ","IsNull",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -6430,6 +7083,14 @@ module.exports['ConvertsToString'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "14",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -6447,7 +7108,27 @@ module.exports['ConvertsToString'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -6471,7 +7152,7 @@ module.exports['ConvertsToString'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","IsTrue",": " ]
+                     "value" : [ "","define ","IsTrue",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -6501,7 +7182,7 @@ module.exports['ConvertsToString'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","IsFalse",": " ]
+                     "value" : [ "","define ","IsFalse",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -6575,7 +7256,7 @@ module.exports['ConvertsToString'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","IsNull",": " ]
+                     "value" : [ "","define ","IsNull",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -6634,6 +7315,14 @@ module.exports['ConvertsToTime'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "12",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -6651,7 +7340,27 @@ module.exports['ConvertsToTime'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -6675,7 +7384,7 @@ module.exports['ConvertsToTime'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","IsTrue",": " ]
+                     "value" : [ "","define ","IsTrue",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -6711,7 +7420,7 @@ module.exports['ConvertsToTime'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","IsFalse",": " ]
+                     "value" : [ "","define ","IsFalse",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -6747,7 +7456,7 @@ module.exports['ConvertsToTime'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","IsNull",": " ]
+                     "value" : [ "","define ","IsNull",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -6808,6 +7517,14 @@ module.exports['ConvertQuantity'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "20",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -6825,7 +7542,27 @@ module.exports['ConvertQuantity'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -6849,7 +7586,7 @@ module.exports['ConvertQuantity'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","ConvertQuantityGood",": " ]
+                     "value" : [ "","define ","ConvertQuantityGood",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -6897,7 +7634,7 @@ module.exports['ConvertQuantity'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","ConvertSyntax",": " ]
+                     "value" : [ "","define ","ConvertSyntax",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -6937,7 +7674,7 @@ module.exports['ConvertQuantity'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","ConvertQuantityToKg",": " ]
+                     "value" : [ "","define ","ConvertQuantityToKg",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -6985,7 +7722,7 @@ module.exports['ConvertQuantity'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","ConvertQuantityToWeeks",": " ]
+                     "value" : [ "","define ","ConvertQuantityToWeeks",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -7033,7 +7770,7 @@ module.exports['ConvertQuantity'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","NullConvertQuantity",": " ]
+                     "value" : [ "","define ","NullConvertQuantity",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -7091,6 +7828,14 @@ module.exports['CanConvertQuantity'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "17",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -7108,7 +7853,27 @@ module.exports['CanConvertQuantity'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -7132,7 +7897,7 @@ module.exports['CanConvertQuantity'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","CanConvertQuantityTrue",": " ]
+                     "value" : [ "","define ","CanConvertQuantityTrue",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -7180,7 +7945,7 @@ module.exports['CanConvertQuantity'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","CanConvertQuantityFalse",": " ]
+                     "value" : [ "","define ","CanConvertQuantityFalse",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -7228,7 +7993,7 @@ module.exports['CanConvertQuantity'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","CanConvertQuantityNullFirstNull",": " ]
+                     "value" : [ "","define ","CanConvertQuantityNullFirstNull",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -7272,7 +8037,7 @@ module.exports['CanConvertQuantity'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","CanConvertQuantityNullSecondNUll",": " ]
+                     "value" : [ "","define ","CanConvertQuantityNullSecondNUll",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {

--- a/test/elm/date/data.js
+++ b/test/elm/date/data.js
@@ -22,6 +22,14 @@ module.exports['Date'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "13",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -39,7 +47,27 @@ module.exports['Date'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -63,7 +91,7 @@ module.exports['Date'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","Year",": " ]
+                     "value" : [ "","define ","Year",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -93,7 +121,7 @@ module.exports['Date'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","Month",": " ]
+                     "value" : [ "","define ","Month",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -129,7 +157,7 @@ module.exports['Date'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","Day",": " ]
+                     "value" : [ "","define ","Day",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -188,6 +216,14 @@ module.exports['DateComponentFrom'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "32",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -205,7 +241,27 @@ module.exports['DateComponentFrom'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -229,7 +285,7 @@ module.exports['DateComponentFrom'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define ","IdesOfMarch",": " ]
+                     "value" : [ "","define ","IdesOfMarch",": " ]
                   }, {
                      "r" : "5",
                      "s" : [ {
@@ -271,7 +327,7 @@ module.exports['DateComponentFrom'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","Year",": " ]
+                     "value" : [ "","define ","Year",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -305,7 +361,7 @@ module.exports['DateComponentFrom'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","Month",": " ]
+                     "value" : [ "","define ","Month",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -339,7 +395,7 @@ module.exports['DateComponentFrom'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","Day",": " ]
+                     "value" : [ "","define ","Day",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -373,7 +429,7 @@ module.exports['DateComponentFrom'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseIdesOfMarch",": " ]
+                     "value" : [ "","define ","ImpreciseIdesOfMarch",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -409,7 +465,7 @@ module.exports['DateComponentFrom'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseComponentTuple",": " ]
+                     "value" : [ "","define ","ImpreciseComponentTuple",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -517,7 +573,7 @@ module.exports['DateComponentFrom'] = {
                "s" : {
                   "r" : "32",
                   "s" : [ {
-                     "value" : [ "define ","NullDate",": " ]
+                     "value" : [ "","define ","NullDate",": " ]
                   }, {
                      "r" : "31",
                      "s" : [ {
@@ -592,6 +648,14 @@ module.exports['SameAs'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "123",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -609,7 +673,27 @@ module.exports['SameAs'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -633,7 +717,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","SameYear",": " ]
+                     "value" : [ "","define ","SameYear",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -713,7 +797,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","NotSameYear",": " ]
+                     "value" : [ "","define ","NotSameYear",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -793,7 +877,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","SameMonth",": " ]
+                     "value" : [ "","define ","SameMonth",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -873,7 +957,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","NotSameMonth",": " ]
+                     "value" : [ "","define ","NotSameMonth",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -953,7 +1037,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "51",
                   "s" : [ {
-                     "value" : [ "define ","SameMonthWrongYear",": " ]
+                     "value" : [ "","define ","SameMonthWrongYear",": " ]
                   }, {
                      "r" : "50",
                      "s" : [ {
@@ -1033,7 +1117,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "61",
                   "s" : [ {
-                     "value" : [ "define ","SameDay",": " ]
+                     "value" : [ "","define ","SameDay",": " ]
                   }, {
                      "r" : "60",
                      "s" : [ {
@@ -1113,7 +1197,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "71",
                   "s" : [ {
-                     "value" : [ "define ","NotSameDay",": " ]
+                     "value" : [ "","define ","NotSameDay",": " ]
                   }, {
                      "r" : "70",
                      "s" : [ {
@@ -1193,7 +1277,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "81",
                   "s" : [ {
-                     "value" : [ "define ","SameDayWrongMonth",": " ]
+                     "value" : [ "","define ","SameDayWrongMonth",": " ]
                   }, {
                      "r" : "80",
                      "s" : [ {
@@ -1273,7 +1357,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "91",
                   "s" : [ {
-                     "value" : [ "define ","Same",": " ]
+                     "value" : [ "","define ","Same",": " ]
                   }, {
                      "r" : "90",
                      "s" : [ {
@@ -1352,7 +1436,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "101",
                   "s" : [ {
-                     "value" : [ "define ","NotSame",": " ]
+                     "value" : [ "","define ","NotSame",": " ]
                   }, {
                      "r" : "100",
                      "s" : [ {
@@ -1431,7 +1515,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "108",
                   "s" : [ {
-                     "value" : [ "define ","NullLeft",": " ]
+                     "value" : [ "","define ","NullLeft",": " ]
                   }, {
                      "r" : "107",
                      "s" : [ {
@@ -1490,7 +1574,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "117",
                   "s" : [ {
-                     "value" : [ "define ","NullRight",": " ]
+                     "value" : [ "","define ","NullRight",": " ]
                   }, {
                      "r" : "116",
                      "s" : [ {
@@ -1573,7 +1657,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "123",
                   "s" : [ {
-                     "value" : [ "define ","NullBoth",": " ]
+                     "value" : [ "","define ","NullBoth",": " ]
                   }, {
                      "r" : "122",
                      "s" : [ {
@@ -1663,6 +1747,14 @@ module.exports['SameOrAfter'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "198",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1680,7 +1772,27 @@ module.exports['SameOrAfter'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1704,7 +1816,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","SameYear",": " ]
+                     "value" : [ "","define ","SameYear",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -1784,7 +1896,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","YearAfter",": " ]
+                     "value" : [ "","define ","YearAfter",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -1864,7 +1976,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","YearBefore",": " ]
+                     "value" : [ "","define ","YearBefore",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -1944,7 +2056,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","SameMonth",": " ]
+                     "value" : [ "","define ","SameMonth",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -2024,7 +2136,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "51",
                   "s" : [ {
-                     "value" : [ "define ","MonthAfter",": " ]
+                     "value" : [ "","define ","MonthAfter",": " ]
                   }, {
                      "r" : "50",
                      "s" : [ {
@@ -2104,7 +2216,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "61",
                   "s" : [ {
-                     "value" : [ "define ","MonthBefore",": " ]
+                     "value" : [ "","define ","MonthBefore",": " ]
                   }, {
                      "r" : "60",
                      "s" : [ {
@@ -2184,7 +2296,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "71",
                   "s" : [ {
-                     "value" : [ "define ","SameDay",": " ]
+                     "value" : [ "","define ","SameDay",": " ]
                   }, {
                      "r" : "70",
                      "s" : [ {
@@ -2264,7 +2376,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "81",
                   "s" : [ {
-                     "value" : [ "define ","DayAfter",": " ]
+                     "value" : [ "","define ","DayAfter",": " ]
                   }, {
                      "r" : "80",
                      "s" : [ {
@@ -2344,7 +2456,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "91",
                   "s" : [ {
-                     "value" : [ "define ","DayBefore",": " ]
+                     "value" : [ "","define ","DayBefore",": " ]
                   }, {
                      "r" : "90",
                      "s" : [ {
@@ -2424,7 +2536,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "101",
                   "s" : [ {
-                     "value" : [ "define ","Same",": " ]
+                     "value" : [ "","define ","Same",": " ]
                   }, {
                      "r" : "100",
                      "s" : [ {
@@ -2503,7 +2615,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "111",
                   "s" : [ {
-                     "value" : [ "define ","After",": " ]
+                     "value" : [ "","define ","After",": " ]
                   }, {
                      "r" : "110",
                      "s" : [ {
@@ -2582,7 +2694,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "121",
                   "s" : [ {
-                     "value" : [ "define ","Before",": " ]
+                     "value" : [ "","define ","Before",": " ]
                   }, {
                      "r" : "120",
                      "s" : [ {
@@ -2661,7 +2773,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "131",
                   "s" : [ {
-                     "value" : [ "define ","SameDayMonthBefore",": " ]
+                     "value" : [ "","define ","SameDayMonthBefore",": " ]
                   }, {
                      "r" : "130",
                      "s" : [ {
@@ -2741,7 +2853,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "141",
                   "s" : [ {
-                     "value" : [ "define ","DayAfterMonthBefore",": " ]
+                     "value" : [ "","define ","DayAfterMonthBefore",": " ]
                   }, {
                      "r" : "140",
                      "s" : [ {
@@ -2821,7 +2933,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "151",
                   "s" : [ {
-                     "value" : [ "define ","DayBeforeMonthAfter",": " ]
+                     "value" : [ "","define ","DayBeforeMonthAfter",": " ]
                   }, {
                      "r" : "150",
                      "s" : [ {
@@ -2901,7 +3013,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "160",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDay",": " ]
+                     "value" : [ "","define ","ImpreciseDay",": " ]
                   }, {
                      "r" : "159",
                      "s" : [ {
@@ -2975,7 +3087,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "169",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDayMonthAfter",": " ]
+                     "value" : [ "","define ","ImpreciseDayMonthAfter",": " ]
                   }, {
                      "r" : "168",
                      "s" : [ {
@@ -3049,7 +3161,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "178",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDayMonthBefore",": " ]
+                     "value" : [ "","define ","ImpreciseDayMonthBefore",": " ]
                   }, {
                      "r" : "177",
                      "s" : [ {
@@ -3123,7 +3235,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "185",
                   "s" : [ {
-                     "value" : [ "define ","NullLeft",": " ]
+                     "value" : [ "","define ","NullLeft",": " ]
                   }, {
                      "r" : "184",
                      "s" : [ {
@@ -3182,7 +3294,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "192",
                   "s" : [ {
-                     "value" : [ "define ","NullRight",": " ]
+                     "value" : [ "","define ","NullRight",": " ]
                   }, {
                      "r" : "191",
                      "s" : [ {
@@ -3241,7 +3353,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "198",
                   "s" : [ {
-                     "value" : [ "define ","NullBoth",": " ]
+                     "value" : [ "","define ","NullBoth",": " ]
                   }, {
                      "r" : "197",
                      "s" : [ {
@@ -3331,6 +3443,14 @@ module.exports['SameOrBefore'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "198",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3348,7 +3468,27 @@ module.exports['SameOrBefore'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3372,7 +3512,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","SameYear",": " ]
+                     "value" : [ "","define ","SameYear",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -3452,7 +3592,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","YearAfter",": " ]
+                     "value" : [ "","define ","YearAfter",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -3532,7 +3672,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","YearBefore",": " ]
+                     "value" : [ "","define ","YearBefore",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -3612,7 +3752,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","SameMonth",": " ]
+                     "value" : [ "","define ","SameMonth",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -3692,7 +3832,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "51",
                   "s" : [ {
-                     "value" : [ "define ","MonthAfter",": " ]
+                     "value" : [ "","define ","MonthAfter",": " ]
                   }, {
                      "r" : "50",
                      "s" : [ {
@@ -3772,7 +3912,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "61",
                   "s" : [ {
-                     "value" : [ "define ","MonthBefore",": " ]
+                     "value" : [ "","define ","MonthBefore",": " ]
                   }, {
                      "r" : "60",
                      "s" : [ {
@@ -3852,7 +3992,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "71",
                   "s" : [ {
-                     "value" : [ "define ","SameDay",": " ]
+                     "value" : [ "","define ","SameDay",": " ]
                   }, {
                      "r" : "70",
                      "s" : [ {
@@ -3932,7 +4072,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "81",
                   "s" : [ {
-                     "value" : [ "define ","DayAfter",": " ]
+                     "value" : [ "","define ","DayAfter",": " ]
                   }, {
                      "r" : "80",
                      "s" : [ {
@@ -4012,7 +4152,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "91",
                   "s" : [ {
-                     "value" : [ "define ","DayBefore",": " ]
+                     "value" : [ "","define ","DayBefore",": " ]
                   }, {
                      "r" : "90",
                      "s" : [ {
@@ -4092,7 +4232,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "101",
                   "s" : [ {
-                     "value" : [ "define ","Same",": " ]
+                     "value" : [ "","define ","Same",": " ]
                   }, {
                      "r" : "100",
                      "s" : [ {
@@ -4171,7 +4311,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "111",
                   "s" : [ {
-                     "value" : [ "define ","After",": " ]
+                     "value" : [ "","define ","After",": " ]
                   }, {
                      "r" : "110",
                      "s" : [ {
@@ -4250,7 +4390,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "121",
                   "s" : [ {
-                     "value" : [ "define ","Before",": " ]
+                     "value" : [ "","define ","Before",": " ]
                   }, {
                      "r" : "120",
                      "s" : [ {
@@ -4329,7 +4469,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "131",
                   "s" : [ {
-                     "value" : [ "define ","SameDayMonthBefore",": " ]
+                     "value" : [ "","define ","SameDayMonthBefore",": " ]
                   }, {
                      "r" : "130",
                      "s" : [ {
@@ -4409,7 +4549,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "141",
                   "s" : [ {
-                     "value" : [ "define ","DayAfterMonthBefore",": " ]
+                     "value" : [ "","define ","DayAfterMonthBefore",": " ]
                   }, {
                      "r" : "140",
                      "s" : [ {
@@ -4489,7 +4629,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "151",
                   "s" : [ {
-                     "value" : [ "define ","DayBeforeMonthAfter",": " ]
+                     "value" : [ "","define ","DayBeforeMonthAfter",": " ]
                   }, {
                      "r" : "150",
                      "s" : [ {
@@ -4569,7 +4709,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "160",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDay",": " ]
+                     "value" : [ "","define ","ImpreciseDay",": " ]
                   }, {
                      "r" : "159",
                      "s" : [ {
@@ -4643,7 +4783,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "169",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDayMonthAfter",": " ]
+                     "value" : [ "","define ","ImpreciseDayMonthAfter",": " ]
                   }, {
                      "r" : "168",
                      "s" : [ {
@@ -4717,7 +4857,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "178",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDayMonthBefore",": " ]
+                     "value" : [ "","define ","ImpreciseDayMonthBefore",": " ]
                   }, {
                      "r" : "177",
                      "s" : [ {
@@ -4791,7 +4931,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "185",
                   "s" : [ {
-                     "value" : [ "define ","NullLeft",": " ]
+                     "value" : [ "","define ","NullLeft",": " ]
                   }, {
                      "r" : "184",
                      "s" : [ {
@@ -4850,7 +4990,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "192",
                   "s" : [ {
-                     "value" : [ "define ","NullRight",": " ]
+                     "value" : [ "","define ","NullRight",": " ]
                   }, {
                      "r" : "191",
                      "s" : [ {
@@ -4909,7 +5049,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "198",
                   "s" : [ {
-                     "value" : [ "define ","NullBoth",": " ]
+                     "value" : [ "","define ","NullBoth",": " ]
                   }, {
                      "r" : "197",
                      "s" : [ {
@@ -4996,6 +5136,14 @@ module.exports['After'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "168",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -5013,7 +5161,27 @@ module.exports['After'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -5037,7 +5205,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","SameYear",": " ]
+                     "value" : [ "","define ","SameYear",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -5117,7 +5285,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","YearAfter",": " ]
+                     "value" : [ "","define ","YearAfter",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -5197,7 +5365,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","YearBefore",": " ]
+                     "value" : [ "","define ","YearBefore",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -5277,7 +5445,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","SameMonth",": " ]
+                     "value" : [ "","define ","SameMonth",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -5357,7 +5525,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "51",
                   "s" : [ {
-                     "value" : [ "define ","MonthAfter",": " ]
+                     "value" : [ "","define ","MonthAfter",": " ]
                   }, {
                      "r" : "50",
                      "s" : [ {
@@ -5437,7 +5605,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "61",
                   "s" : [ {
-                     "value" : [ "define ","MonthBefore",": " ]
+                     "value" : [ "","define ","MonthBefore",": " ]
                   }, {
                      "r" : "60",
                      "s" : [ {
@@ -5517,7 +5685,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "71",
                   "s" : [ {
-                     "value" : [ "define ","SameDay",": " ]
+                     "value" : [ "","define ","SameDay",": " ]
                   }, {
                      "r" : "70",
                      "s" : [ {
@@ -5597,7 +5765,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "81",
                   "s" : [ {
-                     "value" : [ "define ","DayAfter",": " ]
+                     "value" : [ "","define ","DayAfter",": " ]
                   }, {
                      "r" : "80",
                      "s" : [ {
@@ -5677,7 +5845,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "91",
                   "s" : [ {
-                     "value" : [ "define ","DayBefore",": " ]
+                     "value" : [ "","define ","DayBefore",": " ]
                   }, {
                      "r" : "90",
                      "s" : [ {
@@ -5757,7 +5925,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "101",
                   "s" : [ {
-                     "value" : [ "define ","Same",": " ]
+                     "value" : [ "","define ","Same",": " ]
                   }, {
                      "r" : "100",
                      "s" : [ {
@@ -5836,7 +6004,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "111",
                   "s" : [ {
-                     "value" : [ "define ","After",": " ]
+                     "value" : [ "","define ","After",": " ]
                   }, {
                      "r" : "110",
                      "s" : [ {
@@ -5915,7 +6083,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "121",
                   "s" : [ {
-                     "value" : [ "define ","Before",": " ]
+                     "value" : [ "","define ","Before",": " ]
                   }, {
                      "r" : "120",
                      "s" : [ {
@@ -5994,7 +6162,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "130",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDay",": " ]
+                     "value" : [ "","define ","ImpreciseDay",": " ]
                   }, {
                      "r" : "129",
                      "s" : [ {
@@ -6068,7 +6236,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "139",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDayMonthAfter",": " ]
+                     "value" : [ "","define ","ImpreciseDayMonthAfter",": " ]
                   }, {
                      "r" : "138",
                      "s" : [ {
@@ -6142,7 +6310,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "148",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDayMonthBefore",": " ]
+                     "value" : [ "","define ","ImpreciseDayMonthBefore",": " ]
                   }, {
                      "r" : "147",
                      "s" : [ {
@@ -6216,7 +6384,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "155",
                   "s" : [ {
-                     "value" : [ "define ","NullLeft",": " ]
+                     "value" : [ "","define ","NullLeft",": " ]
                   }, {
                      "r" : "154",
                      "s" : [ {
@@ -6275,7 +6443,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "162",
                   "s" : [ {
-                     "value" : [ "define ","NullRight",": " ]
+                     "value" : [ "","define ","NullRight",": " ]
                   }, {
                      "r" : "161",
                      "s" : [ {
@@ -6334,7 +6502,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "168",
                   "s" : [ {
-                     "value" : [ "define ","NullBoth",": " ]
+                     "value" : [ "","define ","NullBoth",": " ]
                   }, {
                      "r" : "167",
                      "s" : [ {
@@ -6421,6 +6589,14 @@ module.exports['Before'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "168",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -6438,7 +6614,27 @@ module.exports['Before'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -6462,7 +6658,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","SameYear",": " ]
+                     "value" : [ "","define ","SameYear",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -6542,7 +6738,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","YearAfter",": " ]
+                     "value" : [ "","define ","YearAfter",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -6622,7 +6818,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","YearBefore",": " ]
+                     "value" : [ "","define ","YearBefore",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -6702,7 +6898,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","SameMonth",": " ]
+                     "value" : [ "","define ","SameMonth",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -6782,7 +6978,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "51",
                   "s" : [ {
-                     "value" : [ "define ","MonthAfter",": " ]
+                     "value" : [ "","define ","MonthAfter",": " ]
                   }, {
                      "r" : "50",
                      "s" : [ {
@@ -6862,7 +7058,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "61",
                   "s" : [ {
-                     "value" : [ "define ","MonthBefore",": " ]
+                     "value" : [ "","define ","MonthBefore",": " ]
                   }, {
                      "r" : "60",
                      "s" : [ {
@@ -6942,7 +7138,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "71",
                   "s" : [ {
-                     "value" : [ "define ","SameDay",": " ]
+                     "value" : [ "","define ","SameDay",": " ]
                   }, {
                      "r" : "70",
                      "s" : [ {
@@ -7022,7 +7218,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "81",
                   "s" : [ {
-                     "value" : [ "define ","DayAfter",": " ]
+                     "value" : [ "","define ","DayAfter",": " ]
                   }, {
                      "r" : "80",
                      "s" : [ {
@@ -7102,7 +7298,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "91",
                   "s" : [ {
-                     "value" : [ "define ","DayBefore",": " ]
+                     "value" : [ "","define ","DayBefore",": " ]
                   }, {
                      "r" : "90",
                      "s" : [ {
@@ -7182,7 +7378,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "101",
                   "s" : [ {
-                     "value" : [ "define ","Same",": " ]
+                     "value" : [ "","define ","Same",": " ]
                   }, {
                      "r" : "100",
                      "s" : [ {
@@ -7261,7 +7457,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "111",
                   "s" : [ {
-                     "value" : [ "define ","After",": " ]
+                     "value" : [ "","define ","After",": " ]
                   }, {
                      "r" : "110",
                      "s" : [ {
@@ -7340,7 +7536,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "121",
                   "s" : [ {
-                     "value" : [ "define ","Before",": " ]
+                     "value" : [ "","define ","Before",": " ]
                   }, {
                      "r" : "120",
                      "s" : [ {
@@ -7419,7 +7615,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "130",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDay",": " ]
+                     "value" : [ "","define ","ImpreciseDay",": " ]
                   }, {
                      "r" : "129",
                      "s" : [ {
@@ -7493,7 +7689,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "139",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDayMonthAfter",": " ]
+                     "value" : [ "","define ","ImpreciseDayMonthAfter",": " ]
                   }, {
                      "r" : "138",
                      "s" : [ {
@@ -7567,7 +7763,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "148",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDayMonthBefore",": " ]
+                     "value" : [ "","define ","ImpreciseDayMonthBefore",": " ]
                   }, {
                      "r" : "147",
                      "s" : [ {
@@ -7641,7 +7837,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "155",
                   "s" : [ {
-                     "value" : [ "define ","NullLeft",": " ]
+                     "value" : [ "","define ","NullLeft",": " ]
                   }, {
                      "r" : "154",
                      "s" : [ {
@@ -7700,7 +7896,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "162",
                   "s" : [ {
-                     "value" : [ "define ","NullRight",": " ]
+                     "value" : [ "","define ","NullRight",": " ]
                   }, {
                      "r" : "161",
                      "s" : [ {
@@ -7759,7 +7955,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "168",
                   "s" : [ {
-                     "value" : [ "define ","NullBoth",": " ]
+                     "value" : [ "","define ","NullBoth",": " ]
                   }, {
                      "r" : "167",
                      "s" : [ {
@@ -7839,6 +8035,14 @@ module.exports['DifferenceBetween'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "47",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -7856,7 +8060,27 @@ module.exports['DifferenceBetween'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -7880,7 +8104,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define ","NewYear2013",": " ]
+                     "value" : [ "","define ","NewYear2013",": " ]
                   }, {
                      "r" : "5",
                      "s" : [ {
@@ -7922,7 +8146,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","NewYear2014",": " ]
+                     "value" : [ "","define ","NewYear2014",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -7964,7 +8188,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","January2014",": " ]
+                     "value" : [ "","define ","January2014",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -8000,7 +8224,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","YearsBetween",": " ]
+                     "value" : [ "","define ","YearsBetween",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -8045,7 +8269,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","MonthsBetween",": " ]
+                     "value" : [ "","define ","MonthsBetween",": " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -8090,7 +8314,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","WeeksBetween",": " ]
+                     "value" : [ "","define ","WeeksBetween",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -8135,7 +8359,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","DaysBetween",": " ]
+                     "value" : [ "","define ","DaysBetween",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -8180,7 +8404,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "35",
                   "s" : [ {
-                     "value" : [ "define ","YearsBetweenUncertainty",": " ]
+                     "value" : [ "","define ","YearsBetweenUncertainty",": " ]
                   }, {
                      "r" : "34",
                      "s" : [ {
@@ -8225,7 +8449,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","MonthsBetweenUncertainty",": " ]
+                     "value" : [ "","define ","MonthsBetweenUncertainty",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -8270,7 +8494,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "43",
                   "s" : [ {
-                     "value" : [ "define ","WeeksBetweenUncertainty",": " ]
+                     "value" : [ "","define ","WeeksBetweenUncertainty",": " ]
                   }, {
                      "r" : "42",
                      "s" : [ {
@@ -8315,7 +8539,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "47",
                   "s" : [ {
-                     "value" : [ "define ","DaysBetweenUncertainty",": " ]
+                     "value" : [ "","define ","DaysBetweenUncertainty",": " ]
                   }, {
                      "r" : "46",
                      "s" : [ {
@@ -8386,6 +8610,14 @@ module.exports['DifferenceBetween Comparisons'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "118",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -8403,7 +8635,27 @@ module.exports['DifferenceBetween Comparisons'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -8427,7 +8679,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define ","NewYear2014",": " ]
+                     "value" : [ "","define ","NewYear2014",": " ]
                   }, {
                      "r" : "5",
                      "s" : [ {
@@ -8469,7 +8721,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","February2014",": " ]
+                     "value" : [ "","define ","February2014",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -8505,7 +8757,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","GreaterThan25DaysAfter",": " ]
+                     "value" : [ "","define ","GreaterThan25DaysAfter",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -8565,7 +8817,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "22",
                   "s" : [ {
-                     "value" : [ "define ","GreaterThan40DaysAfter",": " ]
+                     "value" : [ "","define ","GreaterThan40DaysAfter",": " ]
                   }, {
                      "r" : "21",
                      "s" : [ {
@@ -8625,7 +8877,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "28",
                   "s" : [ {
-                     "value" : [ "define ","GreaterThan80DaysAfter",": " ]
+                     "value" : [ "","define ","GreaterThan80DaysAfter",": " ]
                   }, {
                      "r" : "27",
                      "s" : [ {
@@ -8685,7 +8937,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","GreaterOrEqualTo25DaysAfter",": " ]
+                     "value" : [ "","define ","GreaterOrEqualTo25DaysAfter",": " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -8745,7 +8997,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "40",
                   "s" : [ {
-                     "value" : [ "define ","GreaterOrEqualTo40DaysAfter",": " ]
+                     "value" : [ "","define ","GreaterOrEqualTo40DaysAfter",": " ]
                   }, {
                      "r" : "39",
                      "s" : [ {
@@ -8805,7 +9057,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "46",
                   "s" : [ {
-                     "value" : [ "define ","GreaterOrEqualTo80DaysAfter",": " ]
+                     "value" : [ "","define ","GreaterOrEqualTo80DaysAfter",": " ]
                   }, {
                      "r" : "45",
                      "s" : [ {
@@ -8865,7 +9117,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "52",
                   "s" : [ {
-                     "value" : [ "define ","EqualTo25DaysAfter",": " ]
+                     "value" : [ "","define ","EqualTo25DaysAfter",": " ]
                   }, {
                      "r" : "51",
                      "s" : [ {
@@ -8925,7 +9177,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "58",
                   "s" : [ {
-                     "value" : [ "define ","EqualTo40DaysAfter",": " ]
+                     "value" : [ "","define ","EqualTo40DaysAfter",": " ]
                   }, {
                      "r" : "57",
                      "s" : [ {
@@ -8985,7 +9237,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "64",
                   "s" : [ {
-                     "value" : [ "define ","EqualTo80DaysAfter",": " ]
+                     "value" : [ "","define ","EqualTo80DaysAfter",": " ]
                   }, {
                      "r" : "63",
                      "s" : [ {
@@ -9045,7 +9297,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "70",
                   "s" : [ {
-                     "value" : [ "define ","LessOrEqualTo25DaysAfter",": " ]
+                     "value" : [ "","define ","LessOrEqualTo25DaysAfter",": " ]
                   }, {
                      "r" : "69",
                      "s" : [ {
@@ -9105,7 +9357,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "76",
                   "s" : [ {
-                     "value" : [ "define ","LessOrEqualTo40DaysAfter",": " ]
+                     "value" : [ "","define ","LessOrEqualTo40DaysAfter",": " ]
                   }, {
                      "r" : "75",
                      "s" : [ {
@@ -9165,7 +9417,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "82",
                   "s" : [ {
-                     "value" : [ "define ","LessOrEqualTo80DaysAfter",": " ]
+                     "value" : [ "","define ","LessOrEqualTo80DaysAfter",": " ]
                   }, {
                      "r" : "81",
                      "s" : [ {
@@ -9225,7 +9477,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "88",
                   "s" : [ {
-                     "value" : [ "define ","LessThan25DaysAfter",": " ]
+                     "value" : [ "","define ","LessThan25DaysAfter",": " ]
                   }, {
                      "r" : "87",
                      "s" : [ {
@@ -9285,7 +9537,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "94",
                   "s" : [ {
-                     "value" : [ "define ","LessThan40DaysAfter",": " ]
+                     "value" : [ "","define ","LessThan40DaysAfter",": " ]
                   }, {
                      "r" : "93",
                      "s" : [ {
@@ -9345,7 +9597,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "100",
                   "s" : [ {
-                     "value" : [ "define ","LessThan80DaysAfter",": " ]
+                     "value" : [ "","define ","LessThan80DaysAfter",": " ]
                   }, {
                      "r" : "99",
                      "s" : [ {
@@ -9405,7 +9657,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "106",
                   "s" : [ {
-                     "value" : [ "define ","TwentyFiveDaysLessThanDaysBetween",": " ]
+                     "value" : [ "","define ","TwentyFiveDaysLessThanDaysBetween",": " ]
                   }, {
                      "r" : "105",
                      "s" : [ {
@@ -9465,7 +9717,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "112",
                   "s" : [ {
-                     "value" : [ "define ","FortyDaysEqualToDaysBetween",": " ]
+                     "value" : [ "","define ","FortyDaysEqualToDaysBetween",": " ]
                   }, {
                      "r" : "111",
                      "s" : [ {
@@ -9525,7 +9777,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "118",
                   "s" : [ {
-                     "value" : [ "define ","TwentyFiveDaysGreaterThanDaysBetween",": " ]
+                     "value" : [ "","define ","TwentyFiveDaysGreaterThanDaysBetween",": " ]
                   }, {
                      "r" : "117",
                      "s" : [ {
@@ -9602,6 +9854,14 @@ module.exports['DurationBetween'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "47",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -9619,7 +9879,27 @@ module.exports['DurationBetween'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -9643,7 +9923,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define ","DecTen2013",": " ]
+                     "value" : [ "","define ","DecTen2013",": " ]
                   }, {
                      "r" : "5",
                      "s" : [ {
@@ -9685,7 +9965,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","JanOne2015",": " ]
+                     "value" : [ "","define ","JanOne2015",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -9727,7 +10007,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","January2015",": " ]
+                     "value" : [ "","define ","January2015",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -9763,7 +10043,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","YearsBetween",": " ]
+                     "value" : [ "","define ","YearsBetween",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -9808,7 +10088,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","MonthsBetween",": " ]
+                     "value" : [ "","define ","MonthsBetween",": " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -9853,7 +10133,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","WeeksBetween",": " ]
+                     "value" : [ "","define ","WeeksBetween",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -9898,7 +10178,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","DaysBetween",": " ]
+                     "value" : [ "","define ","DaysBetween",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -9943,7 +10223,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "35",
                   "s" : [ {
-                     "value" : [ "define ","YearsBetweenUncertainty",": " ]
+                     "value" : [ "","define ","YearsBetweenUncertainty",": " ]
                   }, {
                      "r" : "34",
                      "s" : [ {
@@ -9988,7 +10268,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","MonthsBetweenUncertainty",": " ]
+                     "value" : [ "","define ","MonthsBetweenUncertainty",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -10033,7 +10313,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "43",
                   "s" : [ {
-                     "value" : [ "define ","WeeksBetweenUncertainty",": " ]
+                     "value" : [ "","define ","WeeksBetweenUncertainty",": " ]
                   }, {
                      "r" : "42",
                      "s" : [ {
@@ -10078,7 +10358,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "47",
                   "s" : [ {
-                     "value" : [ "define ","DaysBetweenUncertainty",": " ]
+                     "value" : [ "","define ","DaysBetweenUncertainty",": " ]
                   }, {
                      "r" : "46",
                      "s" : [ {
@@ -10138,6 +10418,14 @@ module.exports['DateMath'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "38",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -10155,7 +10443,27 @@ module.exports['DateMath'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -10179,7 +10487,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define ","June15th2013",": " ]
+                     "value" : [ "","define ","June15th2013",": " ]
                   }, {
                      "r" : "5",
                      "s" : [ {
@@ -10221,7 +10529,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","PlusThreeYears",": " ]
+                     "value" : [ "","define ","PlusThreeYears",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -10264,7 +10572,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","MinusThreeYears",": " ]
+                     "value" : [ "","define ","MinusThreeYears",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -10307,7 +10615,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "18",
                   "s" : [ {
-                     "value" : [ "define ","PlusEightMonths",": " ]
+                     "value" : [ "","define ","PlusEightMonths",": " ]
                   }, {
                      "r" : "17",
                      "s" : [ {
@@ -10350,7 +10658,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "22",
                   "s" : [ {
-                     "value" : [ "define ","MinusEightMonths",": " ]
+                     "value" : [ "","define ","MinusEightMonths",": " ]
                   }, {
                      "r" : "21",
                      "s" : [ {
@@ -10393,7 +10701,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "26",
                   "s" : [ {
-                     "value" : [ "define ","PlusThreeWeeks",": " ]
+                     "value" : [ "","define ","PlusThreeWeeks",": " ]
                   }, {
                      "r" : "25",
                      "s" : [ {
@@ -10436,7 +10744,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "30",
                   "s" : [ {
-                     "value" : [ "define ","MinusThreeWeeks",": " ]
+                     "value" : [ "","define ","MinusThreeWeeks",": " ]
                   }, {
                      "r" : "29",
                      "s" : [ {
@@ -10479,7 +10787,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","PlusTwentyDays",": " ]
+                     "value" : [ "","define ","PlusTwentyDays",": " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -10522,7 +10830,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "38",
                   "s" : [ {
-                     "value" : [ "define ","MinusTwentyDays",": " ]
+                     "value" : [ "","define ","MinusTwentyDays",": " ]
                   }, {
                      "r" : "37",
                      "s" : [ {

--- a/test/elm/datetime/data.js
+++ b/test/elm/datetime/data.js
@@ -27,6 +27,14 @@ module.exports['DateTime'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "54",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -44,7 +52,27 @@ module.exports['DateTime'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -68,7 +96,7 @@ module.exports['DateTime'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","Year",": " ]
+                     "value" : [ "","define ","Year",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -98,7 +126,7 @@ module.exports['DateTime'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","Month",": " ]
+                     "value" : [ "","define ","Month",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -134,7 +162,7 @@ module.exports['DateTime'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","Day",": " ]
+                     "value" : [ "","define ","Day",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -176,7 +204,7 @@ module.exports['DateTime'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","Hour",": " ]
+                     "value" : [ "","define ","Hour",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -224,7 +252,7 @@ module.exports['DateTime'] = {
                "s" : {
                   "r" : "26",
                   "s" : [ {
-                     "value" : [ "define ","Minute",": " ]
+                     "value" : [ "","define ","Minute",": " ]
                   }, {
                      "r" : "25",
                      "s" : [ {
@@ -278,7 +306,7 @@ module.exports['DateTime'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","Second",": " ]
+                     "value" : [ "","define ","Second",": " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -338,7 +366,7 @@ module.exports['DateTime'] = {
                "s" : {
                   "r" : "43",
                   "s" : [ {
-                     "value" : [ "define ","Millisecond",": " ]
+                     "value" : [ "","define ","Millisecond",": " ]
                   }, {
                      "r" : "42",
                      "s" : [ {
@@ -404,7 +432,7 @@ module.exports['DateTime'] = {
                "s" : {
                   "r" : "54",
                   "s" : [ {
-                     "value" : [ "define ","TimezoneOffset",": " ]
+                     "value" : [ "","define ","TimezoneOffset",": " ]
                   }, {
                      "r" : "53",
                      "s" : [ {
@@ -498,6 +526,14 @@ module.exports['Time'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "19",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -515,7 +551,27 @@ module.exports['Time'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -539,7 +595,7 @@ module.exports['Time'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","Hour",": " ]
+                     "value" : [ "","define ","Hour",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -569,7 +625,7 @@ module.exports['Time'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","Minute",": " ]
+                     "value" : [ "","define ","Minute",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -605,7 +661,7 @@ module.exports['Time'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","Second",": " ]
+                     "value" : [ "","define ","Second",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -647,7 +703,7 @@ module.exports['Time'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","Millisecond",": " ]
+                     "value" : [ "","define ","Millisecond",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -702,6 +758,14 @@ module.exports['Today'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "3",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -719,7 +783,27 @@ module.exports['Today'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -743,7 +827,7 @@ module.exports['Today'] = {
                "s" : {
                   "r" : "3",
                   "s" : [ {
-                     "value" : [ "define ","TodayVar",": " ]
+                     "value" : [ "","define ","TodayVar",": " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -773,6 +857,14 @@ module.exports['Now'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "3",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -790,7 +882,27 @@ module.exports['Now'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -814,7 +926,7 @@ module.exports['Now'] = {
                "s" : {
                   "r" : "3",
                   "s" : [ {
-                     "value" : [ "define ","NowVar",": " ]
+                     "value" : [ "","define ","NowVar",": " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -844,6 +956,14 @@ module.exports['TimeOfDay'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "3",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -861,7 +981,27 @@ module.exports['TimeOfDay'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -885,7 +1025,7 @@ module.exports['TimeOfDay'] = {
                "s" : {
                   "r" : "3",
                   "s" : [ {
-                     "value" : [ "define ","TimeOfDayVar",": " ]
+                     "value" : [ "","define ","TimeOfDayVar",": " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -933,6 +1073,14 @@ module.exports['DateTimeComponentFrom'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "58",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -950,7 +1098,27 @@ module.exports['DateTimeComponentFrom'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -974,7 +1142,7 @@ module.exports['DateTimeComponentFrom'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","IdesOfMarch",": " ]
+                     "value" : [ "","define ","IdesOfMarch",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -1054,7 +1222,7 @@ module.exports['DateTimeComponentFrom'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","Year",": " ]
+                     "value" : [ "","define ","Year",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -1088,7 +1256,7 @@ module.exports['DateTimeComponentFrom'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","Month",": " ]
+                     "value" : [ "","define ","Month",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -1122,7 +1290,7 @@ module.exports['DateTimeComponentFrom'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","Day",": " ]
+                     "value" : [ "","define ","Day",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -1156,7 +1324,7 @@ module.exports['DateTimeComponentFrom'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","Hour",": " ]
+                     "value" : [ "","define ","Hour",": " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -1190,7 +1358,7 @@ module.exports['DateTimeComponentFrom'] = {
                "s" : {
                   "r" : "26",
                   "s" : [ {
-                     "value" : [ "define ","Minute",": " ]
+                     "value" : [ "","define ","Minute",": " ]
                   }, {
                      "r" : "25",
                      "s" : [ {
@@ -1224,7 +1392,7 @@ module.exports['DateTimeComponentFrom'] = {
                "s" : {
                   "r" : "29",
                   "s" : [ {
-                     "value" : [ "define ","Second",": " ]
+                     "value" : [ "","define ","Second",": " ]
                   }, {
                      "r" : "28",
                      "s" : [ {
@@ -1258,7 +1426,7 @@ module.exports['DateTimeComponentFrom'] = {
                "s" : {
                   "r" : "32",
                   "s" : [ {
-                     "value" : [ "define ","Millisecond",": " ]
+                     "value" : [ "","define ","Millisecond",": " ]
                   }, {
                      "r" : "31",
                      "s" : [ {
@@ -1292,7 +1460,7 @@ module.exports['DateTimeComponentFrom'] = {
                "s" : {
                   "r" : "37",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseIdesOfMarch",": " ]
+                     "value" : [ "","define ","ImpreciseIdesOfMarch",": " ]
                   }, {
                      "r" : "36",
                      "s" : [ {
@@ -1334,7 +1502,7 @@ module.exports['DateTimeComponentFrom'] = {
                "s" : {
                   "r" : "53",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseComponentTuple",": " ]
+                     "value" : [ "","define ","ImpreciseComponentTuple",": " ]
                   }, {
                      "r" : "52",
                      "s" : [ {
@@ -1554,7 +1722,7 @@ module.exports['DateTimeComponentFrom'] = {
                "s" : {
                   "r" : "58",
                   "s" : [ {
-                     "value" : [ "define ","NullDate",": " ]
+                     "value" : [ "","define ","NullDate",": " ]
                   }, {
                      "r" : "57",
                      "s" : [ {
@@ -1619,6 +1787,14 @@ module.exports['DateFrom'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "21",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1636,7 +1812,27 @@ module.exports['DateFrom'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1660,7 +1856,7 @@ module.exports['DateFrom'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","Date",": " ]
+                     "value" : [ "","define ","Date",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -1749,7 +1945,7 @@ module.exports['DateFrom'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDate",": " ]
+                     "value" : [ "","define ","ImpreciseDate",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -1788,7 +1984,7 @@ module.exports['DateFrom'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","NullDate",": " ]
+                     "value" : [ "","define ","NullDate",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -1852,6 +2048,14 @@ module.exports['TimeFrom'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "21",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1869,7 +2073,27 @@ module.exports['TimeFrom'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1893,7 +2117,7 @@ module.exports['TimeFrom'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","Time",": " ]
+                     "value" : [ "","define ","Time",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -1982,7 +2206,7 @@ module.exports['TimeFrom'] = {
                "s" : {
                   "r" : "18",
                   "s" : [ {
-                     "value" : [ "define ","NoTime",": " ]
+                     "value" : [ "","define ","NoTime",": " ]
                   }, {
                      "r" : "17",
                      "s" : [ {
@@ -2033,7 +2257,7 @@ module.exports['TimeFrom'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","NullDate",": " ]
+                     "value" : [ "","define ","NullDate",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -2075,6 +2299,14 @@ module.exports['TimezoneOffsetFrom'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "39",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2092,7 +2324,27 @@ module.exports['TimezoneOffsetFrom'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2116,7 +2368,7 @@ module.exports['TimezoneOffsetFrom'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","CentralEuropean",": " ]
+                     "value" : [ "","define ","CentralEuropean",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -2205,7 +2457,7 @@ module.exports['TimezoneOffsetFrom'] = {
                "s" : {
                   "r" : "24",
                   "s" : [ {
-                     "value" : [ "define ","EasternStandard",": " ]
+                     "value" : [ "","define ","EasternStandard",": " ]
                   }, {
                      "r" : "23",
                      "s" : [ {
@@ -2298,7 +2550,7 @@ module.exports['TimezoneOffsetFrom'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","DefaultTimezone",": " ]
+                     "value" : [ "","define ","DefaultTimezone",": " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -2373,7 +2625,7 @@ module.exports['TimezoneOffsetFrom'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","NullDate",": " ]
+                     "value" : [ "","define ","NullDate",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -2463,6 +2715,14 @@ module.exports['SameAs'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "543",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2480,7 +2740,27 @@ module.exports['SameAs'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2504,7 +2784,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","SameYear",": " ]
+                     "value" : [ "","define ","SameYear",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -2660,7 +2940,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","NotSameYear",": " ]
+                     "value" : [ "","define ","NotSameYear",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -2816,7 +3096,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "61",
                   "s" : [ {
-                     "value" : [ "define ","SameMonth",": " ]
+                     "value" : [ "","define ","SameMonth",": " ]
                   }, {
                      "r" : "60",
                      "s" : [ {
@@ -2972,7 +3252,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "81",
                   "s" : [ {
-                     "value" : [ "define ","NotSameMonth",": " ]
+                     "value" : [ "","define ","NotSameMonth",": " ]
                   }, {
                      "r" : "80",
                      "s" : [ {
@@ -3128,7 +3408,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "101",
                   "s" : [ {
-                     "value" : [ "define ","SameMonthWrongYear",": " ]
+                     "value" : [ "","define ","SameMonthWrongYear",": " ]
                   }, {
                      "r" : "100",
                      "s" : [ {
@@ -3284,7 +3564,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "121",
                   "s" : [ {
-                     "value" : [ "define ","SameDay",": " ]
+                     "value" : [ "","define ","SameDay",": " ]
                   }, {
                      "r" : "120",
                      "s" : [ {
@@ -3440,7 +3720,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "141",
                   "s" : [ {
-                     "value" : [ "define ","NotSameDay",": " ]
+                     "value" : [ "","define ","NotSameDay",": " ]
                   }, {
                      "r" : "140",
                      "s" : [ {
@@ -3596,7 +3876,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "161",
                   "s" : [ {
-                     "value" : [ "define ","SameDayWrongMonth",": " ]
+                     "value" : [ "","define ","SameDayWrongMonth",": " ]
                   }, {
                      "r" : "160",
                      "s" : [ {
@@ -3752,7 +4032,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "181",
                   "s" : [ {
-                     "value" : [ "define ","SameHour",": " ]
+                     "value" : [ "","define ","SameHour",": " ]
                   }, {
                      "r" : "180",
                      "s" : [ {
@@ -3908,7 +4188,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "201",
                   "s" : [ {
-                     "value" : [ "define ","NotSameHour",": " ]
+                     "value" : [ "","define ","NotSameHour",": " ]
                   }, {
                      "r" : "200",
                      "s" : [ {
@@ -4064,7 +4344,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "221",
                   "s" : [ {
-                     "value" : [ "define ","SameHourWrongDay",": " ]
+                     "value" : [ "","define ","SameHourWrongDay",": " ]
                   }, {
                      "r" : "220",
                      "s" : [ {
@@ -4220,7 +4500,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "241",
                   "s" : [ {
-                     "value" : [ "define ","SameMinute",": " ]
+                     "value" : [ "","define ","SameMinute",": " ]
                   }, {
                      "r" : "240",
                      "s" : [ {
@@ -4376,7 +4656,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "261",
                   "s" : [ {
-                     "value" : [ "define ","NotSameMinute",": " ]
+                     "value" : [ "","define ","NotSameMinute",": " ]
                   }, {
                      "r" : "260",
                      "s" : [ {
@@ -4532,7 +4812,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "281",
                   "s" : [ {
-                     "value" : [ "define ","SameMinuteWrongHour",": " ]
+                     "value" : [ "","define ","SameMinuteWrongHour",": " ]
                   }, {
                      "r" : "280",
                      "s" : [ {
@@ -4688,7 +4968,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "301",
                   "s" : [ {
-                     "value" : [ "define ","SameSecond",": " ]
+                     "value" : [ "","define ","SameSecond",": " ]
                   }, {
                      "r" : "300",
                      "s" : [ {
@@ -4844,7 +5124,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "321",
                   "s" : [ {
-                     "value" : [ "define ","NotSameSecond",": " ]
+                     "value" : [ "","define ","NotSameSecond",": " ]
                   }, {
                      "r" : "320",
                      "s" : [ {
@@ -5000,7 +5280,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "341",
                   "s" : [ {
-                     "value" : [ "define ","SameSecondWrongMinute",": " ]
+                     "value" : [ "","define ","SameSecondWrongMinute",": " ]
                   }, {
                      "r" : "340",
                      "s" : [ {
@@ -5156,7 +5436,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "361",
                   "s" : [ {
-                     "value" : [ "define ","SameMillisecond",": " ]
+                     "value" : [ "","define ","SameMillisecond",": " ]
                   }, {
                      "r" : "360",
                      "s" : [ {
@@ -5312,7 +5592,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "381",
                   "s" : [ {
-                     "value" : [ "define ","NotSameMillisecond",": " ]
+                     "value" : [ "","define ","NotSameMillisecond",": " ]
                   }, {
                      "r" : "380",
                      "s" : [ {
@@ -5468,7 +5748,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "401",
                   "s" : [ {
-                     "value" : [ "define ","SameMillisecondWrongSecond",": " ]
+                     "value" : [ "","define ","SameMillisecondWrongSecond",": " ]
                   }, {
                      "r" : "400",
                      "s" : [ {
@@ -5624,7 +5904,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "421",
                   "s" : [ {
-                     "value" : [ "define ","Same",": " ]
+                     "value" : [ "","define ","Same",": " ]
                   }, {
                      "r" : "420",
                      "s" : [ {
@@ -5779,7 +6059,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "441",
                   "s" : [ {
-                     "value" : [ "define ","NotSame",": " ]
+                     "value" : [ "","define ","NotSame",": " ]
                   }, {
                      "r" : "440",
                      "s" : [ {
@@ -5934,7 +6214,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "462",
                   "s" : [ {
-                     "value" : [ "define ","SameNormalized",": " ]
+                     "value" : [ "","define ","SameNormalized",": " ]
                   }, {
                      "r" : "461",
                      "s" : [ {
@@ -6093,7 +6373,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "483",
                   "s" : [ {
-                     "value" : [ "define ","SameHourWrongTimezone",": " ]
+                     "value" : [ "","define ","SameHourWrongTimezone",": " ]
                   }, {
                      "r" : "482",
                      "s" : [ {
@@ -6253,7 +6533,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "497",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseHour",": " ]
+                     "value" : [ "","define ","ImpreciseHour",": " ]
                   }, {
                      "r" : "496",
                      "s" : [ {
@@ -6357,7 +6637,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "511",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseHourWrongDay",": " ]
+                     "value" : [ "","define ","ImpreciseHourWrongDay",": " ]
                   }, {
                      "r" : "510",
                      "s" : [ {
@@ -6461,7 +6741,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "523",
                   "s" : [ {
-                     "value" : [ "define ","NullLeft",": " ]
+                     "value" : [ "","define ","NullLeft",": " ]
                   }, {
                      "r" : "522",
                      "s" : [ {
@@ -6558,7 +6838,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "537",
                   "s" : [ {
-                     "value" : [ "define ","NullRight",": " ]
+                     "value" : [ "","define ","NullRight",": " ]
                   }, {
                      "r" : "536",
                      "s" : [ {
@@ -6679,7 +6959,7 @@ module.exports['SameAs'] = {
                "s" : {
                   "r" : "543",
                   "s" : [ {
-                     "value" : [ "define ","NullBoth",": " ]
+                     "value" : [ "","define ","NullBoth",": " ]
                   }, {
                      "r" : "542",
                      "s" : [ {
@@ -6798,6 +7078,14 @@ module.exports['SameOrAfter'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "853",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -6815,7 +7103,27 @@ module.exports['SameOrAfter'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -6839,7 +7147,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","SameYear",": " ]
+                     "value" : [ "","define ","SameYear",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -6995,7 +7303,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","YearAfter",": " ]
+                     "value" : [ "","define ","YearAfter",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -7151,7 +7459,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "61",
                   "s" : [ {
-                     "value" : [ "define ","YearBefore",": " ]
+                     "value" : [ "","define ","YearBefore",": " ]
                   }, {
                      "r" : "60",
                      "s" : [ {
@@ -7307,7 +7615,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "81",
                   "s" : [ {
-                     "value" : [ "define ","SameMonth",": " ]
+                     "value" : [ "","define ","SameMonth",": " ]
                   }, {
                      "r" : "80",
                      "s" : [ {
@@ -7463,7 +7771,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "101",
                   "s" : [ {
-                     "value" : [ "define ","MonthAfter",": " ]
+                     "value" : [ "","define ","MonthAfter",": " ]
                   }, {
                      "r" : "100",
                      "s" : [ {
@@ -7619,7 +7927,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "121",
                   "s" : [ {
-                     "value" : [ "define ","MonthBefore",": " ]
+                     "value" : [ "","define ","MonthBefore",": " ]
                   }, {
                      "r" : "120",
                      "s" : [ {
@@ -7775,7 +8083,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "141",
                   "s" : [ {
-                     "value" : [ "define ","SameDay",": " ]
+                     "value" : [ "","define ","SameDay",": " ]
                   }, {
                      "r" : "140",
                      "s" : [ {
@@ -7931,7 +8239,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "161",
                   "s" : [ {
-                     "value" : [ "define ","DayAfter",": " ]
+                     "value" : [ "","define ","DayAfter",": " ]
                   }, {
                      "r" : "160",
                      "s" : [ {
@@ -8087,7 +8395,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "181",
                   "s" : [ {
-                     "value" : [ "define ","DayBefore",": " ]
+                     "value" : [ "","define ","DayBefore",": " ]
                   }, {
                      "r" : "180",
                      "s" : [ {
@@ -8243,7 +8551,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "201",
                   "s" : [ {
-                     "value" : [ "define ","SameHour",": " ]
+                     "value" : [ "","define ","SameHour",": " ]
                   }, {
                      "r" : "200",
                      "s" : [ {
@@ -8399,7 +8707,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "221",
                   "s" : [ {
-                     "value" : [ "define ","HourAfter",": " ]
+                     "value" : [ "","define ","HourAfter",": " ]
                   }, {
                      "r" : "220",
                      "s" : [ {
@@ -8555,7 +8863,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "241",
                   "s" : [ {
-                     "value" : [ "define ","HourBefore",": " ]
+                     "value" : [ "","define ","HourBefore",": " ]
                   }, {
                      "r" : "240",
                      "s" : [ {
@@ -8711,7 +9019,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "261",
                   "s" : [ {
-                     "value" : [ "define ","SameMinute",": " ]
+                     "value" : [ "","define ","SameMinute",": " ]
                   }, {
                      "r" : "260",
                      "s" : [ {
@@ -8867,7 +9175,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "281",
                   "s" : [ {
-                     "value" : [ "define ","MinuteAfter",": " ]
+                     "value" : [ "","define ","MinuteAfter",": " ]
                   }, {
                      "r" : "280",
                      "s" : [ {
@@ -9023,7 +9331,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "301",
                   "s" : [ {
-                     "value" : [ "define ","MinuteBefore",": " ]
+                     "value" : [ "","define ","MinuteBefore",": " ]
                   }, {
                      "r" : "300",
                      "s" : [ {
@@ -9179,7 +9487,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "321",
                   "s" : [ {
-                     "value" : [ "define ","SameSecond",": " ]
+                     "value" : [ "","define ","SameSecond",": " ]
                   }, {
                      "r" : "320",
                      "s" : [ {
@@ -9335,7 +9643,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "341",
                   "s" : [ {
-                     "value" : [ "define ","SecondAfter",": " ]
+                     "value" : [ "","define ","SecondAfter",": " ]
                   }, {
                      "r" : "340",
                      "s" : [ {
@@ -9491,7 +9799,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "361",
                   "s" : [ {
-                     "value" : [ "define ","SecondBefore",": " ]
+                     "value" : [ "","define ","SecondBefore",": " ]
                   }, {
                      "r" : "360",
                      "s" : [ {
@@ -9647,7 +9955,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "381",
                   "s" : [ {
-                     "value" : [ "define ","SameMillisecond",": " ]
+                     "value" : [ "","define ","SameMillisecond",": " ]
                   }, {
                      "r" : "380",
                      "s" : [ {
@@ -9803,7 +10111,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "401",
                   "s" : [ {
-                     "value" : [ "define ","MillisecondAfter",": " ]
+                     "value" : [ "","define ","MillisecondAfter",": " ]
                   }, {
                      "r" : "400",
                      "s" : [ {
@@ -9959,7 +10267,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "421",
                   "s" : [ {
-                     "value" : [ "define ","MillisecondBefore",": " ]
+                     "value" : [ "","define ","MillisecondBefore",": " ]
                   }, {
                      "r" : "420",
                      "s" : [ {
@@ -10115,7 +10423,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "441",
                   "s" : [ {
-                     "value" : [ "define ","Same",": " ]
+                     "value" : [ "","define ","Same",": " ]
                   }, {
                      "r" : "440",
                      "s" : [ {
@@ -10270,7 +10578,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "461",
                   "s" : [ {
-                     "value" : [ "define ","After",": " ]
+                     "value" : [ "","define ","After",": " ]
                   }, {
                      "r" : "460",
                      "s" : [ {
@@ -10425,7 +10733,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "481",
                   "s" : [ {
-                     "value" : [ "define ","Before",": " ]
+                     "value" : [ "","define ","Before",": " ]
                   }, {
                      "r" : "480",
                      "s" : [ {
@@ -10580,7 +10888,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "501",
                   "s" : [ {
-                     "value" : [ "define ","SameDayMonthBefore",": " ]
+                     "value" : [ "","define ","SameDayMonthBefore",": " ]
                   }, {
                      "r" : "500",
                      "s" : [ {
@@ -10736,7 +11044,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "521",
                   "s" : [ {
-                     "value" : [ "define ","DayAfterMonthBefore",": " ]
+                     "value" : [ "","define ","DayAfterMonthBefore",": " ]
                   }, {
                      "r" : "520",
                      "s" : [ {
@@ -10892,7 +11200,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "541",
                   "s" : [ {
-                     "value" : [ "define ","DayBeforeMonthAfter",": " ]
+                     "value" : [ "","define ","DayBeforeMonthAfter",": " ]
                   }, {
                      "r" : "540",
                      "s" : [ {
@@ -11048,7 +11356,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "554",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDay",": " ]
+                     "value" : [ "","define ","ImpreciseDay",": " ]
                   }, {
                      "r" : "553",
                      "s" : [ {
@@ -11146,7 +11454,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "567",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDayMonthAfter",": " ]
+                     "value" : [ "","define ","ImpreciseDayMonthAfter",": " ]
                   }, {
                      "r" : "566",
                      "s" : [ {
@@ -11244,7 +11552,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "580",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDayMonthBefore",": " ]
+                     "value" : [ "","define ","ImpreciseDayMonthBefore",": " ]
                   }, {
                      "r" : "579",
                      "s" : [ {
@@ -11342,7 +11650,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "601",
                   "s" : [ {
-                     "value" : [ "define ","SameHourNormalizeZones",": " ]
+                     "value" : [ "","define ","SameHourNormalizeZones",": " ]
                   }, {
                      "r" : "600",
                      "s" : [ {
@@ -11502,7 +11810,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "622",
                   "s" : [ {
-                     "value" : [ "define ","HourAfterNormalizeZones",": " ]
+                     "value" : [ "","define ","HourAfterNormalizeZones",": " ]
                   }, {
                      "r" : "621",
                      "s" : [ {
@@ -11662,7 +11970,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "643",
                   "s" : [ {
-                     "value" : [ "define ","HourBeforeNormalizeZones",": " ]
+                     "value" : [ "","define ","HourBeforeNormalizeZones",": " ]
                   }, {
                      "r" : "642",
                      "s" : [ {
@@ -11822,7 +12130,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "655",
                   "s" : [ {
-                     "value" : [ "define ","NullLeft",": " ]
+                     "value" : [ "","define ","NullLeft",": " ]
                   }, {
                      "r" : "654",
                      "s" : [ {
@@ -11919,7 +12227,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "667",
                   "s" : [ {
-                     "value" : [ "define ","NullRight",": " ]
+                     "value" : [ "","define ","NullRight",": " ]
                   }, {
                      "r" : "666",
                      "s" : [ {
@@ -12016,7 +12324,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "673",
                   "s" : [ {
-                     "value" : [ "define ","NullBoth",": " ]
+                     "value" : [ "","define ","NullBoth",": " ]
                   }, {
                      "r" : "672",
                      "s" : [ {
@@ -12079,7 +12387,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "693",
                   "s" : [ {
-                     "value" : [ "define ","SameOOA",": " ]
+                     "value" : [ "// On Or After:","define ","SameOOA",": " ]
                   }, {
                      "r" : "692",
                      "s" : [ {
@@ -12234,7 +12542,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "713",
                   "s" : [ {
-                     "value" : [ "define ","AfterOOA",": " ]
+                     "value" : [ "","define ","AfterOOA",": " ]
                   }, {
                      "r" : "712",
                      "s" : [ {
@@ -12389,7 +12697,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "733",
                   "s" : [ {
-                     "value" : [ "define ","BeforeOOA",": " ]
+                     "value" : [ "","define ","BeforeOOA",": " ]
                   }, {
                      "r" : "732",
                      "s" : [ {
@@ -12544,7 +12852,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "745",
                   "s" : [ {
-                     "value" : [ "define ","NullLeftOOA",": " ]
+                     "value" : [ "","define ","NullLeftOOA",": " ]
                   }, {
                      "r" : "744",
                      "s" : [ {
@@ -12641,7 +12949,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "757",
                   "s" : [ {
-                     "value" : [ "define ","NullRightOOA",": " ]
+                     "value" : [ "","define ","NullRightOOA",": " ]
                   }, {
                      "r" : "756",
                      "s" : [ {
@@ -12738,7 +13046,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "763",
                   "s" : [ {
-                     "value" : [ "define ","NullBothOOA",": " ]
+                     "value" : [ "","define ","NullBothOOA",": " ]
                   }, {
                      "r" : "762",
                      "s" : [ {
@@ -12801,7 +13109,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "783",
                   "s" : [ {
-                     "value" : [ "define ","SameAOO",": " ]
+                     "value" : [ "// After Or On:","define ","SameAOO",": " ]
                   }, {
                      "r" : "782",
                      "s" : [ {
@@ -12956,7 +13264,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "803",
                   "s" : [ {
-                     "value" : [ "define ","AfterAOO",": " ]
+                     "value" : [ "","define ","AfterAOO",": " ]
                   }, {
                      "r" : "802",
                      "s" : [ {
@@ -13111,7 +13419,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "823",
                   "s" : [ {
-                     "value" : [ "define ","BeforeAOO",": " ]
+                     "value" : [ "","define ","BeforeAOO",": " ]
                   }, {
                      "r" : "822",
                      "s" : [ {
@@ -13266,7 +13574,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "835",
                   "s" : [ {
-                     "value" : [ "define ","NullLeftAOO",": " ]
+                     "value" : [ "","define ","NullLeftAOO",": " ]
                   }, {
                      "r" : "834",
                      "s" : [ {
@@ -13363,7 +13671,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "847",
                   "s" : [ {
-                     "value" : [ "define ","NullRightAOO",": " ]
+                     "value" : [ "","define ","NullRightAOO",": " ]
                   }, {
                      "r" : "846",
                      "s" : [ {
@@ -13460,7 +13768,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "853",
                   "s" : [ {
-                     "value" : [ "define ","NullBothAOO",": " ]
+                     "value" : [ "","define ","NullBothAOO",": " ]
                   }, {
                      "r" : "852",
                      "s" : [ {
@@ -13579,6 +13887,14 @@ module.exports['SameOrBefore'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "853",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -13596,7 +13912,27 @@ module.exports['SameOrBefore'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -13620,7 +13956,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","SameYear",": " ]
+                     "value" : [ "","define ","SameYear",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -13776,7 +14112,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","YearAfter",": " ]
+                     "value" : [ "","define ","YearAfter",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -13932,7 +14268,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "61",
                   "s" : [ {
-                     "value" : [ "define ","YearBefore",": " ]
+                     "value" : [ "","define ","YearBefore",": " ]
                   }, {
                      "r" : "60",
                      "s" : [ {
@@ -14088,7 +14424,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "81",
                   "s" : [ {
-                     "value" : [ "define ","SameMonth",": " ]
+                     "value" : [ "","define ","SameMonth",": " ]
                   }, {
                      "r" : "80",
                      "s" : [ {
@@ -14244,7 +14580,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "101",
                   "s" : [ {
-                     "value" : [ "define ","MonthAfter",": " ]
+                     "value" : [ "","define ","MonthAfter",": " ]
                   }, {
                      "r" : "100",
                      "s" : [ {
@@ -14400,7 +14736,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "121",
                   "s" : [ {
-                     "value" : [ "define ","MonthBefore",": " ]
+                     "value" : [ "","define ","MonthBefore",": " ]
                   }, {
                      "r" : "120",
                      "s" : [ {
@@ -14556,7 +14892,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "141",
                   "s" : [ {
-                     "value" : [ "define ","SameDay",": " ]
+                     "value" : [ "","define ","SameDay",": " ]
                   }, {
                      "r" : "140",
                      "s" : [ {
@@ -14712,7 +15048,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "161",
                   "s" : [ {
-                     "value" : [ "define ","DayAfter",": " ]
+                     "value" : [ "","define ","DayAfter",": " ]
                   }, {
                      "r" : "160",
                      "s" : [ {
@@ -14868,7 +15204,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "181",
                   "s" : [ {
-                     "value" : [ "define ","DayBefore",": " ]
+                     "value" : [ "","define ","DayBefore",": " ]
                   }, {
                      "r" : "180",
                      "s" : [ {
@@ -15024,7 +15360,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "201",
                   "s" : [ {
-                     "value" : [ "define ","SameHour",": " ]
+                     "value" : [ "","define ","SameHour",": " ]
                   }, {
                      "r" : "200",
                      "s" : [ {
@@ -15180,7 +15516,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "221",
                   "s" : [ {
-                     "value" : [ "define ","HourAfter",": " ]
+                     "value" : [ "","define ","HourAfter",": " ]
                   }, {
                      "r" : "220",
                      "s" : [ {
@@ -15336,7 +15672,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "241",
                   "s" : [ {
-                     "value" : [ "define ","HourBefore",": " ]
+                     "value" : [ "","define ","HourBefore",": " ]
                   }, {
                      "r" : "240",
                      "s" : [ {
@@ -15492,7 +15828,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "261",
                   "s" : [ {
-                     "value" : [ "define ","SameMinute",": " ]
+                     "value" : [ "","define ","SameMinute",": " ]
                   }, {
                      "r" : "260",
                      "s" : [ {
@@ -15648,7 +15984,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "281",
                   "s" : [ {
-                     "value" : [ "define ","MinuteAfter",": " ]
+                     "value" : [ "","define ","MinuteAfter",": " ]
                   }, {
                      "r" : "280",
                      "s" : [ {
@@ -15804,7 +16140,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "301",
                   "s" : [ {
-                     "value" : [ "define ","MinuteBefore",": " ]
+                     "value" : [ "","define ","MinuteBefore",": " ]
                   }, {
                      "r" : "300",
                      "s" : [ {
@@ -15960,7 +16296,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "321",
                   "s" : [ {
-                     "value" : [ "define ","SameSecond",": " ]
+                     "value" : [ "","define ","SameSecond",": " ]
                   }, {
                      "r" : "320",
                      "s" : [ {
@@ -16116,7 +16452,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "341",
                   "s" : [ {
-                     "value" : [ "define ","SecondAfter",": " ]
+                     "value" : [ "","define ","SecondAfter",": " ]
                   }, {
                      "r" : "340",
                      "s" : [ {
@@ -16272,7 +16608,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "361",
                   "s" : [ {
-                     "value" : [ "define ","SecondBefore",": " ]
+                     "value" : [ "","define ","SecondBefore",": " ]
                   }, {
                      "r" : "360",
                      "s" : [ {
@@ -16428,7 +16764,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "381",
                   "s" : [ {
-                     "value" : [ "define ","SameMillisecond",": " ]
+                     "value" : [ "","define ","SameMillisecond",": " ]
                   }, {
                      "r" : "380",
                      "s" : [ {
@@ -16584,7 +16920,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "401",
                   "s" : [ {
-                     "value" : [ "define ","MillisecondAfter",": " ]
+                     "value" : [ "","define ","MillisecondAfter",": " ]
                   }, {
                      "r" : "400",
                      "s" : [ {
@@ -16740,7 +17076,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "421",
                   "s" : [ {
-                     "value" : [ "define ","MillisecondBefore",": " ]
+                     "value" : [ "","define ","MillisecondBefore",": " ]
                   }, {
                      "r" : "420",
                      "s" : [ {
@@ -16896,7 +17232,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "441",
                   "s" : [ {
-                     "value" : [ "define ","Same",": " ]
+                     "value" : [ "","define ","Same",": " ]
                   }, {
                      "r" : "440",
                      "s" : [ {
@@ -17051,7 +17387,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "461",
                   "s" : [ {
-                     "value" : [ "define ","After",": " ]
+                     "value" : [ "","define ","After",": " ]
                   }, {
                      "r" : "460",
                      "s" : [ {
@@ -17206,7 +17542,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "481",
                   "s" : [ {
-                     "value" : [ "define ","Before",": " ]
+                     "value" : [ "","define ","Before",": " ]
                   }, {
                      "r" : "480",
                      "s" : [ {
@@ -17361,7 +17697,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "501",
                   "s" : [ {
-                     "value" : [ "define ","SameDayMonthBefore",": " ]
+                     "value" : [ "","define ","SameDayMonthBefore",": " ]
                   }, {
                      "r" : "500",
                      "s" : [ {
@@ -17517,7 +17853,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "521",
                   "s" : [ {
-                     "value" : [ "define ","DayAfterMonthBefore",": " ]
+                     "value" : [ "","define ","DayAfterMonthBefore",": " ]
                   }, {
                      "r" : "520",
                      "s" : [ {
@@ -17673,7 +18009,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "541",
                   "s" : [ {
-                     "value" : [ "define ","DayBeforeMonthAfter",": " ]
+                     "value" : [ "","define ","DayBeforeMonthAfter",": " ]
                   }, {
                      "r" : "540",
                      "s" : [ {
@@ -17829,7 +18165,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "554",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDay",": " ]
+                     "value" : [ "","define ","ImpreciseDay",": " ]
                   }, {
                      "r" : "553",
                      "s" : [ {
@@ -17927,7 +18263,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "567",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDayMonthAfter",": " ]
+                     "value" : [ "","define ","ImpreciseDayMonthAfter",": " ]
                   }, {
                      "r" : "566",
                      "s" : [ {
@@ -18025,7 +18361,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "580",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDayMonthBefore",": " ]
+                     "value" : [ "","define ","ImpreciseDayMonthBefore",": " ]
                   }, {
                      "r" : "579",
                      "s" : [ {
@@ -18123,7 +18459,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "601",
                   "s" : [ {
-                     "value" : [ "define ","SameHourNormalizeZones",": " ]
+                     "value" : [ "","define ","SameHourNormalizeZones",": " ]
                   }, {
                      "r" : "600",
                      "s" : [ {
@@ -18283,7 +18619,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "622",
                   "s" : [ {
-                     "value" : [ "define ","HourAfterNormalizeZones",": " ]
+                     "value" : [ "","define ","HourAfterNormalizeZones",": " ]
                   }, {
                      "r" : "621",
                      "s" : [ {
@@ -18443,7 +18779,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "643",
                   "s" : [ {
-                     "value" : [ "define ","HourBeforeNormalizeZones",": " ]
+                     "value" : [ "","define ","HourBeforeNormalizeZones",": " ]
                   }, {
                      "r" : "642",
                      "s" : [ {
@@ -18603,7 +18939,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "655",
                   "s" : [ {
-                     "value" : [ "define ","NullLeft",": " ]
+                     "value" : [ "","define ","NullLeft",": " ]
                   }, {
                      "r" : "654",
                      "s" : [ {
@@ -18700,7 +19036,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "667",
                   "s" : [ {
-                     "value" : [ "define ","NullRight",": " ]
+                     "value" : [ "","define ","NullRight",": " ]
                   }, {
                      "r" : "666",
                      "s" : [ {
@@ -18797,7 +19133,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "673",
                   "s" : [ {
-                     "value" : [ "define ","NullBoth",": " ]
+                     "value" : [ "","define ","NullBoth",": " ]
                   }, {
                      "r" : "672",
                      "s" : [ {
@@ -18860,7 +19196,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "693",
                   "s" : [ {
-                     "value" : [ "define ","SameOOB",": " ]
+                     "value" : [ "// On Or Before:","define ","SameOOB",": " ]
                   }, {
                      "r" : "692",
                      "s" : [ {
@@ -19015,7 +19351,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "713",
                   "s" : [ {
-                     "value" : [ "define ","AfterOOB",": " ]
+                     "value" : [ "","define ","AfterOOB",": " ]
                   }, {
                      "r" : "712",
                      "s" : [ {
@@ -19170,7 +19506,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "733",
                   "s" : [ {
-                     "value" : [ "define ","BeforeOOB",": " ]
+                     "value" : [ "","define ","BeforeOOB",": " ]
                   }, {
                      "r" : "732",
                      "s" : [ {
@@ -19325,7 +19661,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "745",
                   "s" : [ {
-                     "value" : [ "define ","NullLeftOOB",": " ]
+                     "value" : [ "","define ","NullLeftOOB",": " ]
                   }, {
                      "r" : "744",
                      "s" : [ {
@@ -19422,7 +19758,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "757",
                   "s" : [ {
-                     "value" : [ "define ","NullRightOOB",": " ]
+                     "value" : [ "","define ","NullRightOOB",": " ]
                   }, {
                      "r" : "756",
                      "s" : [ {
@@ -19519,7 +19855,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "763",
                   "s" : [ {
-                     "value" : [ "define ","NullBothOOB",": " ]
+                     "value" : [ "","define ","NullBothOOB",": " ]
                   }, {
                      "r" : "762",
                      "s" : [ {
@@ -19582,7 +19918,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "783",
                   "s" : [ {
-                     "value" : [ "define ","SameBOO",": " ]
+                     "value" : [ "// Before Or On:","define ","SameBOO",": " ]
                   }, {
                      "r" : "782",
                      "s" : [ {
@@ -19737,7 +20073,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "803",
                   "s" : [ {
-                     "value" : [ "define ","AfterBOO",": " ]
+                     "value" : [ "","define ","AfterBOO",": " ]
                   }, {
                      "r" : "802",
                      "s" : [ {
@@ -19892,7 +20228,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "823",
                   "s" : [ {
-                     "value" : [ "define ","BeforeBOO",": " ]
+                     "value" : [ "","define ","BeforeBOO",": " ]
                   }, {
                      "r" : "822",
                      "s" : [ {
@@ -20047,7 +20383,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "835",
                   "s" : [ {
-                     "value" : [ "define ","NullLeftBOO",": " ]
+                     "value" : [ "","define ","NullLeftBOO",": " ]
                   }, {
                      "r" : "834",
                      "s" : [ {
@@ -20144,7 +20480,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "847",
                   "s" : [ {
-                     "value" : [ "define ","NullRightBOO",": " ]
+                     "value" : [ "","define ","NullRightBOO",": " ]
                   }, {
                      "r" : "846",
                      "s" : [ {
@@ -20241,7 +20577,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "853",
                   "s" : [ {
-                     "value" : [ "define ","NullBothBOO",": " ]
+                     "value" : [ "","define ","NullBothBOO",": " ]
                   }, {
                      "r" : "852",
                      "s" : [ {
@@ -20343,6 +20679,14 @@ module.exports['After'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "613",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -20360,7 +20704,27 @@ module.exports['After'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -20384,7 +20748,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","SameYear",": " ]
+                     "value" : [ "","define ","SameYear",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -20540,7 +20904,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","YearAfter",": " ]
+                     "value" : [ "","define ","YearAfter",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -20696,7 +21060,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "61",
                   "s" : [ {
-                     "value" : [ "define ","YearBefore",": " ]
+                     "value" : [ "","define ","YearBefore",": " ]
                   }, {
                      "r" : "60",
                      "s" : [ {
@@ -20852,7 +21216,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "81",
                   "s" : [ {
-                     "value" : [ "define ","SameMonth",": " ]
+                     "value" : [ "","define ","SameMonth",": " ]
                   }, {
                      "r" : "80",
                      "s" : [ {
@@ -21008,7 +21372,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "101",
                   "s" : [ {
-                     "value" : [ "define ","MonthAfter",": " ]
+                     "value" : [ "","define ","MonthAfter",": " ]
                   }, {
                      "r" : "100",
                      "s" : [ {
@@ -21164,7 +21528,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "121",
                   "s" : [ {
-                     "value" : [ "define ","MonthBefore",": " ]
+                     "value" : [ "","define ","MonthBefore",": " ]
                   }, {
                      "r" : "120",
                      "s" : [ {
@@ -21320,7 +21684,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "141",
                   "s" : [ {
-                     "value" : [ "define ","SameDay",": " ]
+                     "value" : [ "","define ","SameDay",": " ]
                   }, {
                      "r" : "140",
                      "s" : [ {
@@ -21476,7 +21840,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "161",
                   "s" : [ {
-                     "value" : [ "define ","DayAfter",": " ]
+                     "value" : [ "","define ","DayAfter",": " ]
                   }, {
                      "r" : "160",
                      "s" : [ {
@@ -21632,7 +21996,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "181",
                   "s" : [ {
-                     "value" : [ "define ","DayBefore",": " ]
+                     "value" : [ "","define ","DayBefore",": " ]
                   }, {
                      "r" : "180",
                      "s" : [ {
@@ -21788,7 +22152,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "201",
                   "s" : [ {
-                     "value" : [ "define ","SameHour",": " ]
+                     "value" : [ "","define ","SameHour",": " ]
                   }, {
                      "r" : "200",
                      "s" : [ {
@@ -21944,7 +22308,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "221",
                   "s" : [ {
-                     "value" : [ "define ","HourAfter",": " ]
+                     "value" : [ "","define ","HourAfter",": " ]
                   }, {
                      "r" : "220",
                      "s" : [ {
@@ -22100,7 +22464,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "241",
                   "s" : [ {
-                     "value" : [ "define ","HourBefore",": " ]
+                     "value" : [ "","define ","HourBefore",": " ]
                   }, {
                      "r" : "240",
                      "s" : [ {
@@ -22256,7 +22620,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "261",
                   "s" : [ {
-                     "value" : [ "define ","SameMinute",": " ]
+                     "value" : [ "","define ","SameMinute",": " ]
                   }, {
                      "r" : "260",
                      "s" : [ {
@@ -22412,7 +22776,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "281",
                   "s" : [ {
-                     "value" : [ "define ","MinuteAfter",": " ]
+                     "value" : [ "","define ","MinuteAfter",": " ]
                   }, {
                      "r" : "280",
                      "s" : [ {
@@ -22568,7 +22932,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "301",
                   "s" : [ {
-                     "value" : [ "define ","MinuteBefore",": " ]
+                     "value" : [ "","define ","MinuteBefore",": " ]
                   }, {
                      "r" : "300",
                      "s" : [ {
@@ -22724,7 +23088,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "321",
                   "s" : [ {
-                     "value" : [ "define ","SameSecond",": " ]
+                     "value" : [ "","define ","SameSecond",": " ]
                   }, {
                      "r" : "320",
                      "s" : [ {
@@ -22880,7 +23244,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "341",
                   "s" : [ {
-                     "value" : [ "define ","SecondAfter",": " ]
+                     "value" : [ "","define ","SecondAfter",": " ]
                   }, {
                      "r" : "340",
                      "s" : [ {
@@ -23036,7 +23400,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "361",
                   "s" : [ {
-                     "value" : [ "define ","SecondBefore",": " ]
+                     "value" : [ "","define ","SecondBefore",": " ]
                   }, {
                      "r" : "360",
                      "s" : [ {
@@ -23192,7 +23556,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "381",
                   "s" : [ {
-                     "value" : [ "define ","SameMillisecond",": " ]
+                     "value" : [ "","define ","SameMillisecond",": " ]
                   }, {
                      "r" : "380",
                      "s" : [ {
@@ -23348,7 +23712,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "401",
                   "s" : [ {
-                     "value" : [ "define ","MillisecondAfter",": " ]
+                     "value" : [ "","define ","MillisecondAfter",": " ]
                   }, {
                      "r" : "400",
                      "s" : [ {
@@ -23504,7 +23868,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "421",
                   "s" : [ {
-                     "value" : [ "define ","MillisecondBefore",": " ]
+                     "value" : [ "","define ","MillisecondBefore",": " ]
                   }, {
                      "r" : "420",
                      "s" : [ {
@@ -23660,7 +24024,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "441",
                   "s" : [ {
-                     "value" : [ "define ","Same",": " ]
+                     "value" : [ "","define ","Same",": " ]
                   }, {
                      "r" : "440",
                      "s" : [ {
@@ -23815,7 +24179,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "461",
                   "s" : [ {
-                     "value" : [ "define ","After",": " ]
+                     "value" : [ "","define ","After",": " ]
                   }, {
                      "r" : "460",
                      "s" : [ {
@@ -23970,7 +24334,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "481",
                   "s" : [ {
-                     "value" : [ "define ","Before",": " ]
+                     "value" : [ "","define ","Before",": " ]
                   }, {
                      "r" : "480",
                      "s" : [ {
@@ -24125,7 +24489,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "494",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDay",": " ]
+                     "value" : [ "","define ","ImpreciseDay",": " ]
                   }, {
                      "r" : "493",
                      "s" : [ {
@@ -24223,7 +24587,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "507",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDayMonthAfter",": " ]
+                     "value" : [ "","define ","ImpreciseDayMonthAfter",": " ]
                   }, {
                      "r" : "506",
                      "s" : [ {
@@ -24321,7 +24685,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "520",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDayMonthBefore",": " ]
+                     "value" : [ "","define ","ImpreciseDayMonthBefore",": " ]
                   }, {
                      "r" : "519",
                      "s" : [ {
@@ -24419,7 +24783,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "541",
                   "s" : [ {
-                     "value" : [ "define ","SameHourNormalizeZones",": " ]
+                     "value" : [ "","define ","SameHourNormalizeZones",": " ]
                   }, {
                      "r" : "540",
                      "s" : [ {
@@ -24579,7 +24943,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "562",
                   "s" : [ {
-                     "value" : [ "define ","HourAfterNormalizeZones",": " ]
+                     "value" : [ "","define ","HourAfterNormalizeZones",": " ]
                   }, {
                      "r" : "561",
                      "s" : [ {
@@ -24739,7 +25103,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "583",
                   "s" : [ {
-                     "value" : [ "define ","HourBeforeNormalizeZones",": " ]
+                     "value" : [ "","define ","HourBeforeNormalizeZones",": " ]
                   }, {
                      "r" : "582",
                      "s" : [ {
@@ -24899,7 +25263,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "595",
                   "s" : [ {
-                     "value" : [ "define ","NullLeft",": " ]
+                     "value" : [ "","define ","NullLeft",": " ]
                   }, {
                      "r" : "594",
                      "s" : [ {
@@ -24996,7 +25360,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "607",
                   "s" : [ {
-                     "value" : [ "define ","NullRight",": " ]
+                     "value" : [ "","define ","NullRight",": " ]
                   }, {
                      "r" : "606",
                      "s" : [ {
@@ -25093,7 +25457,7 @@ module.exports['After'] = {
                "s" : {
                   "r" : "613",
                   "s" : [ {
-                     "value" : [ "define ","NullBoth",": " ]
+                     "value" : [ "","define ","NullBoth",": " ]
                   }, {
                      "r" : "612",
                      "s" : [ {
@@ -25195,6 +25559,14 @@ module.exports['Before'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "613",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -25212,7 +25584,27 @@ module.exports['Before'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -25236,7 +25628,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","SameYear",": " ]
+                     "value" : [ "","define ","SameYear",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -25392,7 +25784,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","YearAfter",": " ]
+                     "value" : [ "","define ","YearAfter",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -25548,7 +25940,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "61",
                   "s" : [ {
-                     "value" : [ "define ","YearBefore",": " ]
+                     "value" : [ "","define ","YearBefore",": " ]
                   }, {
                      "r" : "60",
                      "s" : [ {
@@ -25704,7 +26096,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "81",
                   "s" : [ {
-                     "value" : [ "define ","SameMonth",": " ]
+                     "value" : [ "","define ","SameMonth",": " ]
                   }, {
                      "r" : "80",
                      "s" : [ {
@@ -25860,7 +26252,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "101",
                   "s" : [ {
-                     "value" : [ "define ","MonthAfter",": " ]
+                     "value" : [ "","define ","MonthAfter",": " ]
                   }, {
                      "r" : "100",
                      "s" : [ {
@@ -26016,7 +26408,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "121",
                   "s" : [ {
-                     "value" : [ "define ","MonthBefore",": " ]
+                     "value" : [ "","define ","MonthBefore",": " ]
                   }, {
                      "r" : "120",
                      "s" : [ {
@@ -26172,7 +26564,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "141",
                   "s" : [ {
-                     "value" : [ "define ","SameDay",": " ]
+                     "value" : [ "","define ","SameDay",": " ]
                   }, {
                      "r" : "140",
                      "s" : [ {
@@ -26328,7 +26720,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "161",
                   "s" : [ {
-                     "value" : [ "define ","DayAfter",": " ]
+                     "value" : [ "","define ","DayAfter",": " ]
                   }, {
                      "r" : "160",
                      "s" : [ {
@@ -26484,7 +26876,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "181",
                   "s" : [ {
-                     "value" : [ "define ","DayBefore",": " ]
+                     "value" : [ "","define ","DayBefore",": " ]
                   }, {
                      "r" : "180",
                      "s" : [ {
@@ -26640,7 +27032,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "201",
                   "s" : [ {
-                     "value" : [ "define ","SameHour",": " ]
+                     "value" : [ "","define ","SameHour",": " ]
                   }, {
                      "r" : "200",
                      "s" : [ {
@@ -26796,7 +27188,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "221",
                   "s" : [ {
-                     "value" : [ "define ","HourAfter",": " ]
+                     "value" : [ "","define ","HourAfter",": " ]
                   }, {
                      "r" : "220",
                      "s" : [ {
@@ -26952,7 +27344,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "241",
                   "s" : [ {
-                     "value" : [ "define ","HourBefore",": " ]
+                     "value" : [ "","define ","HourBefore",": " ]
                   }, {
                      "r" : "240",
                      "s" : [ {
@@ -27108,7 +27500,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "261",
                   "s" : [ {
-                     "value" : [ "define ","SameMinute",": " ]
+                     "value" : [ "","define ","SameMinute",": " ]
                   }, {
                      "r" : "260",
                      "s" : [ {
@@ -27264,7 +27656,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "281",
                   "s" : [ {
-                     "value" : [ "define ","MinuteAfter",": " ]
+                     "value" : [ "","define ","MinuteAfter",": " ]
                   }, {
                      "r" : "280",
                      "s" : [ {
@@ -27420,7 +27812,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "301",
                   "s" : [ {
-                     "value" : [ "define ","MinuteBefore",": " ]
+                     "value" : [ "","define ","MinuteBefore",": " ]
                   }, {
                      "r" : "300",
                      "s" : [ {
@@ -27576,7 +27968,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "321",
                   "s" : [ {
-                     "value" : [ "define ","SameSecond",": " ]
+                     "value" : [ "","define ","SameSecond",": " ]
                   }, {
                      "r" : "320",
                      "s" : [ {
@@ -27732,7 +28124,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "341",
                   "s" : [ {
-                     "value" : [ "define ","SecondAfter",": " ]
+                     "value" : [ "","define ","SecondAfter",": " ]
                   }, {
                      "r" : "340",
                      "s" : [ {
@@ -27888,7 +28280,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "361",
                   "s" : [ {
-                     "value" : [ "define ","SecondBefore",": " ]
+                     "value" : [ "","define ","SecondBefore",": " ]
                   }, {
                      "r" : "360",
                      "s" : [ {
@@ -28044,7 +28436,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "381",
                   "s" : [ {
-                     "value" : [ "define ","SameMillisecond",": " ]
+                     "value" : [ "","define ","SameMillisecond",": " ]
                   }, {
                      "r" : "380",
                      "s" : [ {
@@ -28200,7 +28592,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "401",
                   "s" : [ {
-                     "value" : [ "define ","MillisecondAfter",": " ]
+                     "value" : [ "","define ","MillisecondAfter",": " ]
                   }, {
                      "r" : "400",
                      "s" : [ {
@@ -28356,7 +28748,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "421",
                   "s" : [ {
-                     "value" : [ "define ","MillisecondBefore",": " ]
+                     "value" : [ "","define ","MillisecondBefore",": " ]
                   }, {
                      "r" : "420",
                      "s" : [ {
@@ -28512,7 +28904,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "441",
                   "s" : [ {
-                     "value" : [ "define ","Same",": " ]
+                     "value" : [ "","define ","Same",": " ]
                   }, {
                      "r" : "440",
                      "s" : [ {
@@ -28667,7 +29059,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "461",
                   "s" : [ {
-                     "value" : [ "define ","After",": " ]
+                     "value" : [ "","define ","After",": " ]
                   }, {
                      "r" : "460",
                      "s" : [ {
@@ -28822,7 +29214,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "481",
                   "s" : [ {
-                     "value" : [ "define ","Before",": " ]
+                     "value" : [ "","define ","Before",": " ]
                   }, {
                      "r" : "480",
                      "s" : [ {
@@ -28977,7 +29369,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "494",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDay",": " ]
+                     "value" : [ "","define ","ImpreciseDay",": " ]
                   }, {
                      "r" : "493",
                      "s" : [ {
@@ -29075,7 +29467,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "507",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDayMonthAfter",": " ]
+                     "value" : [ "","define ","ImpreciseDayMonthAfter",": " ]
                   }, {
                      "r" : "506",
                      "s" : [ {
@@ -29173,7 +29565,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "520",
                   "s" : [ {
-                     "value" : [ "define ","ImpreciseDayMonthBefore",": " ]
+                     "value" : [ "","define ","ImpreciseDayMonthBefore",": " ]
                   }, {
                      "r" : "519",
                      "s" : [ {
@@ -29271,7 +29663,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "541",
                   "s" : [ {
-                     "value" : [ "define ","SameHourNormalizeZones",": " ]
+                     "value" : [ "","define ","SameHourNormalizeZones",": " ]
                   }, {
                      "r" : "540",
                      "s" : [ {
@@ -29431,7 +29823,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "562",
                   "s" : [ {
-                     "value" : [ "define ","HourAfterNormalizeZones",": " ]
+                     "value" : [ "","define ","HourAfterNormalizeZones",": " ]
                   }, {
                      "r" : "561",
                      "s" : [ {
@@ -29591,7 +29983,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "583",
                   "s" : [ {
-                     "value" : [ "define ","HourBeforeNormalizeZones",": " ]
+                     "value" : [ "","define ","HourBeforeNormalizeZones",": " ]
                   }, {
                      "r" : "582",
                      "s" : [ {
@@ -29751,7 +30143,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "595",
                   "s" : [ {
-                     "value" : [ "define ","NullLeft",": " ]
+                     "value" : [ "","define ","NullLeft",": " ]
                   }, {
                      "r" : "594",
                      "s" : [ {
@@ -29848,7 +30240,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "607",
                   "s" : [ {
-                     "value" : [ "define ","NullRight",": " ]
+                     "value" : [ "","define ","NullRight",": " ]
                   }, {
                      "r" : "606",
                      "s" : [ {
@@ -29945,7 +30337,7 @@ module.exports['Before'] = {
                "s" : {
                   "r" : "613",
                   "s" : [ {
-                     "value" : [ "define ","NullBoth",": " ]
+                     "value" : [ "","define ","NullBoth",": " ]
                   }, {
                      "r" : "612",
                      "s" : [ {
@@ -30037,6 +30429,14 @@ module.exports['DifferenceBetween'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "139",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -30054,7 +30454,27 @@ module.exports['DifferenceBetween'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -30078,7 +30498,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","NewYear2013",": " ]
+                     "value" : [ "","define ","NewYear2013",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -30144,7 +30564,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","NewYear2014",": " ]
+                     "value" : [ "","define ","NewYear2014",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -30210,7 +30630,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","January2014",": " ]
+                     "value" : [ "","define ","January2014",": " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -30246,7 +30666,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","YearsBetween",": " ]
+                     "value" : [ "","define ","YearsBetween",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -30291,7 +30711,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","MonthsBetween",": " ]
+                     "value" : [ "","define ","MonthsBetween",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -30336,7 +30756,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "35",
                   "s" : [ {
-                     "value" : [ "define ","WeeksBetween",": " ]
+                     "value" : [ "","define ","WeeksBetween",": " ]
                   }, {
                      "r" : "34",
                      "s" : [ {
@@ -30381,7 +30801,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","DaysBetween",": " ]
+                     "value" : [ "","define ","DaysBetween",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -30426,7 +30846,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "43",
                   "s" : [ {
-                     "value" : [ "define ","HoursBetween",": " ]
+                     "value" : [ "","define ","HoursBetween",": " ]
                   }, {
                      "r" : "42",
                      "s" : [ {
@@ -30471,7 +30891,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "47",
                   "s" : [ {
-                     "value" : [ "define ","MinutesBetween",": " ]
+                     "value" : [ "","define ","MinutesBetween",": " ]
                   }, {
                      "r" : "46",
                      "s" : [ {
@@ -30516,7 +30936,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "51",
                   "s" : [ {
-                     "value" : [ "define ","SecondsBetween",": " ]
+                     "value" : [ "","define ","SecondsBetween",": " ]
                   }, {
                      "r" : "50",
                      "s" : [ {
@@ -30561,7 +30981,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "55",
                   "s" : [ {
-                     "value" : [ "define ","MillisecondsBetween",": " ]
+                     "value" : [ "","define ","MillisecondsBetween",": " ]
                   }, {
                      "r" : "54",
                      "s" : [ {
@@ -30606,7 +31026,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "59",
                   "s" : [ {
-                     "value" : [ "define ","MillisecondsBetweenReversed",": " ]
+                     "value" : [ "","define ","MillisecondsBetweenReversed",": " ]
                   }, {
                      "r" : "58",
                      "s" : [ {
@@ -30651,7 +31071,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "63",
                   "s" : [ {
-                     "value" : [ "define ","YearsBetweenUncertainty",": " ]
+                     "value" : [ "","define ","YearsBetweenUncertainty",": " ]
                   }, {
                      "r" : "62",
                      "s" : [ {
@@ -30696,7 +31116,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "67",
                   "s" : [ {
-                     "value" : [ "define ","MonthsBetweenUncertainty",": " ]
+                     "value" : [ "","define ","MonthsBetweenUncertainty",": " ]
                   }, {
                      "r" : "66",
                      "s" : [ {
@@ -30741,7 +31161,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "71",
                   "s" : [ {
-                     "value" : [ "define ","WeeksBetweenUncertainty",": " ]
+                     "value" : [ "","define ","WeeksBetweenUncertainty",": " ]
                   }, {
                      "r" : "70",
                      "s" : [ {
@@ -30786,7 +31206,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "75",
                   "s" : [ {
-                     "value" : [ "define ","DaysBetweenUncertainty",": " ]
+                     "value" : [ "","define ","DaysBetweenUncertainty",": " ]
                   }, {
                      "r" : "74",
                      "s" : [ {
@@ -30831,7 +31251,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "79",
                   "s" : [ {
-                     "value" : [ "define ","HoursBetweenUncertainty",": " ]
+                     "value" : [ "","define ","HoursBetweenUncertainty",": " ]
                   }, {
                      "r" : "78",
                      "s" : [ {
@@ -30876,7 +31296,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "83",
                   "s" : [ {
-                     "value" : [ "define ","MinutesBetweenUncertainty",": " ]
+                     "value" : [ "","define ","MinutesBetweenUncertainty",": " ]
                   }, {
                      "r" : "82",
                      "s" : [ {
@@ -30921,7 +31341,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "87",
                   "s" : [ {
-                     "value" : [ "define ","SecondsBetweenUncertainty",": " ]
+                     "value" : [ "","define ","SecondsBetweenUncertainty",": " ]
                   }, {
                      "r" : "86",
                      "s" : [ {
@@ -30966,7 +31386,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "91",
                   "s" : [ {
-                     "value" : [ "define ","MillisecondsBetweenUncertainty",": " ]
+                     "value" : [ "","define ","MillisecondsBetweenUncertainty",": " ]
                   }, {
                      "r" : "90",
                      "s" : [ {
@@ -31011,7 +31431,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "95",
                   "s" : [ {
-                     "value" : [ "define ","MillisecondsBetweenReversedUncertainty",": " ]
+                     "value" : [ "","define ","MillisecondsBetweenReversedUncertainty",": " ]
                   }, {
                      "r" : "94",
                      "s" : [ {
@@ -31056,7 +31476,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "117",
                   "s" : [ {
-                     "value" : [ "define ","HoursBetween1and3CrossingSpringDST",": " ]
+                     "value" : [ "","define ","HoursBetween1and3CrossingSpringDST",": " ]
                   }, {
                      "r" : "116",
                      "s" : [ {
@@ -31221,7 +31641,7 @@ module.exports['DifferenceBetween'] = {
                "s" : {
                   "r" : "139",
                   "s" : [ {
-                     "value" : [ "define ","HoursBetween1and3CrossingFallDST",": " ]
+                     "value" : [ "","define ","HoursBetween1and3CrossingFallDST",": " ]
                   }, {
                      "r" : "138",
                      "s" : [ {
@@ -31414,6 +31834,14 @@ module.exports['DifferenceBetween Comparisons'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "168",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -31431,7 +31859,27 @@ module.exports['DifferenceBetween Comparisons'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -31455,7 +31903,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","NewYear2014",": " ]
+                     "value" : [ "","define ","NewYear2014",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -31521,7 +31969,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","February2014",": " ]
+                     "value" : [ "","define ","February2014",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -31557,7 +32005,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","GreaterThan25DaysAfter",": " ]
+                     "value" : [ "","define ","GreaterThan25DaysAfter",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -31617,7 +32065,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "26",
                   "s" : [ {
-                     "value" : [ "define ","GreaterThan40DaysAfter",": " ]
+                     "value" : [ "","define ","GreaterThan40DaysAfter",": " ]
                   }, {
                      "r" : "25",
                      "s" : [ {
@@ -31677,7 +32125,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "32",
                   "s" : [ {
-                     "value" : [ "define ","GreaterThan80DaysAfter",": " ]
+                     "value" : [ "","define ","GreaterThan80DaysAfter",": " ]
                   }, {
                      "r" : "31",
                      "s" : [ {
@@ -31737,7 +32185,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "38",
                   "s" : [ {
-                     "value" : [ "define ","GreaterOrEqualTo25DaysAfter",": " ]
+                     "value" : [ "","define ","GreaterOrEqualTo25DaysAfter",": " ]
                   }, {
                      "r" : "37",
                      "s" : [ {
@@ -31797,7 +32245,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "44",
                   "s" : [ {
-                     "value" : [ "define ","GreaterOrEqualTo40DaysAfter",": " ]
+                     "value" : [ "","define ","GreaterOrEqualTo40DaysAfter",": " ]
                   }, {
                      "r" : "43",
                      "s" : [ {
@@ -31857,7 +32305,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "50",
                   "s" : [ {
-                     "value" : [ "define ","GreaterOrEqualTo80DaysAfter",": " ]
+                     "value" : [ "","define ","GreaterOrEqualTo80DaysAfter",": " ]
                   }, {
                      "r" : "49",
                      "s" : [ {
@@ -31917,7 +32365,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "56",
                   "s" : [ {
-                     "value" : [ "define ","EqualTo25DaysAfter",": " ]
+                     "value" : [ "","define ","EqualTo25DaysAfter",": " ]
                   }, {
                      "r" : "55",
                      "s" : [ {
@@ -31977,7 +32425,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "62",
                   "s" : [ {
-                     "value" : [ "define ","EqualTo40DaysAfter",": " ]
+                     "value" : [ "","define ","EqualTo40DaysAfter",": " ]
                   }, {
                      "r" : "61",
                      "s" : [ {
@@ -32037,7 +32485,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "68",
                   "s" : [ {
-                     "value" : [ "define ","EqualTo80DaysAfter",": " ]
+                     "value" : [ "","define ","EqualTo80DaysAfter",": " ]
                   }, {
                      "r" : "67",
                      "s" : [ {
@@ -32097,7 +32545,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "74",
                   "s" : [ {
-                     "value" : [ "define ","LessOrEqualTo25DaysAfter",": " ]
+                     "value" : [ "","define ","LessOrEqualTo25DaysAfter",": " ]
                   }, {
                      "r" : "73",
                      "s" : [ {
@@ -32157,7 +32605,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "80",
                   "s" : [ {
-                     "value" : [ "define ","LessOrEqualTo40DaysAfter",": " ]
+                     "value" : [ "","define ","LessOrEqualTo40DaysAfter",": " ]
                   }, {
                      "r" : "79",
                      "s" : [ {
@@ -32217,7 +32665,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "86",
                   "s" : [ {
-                     "value" : [ "define ","LessOrEqualTo80DaysAfter",": " ]
+                     "value" : [ "","define ","LessOrEqualTo80DaysAfter",": " ]
                   }, {
                      "r" : "85",
                      "s" : [ {
@@ -32277,7 +32725,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "92",
                   "s" : [ {
-                     "value" : [ "define ","LessThan25DaysAfter",": " ]
+                     "value" : [ "","define ","LessThan25DaysAfter",": " ]
                   }, {
                      "r" : "91",
                      "s" : [ {
@@ -32337,7 +32785,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "98",
                   "s" : [ {
-                     "value" : [ "define ","LessThan40DaysAfter",": " ]
+                     "value" : [ "","define ","LessThan40DaysAfter",": " ]
                   }, {
                      "r" : "97",
                      "s" : [ {
@@ -32397,7 +32845,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "104",
                   "s" : [ {
-                     "value" : [ "define ","LessThan80DaysAfter",": " ]
+                     "value" : [ "","define ","LessThan80DaysAfter",": " ]
                   }, {
                      "r" : "103",
                      "s" : [ {
@@ -32457,7 +32905,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "110",
                   "s" : [ {
-                     "value" : [ "define ","TwentyFiveDaysLessThanDaysBetween",": " ]
+                     "value" : [ "","define ","TwentyFiveDaysLessThanDaysBetween",": " ]
                   }, {
                      "r" : "109",
                      "s" : [ {
@@ -32517,7 +32965,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "116",
                   "s" : [ {
-                     "value" : [ "define ","FortyDaysEqualToDaysBetween",": " ]
+                     "value" : [ "","define ","FortyDaysEqualToDaysBetween",": " ]
                   }, {
                      "r" : "115",
                      "s" : [ {
@@ -32577,7 +33025,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "122",
                   "s" : [ {
-                     "value" : [ "define ","TwentyFiveDaysGreaterThanDaysBetween",": " ]
+                     "value" : [ "","define ","TwentyFiveDaysGreaterThanDaysBetween",": " ]
                   }, {
                      "r" : "121",
                      "s" : [ {
@@ -32637,7 +33085,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "146",
                   "s" : [ {
-                     "value" : [ "define ","BonnieTestCase",": " ]
+                     "value" : [ "","define ","BonnieTestCase",": " ]
                   }, {
                      "r" : "145",
                      "s" : [ {
@@ -32817,7 +33265,7 @@ module.exports['DifferenceBetween Comparisons'] = {
                "s" : {
                   "r" : "168",
                   "s" : [ {
-                     "value" : [ "define ","BonnieTestCaseZulu",": " ]
+                     "value" : [ "","define ","BonnieTestCaseZulu",": " ]
                   }, {
                      "r" : "167",
                      "s" : [ {
@@ -33002,6 +33450,14 @@ module.exports['DurationBetween'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "139",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -33019,7 +33475,27 @@ module.exports['DurationBetween'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -33043,7 +33519,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","DecTen2013",": " ]
+                     "value" : [ "","define ","DecTen2013",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -33109,7 +33585,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","JanOne2015",": " ]
+                     "value" : [ "","define ","JanOne2015",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -33175,7 +33651,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","January2015",": " ]
+                     "value" : [ "","define ","January2015",": " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -33211,7 +33687,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","YearsBetween",": " ]
+                     "value" : [ "","define ","YearsBetween",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -33256,7 +33732,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","MonthsBetween",": " ]
+                     "value" : [ "","define ","MonthsBetween",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -33301,7 +33777,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "35",
                   "s" : [ {
-                     "value" : [ "define ","WeeksBetween",": " ]
+                     "value" : [ "","define ","WeeksBetween",": " ]
                   }, {
                      "r" : "34",
                      "s" : [ {
@@ -33346,7 +33822,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","DaysBetween",": " ]
+                     "value" : [ "","define ","DaysBetween",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -33391,7 +33867,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "43",
                   "s" : [ {
-                     "value" : [ "define ","HoursBetween",": " ]
+                     "value" : [ "","define ","HoursBetween",": " ]
                   }, {
                      "r" : "42",
                      "s" : [ {
@@ -33436,7 +33912,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "47",
                   "s" : [ {
-                     "value" : [ "define ","MinutesBetween",": " ]
+                     "value" : [ "","define ","MinutesBetween",": " ]
                   }, {
                      "r" : "46",
                      "s" : [ {
@@ -33481,7 +33957,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "51",
                   "s" : [ {
-                     "value" : [ "define ","SecondsBetween",": " ]
+                     "value" : [ "","define ","SecondsBetween",": " ]
                   }, {
                      "r" : "50",
                      "s" : [ {
@@ -33526,7 +34002,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "55",
                   "s" : [ {
-                     "value" : [ "define ","MillisecondsBetween",": " ]
+                     "value" : [ "","define ","MillisecondsBetween",": " ]
                   }, {
                      "r" : "54",
                      "s" : [ {
@@ -33571,7 +34047,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "59",
                   "s" : [ {
-                     "value" : [ "define ","MillisecondsBetweenReversed",": " ]
+                     "value" : [ "","define ","MillisecondsBetweenReversed",": " ]
                   }, {
                      "r" : "58",
                      "s" : [ {
@@ -33616,7 +34092,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "63",
                   "s" : [ {
-                     "value" : [ "define ","YearsBetweenUncertainty",": " ]
+                     "value" : [ "","define ","YearsBetweenUncertainty",": " ]
                   }, {
                      "r" : "62",
                      "s" : [ {
@@ -33661,7 +34137,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "67",
                   "s" : [ {
-                     "value" : [ "define ","MonthsBetweenUncertainty",": " ]
+                     "value" : [ "","define ","MonthsBetweenUncertainty",": " ]
                   }, {
                      "r" : "66",
                      "s" : [ {
@@ -33706,7 +34182,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "71",
                   "s" : [ {
-                     "value" : [ "define ","WeeksBetweenUncertainty",": " ]
+                     "value" : [ "","define ","WeeksBetweenUncertainty",": " ]
                   }, {
                      "r" : "70",
                      "s" : [ {
@@ -33751,7 +34227,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "75",
                   "s" : [ {
-                     "value" : [ "define ","DaysBetweenUncertainty",": " ]
+                     "value" : [ "","define ","DaysBetweenUncertainty",": " ]
                   }, {
                      "r" : "74",
                      "s" : [ {
@@ -33796,7 +34272,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "79",
                   "s" : [ {
-                     "value" : [ "define ","HoursBetweenUncertainty",": " ]
+                     "value" : [ "","define ","HoursBetweenUncertainty",": " ]
                   }, {
                      "r" : "78",
                      "s" : [ {
@@ -33841,7 +34317,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "83",
                   "s" : [ {
-                     "value" : [ "define ","MinutesBetweenUncertainty",": " ]
+                     "value" : [ "","define ","MinutesBetweenUncertainty",": " ]
                   }, {
                      "r" : "82",
                      "s" : [ {
@@ -33886,7 +34362,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "87",
                   "s" : [ {
-                     "value" : [ "define ","SecondsBetweenUncertainty",": " ]
+                     "value" : [ "","define ","SecondsBetweenUncertainty",": " ]
                   }, {
                      "r" : "86",
                      "s" : [ {
@@ -33931,7 +34407,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "91",
                   "s" : [ {
-                     "value" : [ "define ","MillisecondsBetweenUncertainty",": " ]
+                     "value" : [ "","define ","MillisecondsBetweenUncertainty",": " ]
                   }, {
                      "r" : "90",
                      "s" : [ {
@@ -33976,7 +34452,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "95",
                   "s" : [ {
-                     "value" : [ "define ","MillisecondsBetweenReversedUncertainty",": " ]
+                     "value" : [ "","define ","MillisecondsBetweenReversedUncertainty",": " ]
                   }, {
                      "r" : "94",
                      "s" : [ {
@@ -34021,7 +34497,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "117",
                   "s" : [ {
-                     "value" : [ "define ","HoursBetween1and3CrossingSpringDST",": " ]
+                     "value" : [ "","define ","HoursBetween1and3CrossingSpringDST",": " ]
                   }, {
                      "r" : "116",
                      "s" : [ {
@@ -34186,7 +34662,7 @@ module.exports['DurationBetween'] = {
                "s" : {
                   "r" : "139",
                   "s" : [ {
-                     "value" : [ "define ","HoursBetween1and3CrossingFallDST",": " ]
+                     "value" : [ "","define ","HoursBetween1and3CrossingFallDST",": " ]
                   }, {
                      "r" : "138",
                      "s" : [ {
@@ -34374,6 +34850,14 @@ module.exports['DateMath'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "74",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -34391,7 +34875,27 @@ module.exports['DateMath'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -34415,7 +34919,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","June15th2013",": " ]
+                     "value" : [ "","define ","June15th2013",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -34481,7 +34985,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","PlusThreeYears",": " ]
+                     "value" : [ "","define ","PlusThreeYears",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -34524,7 +35028,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "18",
                   "s" : [ {
-                     "value" : [ "define ","MinusThreeYears",": " ]
+                     "value" : [ "","define ","MinusThreeYears",": " ]
                   }, {
                      "r" : "17",
                      "s" : [ {
@@ -34567,7 +35071,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "22",
                   "s" : [ {
-                     "value" : [ "define ","PlusEightMonths",": " ]
+                     "value" : [ "","define ","PlusEightMonths",": " ]
                   }, {
                      "r" : "21",
                      "s" : [ {
@@ -34610,7 +35114,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "26",
                   "s" : [ {
-                     "value" : [ "define ","MinusEightMonths",": " ]
+                     "value" : [ "","define ","MinusEightMonths",": " ]
                   }, {
                      "r" : "25",
                      "s" : [ {
@@ -34653,7 +35157,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "30",
                   "s" : [ {
-                     "value" : [ "define ","PlusThreeWeeks",": " ]
+                     "value" : [ "","define ","PlusThreeWeeks",": " ]
                   }, {
                      "r" : "29",
                      "s" : [ {
@@ -34696,7 +35200,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","MinusThreeWeeks",": " ]
+                     "value" : [ "","define ","MinusThreeWeeks",": " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -34739,7 +35243,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "38",
                   "s" : [ {
-                     "value" : [ "define ","PlusTwentyDays",": " ]
+                     "value" : [ "","define ","PlusTwentyDays",": " ]
                   }, {
                      "r" : "37",
                      "s" : [ {
@@ -34782,7 +35286,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "42",
                   "s" : [ {
-                     "value" : [ "define ","MinusTwentyDays",": " ]
+                     "value" : [ "","define ","MinusTwentyDays",": " ]
                   }, {
                      "r" : "41",
                      "s" : [ {
@@ -34825,7 +35329,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "46",
                   "s" : [ {
-                     "value" : [ "define ","PlusThreeHours",": " ]
+                     "value" : [ "","define ","PlusThreeHours",": " ]
                   }, {
                      "r" : "45",
                      "s" : [ {
@@ -34868,7 +35372,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "50",
                   "s" : [ {
-                     "value" : [ "define ","MinusThreeHours",": " ]
+                     "value" : [ "","define ","MinusThreeHours",": " ]
                   }, {
                      "r" : "49",
                      "s" : [ {
@@ -34911,7 +35415,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "54",
                   "s" : [ {
-                     "value" : [ "define ","PlusThreeMinutes",": " ]
+                     "value" : [ "","define ","PlusThreeMinutes",": " ]
                   }, {
                      "r" : "53",
                      "s" : [ {
@@ -34954,7 +35458,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "58",
                   "s" : [ {
-                     "value" : [ "define ","MinusThreeMinutes",": " ]
+                     "value" : [ "","define ","MinusThreeMinutes",": " ]
                   }, {
                      "r" : "57",
                      "s" : [ {
@@ -34997,7 +35501,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "62",
                   "s" : [ {
-                     "value" : [ "define ","PlusThreeSeconds",": " ]
+                     "value" : [ "","define ","PlusThreeSeconds",": " ]
                   }, {
                      "r" : "61",
                      "s" : [ {
@@ -35040,7 +35544,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "66",
                   "s" : [ {
-                     "value" : [ "define ","MinusThreeSeconds",": " ]
+                     "value" : [ "","define ","MinusThreeSeconds",": " ]
                   }, {
                      "r" : "65",
                      "s" : [ {
@@ -35083,7 +35587,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "70",
                   "s" : [ {
-                     "value" : [ "define ","PlusThreeMilliseconds",": " ]
+                     "value" : [ "","define ","PlusThreeMilliseconds",": " ]
                   }, {
                      "r" : "69",
                      "s" : [ {
@@ -35126,7 +35630,7 @@ module.exports['DateMath'] = {
                "s" : {
                   "r" : "74",
                   "s" : [ {
-                     "value" : [ "define ","MinusThreeMilliseconds",": " ]
+                     "value" : [ "","define ","MinusThreeMilliseconds",": " ]
                   }, {
                      "r" : "73",
                      "s" : [ {

--- a/test/elm/executor/data.js
+++ b/test/elm/executor/data.js
@@ -36,6 +36,14 @@ module.exports['Age'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "39",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -53,7 +61,22 @@ module.exports['Age'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -61,6 +84,36 @@ module.exports['Age'] = {
             "localId" : "11",
             "name" : "MeasurementPeriod",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "11",
+                  "s" : [ {
+                     "value" : [ "","parameter ","MeasurementPeriod"," default " ]
+                  }, {
+                     "r" : "10",
+                     "s" : [ {
+                        "value" : [ "Interval[" ]
+                     }, {
+                        "r" : "5",
+                        "s" : [ {
+                           "r" : "2",
+                           "value" : [ "DateTime","(","2013",", ","1",", ","1",")" ]
+                        } ]
+                     }, {
+                        "value" : [ ", " ]
+                     }, {
+                        "r" : "9",
+                        "s" : [ {
+                           "r" : "6",
+                           "value" : [ "DateTime","(","2014",", ","1",", ","1",")" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "10",
                "lowClosed" : true,
@@ -113,6 +166,13 @@ module.exports['Age'] = {
             }
          } ]
       },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
+         }, {
+            "name" : "Unfiltered"
+         } ]
+      },
       "statements" : {
          "def" : [ {
             "name" : "Patient",
@@ -134,7 +194,7 @@ module.exports['Age'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","Age",":\n  " ]
+                     "value" : [ "","define ","Age",":\n  " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -186,7 +246,7 @@ module.exports['Age'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","InDemographic",":\n  " ]
+                     "value" : [ "","define ","InDemographic",":\n  " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -314,7 +374,7 @@ module.exports['Age'] = {
                "s" : {
                   "r" : "30",
                   "s" : [ {
-                     "value" : [ "define ","AgeSum",": " ]
+                     "value" : [ "","define ","AgeSum",": " ]
                   }, {
                      "r" : "29",
                      "s" : [ {
@@ -349,7 +409,7 @@ module.exports['Age'] = {
                "s" : {
                   "r" : "37",
                   "s" : [ {
-                     "value" : [ "define ","DEMO",": " ]
+                     "value" : [ "","define ","DEMO",": " ]
                   }, {
                      "r" : "36",
                      "s" : [ {
@@ -431,7 +491,7 @@ module.exports['Age'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","AgeSumRef"," : " ]
+                     "value" : [ "","define ","AgeSumRef"," : " ]
                   }, {
                      "r" : "38",
                      "s" : [ {

--- a/test/elm/external/data.js
+++ b/test/elm/external/data.js
@@ -35,6 +35,14 @@ module.exports['Retrieve'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "27",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -52,7 +60,22 @@ module.exports['Retrieve'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "includes" : {
@@ -60,7 +83,22 @@ module.exports['Retrieve'] = {
             "localId" : "2",
             "localIdentifier" : "included",
             "path" : "Included",
-            "version" : "1"
+            "version" : "1",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","include " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Included" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1'"," called ","included" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "codeSystems" : {
@@ -68,7 +106,16 @@ module.exports['Retrieve'] = {
             "localId" : "3",
             "name" : "SNOMED",
             "id" : "2.16.840.1.113883.6.96",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","codesystem ","\"SNOMED\"",": ","'2.16.840.1.113883.6.96'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "valueSets" : {
@@ -76,12 +123,30 @@ module.exports['Retrieve'] = {
             "localId" : "4",
             "name" : "Ambulatory/ED Visit",
             "id" : "2.16.840.1.113883.3.464.1003.101.12.1061",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "4",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"Ambulatory/ED Visit\"",": ","'2.16.840.1.113883.3.464.1003.101.12.1061'" ]
+                  } ]
+               }
+            } ]
          }, {
             "localId" : "5",
             "name" : "Annual Wellness Visit",
             "id" : "2.16.840.1.113883.3.526.3.1240",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"Annual Wellness Visit\"",": ","'2.16.840.1.113883.3.526.3.1240'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "codes" : {
@@ -91,6 +156,22 @@ module.exports['Retrieve'] = {
             "id" : "1532007",
             "display" : "Viral pharyngitis (disorder)",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "7",
+                  "s" : [ {
+                     "value" : [ "","code ","\"Viral pharyngitis code\"",": ","'1532007'"," from " ]
+                  }, {
+                     "r" : "6",
+                     "s" : [ {
+                        "value" : [ "\"SNOMED\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " display ","'Viral pharyngitis (disorder)'" ]
+                  } ]
+               }
+            } ],
             "codeSystem" : {
                "localId" : "6",
                "name" : "SNOMED"
@@ -103,10 +184,31 @@ module.exports['Retrieve'] = {
             "name" : "Viral pharyngitis",
             "display" : "Viral pharyngitis (disorder)",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "9",
+                  "s" : [ {
+                     "value" : [ "","concept ","\"Viral pharyngitis\"",": { " ]
+                  }, {
+                     "r" : "8",
+                     "s" : [ {
+                        "value" : [ "\"Viral pharyngitis code\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " } display ","'Viral pharyngitis (disorder)'" ]
+                  } ]
+               }
+            } ],
             "code" : [ {
                "localId" : "8",
                "name" : "Viral pharyngitis code"
             } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -130,7 +232,7 @@ module.exports['Retrieve'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","Conditions",": " ]
+                     "value" : [ "","define ","Conditions",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -154,7 +256,7 @@ module.exports['Retrieve'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","Encounters",": " ]
+                     "value" : [ "","define ","Encounters",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -178,7 +280,7 @@ module.exports['Retrieve'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","PharyngitisConditions",": " ]
+                     "value" : [ "","define ","PharyngitisConditions",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -197,6 +299,7 @@ module.exports['Retrieve'] = {
                "localId" : "14",
                "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
                "codeProperty" : "code",
+               "codeComparator" : "in",
                "type" : "Retrieve",
                "codes" : {
                   "name" : "Acute Pharyngitis",
@@ -214,7 +317,7 @@ module.exports['Retrieve'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","AmbulatoryEncounters",": " ]
+                     "value" : [ "","define ","AmbulatoryEncounters",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -233,6 +336,7 @@ module.exports['Retrieve'] = {
                "localId" : "16",
                "dataType" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
                "codeProperty" : "code",
+               "codeComparator" : "in",
                "type" : "Retrieve",
                "codes" : {
                   "name" : "Ambulatory/ED Visit",
@@ -249,7 +353,7 @@ module.exports['Retrieve'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","EncountersByCode",": " ]
+                     "value" : [ "","define ","EncountersByCode",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -259,7 +363,7 @@ module.exports['Retrieve'] = {
                            "value" : [ "code" ]
                         } ]
                      }, {
-                        "value" : [ " in " ]
+                        "value" : [ " ","in"," " ]
                      }, {
                         "s" : [ {
                            "value" : [ "\"Ambulatory/ED Visit\"" ]
@@ -274,6 +378,7 @@ module.exports['Retrieve'] = {
                "localId" : "18",
                "dataType" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
                "codeProperty" : "code",
+               "codeComparator" : "in",
                "type" : "Retrieve",
                "codes" : {
                   "name" : "Ambulatory/ED Visit",
@@ -290,7 +395,7 @@ module.exports['Retrieve'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","WrongValueSet",": " ]
+                     "value" : [ "","define ","WrongValueSet",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -309,6 +414,7 @@ module.exports['Retrieve'] = {
                "localId" : "20",
                "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
                "codeProperty" : "code",
+               "codeComparator" : "in",
                "type" : "Retrieve",
                "codes" : {
                   "name" : "Ambulatory/ED Visit",
@@ -325,7 +431,7 @@ module.exports['Retrieve'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","WrongCodeProperty",": " ]
+                     "value" : [ "","define ","WrongCodeProperty",": " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -335,7 +441,7 @@ module.exports['Retrieve'] = {
                            "value" : [ "status" ]
                         } ]
                      }, {
-                        "value" : [ " in " ]
+                        "value" : [ " ","in"," " ]
                      }, {
                         "s" : [ {
                            "value" : [ "\"Ambulatory/ED Visit\"" ]
@@ -350,6 +456,7 @@ module.exports['Retrieve'] = {
                "localId" : "22",
                "dataType" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
                "codeProperty" : "status",
+               "codeComparator" : "in",
                "type" : "Retrieve",
                "codes" : {
                   "name" : "Ambulatory/ED Visit",
@@ -366,7 +473,7 @@ module.exports['Retrieve'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","ConditionsByCode",": " ]
+                     "value" : [ "","define ","ConditionsByCode",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -385,6 +492,7 @@ module.exports['Retrieve'] = {
                "localId" : "24",
                "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
                "codeProperty" : "code",
+               "codeComparator" : "~",
                "type" : "Retrieve",
                "codes" : {
                   "type" : "ToList",
@@ -404,7 +512,7 @@ module.exports['Retrieve'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","ConditionsByConcept",": " ]
+                     "value" : [ "","define ","ConditionsByConcept",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -423,6 +531,7 @@ module.exports['Retrieve'] = {
                "localId" : "26",
                "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
                "codeProperty" : "code",
+               "codeComparator" : "~",
                "type" : "Retrieve",
                "codes" : {
                   "path" : "codes",
@@ -451,6 +560,14 @@ module.exports['Included'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "3",
+            "s" : [ {
+               "value" : [ "","library Included version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "Included",
@@ -468,7 +585,22 @@ module.exports['Included'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "codeSystems" : {
@@ -476,7 +608,16 @@ module.exports['Included'] = {
             "localId" : "2",
             "name" : "SNOMED",
             "id" : "2.16.840.1.113883.6.96",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","codesystem ","\"SNOMED\"",": ","'2.16.840.1.113883.6.96'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "valueSets" : {
@@ -484,7 +625,16 @@ module.exports['Included'] = {
             "localId" : "3",
             "name" : "Acute Pharyngitis",
             "id" : "2.16.840.1.113883.3.464.1003.102.12.1011",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"Acute Pharyngitis\"",": ","'2.16.840.1.113883.3.464.1003.102.12.1011'" ]
+                  } ]
+               }
+            } ]
          } ]
       }
    }

--- a/test/elm/instance/data.js
+++ b/test/elm/instance/data.js
@@ -47,6 +47,14 @@ module.exports['Instance'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "29",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -64,7 +72,22 @@ module.exports['Instance'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "codeSystems" : {
@@ -72,12 +95,30 @@ module.exports['Instance'] = {
             "localId" : "2",
             "name" : "SNOMED",
             "id" : "2.16.840.1.113883.6.96",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","codesystem ","\"SNOMED\"",": ","'2.16.840.1.113883.6.96'" ]
+                  } ]
+               }
+            } ]
          }, {
             "localId" : "3",
             "name" : "SIMPLE",
             "id" : "1.2.3.4.5",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","codesystem ","\"SIMPLE\"",": ","'1.2.3.4.5'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "codes" : {
@@ -87,6 +128,22 @@ module.exports['Instance'] = {
             "id" : "1532007",
             "display" : "Viral pharyngitis (disorder)",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "value" : [ "","code ","\"Viral pharyngitis code\"",": ","'1532007'"," from " ]
+                  }, {
+                     "r" : "4",
+                     "s" : [ {
+                        "value" : [ "\"SNOMED\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " display ","'Viral pharyngitis (disorder)'" ]
+                  } ]
+               }
+            } ],
             "codeSystem" : {
                "localId" : "4",
                "name" : "SNOMED"
@@ -97,10 +154,31 @@ module.exports['Instance'] = {
             "id" : "active",
             "display" : "Active",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "7",
+                  "s" : [ {
+                     "value" : [ "","code ","\"Active code\"",": ","'active'"," from " ]
+                  }, {
+                     "r" : "6",
+                     "s" : [ {
+                        "value" : [ "\"SNOMED\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " display ","'Active'" ]
+                  } ]
+               }
+            } ],
             "codeSystem" : {
                "localId" : "6",
                "name" : "SNOMED"
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -124,7 +202,7 @@ module.exports['Instance'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","QuantityA",": " ]
+                     "value" : [ "","define ","QuantityA",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -186,7 +264,7 @@ module.exports['Instance'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","CodeA",": " ]
+                     "value" : [ "","define ","CodeA",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -287,7 +365,7 @@ module.exports['Instance'] = {
                "s" : {
                   "r" : "22",
                   "s" : [ {
-                     "value" : [ "define ","ConceptA",": " ]
+                     "value" : [ "","define ","ConceptA",": " ]
                   }, {
                      "r" : "21",
                      "s" : [ {
@@ -360,7 +438,7 @@ module.exports['Instance'] = {
                "s" : {
                   "r" : "26",
                   "s" : [ {
-                     "value" : [ "define ","Pharyngitis"," : " ]
+                     "value" : [ "","define ","Pharyngitis"," : " ]
                   }, {
                      "r" : "25",
                      "s" : [ {
@@ -421,7 +499,7 @@ module.exports['Instance'] = {
                "s" : {
                   "r" : "29",
                   "s" : [ {
-                     "value" : [ "define ","val",": " ]
+                     "value" : [ "","define ","val",": " ]
                   }, {
                      "r" : "28",
                      "s" : [ {

--- a/test/elm/library/data.js
+++ b/test/elm/library/data.js
@@ -24,6 +24,14 @@ module.exports['In Age Demographic'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "23",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -41,7 +49,22 @@ module.exports['In Age Demographic'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -49,6 +72,36 @@ module.exports['In Age Demographic'] = {
             "localId" : "11",
             "name" : "MeasurementPeriod",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "11",
+                  "s" : [ {
+                     "value" : [ "","parameter ","MeasurementPeriod"," default " ]
+                  }, {
+                     "r" : "10",
+                     "s" : [ {
+                        "value" : [ "Interval[" ]
+                     }, {
+                        "r" : "5",
+                        "s" : [ {
+                           "r" : "2",
+                           "value" : [ "DateTime","(","2013",", ","1",", ","1",")" ]
+                        } ]
+                     }, {
+                        "value" : [ ", " ]
+                     }, {
+                        "r" : "9",
+                        "s" : [ {
+                           "r" : "6",
+                           "value" : [ "DateTime","(","2014",", ","1",", ","1",")" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "10",
                "lowClosed" : true,
@@ -101,6 +154,11 @@ module.exports['In Age Demographic'] = {
             }
          } ]
       },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
+         } ]
+      },
       "statements" : {
          "def" : [ {
             "name" : "Patient",
@@ -122,7 +180,7 @@ module.exports['In Age Demographic'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","InDemographic",":\n" ]
+                     "value" : [ "","define ","InDemographic",":\n" ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -272,6 +330,14 @@ module.exports['CommonLib'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "42",
+            "s" : [ {
+               "value" : [ "","library Common" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "Common"
@@ -288,14 +354,44 @@ module.exports['CommonLib'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "includes" : {
          "def" : [ {
             "localId" : "2",
             "localIdentifier" : "common2",
-            "path" : "Common2"
+            "path" : "Common2",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","include " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Common2" ]
+                     } ]
+                  }, {
+                     "value" : [ " called ","common2" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -303,6 +399,36 @@ module.exports['CommonLib'] = {
             "localId" : "15",
             "name" : "MeasurementPeriod",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "15",
+                  "s" : [ {
+                     "value" : [ "","parameter ","MeasurementPeriod"," default " ]
+                  }, {
+                     "r" : "14",
+                     "s" : [ {
+                        "value" : [ "Interval[" ]
+                     }, {
+                        "r" : "9",
+                        "s" : [ {
+                           "r" : "6",
+                           "value" : [ "DateTime","(","2013",", ","1",", ","1",")" ]
+                        } ]
+                     }, {
+                        "value" : [ ", " ]
+                     }, {
+                        "r" : "13",
+                        "s" : [ {
+                           "r" : "10",
+                           "value" : [ "DateTime","(","2014",", ","1",", ","1",")" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "14",
                "lowClosed" : true,
@@ -360,7 +486,16 @@ module.exports['CommonLib'] = {
             "localId" : "3",
             "name" : "SNOMEDCT",
             "id" : "2.16.840.1.113883.6.96",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","codesystem ","\"SNOMEDCT\"",": ","'2.16.840.1.113883.6.96'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "codes" : {
@@ -370,10 +505,31 @@ module.exports['CommonLib'] = {
             "id" : "428371000124100",
             "display" : "directReferenceCode",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "value" : [ "","code ","\"directReferenceCode\"",": ","'428371000124100'"," from " ]
+                  }, {
+                     "r" : "4",
+                     "s" : [ {
+                        "value" : [ "\"SNOMEDCT\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " display ","'directReferenceCode'" ]
+                  } ]
+               }
+            } ],
             "codeSystem" : {
                "localId" : "4",
                "name" : "SNOMEDCT"
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -397,7 +553,7 @@ module.exports['CommonLib'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","InDemographic",":\n" ]
+                     "value" : [ "","define ","InDemographic",":\n" ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -526,7 +682,7 @@ module.exports['CommonLib'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define function ","foo"," (","a"," " ]
+                     "value" : [ "","define function ","foo"," (","a"," " ]
                   }, {
                      "r" : "28",
                      "s" : [ {
@@ -600,7 +756,7 @@ module.exports['CommonLib'] = {
                "s" : {
                   "r" : "42",
                   "s" : [ {
-                     "value" : [ "define ","SupportLibDef",":\n  " ]
+                     "value" : [ "","define ","SupportLibDef",":\n  " ]
                   }, {
                      "r" : "41",
                      "s" : [ {
@@ -709,6 +865,14 @@ module.exports['Using CommonLib'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "27",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -726,14 +890,44 @@ module.exports['Using CommonLib'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "includes" : {
          "def" : [ {
             "localId" : "2",
             "localIdentifier" : "common",
-            "path" : "Common"
+            "path" : "Common",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","include " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Common" ]
+                     } ]
+                  }, {
+                     "value" : [ " called ","common" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -741,6 +935,36 @@ module.exports['Using CommonLib'] = {
             "localId" : "12",
             "name" : "MeasurementPeriod",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "12",
+                  "s" : [ {
+                     "value" : [ "","parameter ","MeasurementPeriod"," default " ]
+                  }, {
+                     "r" : "11",
+                     "s" : [ {
+                        "value" : [ "Interval[" ]
+                     }, {
+                        "r" : "6",
+                        "s" : [ {
+                           "r" : "3",
+                           "value" : [ "DateTime","(","2013",", ","1",", ","1",")" ]
+                        } ]
+                     }, {
+                        "value" : [ ", " ]
+                     }, {
+                        "r" : "10",
+                        "s" : [ {
+                           "r" : "7",
+                           "value" : [ "DateTime","(","2014",", ","1",", ","1",")" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "11",
                "lowClosed" : true,
@@ -793,6 +1017,11 @@ module.exports['Using CommonLib'] = {
             }
          } ]
       },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
+         } ]
+      },
       "statements" : {
          "def" : [ {
             "name" : "Patient",
@@ -814,7 +1043,7 @@ module.exports['Using CommonLib'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","ID",": " ]
+                     "value" : [ "","define ","ID",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -849,7 +1078,7 @@ module.exports['Using CommonLib'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","L"," : " ]
+                     "value" : [ "","define ","L"," : " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -899,7 +1128,7 @@ module.exports['Using CommonLib'] = {
                "s" : {
                   "r" : "24",
                   "s" : [ {
-                     "value" : [ "define ","FuncTest"," : " ]
+                     "value" : [ "","define ","FuncTest"," : " ]
                   }, {
                      "r" : "23",
                      "s" : [ {
@@ -946,7 +1175,7 @@ module.exports['Using CommonLib'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","supportLibCode",": " ]
+                     "value" : [ "","define ","supportLibCode",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -1023,6 +1252,14 @@ module.exports['CommonLib2'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "64",
+            "s" : [ {
+               "value" : [ "","library Common2" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "Common2"
@@ -1039,7 +1276,22 @@ module.exports['CommonLib2'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -1047,6 +1299,16 @@ module.exports['CommonLib2'] = {
             "localId" : "3",
             "name" : "SomeNumber",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "r" : "2",
+                     "value" : [ "","parameter ","SomeNumber"," default ","17" ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "2",
                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -1057,12 +1319,27 @@ module.exports['CommonLib2'] = {
             "localId" : "5",
             "name" : "AnotherNumber",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "r" : "4",
+                     "value" : [ "","parameter ","AnotherNumber"," default ","20" ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "4",
                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                "value" : "20",
                "type" : "Literal"
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1086,7 +1363,7 @@ module.exports['CommonLib2'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","TheParameter",":\n  " ]
+                     "value" : [ "","define ","TheParameter",":\n  " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -1111,7 +1388,7 @@ module.exports['CommonLib2'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define function ","addToParameter","(","a"," " ]
+                     "value" : [ "","define function ","addToParameter","(","a"," " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -1171,7 +1448,7 @@ module.exports['CommonLib2'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","AnotherParameter",":\n  " ]
+                     "value" : [ "","define ","AnotherParameter",":\n  " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -1196,7 +1473,7 @@ module.exports['CommonLib2'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define function ","addToAnotherParameter","(","a"," " ]
+                     "value" : [ "","define function ","addToAnotherParameter","(","a"," " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -1257,7 +1534,7 @@ module.exports['CommonLib2'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define function ","multiply","(","a"," " ]
+                     "value" : [ "","define function ","multiply","(","a"," " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -1332,7 +1609,7 @@ module.exports['CommonLib2'] = {
                "s" : {
                   "r" : "30",
                   "s" : [ {
-                     "value" : [ "define function ","square","(","a"," " ]
+                     "value" : [ "","define function ","square","(","a"," " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -1397,7 +1674,7 @@ module.exports['CommonLib2'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","TwoTimesThree",":\n  " ]
+                     "value" : [ "","define ","TwoTimesThree",":\n  " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -1434,7 +1711,7 @@ module.exports['CommonLib2'] = {
                   "r" : "36",
                   "s" : [ {
                      "r" : "35",
-                     "value" : [ "define ","Two",":\n  ","2" ]
+                     "value" : [ "","define ","Two",":\n  ","2" ]
                   } ]
                }
             } ],
@@ -1455,7 +1732,7 @@ module.exports['CommonLib2'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define function ","addTwo","(","a"," " ]
+                     "value" : [ "","define function ","addTwo","(","a"," " ]
                   }, {
                      "r" : "37",
                      "s" : [ {
@@ -1515,7 +1792,7 @@ module.exports['CommonLib2'] = {
                "s" : {
                   "r" : "45",
                   "s" : [ {
-                     "value" : [ "define ","TwoPlusOne",":\n  " ]
+                     "value" : [ "","define ","TwoPlusOne",":\n  " ]
                   }, {
                      "r" : "44",
                      "s" : [ {
@@ -1545,18 +1822,18 @@ module.exports['CommonLib2'] = {
                } ]
             }
          }, {
-            "localId" : "61",
+            "localId" : "64",
             "name" : "SortUsingFunction",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "61",
+                  "r" : "64",
                   "s" : [ {
-                     "value" : [ "define ","SortUsingFunction",":\n  " ]
+                     "value" : [ "","define ","SortUsingFunction",":\n  " ]
                   }, {
-                     "r" : "60",
+                     "r" : "63",
                      "s" : [ {
                         "s" : [ {
                            "r" : "52",
@@ -1603,17 +1880,17 @@ module.exports['CommonLib2'] = {
                      }, {
                         "value" : [ " " ]
                      }, {
-                        "r" : "59",
+                        "r" : "62",
                         "s" : [ {
                            "value" : [ "sort by " ]
                         }, {
-                           "r" : "58",
+                           "r" : "61",
                            "s" : [ {
-                              "r" : "57",
+                              "r" : "60",
                               "s" : [ {
                                  "value" : [ "square","(" ]
                               }, {
-                                 "r" : "56",
+                                 "r" : "59",
                                  "s" : [ {
                                     "value" : [ "N" ]
                                  } ]
@@ -1627,7 +1904,7 @@ module.exports['CommonLib2'] = {
                }
             } ],
             "expression" : {
-               "localId" : "60",
+               "localId" : "63",
                "type" : "Query",
                "source" : [ {
                   "localId" : "52",
@@ -1680,17 +1957,17 @@ module.exports['CommonLib2'] = {
                   }
                },
                "sort" : {
-                  "localId" : "59",
+                  "localId" : "62",
                   "by" : [ {
-                     "localId" : "58",
+                     "localId" : "61",
                      "direction" : "asc",
                      "type" : "ByExpression",
                      "expression" : {
-                        "localId" : "57",
+                        "localId" : "60",
                         "name" : "square",
                         "type" : "FunctionRef",
                         "operand" : [ {
-                           "localId" : "56",
+                           "localId" : "59",
                            "name" : "N",
                            "type" : "IdentifierRef"
                         } ]
@@ -1728,6 +2005,14 @@ module.exports['Using CommonLib2'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "39",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1745,14 +2030,49 @@ module.exports['Using CommonLib2'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "includes" : {
          "def" : [ {
             "localId" : "2",
             "localIdentifier" : "common2",
-            "path" : "Common2"
+            "path" : "Common2",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","include " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Common2" ]
+                     } ]
+                  }, {
+                     "value" : [ " called ","common2" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1776,7 +2096,7 @@ module.exports['Using CommonLib2'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","ExprUsesParam",": " ]
+                     "value" : [ "","define ","ExprUsesParam",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -1811,7 +2131,7 @@ module.exports['Using CommonLib2'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","ExprUsesParamDirectly",": " ]
+                     "value" : [ "","define ","ExprUsesParamDirectly",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -1846,7 +2166,7 @@ module.exports['Using CommonLib2'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","ExprUsesAnotherParam",": " ]
+                     "value" : [ "","define ","ExprUsesAnotherParam",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -1881,7 +2201,7 @@ module.exports['Using CommonLib2'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","ExprUsesAnotherParamDirectly",": " ]
+                     "value" : [ "","define ","ExprUsesAnotherParamDirectly",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -1916,7 +2236,7 @@ module.exports['Using CommonLib2'] = {
                "s" : {
                   "r" : "18",
                   "s" : [ {
-                     "value" : [ "define ","FuncUsesAnotherParam",": " ]
+                     "value" : [ "","define ","FuncUsesAnotherParam",": " ]
                   }, {
                      "r" : "17",
                      "s" : [ {
@@ -1958,7 +2278,7 @@ module.exports['Using CommonLib2'] = {
                "s" : {
                   "r" : "22",
                   "s" : [ {
-                     "value" : [ "define ","FuncUsesParam",": " ]
+                     "value" : [ "","define ","FuncUsesParam",": " ]
                   }, {
                      "r" : "21",
                      "s" : [ {
@@ -2000,7 +2320,7 @@ module.exports['Using CommonLib2'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","ExprCallsFunc",": " ]
+                     "value" : [ "","define ","ExprCallsFunc",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -2035,7 +2355,7 @@ module.exports['Using CommonLib2'] = {
                "s" : {
                   "r" : "29",
                   "s" : [ {
-                     "value" : [ "define ","FuncCallsFunc",": " ]
+                     "value" : [ "","define ","FuncCallsFunc",": " ]
                   }, {
                      "r" : "28",
                      "s" : [ {
@@ -2077,7 +2397,7 @@ module.exports['Using CommonLib2'] = {
                "s" : {
                   "r" : "32",
                   "s" : [ {
-                     "value" : [ "define ","ExprUsesExpr",": " ]
+                     "value" : [ "","define ","ExprUsesExpr",": " ]
                   }, {
                      "r" : "31",
                      "s" : [ {
@@ -2112,7 +2432,7 @@ module.exports['Using CommonLib2'] = {
                "s" : {
                   "r" : "36",
                   "s" : [ {
-                     "value" : [ "define ","FuncUsesExpr",": " ]
+                     "value" : [ "","define ","FuncUsesExpr",": " ]
                   }, {
                      "r" : "35",
                      "s" : [ {
@@ -2154,7 +2474,7 @@ module.exports['Using CommonLib2'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","ExprSortsOnFunc",": " ]
+                     "value" : [ "","define ","ExprSortsOnFunc",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -2201,6 +2521,14 @@ module.exports['Using CommonLib and CommonLib2'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "9",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2218,18 +2546,68 @@ module.exports['Using CommonLib and CommonLib2'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "includes" : {
          "def" : [ {
             "localId" : "2",
             "localIdentifier" : "common2",
-            "path" : "Common2"
+            "path" : "Common2",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","include " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Common2" ]
+                     } ]
+                  }, {
+                     "value" : [ " called ","common2" ]
+                  } ]
+               }
+            } ]
          }, {
             "localId" : "3",
             "localIdentifier" : "common",
-            "path" : "Common"
+            "path" : "Common",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","include " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Common" ]
+                     } ]
+                  }, {
+                     "value" : [ " called ","common" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2253,7 +2631,7 @@ module.exports['Using CommonLib and CommonLib2'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define ","testCommonLib",": " ]
+                     "value" : [ "","define ","testCommonLib",": " ]
                   }, {
                      "r" : "5",
                      "s" : [ {
@@ -2288,7 +2666,7 @@ module.exports['Using CommonLib and CommonLib2'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","testCommon2Lib",": " ]
+                     "value" : [ "","define ","testCommon2Lib",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {

--- a/test/elm/list/data.js
+++ b/test/elm/list/data.js
@@ -24,6 +24,14 @@ module.exports['List'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "24",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -41,7 +49,27 @@ module.exports['List'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -65,7 +93,7 @@ module.exports['List'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","Three",": " ]
+                     "value" : [ "","define ","Three",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -100,7 +128,7 @@ module.exports['List'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","IntList",": " ]
+                     "value" : [ "","define ","IntList",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -140,7 +168,7 @@ module.exports['List'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","StringList",": " ]
+                     "value" : [ "","define ","StringList",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -200,7 +228,7 @@ module.exports['List'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","MixedList",": " ]
+                     "value" : [ "","define ","MixedList",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -260,7 +288,7 @@ module.exports['List'] = {
                "s" : {
                   "r" : "24",
                   "s" : [ {
-                     "value" : [ "define ","EmptyList",": " ]
+                     "value" : [ "","define ","EmptyList",": " ]
                   }, {
                      "r" : "23",
                      "s" : [ {
@@ -303,6 +331,14 @@ module.exports['Exists'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "35",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -320,7 +356,27 @@ module.exports['Exists'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -344,7 +400,7 @@ module.exports['Exists'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","EmptyList",": " ]
+                     "value" : [ "","define ","EmptyList",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -390,7 +446,7 @@ module.exports['Exists'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","FullList",": " ]
+                     "value" : [ "","define ","FullList",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -446,7 +502,7 @@ module.exports['Exists'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","ListWithOneNull",": " ]
+                     "value" : [ "","define ","ListWithOneNull",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -490,7 +546,7 @@ module.exports['Exists'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","ListWithTwoNulls",": " ]
+                     "value" : [ "","define ","ListWithTwoNulls",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -537,7 +593,7 @@ module.exports['Exists'] = {
                "s" : {
                   "r" : "26",
                   "s" : [ {
-                     "value" : [ "define ","ListStartingWithNull",": " ]
+                     "value" : [ "","define ","ListStartingWithNull",": " ]
                   }, {
                      "r" : "25",
                      "s" : [ {
@@ -595,7 +651,7 @@ module.exports['Exists'] = {
                "s" : {
                   "r" : "32",
                   "s" : [ {
-                     "value" : [ "define ","ListWithNull",": " ]
+                     "value" : [ "","define ","ListWithNull",": " ]
                   }, {
                      "r" : "31",
                      "s" : [ {
@@ -653,7 +709,7 @@ module.exports['Exists'] = {
                "s" : {
                   "r" : "35",
                   "s" : [ {
-                     "value" : [ "define ","NullExists",": " ]
+                     "value" : [ "","define ","NullExists",": " ]
                   }, {
                      "r" : "34",
                      "s" : [ {
@@ -712,6 +768,14 @@ module.exports['Equal'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "121",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -729,7 +793,27 @@ module.exports['Equal'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -753,7 +837,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","EqualIntList",": " ]
+                     "value" : [ "","define ","EqualIntList",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -827,7 +911,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","UnequalIntList",": " ]
+                     "value" : [ "","define ","UnequalIntList",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -896,7 +980,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "30",
                   "s" : [ {
-                     "value" : [ "define ","ReverseIntList",": " ]
+                     "value" : [ "","define ","ReverseIntList",": " ]
                   }, {
                      "r" : "29",
                      "s" : [ {
@@ -970,7 +1054,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "38",
                   "s" : [ {
-                     "value" : [ "define ","EqualStringList",": " ]
+                     "value" : [ "","define ","EqualStringList",": " ]
                   }, {
                      "r" : "37",
                      "s" : [ {
@@ -1060,7 +1144,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "46",
                   "s" : [ {
-                     "value" : [ "define ","UnequalStringList",": " ]
+                     "value" : [ "","define ","UnequalStringList",": " ]
                   }, {
                      "r" : "45",
                      "s" : [ {
@@ -1150,7 +1234,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "66",
                   "s" : [ {
-                     "value" : [ "define ","EqualTupleList",": " ]
+                     "value" : [ "","define ","EqualTupleList",": " ]
                   }, {
                      "r" : "65",
                      "s" : [ {
@@ -1414,7 +1498,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "87",
                   "s" : [ {
-                     "value" : [ "define ","UnequalTupleList",": " ]
+                     "value" : [ "","define ","UnequalTupleList",": " ]
                   }, {
                      "r" : "86",
                      "s" : [ {
@@ -1687,7 +1771,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "98",
                   "s" : [ {
-                     "value" : [ "define ","FirstListHasNull",": " ]
+                     "value" : [ "","define ","FirstListHasNull",": " ]
                   }, {
                      "r" : "97",
                      "s" : [ {
@@ -1810,7 +1894,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "109",
                   "s" : [ {
-                     "value" : [ "define ","SecondListHasNull",": " ]
+                     "value" : [ "","define ","SecondListHasNull",": " ]
                   }, {
                      "r" : "108",
                      "s" : [ {
@@ -1933,7 +2017,7 @@ module.exports['Equal'] = {
                "s" : {
                   "r" : "121",
                   "s" : [ {
-                     "value" : [ "define ","BothListsHaveNull",": " ]
+                     "value" : [ "","define ","BothListsHaveNull",": " ]
                   }, {
                      "r" : "120",
                      "s" : [ {
@@ -2068,6 +2152,14 @@ module.exports['NotEqual'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "87",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2085,7 +2177,27 @@ module.exports['NotEqual'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2109,7 +2221,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","EqualIntList",": " ]
+                     "value" : [ "","define ","EqualIntList",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -2186,7 +2298,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","UnequalIntList",": " ]
+                     "value" : [ "","define ","UnequalIntList",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -2258,7 +2370,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "30",
                   "s" : [ {
-                     "value" : [ "define ","ReverseIntList",": " ]
+                     "value" : [ "","define ","ReverseIntList",": " ]
                   }, {
                      "r" : "29",
                      "s" : [ {
@@ -2335,7 +2447,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "38",
                   "s" : [ {
-                     "value" : [ "define ","EqualStringList",": " ]
+                     "value" : [ "","define ","EqualStringList",": " ]
                   }, {
                      "r" : "37",
                      "s" : [ {
@@ -2428,7 +2540,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "46",
                   "s" : [ {
-                     "value" : [ "define ","UnequalStringList",": " ]
+                     "value" : [ "","define ","UnequalStringList",": " ]
                   }, {
                      "r" : "45",
                      "s" : [ {
@@ -2521,7 +2633,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "66",
                   "s" : [ {
-                     "value" : [ "define ","EqualTupleList",": " ]
+                     "value" : [ "","define ","EqualTupleList",": " ]
                   }, {
                      "r" : "65",
                      "s" : [ {
@@ -2788,7 +2900,7 @@ module.exports['NotEqual'] = {
                "s" : {
                   "r" : "87",
                   "s" : [ {
-                     "value" : [ "define ","UnequalTupleList",": " ]
+                     "value" : [ "","define ","UnequalTupleList",": " ]
                   }, {
                      "r" : "86",
                      "s" : [ {
@@ -3077,6 +3189,14 @@ module.exports['Union'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "86",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3094,7 +3214,27 @@ module.exports['Union'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3118,7 +3258,7 @@ module.exports['Union'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","OneToTen",": " ]
+                     "value" : [ "","define ","OneToTen",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -3212,7 +3352,7 @@ module.exports['Union'] = {
                "s" : {
                   "r" : "26",
                   "s" : [ {
-                     "value" : [ "define ","OneToFiveOverlapped",": " ]
+                     "value" : [ "","define ","OneToFiveOverlapped",": " ]
                   }, {
                      "r" : "25",
                      "s" : [ {
@@ -3291,7 +3431,7 @@ module.exports['Union'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","OneToFiveOverlappedWithNulls",": " ]
+                     "value" : [ "","define ","OneToFiveOverlappedWithNulls",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -3384,7 +3524,7 @@ module.exports['Union'] = {
                "s" : {
                   "r" : "47",
                   "s" : [ {
-                     "value" : [ "define ","Disjoint",": " ]
+                     "value" : [ "","define ","Disjoint",": " ]
                   }, {
                      "r" : "46",
                      "s" : [ {
@@ -3448,7 +3588,7 @@ module.exports['Union'] = {
                "s" : {
                   "r" : "72",
                   "s" : [ {
-                     "value" : [ "define ","NestedToFifteen",": " ]
+                     "value" : [ "","define ","NestedToFifteen",": " ]
                   }, {
                      "r" : "71",
                      "s" : [ {
@@ -3623,7 +3763,7 @@ module.exports['Union'] = {
                "s" : {
                   "r" : "79",
                   "s" : [ {
-                     "value" : [ "define ","NullUnion",": " ]
+                     "value" : [ "","define ","NullUnion",": " ]
                   }, {
                      "r" : "78",
                      "s" : [ {
@@ -3686,7 +3826,7 @@ module.exports['Union'] = {
                "s" : {
                   "r" : "86",
                   "s" : [ {
-                     "value" : [ "define ","UnionNull",": " ]
+                     "value" : [ "","define ","UnionNull",": " ]
                   }, {
                      "r" : "85",
                      "s" : [ {
@@ -3767,6 +3907,14 @@ module.exports['Except'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "126",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3784,7 +3932,27 @@ module.exports['Except'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3808,7 +3976,7 @@ module.exports['Except'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","ExceptThreeFour",": " ]
+                     "value" : [ "","define ","ExceptThreeFour",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -3887,7 +4055,7 @@ module.exports['Except'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","ThreeFourExcept",": " ]
+                     "value" : [ "","define ","ThreeFourExcept",": " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -3966,7 +4134,7 @@ module.exports['Except'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","ExceptFiveThree",": " ]
+                     "value" : [ "","define ","ExceptFiveThree",": " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -4045,7 +4213,7 @@ module.exports['Except'] = {
                "s" : {
                   "r" : "49",
                   "s" : [ {
-                     "value" : [ "define ","ExceptNoOp",": " ]
+                     "value" : [ "","define ","ExceptNoOp",": " ]
                   }, {
                      "r" : "48",
                      "s" : [ {
@@ -4144,7 +4312,7 @@ module.exports['Except'] = {
                "s" : {
                   "r" : "64",
                   "s" : [ {
-                     "value" : [ "define ","ExceptEverything",": " ]
+                     "value" : [ "","define ","ExceptEverything",": " ]
                   }, {
                      "r" : "63",
                      "s" : [ {
@@ -4243,7 +4411,7 @@ module.exports['Except'] = {
                "s" : {
                   "r" : "76",
                   "s" : [ {
-                     "value" : [ "define ","MultipleNullExcept",": " ]
+                     "value" : [ "","define ","MultipleNullExcept",": " ]
                   }, {
                      "r" : "75",
                      "s" : [ {
@@ -4333,7 +4501,7 @@ module.exports['Except'] = {
                "s" : {
                   "r" : "86",
                   "s" : [ {
-                     "value" : [ "define ","SomethingExceptNothing",": " ]
+                     "value" : [ "","define ","SomethingExceptNothing",": " ]
                   }, {
                      "r" : "85",
                      "s" : [ {
@@ -4407,7 +4575,7 @@ module.exports['Except'] = {
                "s" : {
                   "r" : "96",
                   "s" : [ {
-                     "value" : [ "define ","NothingExceptSomething",": " ]
+                     "value" : [ "","define ","NothingExceptSomething",": " ]
                   }, {
                      "r" : "95",
                      "s" : [ {
@@ -4481,7 +4649,7 @@ module.exports['Except'] = {
                "s" : {
                   "r" : "108",
                   "s" : [ {
-                     "value" : [ "define ","ExceptTuples",": " ]
+                     "value" : [ "","define ","ExceptTuples",": " ]
                   }, {
                      "r" : "107",
                      "s" : [ {
@@ -4627,7 +4795,7 @@ module.exports['Except'] = {
                "s" : {
                   "r" : "117",
                   "s" : [ {
-                     "value" : [ "define ","ExceptNull",": " ]
+                     "value" : [ "","define ","ExceptNull",": " ]
                   }, {
                      "r" : "116",
                      "s" : [ {
@@ -4700,7 +4868,7 @@ module.exports['Except'] = {
                "s" : {
                   "r" : "126",
                   "s" : [ {
-                     "value" : [ "define ","NullExcept",": " ]
+                     "value" : [ "","define ","NullExcept",": " ]
                   }, {
                      "r" : "125",
                      "s" : [ {
@@ -4789,6 +4957,14 @@ module.exports['Intersect'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "149",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -4806,7 +4982,27 @@ module.exports['Intersect'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -4830,7 +5026,7 @@ module.exports['Intersect'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","NoIntersection",": " ]
+                     "value" : [ "","define ","NoIntersection",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -4909,7 +5105,7 @@ module.exports['Intersect'] = {
                "s" : {
                   "r" : "24",
                   "s" : [ {
-                     "value" : [ "define ","IntersectOnFive",": " ]
+                     "value" : [ "","define ","IntersectOnFive",": " ]
                   }, {
                      "r" : "23",
                      "s" : [ {
@@ -4993,7 +5189,7 @@ module.exports['Intersect'] = {
                "s" : {
                   "r" : "37",
                   "s" : [ {
-                     "value" : [ "define ","IntersectionOnFourDuplicates",": " ]
+                     "value" : [ "","define ","IntersectionOnFourDuplicates",": " ]
                   }, {
                      "r" : "36",
                      "s" : [ {
@@ -5082,7 +5278,7 @@ module.exports['Intersect'] = {
                "s" : {
                   "r" : "58",
                   "s" : [ {
-                     "value" : [ "define ","IntersectOnEvens",": " ]
+                     "value" : [ "","define ","IntersectOnEvens",": " ]
                   }, {
                      "r" : "57",
                      "s" : [ {
@@ -5211,7 +5407,7 @@ module.exports['Intersect'] = {
                "s" : {
                   "r" : "72",
                   "s" : [ {
-                     "value" : [ "define ","IntersectOnAll",": " ]
+                     "value" : [ "","define ","IntersectOnAll",": " ]
                   }, {
                      "r" : "71",
                      "s" : [ {
@@ -5305,7 +5501,7 @@ module.exports['Intersect'] = {
                "s" : {
                   "r" : "100",
                   "s" : [ {
-                     "value" : [ "define ","NestedIntersects",": " ]
+                     "value" : [ "","define ","NestedIntersects",": " ]
                   }, {
                      "r" : "99",
                      "s" : [ {
@@ -5486,7 +5682,7 @@ module.exports['Intersect'] = {
                "s" : {
                   "r" : "125",
                   "s" : [ {
-                     "value" : [ "define ","IntersectTuples",": " ]
+                     "value" : [ "","define ","IntersectTuples",": " ]
                   }, {
                      "r" : "124",
                      "s" : [ {
@@ -5843,7 +6039,7 @@ module.exports['Intersect'] = {
                "s" : {
                   "r" : "132",
                   "s" : [ {
-                     "value" : [ "define ","NullIntersect",": " ]
+                     "value" : [ "","define ","NullIntersect",": " ]
                   }, {
                      "r" : "131",
                      "s" : [ {
@@ -5906,7 +6102,7 @@ module.exports['Intersect'] = {
                "s" : {
                   "r" : "139",
                   "s" : [ {
-                     "value" : [ "define ","IntersectNull",": " ]
+                     "value" : [ "","define ","IntersectNull",": " ]
                   }, {
                      "r" : "138",
                      "s" : [ {
@@ -5969,7 +6165,7 @@ module.exports['Intersect'] = {
                "s" : {
                   "r" : "149",
                   "s" : [ {
-                     "value" : [ "define ","MultipleNullInListIntersect",": " ]
+                     "value" : [ "","define ","MultipleNullInListIntersect",": " ]
                   }, {
                      "r" : "148",
                      "s" : [ {
@@ -6063,6 +6259,14 @@ module.exports['IndexOf'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "95",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -6080,7 +6284,27 @@ module.exports['IndexOf'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -6104,7 +6328,7 @@ module.exports['IndexOf'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","IndexOfSecond",": " ]
+                     "value" : [ "","define ","IndexOfSecond",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -6200,7 +6424,7 @@ module.exports['IndexOf'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","IndexOfThirdTuple",": " ]
+                     "value" : [ "","define ","IndexOfThirdTuple",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -6340,7 +6564,7 @@ module.exports['IndexOf'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","MultipleMatches",": " ]
+                     "value" : [ "","define ","MultipleMatches",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -6472,7 +6696,7 @@ module.exports['IndexOf'] = {
                "s" : {
                   "r" : "38",
                   "s" : [ {
-                     "value" : [ "define ","ItemNotFound",": " ]
+                     "value" : [ "","define ","ItemNotFound",": " ]
                   }, {
                      "r" : "37",
                      "s" : [ {
@@ -6556,7 +6780,7 @@ module.exports['IndexOf'] = {
                "s" : {
                   "r" : "42",
                   "s" : [ {
-                     "value" : [ "define ","NullList",": " ]
+                     "value" : [ "","define ","NullList",": " ]
                   }, {
                      "r" : "41",
                      "s" : [ {
@@ -6607,7 +6831,7 @@ module.exports['IndexOf'] = {
                "s" : {
                   "r" : "49",
                   "s" : [ {
-                     "value" : [ "define ","NullItem",": " ]
+                     "value" : [ "","define ","NullItem",": " ]
                   }, {
                      "r" : "48",
                      "s" : [ {
@@ -6687,7 +6911,7 @@ module.exports['IndexOf'] = {
                "s" : {
                   "r" : "62",
                   "s" : [ {
-                     "value" : [ "define ","ListCode",": " ]
+                     "value" : [ "","define ","ListCode",": " ]
                   }, {
                      "r" : "61",
                      "s" : [ {
@@ -6899,7 +7123,7 @@ module.exports['IndexOf'] = {
                "s" : {
                   "r" : "73",
                   "s" : [ {
-                     "value" : [ "define ","ListCodeUndefined",": " ]
+                     "value" : [ "","define ","ListCodeUndefined",": " ]
                   }, {
                      "r" : "72",
                      "s" : [ {
@@ -7073,7 +7297,7 @@ module.exports['IndexOf'] = {
                "s" : {
                   "r" : "84",
                   "s" : [ {
-                     "value" : [ "define ","ListWrongCode",": " ]
+                     "value" : [ "","define ","ListWrongCode",": " ]
                   }, {
                      "r" : "83",
                      "s" : [ {
@@ -7247,7 +7471,7 @@ module.exports['IndexOf'] = {
                "s" : {
                   "r" : "95",
                   "s" : [ {
-                     "value" : [ "define ","ListWrongCodeSystem",": " ]
+                     "value" : [ "","define ","ListWrongCodeSystem",": " ]
                   }, {
                      "r" : "94",
                      "s" : [ {
@@ -7432,6 +7656,14 @@ module.exports['Indexer'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "40",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -7449,7 +7681,27 @@ module.exports['Indexer'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -7473,7 +7725,7 @@ module.exports['Indexer'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","SecondItem",": " ]
+                     "value" : [ "","define ","SecondItem",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -7560,7 +7812,7 @@ module.exports['Indexer'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","ZeroIndex",": " ]
+                     "value" : [ "","define ","ZeroIndex",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -7647,7 +7899,7 @@ module.exports['Indexer'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","OutOfBounds",": " ]
+                     "value" : [ "","define ","OutOfBounds",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -7734,7 +7986,7 @@ module.exports['Indexer'] = {
                "s" : {
                   "r" : "32",
                   "s" : [ {
-                     "value" : [ "define ","NullList",": " ]
+                     "value" : [ "","define ","NullList",": " ]
                   }, {
                      "r" : "31",
                      "s" : [ {
@@ -7806,7 +8058,7 @@ module.exports['Indexer'] = {
                "s" : {
                   "r" : "40",
                   "s" : [ {
-                     "value" : [ "define ","NullIndexer",": " ]
+                     "value" : [ "","define ","NullIndexer",": " ]
                   }, {
                      "r" : "39",
                      "s" : [ {
@@ -7908,6 +8160,14 @@ module.exports['In'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "64",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -7925,7 +8185,27 @@ module.exports['In'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -7949,7 +8229,7 @@ module.exports['In'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","IsIn",": " ]
+                     "value" : [ "","define ","IsIn",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -8004,7 +8284,7 @@ module.exports['In'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","IsNotIn",": " ]
+                     "value" : [ "","define ","IsNotIn",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -8059,7 +8339,7 @@ module.exports['In'] = {
                "s" : {
                   "r" : "30",
                   "s" : [ {
-                     "value" : [ "define ","TupleIsIn",": " ]
+                     "value" : [ "","define ","TupleIsIn",": " ]
                   }, {
                      "r" : "29",
                      "s" : [ {
@@ -8270,7 +8550,7 @@ module.exports['In'] = {
                "s" : {
                   "r" : "45",
                   "s" : [ {
-                     "value" : [ "define ","TupleIsNotIn",": " ]
+                     "value" : [ "","define ","TupleIsNotIn",": " ]
                   }, {
                      "r" : "44",
                      "s" : [ {
@@ -8481,7 +8761,7 @@ module.exports['In'] = {
                "s" : {
                   "r" : "53",
                   "s" : [ {
-                     "value" : [ "define ","NullIn",": " ]
+                     "value" : [ "","define ","NullIn",": " ]
                   }, {
                      "r" : "52",
                      "s" : [ {
@@ -8545,7 +8825,7 @@ module.exports['In'] = {
                "s" : {
                   "r" : "57",
                   "s" : [ {
-                     "value" : [ "define ","InNull",": " ]
+                     "value" : [ "","define ","InNull",": " ]
                   }, {
                      "r" : "56",
                      "s" : [ {
@@ -8588,7 +8868,7 @@ module.exports['In'] = {
                "s" : {
                   "r" : "64",
                   "s" : [ {
-                     "value" : [ "define ","NullNotIn",": " ]
+                     "value" : [ "","define ","NullNotIn",": " ]
                   }, {
                      "r" : "63",
                      "s" : [ {
@@ -8658,6 +8938,14 @@ module.exports['Contains'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "67",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -8675,7 +8963,27 @@ module.exports['Contains'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -8699,7 +9007,7 @@ module.exports['Contains'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","IsIn",": " ]
+                     "value" : [ "","define ","IsIn",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -8754,7 +9062,7 @@ module.exports['Contains'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","IsNotIn",": " ]
+                     "value" : [ "","define ","IsNotIn",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -8809,7 +9117,7 @@ module.exports['Contains'] = {
                "s" : {
                   "r" : "30",
                   "s" : [ {
-                     "value" : [ "define ","TupleIsIn",": " ]
+                     "value" : [ "","define ","TupleIsIn",": " ]
                   }, {
                      "r" : "29",
                      "s" : [ {
@@ -9020,7 +9328,7 @@ module.exports['Contains'] = {
                "s" : {
                   "r" : "45",
                   "s" : [ {
-                     "value" : [ "define ","TupleIsNotIn",": " ]
+                     "value" : [ "","define ","TupleIsNotIn",": " ]
                   }, {
                      "r" : "44",
                      "s" : [ {
@@ -9231,7 +9539,7 @@ module.exports['Contains'] = {
                "s" : {
                   "r" : "52",
                   "s" : [ {
-                     "value" : [ "define ","InNull",": " ]
+                     "value" : [ "","define ","InNull",": " ]
                   }, {
                      "r" : "51",
                      "s" : [ {
@@ -9303,7 +9611,7 @@ module.exports['Contains'] = {
                "s" : {
                   "r" : "60",
                   "s" : [ {
-                     "value" : [ "define ","NullIn",": " ]
+                     "value" : [ "","define ","NullIn",": " ]
                   }, {
                      "r" : "59",
                      "s" : [ {
@@ -9367,7 +9675,7 @@ module.exports['Contains'] = {
                "s" : {
                   "r" : "67",
                   "s" : [ {
-                     "value" : [ "define ","NullNotIn",": " ]
+                     "value" : [ "","define ","NullNotIn",": " ]
                   }, {
                      "r" : "66",
                      "s" : [ {
@@ -9521,6 +9829,14 @@ module.exports['Includes'] = {
          "errorType" : "semantic",
          "errorSeverity" : "warning",
          "type" : "CqlToElmError"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "189",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -9538,7 +9854,27 @@ module.exports['Includes'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -9562,7 +9898,7 @@ module.exports['Includes'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","IsIncluded",": " ]
+                     "value" : [ "","define ","IsIncluded",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -9647,7 +9983,7 @@ module.exports['Includes'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","IsIncludedReversed",": " ]
+                     "value" : [ "","define ","IsIncludedReversed",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -9732,7 +10068,7 @@ module.exports['Includes'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","IsSame",": " ]
+                     "value" : [ "","define ","IsSame",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -9827,7 +10163,7 @@ module.exports['Includes'] = {
                "s" : {
                   "r" : "51",
                   "s" : [ {
-                     "value" : [ "define ","IsNotIncluded",": " ]
+                     "value" : [ "","define ","IsNotIncluded",": " ]
                   }, {
                      "r" : "50",
                      "s" : [ {
@@ -9912,7 +10248,7 @@ module.exports['Includes'] = {
                "s" : {
                   "r" : "70",
                   "s" : [ {
-                     "value" : [ "define ","TuplesIncluded",": " ]
+                     "value" : [ "","define ","TuplesIncluded",": " ]
                   }, {
                      "r" : "69",
                      "s" : [ {
@@ -10180,7 +10516,7 @@ module.exports['Includes'] = {
                "s" : {
                   "r" : "89",
                   "s" : [ {
-                     "value" : [ "define ","TuplesNotIncluded",": " ]
+                     "value" : [ "","define ","TuplesNotIncluded",": " ]
                   }, {
                      "r" : "88",
                      "s" : [ {
@@ -10448,7 +10784,7 @@ module.exports['Includes'] = {
                "s" : {
                   "r" : "98",
                   "s" : [ {
-                     "value" : [ "define ","NullIncluded",": " ]
+                     "value" : [ "","define ","NullIncluded",": " ]
                   }, {
                      "r" : "97",
                      "s" : [ {
@@ -10521,7 +10857,7 @@ module.exports['Includes'] = {
                "s" : {
                   "r" : "107",
                   "s" : [ {
-                     "value" : [ "define ","NullIncludes",": " ]
+                     "value" : [ "","define ","NullIncludes",": " ]
                   }, {
                      "r" : "106",
                      "s" : [ {
@@ -10594,7 +10930,7 @@ module.exports['Includes'] = {
                "s" : {
                   "r" : "126",
                   "s" : [ {
-                     "value" : [ "define ","DayIncluded",": " ]
+                     "value" : [ "","define ","DayIncluded",": " ]
                   }, {
                      "r" : "125",
                      "s" : [ {
@@ -10742,7 +11078,7 @@ module.exports['Includes'] = {
                "s" : {
                   "r" : "145",
                   "s" : [ {
-                     "value" : [ "define ","DayNotIncluded",": " ]
+                     "value" : [ "","define ","DayNotIncluded",": " ]
                   }, {
                      "r" : "144",
                      "s" : [ {
@@ -10890,7 +11226,7 @@ module.exports['Includes'] = {
                "s" : {
                   "r" : "154",
                   "s" : [ {
-                     "value" : [ "define ","IntegerIncluded",": " ]
+                     "value" : [ "","define ","IntegerIncluded",": " ]
                   }, {
                      "r" : "153",
                      "s" : [ {
@@ -10955,7 +11291,7 @@ module.exports['Includes'] = {
                "s" : {
                   "r" : "163",
                   "s" : [ {
-                     "value" : [ "define ","IntegerNotIncluded",": " ]
+                     "value" : [ "","define ","IntegerNotIncluded",": " ]
                   }, {
                      "r" : "162",
                      "s" : [ {
@@ -11020,7 +11356,7 @@ module.exports['Includes'] = {
                "s" : {
                   "r" : "176",
                   "s" : [ {
-                     "value" : [ "define ","QuantityInList",": " ]
+                     "value" : [ "","define ","QuantityInList",": " ]
                   }, {
                      "r" : "175",
                      "s" : [ {
@@ -11167,7 +11503,7 @@ module.exports['Includes'] = {
                "s" : {
                   "r" : "189",
                   "s" : [ {
-                     "value" : [ "define ","QuantityNotInList",": " ]
+                     "value" : [ "","define ","QuantityNotInList",": " ]
                   }, {
                      "r" : "188",
                      "s" : [ {
@@ -11400,6 +11736,14 @@ module.exports['IncludedIn'] = {
          "errorType" : "semantic",
          "errorSeverity" : "warning",
          "type" : "CqlToElmError"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "189",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -11417,7 +11761,27 @@ module.exports['IncludedIn'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -11441,7 +11805,7 @@ module.exports['IncludedIn'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","IsIncluded",": " ]
+                     "value" : [ "","define ","IsIncluded",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -11526,7 +11890,7 @@ module.exports['IncludedIn'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","IsIncludedReversed",": " ]
+                     "value" : [ "","define ","IsIncludedReversed",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -11611,7 +11975,7 @@ module.exports['IncludedIn'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","IsSame",": " ]
+                     "value" : [ "","define ","IsSame",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -11706,7 +12070,7 @@ module.exports['IncludedIn'] = {
                "s" : {
                   "r" : "51",
                   "s" : [ {
-                     "value" : [ "define ","IsNotIncluded",": " ]
+                     "value" : [ "","define ","IsNotIncluded",": " ]
                   }, {
                      "r" : "50",
                      "s" : [ {
@@ -11791,7 +12155,7 @@ module.exports['IncludedIn'] = {
                "s" : {
                   "r" : "70",
                   "s" : [ {
-                     "value" : [ "define ","TuplesIncluded",": " ]
+                     "value" : [ "","define ","TuplesIncluded",": " ]
                   }, {
                      "r" : "69",
                      "s" : [ {
@@ -12059,7 +12423,7 @@ module.exports['IncludedIn'] = {
                "s" : {
                   "r" : "89",
                   "s" : [ {
-                     "value" : [ "define ","TuplesNotIncluded",": " ]
+                     "value" : [ "","define ","TuplesNotIncluded",": " ]
                   }, {
                      "r" : "88",
                      "s" : [ {
@@ -12327,7 +12691,7 @@ module.exports['IncludedIn'] = {
                "s" : {
                   "r" : "98",
                   "s" : [ {
-                     "value" : [ "define ","NullIncludes",": " ]
+                     "value" : [ "","define ","NullIncludes",": " ]
                   }, {
                      "r" : "97",
                      "s" : [ {
@@ -12400,7 +12764,7 @@ module.exports['IncludedIn'] = {
                "s" : {
                   "r" : "107",
                   "s" : [ {
-                     "value" : [ "define ","NullIncluded",": " ]
+                     "value" : [ "","define ","NullIncluded",": " ]
                   }, {
                      "r" : "106",
                      "s" : [ {
@@ -12473,7 +12837,7 @@ module.exports['IncludedIn'] = {
                "s" : {
                   "r" : "126",
                   "s" : [ {
-                     "value" : [ "define ","DayIncluded",": " ]
+                     "value" : [ "","define ","DayIncluded",": " ]
                   }, {
                      "r" : "125",
                      "s" : [ {
@@ -12621,7 +12985,7 @@ module.exports['IncludedIn'] = {
                "s" : {
                   "r" : "145",
                   "s" : [ {
-                     "value" : [ "define ","DayNotIncluded",": " ]
+                     "value" : [ "","define ","DayNotIncluded",": " ]
                   }, {
                      "r" : "144",
                      "s" : [ {
@@ -12769,7 +13133,7 @@ module.exports['IncludedIn'] = {
                "s" : {
                   "r" : "154",
                   "s" : [ {
-                     "value" : [ "define ","IntegerIncluded",": " ]
+                     "value" : [ "","define ","IntegerIncluded",": " ]
                   }, {
                      "r" : "153",
                      "s" : [ {
@@ -12834,7 +13198,7 @@ module.exports['IncludedIn'] = {
                "s" : {
                   "r" : "163",
                   "s" : [ {
-                     "value" : [ "define ","IntegerNotIncluded",": " ]
+                     "value" : [ "","define ","IntegerNotIncluded",": " ]
                   }, {
                      "r" : "162",
                      "s" : [ {
@@ -12899,7 +13263,7 @@ module.exports['IncludedIn'] = {
                "s" : {
                   "r" : "176",
                   "s" : [ {
-                     "value" : [ "define ","QuantityInList",": " ]
+                     "value" : [ "","define ","QuantityInList",": " ]
                   }, {
                      "r" : "175",
                      "s" : [ {
@@ -13046,7 +13410,7 @@ module.exports['IncludedIn'] = {
                "s" : {
                   "r" : "189",
                   "s" : [ {
-                     "value" : [ "define ","QuantityNotInList",": " ]
+                     "value" : [ "","define ","QuantityNotInList",": " ]
                   }, {
                      "r" : "188",
                      "s" : [ {
@@ -13284,6 +13648,14 @@ module.exports['ProperIncludes'] = {
          "errorType" : "semantic",
          "errorSeverity" : "warning",
          "type" : "CqlToElmError"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "110",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -13301,7 +13673,27 @@ module.exports['ProperIncludes'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -13325,7 +13717,7 @@ module.exports['ProperIncludes'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","IsIncluded",": " ]
+                     "value" : [ "","define ","IsIncluded",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -13415,7 +13807,7 @@ module.exports['ProperIncludes'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","IsIncludedReversed",": " ]
+                     "value" : [ "","define ","IsIncludedReversed",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -13505,7 +13897,7 @@ module.exports['ProperIncludes'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","IsSame",": " ]
+                     "value" : [ "","define ","IsSame",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -13600,7 +13992,7 @@ module.exports['ProperIncludes'] = {
                "s" : {
                   "r" : "54",
                   "s" : [ {
-                     "value" : [ "define ","IsNotIncluded",": " ]
+                     "value" : [ "","define ","IsNotIncluded",": " ]
                   }, {
                      "r" : "53",
                      "s" : [ {
@@ -13690,7 +14082,7 @@ module.exports['ProperIncludes'] = {
                "s" : {
                   "r" : "73",
                   "s" : [ {
-                     "value" : [ "define ","TuplesIncluded",": " ]
+                     "value" : [ "","define ","TuplesIncluded",": " ]
                   }, {
                      "r" : "72",
                      "s" : [ {
@@ -13958,7 +14350,7 @@ module.exports['ProperIncludes'] = {
                "s" : {
                   "r" : "92",
                   "s" : [ {
-                     "value" : [ "define ","TuplesNotIncluded",": " ]
+                     "value" : [ "","define ","TuplesNotIncluded",": " ]
                   }, {
                      "r" : "91",
                      "s" : [ {
@@ -14226,7 +14618,7 @@ module.exports['ProperIncludes'] = {
                "s" : {
                   "r" : "101",
                   "s" : [ {
-                     "value" : [ "define ","NullIncluded",": " ]
+                     "value" : [ "","define ","NullIncluded",": " ]
                   }, {
                      "r" : "100",
                      "s" : [ {
@@ -14299,7 +14691,7 @@ module.exports['ProperIncludes'] = {
                "s" : {
                   "r" : "110",
                   "s" : [ {
-                     "value" : [ "define ","NullIncludes",": " ]
+                     "value" : [ "","define ","NullIncludes",": " ]
                   }, {
                      "r" : "109",
                      "s" : [ {
@@ -14463,6 +14855,14 @@ module.exports['ProperIncludedIn'] = {
          "errorType" : "semantic",
          "errorSeverity" : "warning",
          "type" : "CqlToElmError"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "110",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -14480,7 +14880,27 @@ module.exports['ProperIncludedIn'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -14504,7 +14924,7 @@ module.exports['ProperIncludedIn'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","IsIncluded",": " ]
+                     "value" : [ "","define ","IsIncluded",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -14589,7 +15009,7 @@ module.exports['ProperIncludedIn'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","IsIncludedReversed",": " ]
+                     "value" : [ "","define ","IsIncludedReversed",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -14674,7 +15094,7 @@ module.exports['ProperIncludedIn'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","IsSame",": " ]
+                     "value" : [ "","define ","IsSame",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -14769,7 +15189,7 @@ module.exports['ProperIncludedIn'] = {
                "s" : {
                   "r" : "51",
                   "s" : [ {
-                     "value" : [ "define ","IsNotIncluded",": " ]
+                     "value" : [ "","define ","IsNotIncluded",": " ]
                   }, {
                      "r" : "50",
                      "s" : [ {
@@ -14854,7 +15274,7 @@ module.exports['ProperIncludedIn'] = {
                "s" : {
                   "r" : "70",
                   "s" : [ {
-                     "value" : [ "define ","TuplesIncluded",": " ]
+                     "value" : [ "","define ","TuplesIncluded",": " ]
                   }, {
                      "r" : "69",
                      "s" : [ {
@@ -15122,7 +15542,7 @@ module.exports['ProperIncludedIn'] = {
                "s" : {
                   "r" : "89",
                   "s" : [ {
-                     "value" : [ "define ","TuplesNotIncluded",": " ]
+                     "value" : [ "","define ","TuplesNotIncluded",": " ]
                   }, {
                      "r" : "88",
                      "s" : [ {
@@ -15390,7 +15810,7 @@ module.exports['ProperIncludedIn'] = {
                "s" : {
                   "r" : "98",
                   "s" : [ {
-                     "value" : [ "define ","NullIncludes",": " ]
+                     "value" : [ "","define ","NullIncludes",": " ]
                   }, {
                      "r" : "97",
                      "s" : [ {
@@ -15463,7 +15883,7 @@ module.exports['ProperIncludedIn'] = {
                "s" : {
                   "r" : "110",
                   "s" : [ {
-                     "value" : [ "define ","NullIncluded",": " ]
+                     "value" : [ "","define ","NullIncluded",": " ]
                   }, {
                      "r" : "109",
                      "s" : [ {
@@ -15573,6 +15993,14 @@ module.exports['Flatten'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "31",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -15590,7 +16018,27 @@ module.exports['Flatten'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -15614,7 +16062,7 @@ module.exports['Flatten'] = {
                "s" : {
                   "r" : "28",
                   "s" : [ {
-                     "value" : [ "define ","ListOfLists",": " ]
+                     "value" : [ "","define ","ListOfLists",": " ]
                   }, {
                      "r" : "27",
                      "s" : [ {
@@ -15809,7 +16257,7 @@ module.exports['Flatten'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","NullValue",": " ]
+                     "value" : [ "","define ","NullValue",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -15861,6 +16309,14 @@ module.exports['Distinct'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "60",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -15878,7 +16334,27 @@ module.exports['Distinct'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -15902,7 +16378,7 @@ module.exports['Distinct'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","LotsOfDups",": " ]
+                     "value" : [ "","define ","LotsOfDups",": " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -16031,7 +16507,7 @@ module.exports['Distinct'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","NoDups",": " ]
+                     "value" : [ "","define ","NoDups",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -16090,7 +16566,7 @@ module.exports['Distinct'] = {
                "s" : {
                   "r" : "42",
                   "s" : [ {
-                     "value" : [ "define ","DupsTuples",": " ]
+                     "value" : [ "","define ","DupsTuples",": " ]
                   }, {
                      "r" : "41",
                      "s" : [ {
@@ -16243,7 +16719,7 @@ module.exports['Distinct'] = {
                "s" : {
                   "r" : "49",
                   "s" : [ {
-                     "value" : [ "define ","NoDupsTuples",": " ]
+                     "value" : [ "","define ","NoDupsTuples",": " ]
                   }, {
                      "r" : "48",
                      "s" : [ {
@@ -16336,7 +16812,7 @@ module.exports['Distinct'] = {
                "s" : {
                   "r" : "60",
                   "s" : [ {
-                     "value" : [ "define ","DuplicateNulls",": " ]
+                     "value" : [ "","define ","DuplicateNulls",": " ]
                   }, {
                      "r" : "59",
                      "s" : [ {
@@ -16429,6 +16905,14 @@ module.exports['First'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "53",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -16446,7 +16930,27 @@ module.exports['First'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -16470,7 +16974,7 @@ module.exports['First'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","Numbers",": " ]
+                     "value" : [ "","define ","Numbers",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -16526,7 +17030,7 @@ module.exports['First'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","Letters",": " ]
+                     "value" : [ "","define ","Letters",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -16597,7 +17101,7 @@ module.exports['First'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","Lists",": " ]
+                     "value" : [ "","define ","Lists",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -16726,7 +17230,7 @@ module.exports['First'] = {
                "s" : {
                   "r" : "36",
                   "s" : [ {
-                     "value" : [ "define ","Tuples",": " ]
+                     "value" : [ "","define ","Tuples",": " ]
                   }, {
                      "r" : "35",
                      "s" : [ {
@@ -16873,7 +17377,7 @@ module.exports['First'] = {
                "s" : {
                   "r" : "43",
                   "s" : [ {
-                     "value" : [ "define ","Unordered",": " ]
+                     "value" : [ "","define ","Unordered",": " ]
                   }, {
                      "r" : "42",
                      "s" : [ {
@@ -16929,7 +17433,7 @@ module.exports['First'] = {
                "s" : {
                   "r" : "47",
                   "s" : [ {
-                     "value" : [ "define ","Empty",": " ]
+                     "value" : [ "","define ","Empty",": " ]
                   }, {
                      "r" : "46",
                      "s" : [ {
@@ -16970,7 +17474,7 @@ module.exports['First'] = {
                "s" : {
                   "r" : "53",
                   "s" : [ {
-                     "value" : [ "define ","NullValue",": " ]
+                     "value" : [ "","define ","NullValue",": " ]
                   }, {
                      "r" : "52",
                      "s" : [ {
@@ -17044,6 +17548,14 @@ module.exports['Last'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "53",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -17061,7 +17573,27 @@ module.exports['Last'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -17085,7 +17617,7 @@ module.exports['Last'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","Numbers",": " ]
+                     "value" : [ "","define ","Numbers",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -17141,7 +17673,7 @@ module.exports['Last'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","Letters",": " ]
+                     "value" : [ "","define ","Letters",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -17212,7 +17744,7 @@ module.exports['Last'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","Lists",": " ]
+                     "value" : [ "","define ","Lists",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -17341,7 +17873,7 @@ module.exports['Last'] = {
                "s" : {
                   "r" : "36",
                   "s" : [ {
-                     "value" : [ "define ","Tuples",": " ]
+                     "value" : [ "","define ","Tuples",": " ]
                   }, {
                      "r" : "35",
                      "s" : [ {
@@ -17488,7 +18020,7 @@ module.exports['Last'] = {
                "s" : {
                   "r" : "43",
                   "s" : [ {
-                     "value" : [ "define ","Unordered",": " ]
+                     "value" : [ "","define ","Unordered",": " ]
                   }, {
                      "r" : "42",
                      "s" : [ {
@@ -17544,7 +18076,7 @@ module.exports['Last'] = {
                "s" : {
                   "r" : "47",
                   "s" : [ {
-                     "value" : [ "define ","Empty",": " ]
+                     "value" : [ "","define ","Empty",": " ]
                   }, {
                      "r" : "46",
                      "s" : [ {
@@ -17585,7 +18117,7 @@ module.exports['Last'] = {
                "s" : {
                   "r" : "53",
                   "s" : [ {
-                     "value" : [ "define ","NullValue",": " ]
+                     "value" : [ "","define ","NullValue",": " ]
                   }, {
                      "r" : "52",
                      "s" : [ {
@@ -17657,6 +18189,14 @@ module.exports['Length'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "49",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -17674,7 +18214,27 @@ module.exports['Length'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -17698,7 +18258,7 @@ module.exports['Length'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","Numbers",": " ]
+                     "value" : [ "","define ","Numbers",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -17759,7 +18319,7 @@ module.exports['Length'] = {
                "s" : {
                   "r" : "28",
                   "s" : [ {
-                     "value" : [ "define ","Lists",": " ]
+                     "value" : [ "","define ","Lists",": " ]
                   }, {
                      "r" : "27",
                      "s" : [ {
@@ -17902,7 +18462,7 @@ module.exports['Length'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","Tuples",": " ]
+                     "value" : [ "","define ","Tuples",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -18049,7 +18609,7 @@ module.exports['Length'] = {
                "s" : {
                   "r" : "43",
                   "s" : [ {
-                     "value" : [ "define ","Empty",": " ]
+                     "value" : [ "","define ","Empty",": " ]
                   }, {
                      "r" : "42",
                      "s" : [ {
@@ -18090,7 +18650,7 @@ module.exports['Length'] = {
                "s" : {
                   "r" : "49",
                   "s" : [ {
-                     "value" : [ "define ","NullValue",": " ]
+                     "value" : [ "","define ","NullValue",": " ]
                   }, {
                      "r" : "48",
                      "s" : [ {
@@ -18160,6 +18720,14 @@ module.exports['ToList'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "14",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -18177,7 +18745,27 @@ module.exports['ToList'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -18201,7 +18789,7 @@ module.exports['ToList'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","FiveInFive",": " ]
+                     "value" : [ "","define ","FiveInFive",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -18239,7 +18827,7 @@ module.exports['ToList'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","FourInFive",": " ]
+                     "value" : [ "// CQL-to-ELM will promote the second 5 to a list via ToList","define ","FourInFive",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -18277,7 +18865,7 @@ module.exports['ToList'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","LengthOfNull",": " ]
+                     "value" : [ "// CQL-to-ELM will promote the 5 to a list via ToList","define ","LengthOfNull",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -18340,6 +18928,14 @@ module.exports['Skip'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "29",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -18357,7 +18953,27 @@ module.exports['Skip'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -18381,7 +18997,7 @@ module.exports['Skip'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","Skip2",": " ]
+                     "value" : [ "","define ","Skip2",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -18453,7 +19069,7 @@ module.exports['Skip'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","SkipNull",": " ]
+                     "value" : [ "","define ","SkipNull",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -18517,7 +19133,7 @@ module.exports['Skip'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","SkipEmpty",": " ]
+                     "value" : [ "","define ","SkipEmpty",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -18590,7 +19206,7 @@ module.exports['Skip'] = {
                "s" : {
                   "r" : "29",
                   "s" : [ {
-                     "value" : [ "define ","SkipIsNull",": " ]
+                     "value" : [ "","define ","SkipIsNull",": " ]
                   }, {
                      "r" : "28",
                      "s" : [ {
@@ -18647,6 +19263,14 @@ module.exports['Tail'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "14",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -18664,7 +19288,27 @@ module.exports['Tail'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -18688,7 +19332,7 @@ module.exports['Tail'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","Tail234",": " ]
+                     "value" : [ "","define ","Tail234",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -18753,7 +19397,7 @@ module.exports['Tail'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","TailEmpty",": " ]
+                     "value" : [ "","define ","TailEmpty",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -18790,7 +19434,7 @@ module.exports['Tail'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","TailIsNull",": " ]
+                     "value" : [ "","define ","TailIsNull",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -18847,6 +19491,14 @@ module.exports['Take'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "27",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -18864,7 +19516,27 @@ module.exports['Take'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -18888,7 +19560,7 @@ module.exports['Take'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","Take2",": " ]
+                     "value" : [ "","define ","Take2",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -18963,7 +19635,7 @@ module.exports['Take'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","TakeTooMany",": " ]
+                     "value" : [ "","define ","TakeTooMany",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -19028,7 +19700,7 @@ module.exports['Take'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","TakeEmpty",": " ]
+                     "value" : [ "","define ","TakeEmpty",": " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -19105,7 +19777,7 @@ module.exports['Take'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","TakeIsNull",": " ]
+                     "value" : [ "","define ","TakeIsNull",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {

--- a/test/elm/literal/data.js
+++ b/test/elm/literal/data.js
@@ -26,6 +26,14 @@ module.exports['Literal'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "15",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -43,7 +51,27 @@ module.exports['Literal'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -68,7 +96,7 @@ module.exports['Literal'] = {
                   "r" : "3",
                   "s" : [ {
                      "r" : "2",
-                     "value" : [ "define ","BoolTrue",": ","true" ]
+                     "value" : [ "","define ","BoolTrue",": ","true" ]
                   } ]
                }
             } ],
@@ -89,7 +117,7 @@ module.exports['Literal'] = {
                   "r" : "5",
                   "s" : [ {
                      "r" : "4",
-                     "value" : [ "define ","BoolFalse",": ","false" ]
+                     "value" : [ "","define ","BoolFalse",": ","false" ]
                   } ]
                }
             } ],
@@ -110,7 +138,7 @@ module.exports['Literal'] = {
                   "r" : "7",
                   "s" : [ {
                      "r" : "6",
-                     "value" : [ "define ","IntOne",": ","1" ]
+                     "value" : [ "","define ","IntOne",": ","1" ]
                   } ]
                }
             } ],
@@ -131,7 +159,7 @@ module.exports['Literal'] = {
                   "r" : "9",
                   "s" : [ {
                      "r" : "8",
-                     "value" : [ "define ","DecimalTenth",": ","0.1" ]
+                     "value" : [ "","define ","DecimalTenth",": ","0.1" ]
                   } ]
                }
             } ],
@@ -151,7 +179,7 @@ module.exports['Literal'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","StringTrue",": " ]
+                     "value" : [ "","define ","StringTrue",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -177,7 +205,7 @@ module.exports['Literal'] = {
                   "r" : "13",
                   "s" : [ {
                      "r" : "12",
-                     "value" : [ "define ","DateTimeX",": ","@2012-02-15T12:10:59.456Z" ]
+                     "value" : [ "","define ","DateTimeX",": ","@2012-02-15T12:10:59.456Z" ]
                   } ]
                }
             } ],
@@ -236,7 +264,7 @@ module.exports['Literal'] = {
                   "r" : "15",
                   "s" : [ {
                      "r" : "14",
-                     "value" : [ "define ","TimeX",": ","@T12:10:59.456" ]
+                     "value" : [ "","define ","TimeX",": ","@T12:10:59.456" ]
                   } ]
                }
             } ],
@@ -289,6 +317,14 @@ module.exports['Escape'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "19",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -306,7 +342,27 @@ module.exports['Escape'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -330,7 +386,7 @@ module.exports['Escape'] = {
                "s" : {
                   "r" : "3",
                   "s" : [ {
-                     "value" : [ "define ","SingleQuote",": " ]
+                     "value" : [ "","define ","SingleQuote",": " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -355,7 +411,7 @@ module.exports['Escape'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","DoubleQuote",": " ]
+                     "value" : [ "","define ","DoubleQuote",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -380,7 +436,7 @@ module.exports['Escape'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","Backtick",": " ]
+                     "value" : [ "","define ","Backtick",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -405,7 +461,7 @@ module.exports['Escape'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","CarriageReturn",": " ]
+                     "value" : [ "","define ","CarriageReturn",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -430,7 +486,7 @@ module.exports['Escape'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","LineFeed",": " ]
+                     "value" : [ "","define ","LineFeed",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -455,7 +511,7 @@ module.exports['Escape'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","Tab",": " ]
+                     "value" : [ "","define ","Tab",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -480,7 +536,7 @@ module.exports['Escape'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","FormFeed",": " ]
+                     "value" : [ "","define ","FormFeed",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -505,7 +561,7 @@ module.exports['Escape'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","Backslash",": " ]
+                     "value" : [ "","define ","Backslash",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -530,7 +586,7 @@ module.exports['Escape'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","Unicode",": " ]
+                     "value" : [ "","define ","Unicode",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {

--- a/test/elm/logical/data.js
+++ b/test/elm/logical/data.js
@@ -28,6 +28,14 @@ module.exports['And'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "37",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -45,7 +53,27 @@ module.exports['And'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -69,7 +97,7 @@ module.exports['And'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","TT",": " ]
+                     "value" : [ "","define ","TT",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -104,7 +132,7 @@ module.exports['And'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","TF",": " ]
+                     "value" : [ "","define ","TF",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -139,7 +167,7 @@ module.exports['And'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","TN",": " ]
+                     "value" : [ "","define ","TN",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -176,7 +204,7 @@ module.exports['And'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","FF",": " ]
+                     "value" : [ "","define ","FF",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -211,7 +239,7 @@ module.exports['And'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","FT",": " ]
+                     "value" : [ "","define ","FT",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -246,7 +274,7 @@ module.exports['And'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","FN",": " ]
+                     "value" : [ "","define ","FN",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -283,7 +311,7 @@ module.exports['And'] = {
                "s" : {
                   "r" : "29",
                   "s" : [ {
-                     "value" : [ "define ","NN",": " ]
+                     "value" : [ "","define ","NN",": " ]
                   }, {
                      "r" : "28",
                      "s" : [ {
@@ -322,7 +350,7 @@ module.exports['And'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","NT",": " ]
+                     "value" : [ "","define ","NT",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -359,7 +387,7 @@ module.exports['And'] = {
                "s" : {
                   "r" : "37",
                   "s" : [ {
-                     "value" : [ "define ","NF",": " ]
+                     "value" : [ "","define ","NF",": " ]
                   }, {
                      "r" : "36",
                      "s" : [ {
@@ -411,6 +439,14 @@ module.exports['Or'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "37",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -428,7 +464,27 @@ module.exports['Or'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -452,7 +508,7 @@ module.exports['Or'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","TT",": " ]
+                     "value" : [ "","define ","TT",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -487,7 +543,7 @@ module.exports['Or'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","TF",": " ]
+                     "value" : [ "","define ","TF",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -522,7 +578,7 @@ module.exports['Or'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","TN",": " ]
+                     "value" : [ "","define ","TN",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -559,7 +615,7 @@ module.exports['Or'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","FF",": " ]
+                     "value" : [ "","define ","FF",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -594,7 +650,7 @@ module.exports['Or'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","FT",": " ]
+                     "value" : [ "","define ","FT",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -629,7 +685,7 @@ module.exports['Or'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","FN",": " ]
+                     "value" : [ "","define ","FN",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -666,7 +722,7 @@ module.exports['Or'] = {
                "s" : {
                   "r" : "29",
                   "s" : [ {
-                     "value" : [ "define ","NN",": " ]
+                     "value" : [ "","define ","NN",": " ]
                   }, {
                      "r" : "28",
                      "s" : [ {
@@ -705,7 +761,7 @@ module.exports['Or'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","NT",": " ]
+                     "value" : [ "","define ","NT",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -742,7 +798,7 @@ module.exports['Or'] = {
                "s" : {
                   "r" : "37",
                   "s" : [ {
-                     "value" : [ "define ","NF",": " ]
+                     "value" : [ "","define ","NF",": " ]
                   }, {
                      "r" : "36",
                      "s" : [ {
@@ -794,6 +850,14 @@ module.exports['XOr'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "37",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -811,7 +875,27 @@ module.exports['XOr'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -835,7 +919,7 @@ module.exports['XOr'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","TT",": " ]
+                     "value" : [ "","define ","TT",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -870,7 +954,7 @@ module.exports['XOr'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","TF",": " ]
+                     "value" : [ "","define ","TF",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -905,7 +989,7 @@ module.exports['XOr'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","TN",": " ]
+                     "value" : [ "","define ","TN",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -942,7 +1026,7 @@ module.exports['XOr'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","FF",": " ]
+                     "value" : [ "","define ","FF",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -977,7 +1061,7 @@ module.exports['XOr'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","FT",": " ]
+                     "value" : [ "","define ","FT",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -1012,7 +1096,7 @@ module.exports['XOr'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","FN",": " ]
+                     "value" : [ "","define ","FN",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -1049,7 +1133,7 @@ module.exports['XOr'] = {
                "s" : {
                   "r" : "29",
                   "s" : [ {
-                     "value" : [ "define ","NN",": " ]
+                     "value" : [ "","define ","NN",": " ]
                   }, {
                      "r" : "28",
                      "s" : [ {
@@ -1088,7 +1172,7 @@ module.exports['XOr'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","NT",": " ]
+                     "value" : [ "","define ","NT",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -1125,7 +1209,7 @@ module.exports['XOr'] = {
                "s" : {
                   "r" : "37",
                   "s" : [ {
-                     "value" : [ "define ","NF",": " ]
+                     "value" : [ "","define ","NF",": " ]
                   }, {
                      "r" : "36",
                      "s" : [ {
@@ -1171,6 +1255,14 @@ module.exports['Not'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "10",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1188,7 +1280,27 @@ module.exports['Not'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1212,7 +1324,7 @@ module.exports['Not'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","NotTrue",": " ]
+                     "value" : [ "","define ","NotTrue",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -1242,7 +1354,7 @@ module.exports['Not'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","NotFalse",": " ]
+                     "value" : [ "","define ","NotFalse",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -1272,7 +1384,7 @@ module.exports['Not'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","NotNull",": " ]
+                     "value" : [ "","define ","NotNull",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -1313,6 +1425,14 @@ module.exports['IsTrue'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "10",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1330,7 +1450,27 @@ module.exports['IsTrue'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1354,7 +1494,7 @@ module.exports['IsTrue'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","TrueIsTrue",": " ]
+                     "value" : [ "","define ","TrueIsTrue",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -1384,7 +1524,7 @@ module.exports['IsTrue'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","FalseIsTrue",": " ]
+                     "value" : [ "","define ","FalseIsTrue",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -1414,7 +1554,7 @@ module.exports['IsTrue'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","NullIsTrue",": " ]
+                     "value" : [ "","define ","NullIsTrue",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -1455,6 +1595,14 @@ module.exports['IsFalse'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "10",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1472,7 +1620,27 @@ module.exports['IsFalse'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1496,7 +1664,7 @@ module.exports['IsFalse'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","TrueIsFalse",": " ]
+                     "value" : [ "","define ","TrueIsFalse",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -1526,7 +1694,7 @@ module.exports['IsFalse'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","FalseIsFalse",": " ]
+                     "value" : [ "","define ","FalseIsFalse",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -1556,7 +1724,7 @@ module.exports['IsFalse'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","NullIsFalse",": " ]
+                     "value" : [ "","define ","NullIsFalse",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {

--- a/test/elm/nullological/data.js
+++ b/test/elm/nullological/data.js
@@ -20,6 +20,14 @@ module.exports['Nil'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "3",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -37,7 +45,27 @@ module.exports['Nil'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -62,7 +90,7 @@ module.exports['Nil'] = {
                   "r" : "3",
                   "s" : [ {
                      "r" : "2",
-                     "value" : [ "define ","Nil",": ","null" ]
+                     "value" : [ "","define ","Nil",": ","null" ]
                   } ]
                }
             } ],
@@ -92,6 +120,14 @@ module.exports['IsNull'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "17",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -109,7 +145,27 @@ module.exports['IsNull'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -134,7 +190,7 @@ module.exports['IsNull'] = {
                   "r" : "3",
                   "s" : [ {
                      "r" : "2",
-                     "value" : [ "define ","Nil",": ","null" ]
+                     "value" : [ "","define ","Nil",": ","null" ]
                   } ]
                }
             } ],
@@ -153,7 +209,7 @@ module.exports['IsNull'] = {
                   "r" : "5",
                   "s" : [ {
                      "r" : "4",
-                     "value" : [ "define ","One",": ","1" ]
+                     "value" : [ "","define ","One",": ","1" ]
                   } ]
                }
             } ],
@@ -173,7 +229,7 @@ module.exports['IsNull'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","NullIsNull",": " ]
+                     "value" : [ "","define ","NullIsNull",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -201,7 +257,7 @@ module.exports['IsNull'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","NullVarIsNull",": " ]
+                     "value" : [ "","define ","NullVarIsNull",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -234,7 +290,7 @@ module.exports['IsNull'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","StringIsNull",": " ]
+                     "value" : [ "","define ","StringIsNull",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -268,7 +324,7 @@ module.exports['IsNull'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","NonNullVarIsNull",": " ]
+                     "value" : [ "","define ","NonNullVarIsNull",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -317,6 +373,14 @@ module.exports['Coalesce'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "57",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -334,7 +398,27 @@ module.exports['Coalesce'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -358,7 +442,7 @@ module.exports['Coalesce'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","NullNullHelloNullWorld",": " ]
+                     "value" : [ "","define ","NullNullHelloNullWorld",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -417,7 +501,7 @@ module.exports['Coalesce'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","FooNullNullBar",": " ]
+                     "value" : [ "","define ","FooNullNullBar",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -480,7 +564,7 @@ module.exports['Coalesce'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","AllNull",": " ]
+                     "value" : [ "","define ","AllNull",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -514,7 +598,7 @@ module.exports['Coalesce'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","ListArgStartsWithNull",": " ]
+                     "value" : [ "","define ","ListArgStartsWithNull",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -596,7 +680,7 @@ module.exports['Coalesce'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","ListArgAllNull",": " ]
+                     "value" : [ "","define ","ListArgAllNull",": " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -644,7 +728,7 @@ module.exports['Coalesce'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","ListWithNull",": " ]
+                     "value" : [ "","define ","ListWithNull",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -715,7 +799,7 @@ module.exports['Coalesce'] = {
                "s" : {
                   "r" : "44",
                   "s" : [ {
-                     "value" : [ "define ","ListExpressionRef",": " ]
+                     "value" : [ "","define ","ListExpressionRef",": " ]
                   }, {
                      "r" : "43",
                      "s" : [ {
@@ -750,7 +834,7 @@ module.exports['Coalesce'] = {
                "s" : {
                   "r" : "47",
                   "s" : [ {
-                     "value" : [ "define ","RetrieveAsList",": " ]
+                     "value" : [ "","define ","RetrieveAsList",": " ]
                   }, {
                      "r" : "46",
                      "s" : [ {
@@ -785,7 +869,7 @@ module.exports['Coalesce'] = {
                "s" : {
                   "r" : "52",
                   "s" : [ {
-                     "value" : [ "define ","ListA",": " ]
+                     "value" : [ "","define ","ListA",": " ]
                   }, {
                      "r" : "51",
                      "s" : [ {
@@ -829,7 +913,7 @@ module.exports['Coalesce'] = {
                "s" : {
                   "r" : "57",
                   "s" : [ {
-                     "value" : [ "define ","UnionAsList",": " ]
+                     "value" : [ "","define ","UnionAsList",": " ]
                   }, {
                      "r" : "56",
                      "s" : [ {

--- a/test/elm/parameters/data.js
+++ b/test/elm/parameters/data.js
@@ -24,6 +24,14 @@ module.exports['ParameterDef'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "27",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -41,7 +49,22 @@ module.exports['ParameterDef'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -49,6 +72,16 @@ module.exports['ParameterDef'] = {
             "localId" : "3",
             "name" : "MeasureYear",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "r" : "2",
+                     "value" : [ "","parameter ","MeasureYear"," default ","2012" ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "2",
                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -59,6 +92,20 @@ module.exports['ParameterDef'] = {
             "localId" : "5",
             "name" : "IntParameter",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "value" : [ "","parameter ","IntParameter"," " ]
+                  }, {
+                     "r" : "4",
+                     "s" : [ {
+                        "value" : [ "Integer" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "4",
                "name" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -68,6 +115,27 @@ module.exports['ParameterDef'] = {
             "localId" : "8",
             "name" : "ListParameter",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "8",
+                  "s" : [ {
+                     "value" : [ "","parameter ","ListParameter"," " ]
+                  }, {
+                     "r" : "7",
+                     "s" : [ {
+                        "value" : [ "List<" ]
+                     }, {
+                        "r" : "6",
+                        "s" : [ {
+                           "value" : [ "String" ]
+                        } ]
+                     }, {
+                        "value" : [ ">" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "7",
                "type" : "ListTypeSpecifier",
@@ -81,6 +149,111 @@ module.exports['ParameterDef'] = {
             "localId" : "25",
             "name" : "TupleParameter",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "25",
+                  "s" : [ {
+                     "value" : [ "","parameter ","TupleParameter"," " ]
+                  }, {
+                     "r" : "24",
+                     "s" : [ {
+                        "value" : [ "Tuple{" ]
+                     }, {
+                        "r" : "10",
+                        "s" : [ {
+                           "value" : [ "a"," " ]
+                        }, {
+                           "r" : "9",
+                           "s" : [ {
+                              "value" : [ "Integer" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ ", " ]
+                     }, {
+                        "r" : "12",
+                        "s" : [ {
+                           "value" : [ "b"," " ]
+                        }, {
+                           "r" : "11",
+                           "s" : [ {
+                              "value" : [ "String" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ ", " ]
+                     }, {
+                        "r" : "14",
+                        "s" : [ {
+                           "value" : [ "c"," " ]
+                        }, {
+                           "r" : "13",
+                           "s" : [ {
+                              "value" : [ "Boolean" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ ", " ]
+                     }, {
+                        "r" : "17",
+                        "s" : [ {
+                           "value" : [ "d"," " ]
+                        }, {
+                           "r" : "16",
+                           "s" : [ {
+                              "value" : [ "List<" ]
+                           }, {
+                              "r" : "15",
+                              "s" : [ {
+                                 "value" : [ "Integer" ]
+                              } ]
+                           }, {
+                              "value" : [ ">" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ ", " ]
+                     }, {
+                        "r" : "23",
+                        "s" : [ {
+                           "value" : [ "e"," " ]
+                        }, {
+                           "r" : "22",
+                           "s" : [ {
+                              "value" : [ "Tuple{ " ]
+                           }, {
+                              "r" : "19",
+                              "s" : [ {
+                                 "value" : [ "f"," " ]
+                              }, {
+                                 "r" : "18",
+                                 "s" : [ {
+                                    "value" : [ "String" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ ", " ]
+                           }, {
+                              "r" : "21",
+                              "s" : [ {
+                                 "value" : [ "g"," " ]
+                              }, {
+                                 "r" : "20",
+                                 "s" : [ {
+                                    "value" : [ "Boolean" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ "}" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ "}" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "24",
                "type" : "TupleTypeSpecifier",
@@ -148,6 +321,11 @@ module.exports['ParameterDef'] = {
             }
          } ]
       },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
+         } ]
+      },
       "statements" : {
          "def" : [ {
             "name" : "Patient",
@@ -169,7 +347,7 @@ module.exports['ParameterDef'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","foo",": " ]
+                     "value" : [ "","define ","foo",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -202,6 +380,14 @@ module.exports['ParameterRef'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "5",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -219,7 +405,22 @@ module.exports['ParameterRef'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -227,12 +428,31 @@ module.exports['ParameterRef'] = {
             "localId" : "3",
             "name" : "FooP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooP"," default " ]
+                  }, {
+                     "r" : "2",
+                     "s" : [ {
+                        "value" : [ "'Bar'" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "2",
                "valueType" : "{urn:hl7-org:elm-types:r1}String",
                "value" : "Bar",
                "type" : "Literal"
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -256,7 +476,7 @@ module.exports['ParameterRef'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -290,6 +510,14 @@ module.exports['BooleanParameterTypes'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "9",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -307,7 +535,22 @@ module.exports['BooleanParameterTypes'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -315,6 +558,20 @@ module.exports['BooleanParameterTypes'] = {
             "localId" : "3",
             "name" : "FooP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooP"," " ]
+                  }, {
+                     "r" : "2",
+                     "s" : [ {
+                        "value" : [ "Boolean" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "2",
                "name" : "{urn:hl7-org:elm-types:r1}Boolean",
@@ -324,12 +581,27 @@ module.exports['BooleanParameterTypes'] = {
             "localId" : "5",
             "name" : "FooDP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "r" : "4",
+                     "value" : [ "","parameter ","FooDP"," default ","true" ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "4",
                "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
                "value" : "true",
                "type" : "Literal"
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -353,7 +625,7 @@ module.exports['BooleanParameterTypes'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -377,7 +649,7 @@ module.exports['BooleanParameterTypes'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","Foo2",": " ]
+                     "value" : [ "","define ","Foo2",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -411,6 +683,14 @@ module.exports['DecimalParameterTypes'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "9",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -428,7 +708,22 @@ module.exports['DecimalParameterTypes'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -436,6 +731,20 @@ module.exports['DecimalParameterTypes'] = {
             "localId" : "3",
             "name" : "FooP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooP"," " ]
+                  }, {
+                     "r" : "2",
+                     "s" : [ {
+                        "value" : [ "Decimal" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "2",
                "name" : "{urn:hl7-org:elm-types:r1}Decimal",
@@ -445,12 +754,27 @@ module.exports['DecimalParameterTypes'] = {
             "localId" : "5",
             "name" : "FooDP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "r" : "4",
+                     "value" : [ "","parameter ","FooDP"," default ","1.5" ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "4",
                "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
                "value" : "1.5",
                "type" : "Literal"
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -474,7 +798,7 @@ module.exports['DecimalParameterTypes'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -498,7 +822,7 @@ module.exports['DecimalParameterTypes'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","Foo2",": " ]
+                     "value" : [ "","define ","Foo2",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -532,6 +856,14 @@ module.exports['IntegerParameterTypes'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "9",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -549,7 +881,22 @@ module.exports['IntegerParameterTypes'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -557,6 +904,20 @@ module.exports['IntegerParameterTypes'] = {
             "localId" : "3",
             "name" : "FooP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooP"," " ]
+                  }, {
+                     "r" : "2",
+                     "s" : [ {
+                        "value" : [ "Integer" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "2",
                "name" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -566,12 +927,27 @@ module.exports['IntegerParameterTypes'] = {
             "localId" : "5",
             "name" : "FooDP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "r" : "4",
+                     "value" : [ "","parameter ","FooDP"," default ","2" ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "4",
                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                "value" : "2",
                "type" : "Literal"
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -595,7 +971,7 @@ module.exports['IntegerParameterTypes'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -619,7 +995,7 @@ module.exports['IntegerParameterTypes'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","Foo2",": " ]
+                     "value" : [ "","define ","Foo2",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -653,6 +1029,14 @@ module.exports['StringParameterTypes'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "9",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -670,7 +1054,22 @@ module.exports['StringParameterTypes'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -678,6 +1077,20 @@ module.exports['StringParameterTypes'] = {
             "localId" : "3",
             "name" : "FooP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooP"," " ]
+                  }, {
+                     "r" : "2",
+                     "s" : [ {
+                        "value" : [ "String" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "2",
                "name" : "{urn:hl7-org:elm-types:r1}String",
@@ -687,12 +1100,31 @@ module.exports['StringParameterTypes'] = {
             "localId" : "5",
             "name" : "FooDP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooDP"," default " ]
+                  }, {
+                     "r" : "4",
+                     "s" : [ {
+                        "value" : [ "'Hello'" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "4",
                "valueType" : "{urn:hl7-org:elm-types:r1}String",
                "value" : "Hello",
                "type" : "Literal"
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -716,7 +1148,7 @@ module.exports['StringParameterTypes'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -740,7 +1172,7 @@ module.exports['StringParameterTypes'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","Foo2",": " ]
+                     "value" : [ "","define ","Foo2",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -775,6 +1207,14 @@ module.exports['CodeParameterTypes'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "11",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -792,7 +1232,22 @@ module.exports['CodeParameterTypes'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -800,6 +1255,20 @@ module.exports['CodeParameterTypes'] = {
             "localId" : "4",
             "name" : "FooP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "4",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooP"," " ]
+                  }, {
+                     "r" : "3",
+                     "s" : [ {
+                        "value" : [ "Code" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "3",
                "name" : "{urn:hl7-org:elm-types:r1}Code",
@@ -809,6 +1278,27 @@ module.exports['CodeParameterTypes'] = {
             "localId" : "7",
             "name" : "FooDP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "7",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooDP"," default " ]
+                  }, {
+                     "r" : "6",
+                     "s" : [ {
+                        "value" : [ "Code ","'FooTest'"," from " ]
+                     }, {
+                        "r" : "5",
+                        "s" : [ {
+                           "value" : [ "\"FOOTESTCS\"" ]
+                        } ]
+                     }, {
+                        "value" : [ " display ","'Foo Test'" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "6",
                "code" : "FooTest",
@@ -826,7 +1316,21 @@ module.exports['CodeParameterTypes'] = {
             "localId" : "2",
             "name" : "FOOTESTCS",
             "id" : "http://footest.org",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","codesystem ","\"FOOTESTCS\"",": ","'http://footest.org'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -850,7 +1354,7 @@ module.exports['CodeParameterTypes'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -874,7 +1378,7 @@ module.exports['CodeParameterTypes'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","Foo2",": " ]
+                     "value" : [ "","define ","Foo2",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -909,6 +1413,14 @@ module.exports['ConceptParameterTypes'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "12",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -926,7 +1438,22 @@ module.exports['ConceptParameterTypes'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -934,6 +1461,20 @@ module.exports['ConceptParameterTypes'] = {
             "localId" : "4",
             "name" : "FooP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "4",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooP"," " ]
+                  }, {
+                     "r" : "3",
+                     "s" : [ {
+                        "value" : [ "Concept" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "3",
                "name" : "{urn:hl7-org:elm-types:r1}Concept",
@@ -943,6 +1484,32 @@ module.exports['ConceptParameterTypes'] = {
             "localId" : "8",
             "name" : "FooDP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "8",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooDP"," default " ]
+                  }, {
+                     "r" : "7",
+                     "s" : [ {
+                        "value" : [ "Concept { " ]
+                     }, {
+                        "r" : "6",
+                        "s" : [ {
+                           "value" : [ "Code ","'FooTest'"," from " ]
+                        }, {
+                           "r" : "5",
+                           "s" : [ {
+                              "value" : [ "\"FOOTESTCS\"" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ " } display ","'Foo Test'" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "7",
                "display" : "Foo Test",
@@ -963,7 +1530,21 @@ module.exports['ConceptParameterTypes'] = {
             "localId" : "2",
             "name" : "FOOTESTCS",
             "id" : "http://footest.org",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","codesystem ","\"FOOTESTCS\"",": ","'http://footest.org'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -987,7 +1568,7 @@ module.exports['ConceptParameterTypes'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -1011,7 +1592,7 @@ module.exports['ConceptParameterTypes'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","Foo2",": " ]
+                     "value" : [ "","define ","Foo2",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -1045,6 +1626,14 @@ module.exports['DateTimeParameterTypes'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "9",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1062,7 +1651,22 @@ module.exports['DateTimeParameterTypes'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -1070,6 +1674,20 @@ module.exports['DateTimeParameterTypes'] = {
             "localId" : "3",
             "name" : "FooP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooP"," " ]
+                  }, {
+                     "r" : "2",
+                     "s" : [ {
+                        "value" : [ "DateTime" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "2",
                "name" : "{urn:hl7-org:elm-types:r1}DateTime",
@@ -1079,6 +1697,16 @@ module.exports['DateTimeParameterTypes'] = {
             "localId" : "5",
             "name" : "FooDP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "r" : "4",
+                     "value" : [ "","parameter ","FooDP"," default ","@2012-04-01T12:11:10" ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "4",
                "type" : "DateTime",
@@ -1115,6 +1743,11 @@ module.exports['DateTimeParameterTypes'] = {
             }
          } ]
       },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
+         } ]
+      },
       "statements" : {
          "def" : [ {
             "name" : "Patient",
@@ -1136,7 +1769,7 @@ module.exports['DateTimeParameterTypes'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -1160,7 +1793,7 @@ module.exports['DateTimeParameterTypes'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","Foo2",": " ]
+                     "value" : [ "","define ","Foo2",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -1194,6 +1827,14 @@ module.exports['DateParameterTypes'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "9",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1211,7 +1852,22 @@ module.exports['DateParameterTypes'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -1219,6 +1875,20 @@ module.exports['DateParameterTypes'] = {
             "localId" : "3",
             "name" : "FooP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooP"," " ]
+                  }, {
+                     "r" : "2",
+                     "s" : [ {
+                        "value" : [ "Date" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "2",
                "name" : "{urn:hl7-org:elm-types:r1}Date",
@@ -1228,6 +1898,16 @@ module.exports['DateParameterTypes'] = {
             "localId" : "5",
             "name" : "FooDP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "r" : "4",
+                     "value" : [ "","parameter ","FooDP"," default ","@2012-04-01" ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "4",
                "type" : "Date",
@@ -1247,6 +1927,11 @@ module.exports['DateParameterTypes'] = {
                   "type" : "Literal"
                }
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1270,7 +1955,7 @@ module.exports['DateParameterTypes'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -1294,7 +1979,7 @@ module.exports['DateParameterTypes'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","Foo2",": " ]
+                     "value" : [ "","define ","Foo2",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -1328,6 +2013,14 @@ module.exports['QuantityParameterTypes'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "9",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1345,7 +2038,22 @@ module.exports['QuantityParameterTypes'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -1353,6 +2061,20 @@ module.exports['QuantityParameterTypes'] = {
             "localId" : "3",
             "name" : "FooP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooP"," " ]
+                  }, {
+                     "r" : "2",
+                     "s" : [ {
+                        "value" : [ "Quantity" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "2",
                "name" : "{urn:hl7-org:elm-types:r1}Quantity",
@@ -1362,12 +2084,31 @@ module.exports['QuantityParameterTypes'] = {
             "localId" : "5",
             "name" : "FooDP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooDP"," default " ]
+                  }, {
+                     "r" : "4",
+                     "s" : [ {
+                        "value" : [ "10 ","'dL'" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "4",
                "value" : 10,
                "unit" : "dL",
                "type" : "Quantity"
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1391,7 +2132,7 @@ module.exports['QuantityParameterTypes'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -1415,7 +2156,7 @@ module.exports['QuantityParameterTypes'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","Foo2",": " ]
+                     "value" : [ "","define ","Foo2",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -1449,6 +2190,14 @@ module.exports['TimeParameterTypes'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "9",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1466,7 +2215,22 @@ module.exports['TimeParameterTypes'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -1474,6 +2238,20 @@ module.exports['TimeParameterTypes'] = {
             "localId" : "3",
             "name" : "FooP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooP"," " ]
+                  }, {
+                     "r" : "2",
+                     "s" : [ {
+                        "value" : [ "Time" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "2",
                "name" : "{urn:hl7-org:elm-types:r1}Time",
@@ -1483,6 +2261,16 @@ module.exports['TimeParameterTypes'] = {
             "localId" : "5",
             "name" : "FooDP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "r" : "4",
+                     "value" : [ "","parameter ","FooDP"," default ","@T12:00:00" ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "4",
                "type" : "Time",
@@ -1502,6 +2290,11 @@ module.exports['TimeParameterTypes'] = {
                   "type" : "Literal"
                }
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1525,7 +2318,7 @@ module.exports['TimeParameterTypes'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -1549,7 +2342,7 @@ module.exports['TimeParameterTypes'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","Foo2",": " ]
+                     "value" : [ "","define ","Foo2",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -1583,6 +2376,14 @@ module.exports['ListParameterTypes'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "13",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1600,7 +2401,22 @@ module.exports['ListParameterTypes'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -1608,6 +2424,27 @@ module.exports['ListParameterTypes'] = {
             "localId" : "4",
             "name" : "FooP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "4",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooP"," " ]
+                  }, {
+                     "r" : "3",
+                     "s" : [ {
+                        "value" : [ "List<" ]
+                     }, {
+                        "r" : "2",
+                        "s" : [ {
+                           "value" : [ "String" ]
+                        } ]
+                     }, {
+                        "value" : [ ">" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "3",
                "type" : "ListTypeSpecifier",
@@ -1621,6 +2458,41 @@ module.exports['ListParameterTypes'] = {
             "localId" : "9",
             "name" : "FooDP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "9",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooDP"," default " ]
+                  }, {
+                     "r" : "8",
+                     "s" : [ {
+                        "value" : [ "{ " ]
+                     }, {
+                        "r" : "5",
+                        "s" : [ {
+                           "value" : [ "'a'" ]
+                        } ]
+                     }, {
+                        "value" : [ ", " ]
+                     }, {
+                        "r" : "6",
+                        "s" : [ {
+                           "value" : [ "'b'" ]
+                        } ]
+                     }, {
+                        "value" : [ ", " ]
+                     }, {
+                        "r" : "7",
+                        "s" : [ {
+                           "value" : [ "'c'" ]
+                        } ]
+                     }, {
+                        "value" : [ " }" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "8",
                "type" : "List",
@@ -1641,6 +2513,11 @@ module.exports['ListParameterTypes'] = {
                   "type" : "Literal"
                } ]
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1664,7 +2541,7 @@ module.exports['ListParameterTypes'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -1688,7 +2565,7 @@ module.exports['ListParameterTypes'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","Foo2",": " ]
+                     "value" : [ "","define ","Foo2",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -1722,6 +2599,14 @@ module.exports['IntervalParameterTypes'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "12",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1739,7 +2624,22 @@ module.exports['IntervalParameterTypes'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -1747,6 +2647,27 @@ module.exports['IntervalParameterTypes'] = {
             "localId" : "4",
             "name" : "FooP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "4",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooP"," " ]
+                  }, {
+                     "r" : "3",
+                     "s" : [ {
+                        "value" : [ "Interval<" ]
+                     }, {
+                        "r" : "2",
+                        "s" : [ {
+                           "value" : [ "Integer" ]
+                        } ]
+                     }, {
+                        "value" : [ ">" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "3",
                "type" : "IntervalTypeSpecifier",
@@ -1760,6 +2681,21 @@ module.exports['IntervalParameterTypes'] = {
             "localId" : "8",
             "name" : "FooDP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "8",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooDP"," default " ]
+                  }, {
+                     "r" : "7",
+                     "s" : [ {
+                        "r" : "5",
+                        "value" : [ "Interval[","2",",","6","]" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "7",
                "lowClosed" : true,
@@ -1778,6 +2714,11 @@ module.exports['IntervalParameterTypes'] = {
                   "type" : "Literal"
                }
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1801,7 +2742,7 @@ module.exports['IntervalParameterTypes'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -1825,7 +2766,7 @@ module.exports['IntervalParameterTypes'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","Foo2",": " ]
+                     "value" : [ "","define ","Foo2",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -1859,6 +2800,14 @@ module.exports['TupleParameterTypes'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "15",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1876,7 +2825,22 @@ module.exports['TupleParameterTypes'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -1884,6 +2848,44 @@ module.exports['TupleParameterTypes'] = {
             "localId" : "7",
             "name" : "FooP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "7",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooP"," " ]
+                  }, {
+                     "r" : "6",
+                     "s" : [ {
+                        "value" : [ "Tuple { " ]
+                     }, {
+                        "r" : "3",
+                        "s" : [ {
+                           "value" : [ "Hello"," " ]
+                        }, {
+                           "r" : "2",
+                           "s" : [ {
+                              "value" : [ "String" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ ", " ]
+                     }, {
+                        "r" : "5",
+                        "s" : [ {
+                           "value" : [ "MeaningOfLife"," " ]
+                        }, {
+                           "r" : "4",
+                           "s" : [ {
+                              "value" : [ "Integer" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ " }" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "6",
                "type" : "TupleTypeSpecifier",
@@ -1909,6 +2911,38 @@ module.exports['TupleParameterTypes'] = {
             "localId" : "11",
             "name" : "FooDP",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "11",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooDP"," default " ]
+                  }, {
+                     "r" : "10",
+                     "s" : [ {
+                        "value" : [ "Tuple { " ]
+                     }, {
+                        "s" : [ {
+                           "value" : [ "Hello",": " ]
+                        }, {
+                           "r" : "8",
+                           "s" : [ {
+                              "value" : [ "'Universe'" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ ", " ]
+                     }, {
+                        "s" : [ {
+                           "r" : "9",
+                           "value" : [ "MeaningOfLife",": ","24" ]
+                        } ]
+                     }, {
+                        "value" : [ " }" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "10",
                "type" : "Tuple",
@@ -1932,6 +2966,11 @@ module.exports['TupleParameterTypes'] = {
             }
          } ]
       },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
+         } ]
+      },
       "statements" : {
          "def" : [ {
             "name" : "Patient",
@@ -1953,7 +2992,7 @@ module.exports['TupleParameterTypes'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -1977,7 +3016,7 @@ module.exports['TupleParameterTypes'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","Foo2",": " ]
+                     "value" : [ "","define ","Foo2",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -2011,6 +3050,14 @@ module.exports['DefaultAndNoDefault'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "9",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2028,7 +3075,22 @@ module.exports['DefaultAndNoDefault'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -2036,6 +3098,20 @@ module.exports['DefaultAndNoDefault'] = {
             "localId" : "3",
             "name" : "FooWithNoDefault",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","parameter ","FooWithNoDefault"," " ]
+                  }, {
+                     "r" : "2",
+                     "s" : [ {
+                        "value" : [ "Integer" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "2",
                "name" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -2045,12 +3121,27 @@ module.exports['DefaultAndNoDefault'] = {
             "localId" : "5",
             "name" : "FooWithDefault",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "r" : "4",
+                     "value" : [ "","parameter ","FooWithDefault"," default ","5" ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "4",
                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                "value" : "5",
                "type" : "Literal"
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2074,7 +3165,7 @@ module.exports['DefaultAndNoDefault'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -2098,7 +3189,7 @@ module.exports['DefaultAndNoDefault'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","Foo2",": " ]
+                     "value" : [ "","define ","Foo2",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -2130,6 +3221,14 @@ module.exports['MeasurementPeriodParameter'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "16",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2147,7 +3246,22 @@ module.exports['MeasurementPeriodParameter'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -2155,6 +3269,27 @@ module.exports['MeasurementPeriodParameter'] = {
             "localId" : "4",
             "name" : "Measurement Period",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "4",
+                  "s" : [ {
+                     "value" : [ "","parameter ","\"Measurement Period\""," " ]
+                  }, {
+                     "r" : "3",
+                     "s" : [ {
+                        "value" : [ "Interval<" ]
+                     }, {
+                        "r" : "2",
+                        "s" : [ {
+                           "value" : [ "DateTime" ]
+                        } ]
+                     }, {
+                        "value" : [ ">" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "parameterTypeSpecifier" : {
                "localId" : "3",
                "type" : "IntervalTypeSpecifier",
@@ -2164,6 +3299,11 @@ module.exports['MeasurementPeriodParameter'] = {
                   "type" : "NamedTypeSpecifier"
                }
             }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2187,7 +3327,7 @@ module.exports['MeasurementPeriodParameter'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","MeasurementPeriod",": " ]
+                     "value" : [ "","define ","MeasurementPeriod",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {

--- a/test/elm/query/data.js
+++ b/test/elm/query/data.js
@@ -24,6 +24,14 @@ module.exports['DateRangeOptimizedQuery'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "36",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -41,7 +49,22 @@ module.exports['DateRangeOptimizedQuery'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -49,6 +72,36 @@ module.exports['DateRangeOptimizedQuery'] = {
             "localId" : "12",
             "name" : "MeasurementPeriod",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "12",
+                  "s" : [ {
+                     "value" : [ "","parameter ","MeasurementPeriod"," default " ]
+                  }, {
+                     "r" : "11",
+                     "s" : [ {
+                        "value" : [ "Interval[" ]
+                     }, {
+                        "r" : "6",
+                        "s" : [ {
+                           "r" : "3",
+                           "value" : [ "DateTime","(","2013",", ","1",", ","1",")" ]
+                        } ]
+                     }, {
+                        "value" : [ ", " ]
+                     }, {
+                        "r" : "10",
+                        "s" : [ {
+                           "r" : "7",
+                           "value" : [ "DateTime","(","2014",", ","1",", ","1",")" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "11",
                "lowClosed" : true,
@@ -106,7 +159,21 @@ module.exports['DateRangeOptimizedQuery'] = {
             "localId" : "2",
             "name" : "Ambulatory/ED Visit",
             "id" : "2.16.840.1.113883.3.464.1003.101.12.1061",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"Ambulatory/ED Visit\"",": ","'2.16.840.1.113883.3.464.1003.101.12.1061'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -130,7 +197,7 @@ module.exports['DateRangeOptimizedQuery'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","EncountersDuringMP",": " ]
+                     "value" : [ "","define ","EncountersDuringMP",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -215,7 +282,7 @@ module.exports['DateRangeOptimizedQuery'] = {
                "s" : {
                   "r" : "28",
                   "s" : [ {
-                     "value" : [ "define ","AmbulatoryEncountersDuringMP",": " ]
+                     "value" : [ "","define ","AmbulatoryEncountersDuringMP",": " ]
                   }, {
                      "r" : "27",
                      "s" : [ {
@@ -286,6 +353,7 @@ module.exports['DateRangeOptimizedQuery'] = {
                      "localId" : "21",
                      "dataType" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
                      "codeProperty" : "code",
+                     "codeComparator" : "in",
                      "dateProperty" : "period",
                      "type" : "Retrieve",
                      "codes" : {
@@ -311,7 +379,7 @@ module.exports['DateRangeOptimizedQuery'] = {
                "s" : {
                   "r" : "36",
                   "s" : [ {
-                     "value" : [ "define ","AmbulatoryEncountersIncludedInMP",": " ]
+                     "value" : [ "","define ","AmbulatoryEncountersIncludedInMP",": " ]
                   }, {
                      "r" : "35",
                      "s" : [ {
@@ -382,6 +450,7 @@ module.exports['DateRangeOptimizedQuery'] = {
                      "localId" : "29",
                      "dataType" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
                      "codeProperty" : "code",
+                     "codeComparator" : "in",
                      "dateProperty" : "period",
                      "type" : "Retrieve",
                      "codes" : {
@@ -415,6 +484,14 @@ module.exports['FunctionQuery'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "17",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -432,7 +509,27 @@ module.exports['FunctionQuery'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -457,7 +554,7 @@ module.exports['FunctionQuery'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define function ","\"FunctionWithThis\"","(","Encounter"," " ]
+                     "value" : [ "","define function ","\"FunctionWithThis\"","(","Encounter"," " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -548,6 +645,7 @@ module.exports['FunctionQuery'] = {
                            }
                         },
                         "return" : {
+                           "distinct" : false,
                            "expression" : {
                               "path" : "period",
                               "type" : "Property",
@@ -592,7 +690,7 @@ module.exports['FunctionQuery'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","queryWithThis",": " ]
+                     "value" : [ "","define ","queryWithThis",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -674,6 +772,14 @@ module.exports['IncludesQuery'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "20",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -691,7 +797,22 @@ module.exports['IncludesQuery'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -699,6 +820,36 @@ module.exports['IncludesQuery'] = {
             "localId" : "12",
             "name" : "MeasurementPeriod",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "12",
+                  "s" : [ {
+                     "value" : [ "","parameter ","MeasurementPeriod"," default " ]
+                  }, {
+                     "r" : "11",
+                     "s" : [ {
+                        "value" : [ "Interval[" ]
+                     }, {
+                        "r" : "6",
+                        "s" : [ {
+                           "r" : "3",
+                           "value" : [ "DateTime","(","2013",", ","1",", ","1",")" ]
+                        } ]
+                     }, {
+                        "value" : [ ", " ]
+                     }, {
+                        "r" : "10",
+                        "s" : [ {
+                           "r" : "7",
+                           "value" : [ "DateTime","(","2014",", ","1",", ","1",")" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "11",
                "lowClosed" : true,
@@ -756,7 +907,21 @@ module.exports['IncludesQuery'] = {
             "localId" : "2",
             "name" : "Ambulatory/ED Visit",
             "id" : "2.16.840.1.113883.3.464.1003.101.12.1061",
-            "accessLevel" : "Public"
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"Ambulatory/ED Visit\"",": ","'2.16.840.1.113883.3.464.1003.101.12.1061'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -780,7 +945,7 @@ module.exports['IncludesQuery'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","MPIncludedAmbulatoryEncounters",": " ]
+                     "value" : [ "","define ","MPIncludedAmbulatoryEncounters",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -851,6 +1016,7 @@ module.exports['IncludesQuery'] = {
                      "localId" : "13",
                      "dataType" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
                      "codeProperty" : "code",
+                     "codeComparator" : "in",
                      "type" : "Retrieve",
                      "codes" : {
                         "name" : "Ambulatory/ED Visit",
@@ -899,6 +1065,14 @@ module.exports['MultiSourceQuery'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "46",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -916,7 +1090,22 @@ module.exports['MultiSourceQuery'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
          } ]
       },
       "parameters" : {
@@ -924,6 +1113,36 @@ module.exports['MultiSourceQuery'] = {
             "localId" : "11",
             "name" : "MeasurementPeriod",
             "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "11",
+                  "s" : [ {
+                     "value" : [ "","parameter ","MeasurementPeriod"," default " ]
+                  }, {
+                     "r" : "10",
+                     "s" : [ {
+                        "value" : [ "Interval[" ]
+                     }, {
+                        "r" : "5",
+                        "s" : [ {
+                           "r" : "2",
+                           "value" : [ "DateTime","(","2013",", ","1",", ","1",")" ]
+                        } ]
+                     }, {
+                        "value" : [ ", " ]
+                     }, {
+                        "r" : "9",
+                        "s" : [ {
+                           "r" : "6",
+                           "value" : [ "DateTime","(","2014",", ","1",", ","1",")" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
             "default" : {
                "localId" : "10",
                "lowClosed" : true,
@@ -976,6 +1195,11 @@ module.exports['MultiSourceQuery'] = {
             }
          } ]
       },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
+         } ]
+      },
       "statements" : {
          "def" : [ {
             "name" : "Patient",
@@ -997,7 +1221,7 @@ module.exports['MultiSourceQuery'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","msQueryWhere",": " ]
+                     "value" : [ "","define ","msQueryWhere",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -1126,7 +1350,7 @@ module.exports['MultiSourceQuery'] = {
                "s" : {
                   "r" : "36",
                   "s" : [ {
-                     "value" : [ "define ","msQueryWhere2",": " ]
+                     "value" : [ "","define ","msQueryWhere2",": " ]
                   }, {
                      "r" : "35",
                      "s" : [ {
@@ -1300,7 +1524,7 @@ module.exports['MultiSourceQuery'] = {
                "s" : {
                   "r" : "46",
                   "s" : [ {
-                     "value" : [ "define ","msQuery",": " ]
+                     "value" : [ "","define ","msQuery",": " ]
                   }, {
                      "r" : "45",
                      "s" : [ {
@@ -1444,6 +1668,14 @@ module.exports['QueryRelationship'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "45",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1461,7 +1693,27 @@ module.exports['QueryRelationship'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1485,7 +1737,7 @@ module.exports['QueryRelationship'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","withQuery",":  " ]
+                     "value" : [ "","define ","withQuery",":  " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -1602,7 +1854,7 @@ module.exports['QueryRelationship'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","withQuery2",":  " ]
+                     "value" : [ "","define ","withQuery2",":  " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -1719,7 +1971,7 @@ module.exports['QueryRelationship'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","withOutQuery",":  " ]
+                     "value" : [ "","define ","withOutQuery",":  " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -1836,7 +2088,7 @@ module.exports['QueryRelationship'] = {
                "s" : {
                   "r" : "45",
                   "s" : [ {
-                     "value" : [ "define ","withOutQuery2",":  " ]
+                     "value" : [ "","define ","withOutQuery2",":  " ]
                   }, {
                      "r" : "44",
                      "s" : [ {
@@ -1962,6 +2214,14 @@ module.exports['QueryLet'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "11",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1979,7 +2239,27 @@ module.exports['QueryLet'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2003,7 +2283,7 @@ module.exports['QueryLet'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","query",":  " ]
+                     "value" : [ "","define ","query",":  " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -2137,6 +2417,14 @@ module.exports['Tuple'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "11",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2154,7 +2442,27 @@ module.exports['Tuple'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2178,7 +2486,7 @@ module.exports['Tuple'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","query",":  " ]
+                     "value" : [ "","define ","query",":  " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -2309,6 +2617,14 @@ module.exports['QueryFilterNulls'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "12",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2326,7 +2642,27 @@ module.exports['QueryFilterNulls'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2350,7 +2686,7 @@ module.exports['QueryFilterNulls'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","query",":  " ]
+                     "value" : [ "","define ","query",":  " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -2504,6 +2840,14 @@ module.exports['Sorting'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "216",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2521,7 +2865,27 @@ module.exports['Sorting'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2545,7 +2909,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","QuantityListAsc",": " ]
+                     "value" : [ "","define ","QuantityListAsc",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -2671,7 +3035,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "26",
                   "s" : [ {
-                     "value" : [ "define ","QuantityListSort",": " ]
+                     "value" : [ "","define ","QuantityListSort",": " ]
                   }, {
                      "r" : "25",
                      "s" : [ {
@@ -2836,7 +3200,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","TupleAsc",": " ]
+                     "value" : [ "","define ","TupleAsc",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -2906,7 +3270,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "42",
                   "s" : [ {
-                     "value" : [ "define ","TupleReturnAsc",": " ]
+                     "value" : [ "","define ","TupleReturnAsc",": " ]
                   }, {
                      "r" : "41",
                      "s" : [ {
@@ -2996,7 +3360,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "53",
                   "s" : [ {
-                     "value" : [ "define ","TupleReturnTupleAsc",": " ]
+                     "value" : [ "","define ","TupleReturnTupleAsc",": " ]
                   }, {
                      "r" : "52",
                      "s" : [ {
@@ -3123,7 +3487,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "60",
                   "s" : [ {
-                     "value" : [ "define ","TupleDesc",": " ]
+                     "value" : [ "","define ","TupleDesc",": " ]
                   }, {
                      "r" : "59",
                      "s" : [ {
@@ -3195,7 +3559,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "69",
                   "s" : [ {
-                     "value" : [ "define ","TupleReturnDesc",": " ]
+                     "value" : [ "","define ","TupleReturnDesc",": " ]
                   }, {
                      "r" : "68",
                      "s" : [ {
@@ -3287,7 +3651,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "80",
                   "s" : [ {
-                     "value" : [ "define ","TupleReturnTupleDesc",":  " ]
+                     "value" : [ "","define ","TupleReturnTupleDesc",":  " ]
                   }, {
                      "r" : "79",
                      "s" : [ {
@@ -3416,7 +3780,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "88",
                   "s" : [ {
-                     "value" : [ "define ","ConditionDates",": " ]
+                     "value" : [ "","define ","ConditionDates",": " ]
                   }, {
                      "r" : "87",
                      "s" : [ {
@@ -3508,7 +3872,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "91",
                   "s" : [ {
-                     "value" : [ "define ","lastDateUnsorted",": " ]
+                     "value" : [ "","define ","lastDateUnsorted",": " ]
                   }, {
                      "r" : "90",
                      "s" : [ {
@@ -3543,7 +3907,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "99",
                   "s" : [ {
-                     "value" : [ "define ","lastDateByThis",": " ]
+                     "value" : [ "","define ","lastDateByThis",": " ]
                   }, {
                      "r" : "98",
                      "s" : [ {
@@ -3621,7 +3985,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "111",
                   "s" : [ {
-                     "value" : [ "define ","numberAsc",": " ]
+                     "value" : [ "","define ","numberAsc",": " ]
                   }, {
                      "r" : "110",
                      "s" : [ {
@@ -3717,7 +4081,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "125",
                   "s" : [ {
-                     "value" : [ "define ","numberReturnAsc",": " ]
+                     "value" : [ "","define ","numberReturnAsc",": " ]
                   }, {
                      "r" : "124",
                      "s" : [ {
@@ -3833,7 +4197,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "137",
                   "s" : [ {
-                     "value" : [ "define ","numberDesc",": " ]
+                     "value" : [ "","define ","numberDesc",": " ]
                   }, {
                      "r" : "136",
                      "s" : [ {
@@ -3929,7 +4293,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "151",
                   "s" : [ {
-                     "value" : [ "define ","numberReturnDesc",": " ]
+                     "value" : [ "","define ","numberReturnDesc",": " ]
                   }, {
                      "r" : "150",
                      "s" : [ {
@@ -4045,7 +4409,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "161",
                   "s" : [ {
-                     "value" : [ "define ","stringAsc",": " ]
+                     "value" : [ "","define ","stringAsc",": " ]
                   }, {
                      "r" : "160",
                      "s" : [ {
@@ -4165,7 +4529,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "173",
                   "s" : [ {
-                     "value" : [ "define ","stringReturnAsc",": " ]
+                     "value" : [ "","define ","stringReturnAsc",": " ]
                   }, {
                      "r" : "172",
                      "s" : [ {
@@ -4305,7 +4669,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "183",
                   "s" : [ {
-                     "value" : [ "define ","stringDesc",": " ]
+                     "value" : [ "","define ","stringDesc",": " ]
                   }, {
                      "r" : "182",
                      "s" : [ {
@@ -4425,7 +4789,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "195",
                   "s" : [ {
-                     "value" : [ "define ","stringReturnDesc",": " ]
+                     "value" : [ "","define ","stringReturnDesc",": " ]
                   }, {
                      "r" : "194",
                      "s" : [ {
@@ -4566,7 +4930,7 @@ module.exports['Sorting'] = {
                   "r" : "197",
                   "s" : [ {
                      "r" : "196",
-                     "value" : [ "define ","five",": ","5" ]
+                     "value" : [ "","define ","five",": ","5" ]
                   } ]
                }
             } ],
@@ -4586,7 +4950,7 @@ module.exports['Sorting'] = {
                "s" : {
                   "r" : "216",
                   "s" : [ {
-                     "value" : [ "define ","sortByExpression",": " ]
+                     "value" : [ "","define ","sortByExpression",": " ]
                   }, {
                      "r" : "215",
                      "s" : [ {
@@ -4778,6 +5142,14 @@ module.exports['Distinct'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "142",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -4795,7 +5167,27 @@ module.exports['Distinct'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -4819,7 +5211,7 @@ module.exports['Distinct'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","defaultNumbers",": " ]
+                     "value" : [ "","define ","defaultNumbers",": " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -4970,7 +5362,7 @@ module.exports['Distinct'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","defaultStrings",": " ]
+                     "value" : [ "","define ","defaultStrings",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -5088,7 +5480,7 @@ module.exports['Distinct'] = {
                "s" : {
                   "r" : "48",
                   "s" : [ {
-                     "value" : [ "define ","defaultTuples",": " ]
+                     "value" : [ "","define ","defaultTuples",": " ]
                   }, {
                      "r" : "47",
                      "s" : [ {
@@ -5281,7 +5673,7 @@ module.exports['Distinct'] = {
                "s" : {
                   "r" : "70",
                   "s" : [ {
-                     "value" : [ "define ","distinctNumbers",": " ]
+                     "value" : [ "","define ","distinctNumbers",": " ]
                   }, {
                      "r" : "69",
                      "s" : [ {
@@ -5433,7 +5825,7 @@ module.exports['Distinct'] = {
                "s" : {
                   "r" : "80",
                   "s" : [ {
-                     "value" : [ "define ","distinctStrings",": " ]
+                     "value" : [ "","define ","distinctStrings",": " ]
                   }, {
                      "r" : "79",
                      "s" : [ {
@@ -5552,7 +5944,7 @@ module.exports['Distinct'] = {
                "s" : {
                   "r" : "95",
                   "s" : [ {
-                     "value" : [ "define ","distinctTuples",": " ]
+                     "value" : [ "","define ","distinctTuples",": " ]
                   }, {
                      "r" : "94",
                      "s" : [ {
@@ -5746,7 +6138,7 @@ module.exports['Distinct'] = {
                "s" : {
                   "r" : "117",
                   "s" : [ {
-                     "value" : [ "define ","allNumbers",": " ]
+                     "value" : [ "","define ","allNumbers",": " ]
                   }, {
                      "r" : "116",
                      "s" : [ {
@@ -5898,7 +6290,7 @@ module.exports['Distinct'] = {
                "s" : {
                   "r" : "127",
                   "s" : [ {
-                     "value" : [ "define ","allStrings",": " ]
+                     "value" : [ "","define ","allStrings",": " ]
                   }, {
                      "r" : "126",
                      "s" : [ {
@@ -6017,7 +6409,7 @@ module.exports['Distinct'] = {
                "s" : {
                   "r" : "142",
                   "s" : [ {
-                     "value" : [ "define ","allTuples",": " ]
+                     "value" : [ "","define ","allTuples",": " ]
                   }, {
                      "r" : "141",
                      "s" : [ {
@@ -6239,6 +6631,14 @@ module.exports['SingleObjectAlias'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "121",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -6256,7 +6656,27 @@ module.exports['SingleObjectAlias'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -6280,7 +6700,7 @@ module.exports['SingleObjectAlias'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","encounters",": " ]
+                     "value" : [ "","define ","encounters",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -6326,7 +6746,7 @@ module.exports['SingleObjectAlias'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","conditions",": " ]
+                     "value" : [ "","define ","conditions",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -6372,7 +6792,7 @@ module.exports['SingleObjectAlias'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","firstEncounter",": " ]
+                     "value" : [ "","define ","firstEncounter",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -6429,7 +6849,7 @@ module.exports['SingleObjectAlias'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","firstCondition",": " ]
+                     "value" : [ "","define ","firstCondition",": " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -6533,7 +6953,7 @@ module.exports['SingleObjectAlias'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","singleAlias",": " ]
+                     "value" : [ "","define ","singleAlias",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -6578,7 +6998,7 @@ module.exports['SingleObjectAlias'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","singleAliasWhere",": " ]
+                     "value" : [ "","define ","singleAliasWhere",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -6652,7 +7072,7 @@ module.exports['SingleObjectAlias'] = {
                "s" : {
                   "r" : "40",
                   "s" : [ {
-                     "value" : [ "define ","singleAliasWhereToNull",": " ]
+                     "value" : [ "","define ","singleAliasWhereToNull",": " ]
                   }, {
                      "r" : "39",
                      "s" : [ {
@@ -6734,7 +7154,7 @@ module.exports['SingleObjectAlias'] = {
                "s" : {
                   "r" : "46",
                   "s" : [ {
-                     "value" : [ "define ","singleAliases",": " ]
+                     "value" : [ "","define ","singleAliases",": " ]
                   }, {
                      "r" : "45",
                      "s" : [ {
@@ -6822,7 +7242,7 @@ module.exports['SingleObjectAlias'] = {
                "s" : {
                   "r" : "54",
                   "s" : [ {
-                     "value" : [ "define ","singleAliasesAndList",": " ]
+                     "value" : [ "","define ","singleAliasesAndList",": " ]
                   }, {
                      "r" : "53",
                      "s" : [ {
@@ -6938,7 +7358,7 @@ module.exports['SingleObjectAlias'] = {
                "s" : {
                   "r" : "65",
                   "s" : [ {
-                     "value" : [ "define ","singleAliasWith",":  " ]
+                     "value" : [ "","define ","singleAliasWith",":  " ]
                   }, {
                      "r" : "64",
                      "s" : [ {
@@ -7054,7 +7474,7 @@ module.exports['SingleObjectAlias'] = {
                "s" : {
                   "r" : "76",
                   "s" : [ {
-                     "value" : [ "define ","singleAliasWithOut",":  " ]
+                     "value" : [ "","define ","singleAliasWithOut",":  " ]
                   }, {
                      "r" : "75",
                      "s" : [ {
@@ -7170,7 +7590,7 @@ module.exports['SingleObjectAlias'] = {
                "s" : {
                   "r" : "87",
                   "s" : [ {
-                     "value" : [ "define ","singleAliasWithEmpty",":  " ]
+                     "value" : [ "","define ","singleAliasWithEmpty",":  " ]
                   }, {
                      "r" : "86",
                      "s" : [ {
@@ -7286,7 +7706,7 @@ module.exports['SingleObjectAlias'] = {
                "s" : {
                   "r" : "98",
                   "s" : [ {
-                     "value" : [ "define ","singleAliasWithOutEmpty",":  " ]
+                     "value" : [ "","define ","singleAliasWithOutEmpty",":  " ]
                   }, {
                      "r" : "97",
                      "s" : [ {
@@ -7403,7 +7823,7 @@ module.exports['SingleObjectAlias'] = {
                   "r" : "100",
                   "s" : [ {
                      "r" : "99",
-                     "value" : [ "define ","asNull",": ","null" ]
+                     "value" : [ "","define ","asNull",": ","null" ]
                   } ]
                }
             } ],
@@ -7421,7 +7841,7 @@ module.exports['SingleObjectAlias'] = {
                "s" : {
                   "r" : "104",
                   "s" : [ {
-                     "value" : [ "define ","nullQuery",": " ]
+                     "value" : [ "","define ","nullQuery",": " ]
                   }, {
                      "r" : "103",
                      "s" : [ {
@@ -7466,7 +7886,7 @@ module.exports['SingleObjectAlias'] = {
                "s" : {
                   "r" : "111",
                   "s" : [ {
-                     "value" : [ "define ","singleAliasReturnTuple",": " ]
+                     "value" : [ "//define singleAliasWith: firstEncounter E with [Condition] C\n//                         such that C.id = 'http://cqframework.org/3/2'\n//define singleAliasWithNull: firstEncounter E with conditions C\n//                        such that C.id is null","define ","singleAliasReturnTuple",": " ]
                   }, {
                      "r" : "110",
                      "s" : [ {
@@ -7546,7 +7966,7 @@ module.exports['SingleObjectAlias'] = {
                "s" : {
                   "r" : "121",
                   "s" : [ {
-                     "value" : [ "define ","singleAliasReturnList",": " ]
+                     "value" : [ "","define ","singleAliasReturnList",": " ]
                   }, {
                      "r" : "120",
                      "s" : [ {

--- a/test/elm/reusable/data.js
+++ b/test/elm/reusable/data.js
@@ -20,6 +20,14 @@ module.exports['ExpressionDef'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "3",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -37,7 +45,27 @@ module.exports['ExpressionDef'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -61,7 +89,7 @@ module.exports['ExpressionDef'] = {
                "s" : {
                   "r" : "3",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -94,6 +122,14 @@ module.exports['ExpressionRef'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "5",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -111,7 +147,27 @@ module.exports['ExpressionRef'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -136,7 +192,7 @@ module.exports['ExpressionRef'] = {
                   "r" : "3",
                   "s" : [ {
                      "r" : "2",
-                     "value" : [ "define ","Life",": ","42" ]
+                     "value" : [ "","define ","Life",": ","42" ]
                   } ]
                }
             } ],
@@ -156,7 +212,7 @@ module.exports['ExpressionRef'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","Foo",": " ]
+                     "value" : [ "","define ","Foo",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -190,6 +246,14 @@ module.exports['FunctionDefinitions'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "11",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -207,7 +271,27 @@ module.exports['FunctionDefinitions'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -232,7 +316,7 @@ module.exports['FunctionDefinitions'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define function ","\"foo bar\"","(","a"," " ]
+                     "value" : [ "","define function ","\"foo bar\"","(","a"," " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -306,7 +390,7 @@ module.exports['FunctionDefinitions'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","testValue",": " ]
+                     "value" : [ "","define ","testValue",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -356,6 +440,14 @@ module.exports['FunctionOverloadsWithSingleArgument'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "17",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -373,7 +465,27 @@ module.exports['FunctionOverloadsWithSingleArgument'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -398,7 +510,7 @@ module.exports['FunctionOverloadsWithSingleArgument'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define function ","process","(","a"," " ]
+                     "value" : [ "","define function ","process","(","a"," " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -456,7 +568,7 @@ module.exports['FunctionOverloadsWithSingleArgument'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define function ","process","(","a"," " ]
+                     "value" : [ "","define function ","process","(","a"," " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -517,7 +629,7 @@ module.exports['FunctionOverloadsWithSingleArgument'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","testValue1",": " ]
+                     "value" : [ "","define ","testValue1",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -548,7 +660,7 @@ module.exports['FunctionOverloadsWithSingleArgument'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","testValue2",": " ]
+                     "value" : [ "","define ","testValue2",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -599,6 +711,14 @@ module.exports['FunctionOverloadsWithMultipleArguments'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "31",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -616,7 +736,27 @@ module.exports['FunctionOverloadsWithMultipleArguments'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -641,7 +781,7 @@ module.exports['FunctionOverloadsWithMultipleArguments'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define function ","process","(","inverse"," " ]
+                     "value" : [ "","define function ","process","(","inverse"," " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -702,13 +842,9 @@ module.exports['FunctionOverloadsWithMultipleArguments'] = {
                "localId" : "11",
                "type" : "If",
                "condition" : {
-                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                  "type" : "As",
-                  "operand" : {
-                     "localId" : "4",
-                     "name" : "inverse",
-                     "type" : "OperandRef"
-                  }
+                  "localId" : "4",
+                  "name" : "inverse",
+                  "type" : "OperandRef"
                },
                "then" : {
                   "localId" : "7",
@@ -765,7 +901,7 @@ module.exports['FunctionOverloadsWithMultipleArguments'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define function ","process","(","inverse"," " ]
+                     "value" : [ "","define function ","process","(","inverse"," " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -834,13 +970,9 @@ module.exports['FunctionOverloadsWithMultipleArguments'] = {
                "localId" : "22",
                "type" : "If",
                "condition" : {
-                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                  "type" : "As",
-                  "operand" : {
-                     "localId" : "15",
-                     "name" : "inverse",
-                     "type" : "OperandRef"
-                  }
+                  "localId" : "15",
+                  "name" : "inverse",
+                  "type" : "OperandRef"
                },
                "then" : {
                   "localId" : "18",
@@ -896,7 +1028,7 @@ module.exports['FunctionOverloadsWithMultipleArguments'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","testValue1",": " ]
+                     "value" : [ "","define ","testValue1",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -932,7 +1064,7 @@ module.exports['FunctionOverloadsWithMultipleArguments'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","testValue2",": " ]
+                     "value" : [ "","define ","testValue2",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -990,6 +1122,14 @@ module.exports['FunctionOverloadsWithDifferentNumberOfArguments'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "32",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1007,7 +1147,27 @@ module.exports['FunctionOverloadsWithDifferentNumberOfArguments'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1032,7 +1192,7 @@ module.exports['FunctionOverloadsWithDifferentNumberOfArguments'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define function ","process","(","a"," " ]
+                     "value" : [ "","define function ","process","(","a"," " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -1094,7 +1254,7 @@ module.exports['FunctionOverloadsWithDifferentNumberOfArguments'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define function ","process","(","a"," " ]
+                     "value" : [ "","define function ","process","(","a"," " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -1183,13 +1343,9 @@ module.exports['FunctionOverloadsWithDifferentNumberOfArguments'] = {
                "localId" : "20",
                "type" : "If",
                "condition" : {
-                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                  "type" : "As",
-                  "operand" : {
-                     "localId" : "9",
-                     "name" : "isSpanish",
-                     "type" : "OperandRef"
-                  }
+                  "localId" : "9",
+                  "name" : "isSpanish",
+                  "type" : "OperandRef"
                },
                "then" : {
                   "localId" : "14",
@@ -1263,7 +1419,7 @@ module.exports['FunctionOverloadsWithDifferentNumberOfArguments'] = {
                "s" : {
                   "r" : "24",
                   "s" : [ {
-                     "value" : [ "define ","testValue1",": " ]
+                     "value" : [ "","define ","testValue1",": " ]
                   }, {
                      "r" : "23",
                      "s" : [ {
@@ -1300,7 +1456,7 @@ module.exports['FunctionOverloadsWithDifferentNumberOfArguments'] = {
                "s" : {
                   "r" : "28",
                   "s" : [ {
-                     "value" : [ "define ","testValue2",": " ]
+                     "value" : [ "","define ","testValue2",": " ]
                   }, {
                      "r" : "27",
                      "s" : [ {
@@ -1343,7 +1499,7 @@ module.exports['FunctionOverloadsWithDifferentNumberOfArguments'] = {
                "s" : {
                   "r" : "32",
                   "s" : [ {
-                     "value" : [ "define ","testValue3",": " ]
+                     "value" : [ "","define ","testValue3",": " ]
                   }, {
                      "r" : "31",
                      "s" : [ {
@@ -1400,6 +1556,14 @@ module.exports['FunctionOverloadsWithArgumentsFromCustomDataModel'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "21",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1417,7 +1581,27 @@ module.exports['FunctionOverloadsWithArgumentsFromCustomDataModel'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1442,7 +1626,7 @@ module.exports['FunctionOverloadsWithArgumentsFromCustomDataModel'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define function ","process","(","e"," " ]
+                     "value" : [ "","define function ","process","(","e"," " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -1519,7 +1703,7 @@ module.exports['FunctionOverloadsWithArgumentsFromCustomDataModel'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define function ","process","(","c"," " ]
+                     "value" : [ "","define function ","process","(","c"," " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -1595,7 +1779,7 @@ module.exports['FunctionOverloadsWithArgumentsFromCustomDataModel'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","testValue1",": " ]
+                     "value" : [ "","define ","testValue1",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -1642,7 +1826,7 @@ module.exports['FunctionOverloadsWithArgumentsFromCustomDataModel'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","testValue2",": " ]
+                     "value" : [ "","define ","testValue2",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {

--- a/test/elm/string/data.js
+++ b/test/elm/string/data.js
@@ -31,6 +31,14 @@ module.exports['Concat'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "97",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -48,7 +56,27 @@ module.exports['Concat'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -72,7 +100,7 @@ module.exports['Concat'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","HelloWorld",": " ]
+                     "value" : [ "","define ","HelloWorld",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -116,7 +144,7 @@ module.exports['Concat'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","Sentence",": " ]
+                     "value" : [ "","define ","Sentence",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -445,7 +473,7 @@ module.exports['Concat'] = {
                "s" : {
                   "r" : "43",
                   "s" : [ {
-                     "value" : [ "define ","ConcatNull",": " ]
+                     "value" : [ "","define ","ConcatNull",": " ]
                   }, {
                      "r" : "42",
                      "s" : [ {
@@ -487,7 +515,7 @@ module.exports['Concat'] = {
                "s" : {
                   "r" : "45",
                   "s" : [ {
-                     "value" : [ "define ","Hello",": " ]
+                     "value" : [ "","define ","Hello",": " ]
                   }, {
                      "r" : "44",
                      "s" : [ {
@@ -512,7 +540,7 @@ module.exports['Concat'] = {
                "s" : {
                   "r" : "47",
                   "s" : [ {
-                     "value" : [ "define ","World",": " ]
+                     "value" : [ "","define ","World",": " ]
                   }, {
                      "r" : "46",
                      "s" : [ {
@@ -537,7 +565,7 @@ module.exports['Concat'] = {
                "s" : {
                   "r" : "51",
                   "s" : [ {
-                     "value" : [ "define ","HelloWorldVariables",": " ]
+                     "value" : [ "","define ","HelloWorldVariables",": " ]
                   }, {
                      "r" : "50",
                      "s" : [ {
@@ -579,7 +607,7 @@ module.exports['Concat'] = {
                "s" : {
                   "r" : "55",
                   "s" : [ {
-                     "value" : [ "define ","AndHelloWorld",": " ]
+                     "value" : [ "","define ","AndHelloWorld",": " ]
                   }, {
                      "r" : "54",
                      "s" : [ {
@@ -637,7 +665,7 @@ module.exports['Concat'] = {
                "s" : {
                   "r" : "89",
                   "s" : [ {
-                     "value" : [ "define ","AndSentence",": " ]
+                     "value" : [ "","define ","AndSentence",": " ]
                   }, {
                      "r" : "88",
                      "s" : [ {
@@ -1190,7 +1218,7 @@ module.exports['Concat'] = {
                "s" : {
                   "r" : "93",
                   "s" : [ {
-                     "value" : [ "define ","AndConcatNull",": " ]
+                     "value" : [ "","define ","AndConcatNull",": " ]
                   }, {
                      "r" : "92",
                      "s" : [ {
@@ -1246,7 +1274,7 @@ module.exports['Concat'] = {
                "s" : {
                   "r" : "97",
                   "s" : [ {
-                     "value" : [ "define ","AndHelloWorldVariables",": " ]
+                     "value" : [ "","define ","AndHelloWorldVariables",": " ]
                   }, {
                      "r" : "96",
                      "s" : [ {
@@ -1314,6 +1342,14 @@ module.exports['Combine'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "37",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1331,7 +1367,27 @@ module.exports['Combine'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1355,7 +1411,7 @@ module.exports['Combine'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","NoSeparator",": " ]
+                     "value" : [ "","define ","NoSeparator",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -1438,7 +1494,7 @@ module.exports['Combine'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","Separator",": " ]
+                     "value" : [ "","define ","Separator",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -1534,7 +1590,7 @@ module.exports['Combine'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","CombineNull",": " ]
+                     "value" : [ "","define ","CombineNull",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -1585,7 +1641,7 @@ module.exports['Combine'] = {
                "s" : {
                   "r" : "28",
                   "s" : [ {
-                     "value" : [ "define ","CombineNullItem",": " ]
+                     "value" : [ "","define ","CombineNullItem",": " ]
                   }, {
                      "r" : "27",
                      "s" : [ {
@@ -1677,7 +1733,7 @@ module.exports['Combine'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","CombineOneNullItem",": " ]
+                     "value" : [ "","define ","CombineOneNullItem",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -1746,7 +1802,7 @@ module.exports['Combine'] = {
                "s" : {
                   "r" : "37",
                   "s" : [ {
-                     "value" : [ "define ","CombineEmptyNull",": " ]
+                     "value" : [ "","define ","CombineEmptyNull",": " ]
                   }, {
                      "r" : "36",
                      "s" : [ {
@@ -1814,6 +1870,14 @@ module.exports['Split'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "17",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1831,7 +1895,27 @@ module.exports['Split'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1855,7 +1939,7 @@ module.exports['Split'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","CommaSeparated",": " ]
+                     "value" : [ "","define ","CommaSeparated",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -1904,7 +1988,7 @@ module.exports['Split'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","SeparatorNotUsed",": " ]
+                     "value" : [ "","define ","SeparatorNotUsed",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -1953,7 +2037,7 @@ module.exports['Split'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","SeparateNull",": " ]
+                     "value" : [ "","define ","SeparateNull",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -1998,7 +2082,7 @@ module.exports['Split'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","SeparateUsingNull",": " ]
+                     "value" : [ "","define ","SeparateUsingNull",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -2055,6 +2139,14 @@ module.exports['SplitOnMatches'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "25",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2072,7 +2164,27 @@ module.exports['SplitOnMatches'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2096,7 +2208,7 @@ module.exports['SplitOnMatches'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","SplitOnMatchesListReturn",": " ]
+                     "value" : [ "","define ","SplitOnMatchesListReturn",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -2145,7 +2257,7 @@ module.exports['SplitOnMatches'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","SplitOnMatchesOriginalString",": " ]
+                     "value" : [ "","define ","SplitOnMatchesOriginalString",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -2194,7 +2306,7 @@ module.exports['SplitOnMatches'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","SplitOnMatchesNoMatch",": " ]
+                     "value" : [ "","define ","SplitOnMatchesNoMatch",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -2243,7 +2355,7 @@ module.exports['SplitOnMatches'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","SplitOnMatchesIsNullFirst",": " ]
+                     "value" : [ "","define ","SplitOnMatchesIsNullFirst",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -2288,7 +2400,7 @@ module.exports['SplitOnMatches'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","SplitOnMatchesIsNullSecond",": " ]
+                     "value" : [ "","define ","SplitOnMatchesIsNullSecond",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -2333,7 +2445,7 @@ module.exports['SplitOnMatches'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","SplitOnMatchesAllNull",": " ]
+                     "value" : [ "","define ","SplitOnMatchesAllNull",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -2381,6 +2493,14 @@ module.exports['Length'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "9",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2398,7 +2518,27 @@ module.exports['Length'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2422,7 +2562,7 @@ module.exports['Length'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","ElevenLetters",": " ]
+                     "value" : [ "","define ","ElevenLetters",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -2458,7 +2598,7 @@ module.exports['Length'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","NullString",": " ]
+                     "value" : [ "","define ","NullString",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -2518,6 +2658,14 @@ module.exports['Upper'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "13",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2535,7 +2683,27 @@ module.exports['Upper'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2559,7 +2727,7 @@ module.exports['Upper'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","LowerC",": " ]
+                     "value" : [ "","define ","LowerC",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -2595,7 +2763,7 @@ module.exports['Upper'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","UpperC",": " ]
+                     "value" : [ "","define ","UpperC",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -2631,7 +2799,7 @@ module.exports['Upper'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","CamelC",": " ]
+                     "value" : [ "","define ","CamelC",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -2667,7 +2835,7 @@ module.exports['Upper'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","NullString",": " ]
+                     "value" : [ "","define ","NullString",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -2709,6 +2877,14 @@ module.exports['Lower'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "13",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2726,7 +2902,27 @@ module.exports['Lower'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2750,7 +2946,7 @@ module.exports['Lower'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define ","LowerC",": " ]
+                     "value" : [ "","define ","LowerC",": " ]
                   }, {
                      "r" : "3",
                      "s" : [ {
@@ -2786,7 +2982,7 @@ module.exports['Lower'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","UpperC",": " ]
+                     "value" : [ "","define ","UpperC",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -2822,7 +3018,7 @@ module.exports['Lower'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","CamelC",": " ]
+                     "value" : [ "","define ","CamelC",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -2858,7 +3054,7 @@ module.exports['Lower'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","NullString",": " ]
+                     "value" : [ "","define ","NullString",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -2901,6 +3097,14 @@ module.exports['Indexer'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "23",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2918,7 +3122,27 @@ module.exports['Indexer'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2942,7 +3166,7 @@ module.exports['Indexer'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","HelloWorldSix",": " ]
+                     "value" : [ "","define ","HelloWorldSix",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -2982,7 +3206,7 @@ module.exports['Indexer'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","HelloWorldZero",": " ]
+                     "value" : [ "","define ","HelloWorldZero",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -3022,7 +3246,7 @@ module.exports['Indexer'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","HelloWorldTwenty",": " ]
+                     "value" : [ "","define ","HelloWorldTwenty",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -3062,7 +3286,7 @@ module.exports['Indexer'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","NullString",": " ]
+                     "value" : [ "","define ","NullString",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -3123,7 +3347,7 @@ module.exports['Indexer'] = {
                "s" : {
                   "r" : "23",
                   "s" : [ {
-                     "value" : [ "define ","NullIndex",": " ]
+                     "value" : [ "","define ","NullIndex",": " ]
                   }, {
                      "r" : "22",
                      "s" : [ {
@@ -3176,6 +3400,14 @@ module.exports['Matches'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "21",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3193,7 +3425,27 @@ module.exports['Matches'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3217,7 +3469,7 @@ module.exports['Matches'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","MatchesTrue",": " ]
+                     "value" : [ "","define ","MatchesTrue",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -3265,7 +3517,7 @@ module.exports['Matches'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","MatchesFalse",": " ]
+                     "value" : [ "","define ","MatchesFalse",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -3313,7 +3565,7 @@ module.exports['Matches'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","MatchesIsNullFirst",": " ]
+                     "value" : [ "","define ","MatchesIsNullFirst",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -3357,7 +3609,7 @@ module.exports['Matches'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","MatchesIsNullSecond",": " ]
+                     "value" : [ "","define ","MatchesIsNullSecond",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -3401,7 +3653,7 @@ module.exports['Matches'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","MatchesAllNull",": " ]
+                     "value" : [ "","define ","MatchesAllNull",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -3450,6 +3702,14 @@ module.exports['PositionOf'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "17",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3467,7 +3727,27 @@ module.exports['PositionOf'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3491,7 +3771,7 @@ module.exports['PositionOf'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","Found",": " ]
+                     "value" : [ "","define ","Found",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -3540,7 +3820,7 @@ module.exports['PositionOf'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","NotFound",": " ]
+                     "value" : [ "","define ","NotFound",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -3589,7 +3869,7 @@ module.exports['PositionOf'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","NullPattern",": " ]
+                     "value" : [ "","define ","NullPattern",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -3634,7 +3914,7 @@ module.exports['PositionOf'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","NullString",": " ]
+                     "value" : [ "","define ","NullString",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -3689,6 +3969,14 @@ module.exports['LastPositionOf'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "17",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3706,7 +3994,27 @@ module.exports['LastPositionOf'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3730,7 +4038,7 @@ module.exports['LastPositionOf'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","Found",": " ]
+                     "value" : [ "","define ","Found",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -3779,7 +4087,7 @@ module.exports['LastPositionOf'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","NotFound",": " ]
+                     "value" : [ "// 7","define ","NotFound",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -3828,7 +4136,7 @@ module.exports['LastPositionOf'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","NullPattern",": " ]
+                     "value" : [ "// -1","define ","NullPattern",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -3873,7 +4181,7 @@ module.exports['LastPositionOf'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","NullString",": " ]
+                     "value" : [ "// null","define ","NullString",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -3933,6 +4241,14 @@ module.exports['Substring'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "43",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3950,7 +4266,27 @@ module.exports['Substring'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3974,7 +4310,7 @@ module.exports['Substring'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","World",": " ]
+                     "value" : [ "","define ","World",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -4017,7 +4353,7 @@ module.exports['Substring'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","Or",": " ]
+                     "value" : [ "","define ","Or",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -4066,7 +4402,7 @@ module.exports['Substring'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","ZeroLength",": " ]
+                     "value" : [ "","define ","ZeroLength",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -4115,7 +4451,7 @@ module.exports['Substring'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","StartTooLow",": " ]
+                     "value" : [ "","define ","StartTooLow",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -4169,7 +4505,7 @@ module.exports['Substring'] = {
                "s" : {
                   "r" : "24",
                   "s" : [ {
-                     "value" : [ "define ","StartZero",": " ]
+                     "value" : [ "","define ","StartZero",": " ]
                   }, {
                      "r" : "23",
                      "s" : [ {
@@ -4212,7 +4548,7 @@ module.exports['Substring'] = {
                "s" : {
                   "r" : "29",
                   "s" : [ {
-                     "value" : [ "define ","TooMuchLength",": " ]
+                     "value" : [ "","define ","TooMuchLength",": " ]
                   }, {
                      "r" : "28",
                      "s" : [ {
@@ -4261,7 +4597,7 @@ module.exports['Substring'] = {
                "s" : {
                   "r" : "35",
                   "s" : [ {
-                     "value" : [ "define ","NegativeLength",": " ]
+                     "value" : [ "","define ","NegativeLength",": " ]
                   }, {
                      "r" : "34",
                      "s" : [ {
@@ -4322,7 +4658,7 @@ module.exports['Substring'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","NullString",": " ]
+                     "value" : [ "","define ","NullString",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -4360,7 +4696,7 @@ module.exports['Substring'] = {
                "s" : {
                   "r" : "43",
                   "s" : [ {
-                     "value" : [ "define ","NullStart",": " ]
+                     "value" : [ "","define ","NullStart",": " ]
                   }, {
                      "r" : "42",
                      "s" : [ {
@@ -4419,6 +4755,14 @@ module.exports['StartsWith'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "37",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -4436,7 +4780,27 @@ module.exports['StartsWith'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -4460,7 +4824,7 @@ module.exports['StartsWith'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","FooBarStartsWithFoo",": " ]
+                     "value" : [ "","define ","FooBarStartsWithFoo",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -4508,7 +4872,7 @@ module.exports['StartsWith'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","FooBarStartsWithBar",": " ]
+                     "value" : [ "","define ","FooBarStartsWithBar",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -4556,7 +4920,7 @@ module.exports['StartsWith'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","FooBarStartsWithBlank",": " ]
+                     "value" : [ "","define ","FooBarStartsWithBlank",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -4604,7 +4968,7 @@ module.exports['StartsWith'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","BlankStartsWithFoo",": " ]
+                     "value" : [ "","define ","BlankStartsWithFoo",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -4652,7 +5016,7 @@ module.exports['StartsWith'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","StartsWithNull",": " ]
+                     "value" : [ "","define ","StartsWithNull",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -4696,7 +5060,7 @@ module.exports['StartsWith'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","StartsWithNullAsString",": " ]
+                     "value" : [ "","define ","StartsWithNullAsString",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -4758,7 +5122,7 @@ module.exports['StartsWith'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","NullStartsWith",": " ]
+                     "value" : [ "","define ","NullStartsWith",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -4802,7 +5166,7 @@ module.exports['StartsWith'] = {
                "s" : {
                   "r" : "37",
                   "s" : [ {
-                     "value" : [ "define ","NullAsStringStartsWith",": " ]
+                     "value" : [ "","define ","NullAsStringStartsWith",": " ]
                   }, {
                      "r" : "36",
                      "s" : [ {
@@ -4878,6 +5242,14 @@ module.exports['EndsWith'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "39",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -4895,7 +5267,27 @@ module.exports['EndsWith'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -4919,7 +5311,7 @@ module.exports['EndsWith'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","FooBarEndsWithBar",": " ]
+                     "value" : [ "","define ","FooBarEndsWithBar",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -4967,7 +5359,7 @@ module.exports['EndsWith'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","FooBarEndsWithFoo",": " ]
+                     "value" : [ "","define ","FooBarEndsWithFoo",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -5015,7 +5407,7 @@ module.exports['EndsWith'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","FooBarEndsWithBlank",": " ]
+                     "value" : [ "","define ","FooBarEndsWithBlank",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -5063,7 +5455,7 @@ module.exports['EndsWith'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","BlankEndsWithFoo",": " ]
+                     "value" : [ "","define ","BlankEndsWithFoo",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -5111,7 +5503,7 @@ module.exports['EndsWith'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","EndsWithNull",": " ]
+                     "value" : [ "","define ","EndsWithNull",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -5155,7 +5547,7 @@ module.exports['EndsWith'] = {
                "s" : {
                   "r" : "27",
                   "s" : [ {
-                     "value" : [ "define ","EndsWithNullAsString",": " ]
+                     "value" : [ "","define ","EndsWithNullAsString",": " ]
                   }, {
                      "r" : "26",
                      "s" : [ {
@@ -5217,7 +5609,7 @@ module.exports['EndsWith'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","NullEndsWith",": " ]
+                     "value" : [ "","define ","NullEndsWith",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -5279,7 +5671,7 @@ module.exports['EndsWith'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","NullAsStringEndsWith",": " ]
+                     "value" : [ "","define ","NullAsStringEndsWith",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -5359,6 +5751,14 @@ module.exports['ReplaceMatches'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "61",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -5376,7 +5776,27 @@ module.exports['ReplaceMatches'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -5400,7 +5820,7 @@ module.exports['ReplaceMatches'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define ","ReplaceOne",": " ]
+                     "value" : [ "","define ","ReplaceOne",": " ]
                   }, {
                      "r" : "5",
                      "s" : [ {
@@ -5460,7 +5880,7 @@ module.exports['ReplaceMatches'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","ReplaceMany",": " ]
+                     "value" : [ "","define ","ReplaceMany",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -5520,7 +5940,7 @@ module.exports['ReplaceMatches'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","ReplaceCapital",": " ]
+                     "value" : [ "","define ","ReplaceCapital",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -5580,7 +6000,7 @@ module.exports['ReplaceMatches'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","ReplaceDiacritical",": " ]
+                     "value" : [ "","define ","ReplaceDiacritical",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -5640,7 +6060,7 @@ module.exports['ReplaceMatches'] = {
                "s" : {
                   "r" : "26",
                   "s" : [ {
-                     "value" : [ "define ","ReplaceUnicode",": " ]
+                     "value" : [ "","define ","ReplaceUnicode",": " ]
                   }, {
                      "r" : "25",
                      "s" : [ {
@@ -5700,7 +6120,7 @@ module.exports['ReplaceMatches'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","ReplaceSpace",": " ]
+                     "value" : [ "","define ","ReplaceSpace",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -5760,7 +6180,7 @@ module.exports['ReplaceMatches'] = {
                "s" : {
                   "r" : "36",
                   "s" : [ {
-                     "value" : [ "define ","ReplaceEmpty",": " ]
+                     "value" : [ "","define ","ReplaceEmpty",": " ]
                   }, {
                      "r" : "35",
                      "s" : [ {
@@ -5820,7 +6240,7 @@ module.exports['ReplaceMatches'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","ReplaceMatchGroups",": " ]
+                     "value" : [ "","define ","ReplaceMatchGroups",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -5880,7 +6300,7 @@ module.exports['ReplaceMatches'] = {
                "s" : {
                   "r" : "46",
                   "s" : [ {
-                     "value" : [ "define ","ReplaceNone",": " ]
+                     "value" : [ "","define ","ReplaceNone",": " ]
                   }, {
                      "r" : "45",
                      "s" : [ {
@@ -5940,7 +6360,7 @@ module.exports['ReplaceMatches'] = {
                "s" : {
                   "r" : "51",
                   "s" : [ {
-                     "value" : [ "define ","ReplaceArgumentIsNull",": " ]
+                     "value" : [ "","define ","ReplaceArgumentIsNull",": " ]
                   }, {
                      "r" : "50",
                      "s" : [ {
@@ -5996,7 +6416,7 @@ module.exports['ReplaceMatches'] = {
                "s" : {
                   "r" : "56",
                   "s" : [ {
-                     "value" : [ "define ","ReplacePatternIsNull",": " ]
+                     "value" : [ "","define ","ReplacePatternIsNull",": " ]
                   }, {
                      "r" : "55",
                      "s" : [ {
@@ -6052,7 +6472,7 @@ module.exports['ReplaceMatches'] = {
                "s" : {
                   "r" : "61",
                   "s" : [ {
-                     "value" : [ "define ","ReplaceSubstitutionIsNull",": " ]
+                     "value" : [ "","define ","ReplaceSubstitutionIsNull",": " ]
                   }, {
                      "r" : "60",
                      "s" : [ {

--- a/test/elm/structured/data.js
+++ b/test/elm/structured/data.js
@@ -21,6 +21,14 @@ module.exports['Tuple'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "7",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -38,7 +46,27 @@ module.exports['Tuple'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -62,7 +90,7 @@ module.exports['Tuple'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","tup",": " ]
+                     "value" : [ "","define ","tup",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -117,7 +145,7 @@ module.exports['Tuple'] = {
                   "r" : "7",
                   "s" : [ {
                      "r" : "6",
-                     "value" : [ "define ","emptyTup",": ","{:}" ]
+                     "value" : [ "","define ","emptyTup",": ","{:}" ]
                   } ]
                }
             } ],

--- a/test/elm/type/data.js
+++ b/test/elm/type/data.js
@@ -23,6 +23,14 @@ module.exports['IsSystemType'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "17",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -40,7 +48,27 @@ module.exports['IsSystemType'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -64,7 +92,7 @@ module.exports['IsSystemType'] = {
                "s" : {
                   "r" : "5",
                   "s" : [ {
-                     "value" : [ "define ","FiveIsInteger",": " ]
+                     "value" : [ "","define ","FiveIsInteger",": " ]
                   }, {
                      "r" : "4",
                      "s" : [ {
@@ -104,7 +132,7 @@ module.exports['IsSystemType'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","FiveIsString",": " ]
+                     "value" : [ "","define ","FiveIsString",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -144,7 +172,7 @@ module.exports['IsSystemType'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","StringFiveIsInteger",": " ]
+                     "value" : [ "","define ","StringFiveIsInteger",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -188,7 +216,7 @@ module.exports['IsSystemType'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "define ","StringFiveIsString",": " ]
+                     "value" : [ "","define ","StringFiveIsString",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -240,6 +268,14 @@ module.exports['IsListType'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "21",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -257,7 +293,27 @@ module.exports['IsListType'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -281,7 +337,7 @@ module.exports['IsListType'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","ListOfIntegersIsListOfIntegers",": " ]
+                     "value" : [ "","define ","ListOfIntegersIsListOfIntegers",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -361,7 +417,7 @@ module.exports['IsListType'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","ListOfDecimalsIsListOfIntegers",": " ]
+                     "value" : [ "","define ","ListOfDecimalsIsListOfIntegers",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -449,6 +505,14 @@ module.exports['IsIntervalType'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "15",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -466,7 +530,27 @@ module.exports['IsIntervalType'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -490,7 +574,7 @@ module.exports['IsIntervalType'] = {
                "s" : {
                   "r" : "8",
                   "s" : [ {
-                     "value" : [ "define ","IntervalOfIntegersIsIntervalOfIntegers",": " ]
+                     "value" : [ "","define ","IntervalOfIntegersIsIntervalOfIntegers",": " ]
                   }, {
                      "r" : "7",
                      "s" : [ {
@@ -558,7 +642,7 @@ module.exports['IsIntervalType'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","IntervalOfDecimalsIsIntervalOfIntegers",": " ]
+                     "value" : [ "","define ","IntervalOfDecimalsIsIntervalOfIntegers",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -634,6 +718,14 @@ module.exports['IsTupleType'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "21",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -651,7 +743,27 @@ module.exports['IsTupleType'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -675,7 +787,7 @@ module.exports['IsTupleType'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","TupleOfIntegersIsTupleOfIntegers",": " ]
+                     "value" : [ "","define ","TupleOfIntegersIsTupleOfIntegers",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -788,7 +900,7 @@ module.exports['IsTupleType'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","TupleOfDecimalsIsTupleOfIntegers",": " ]
+                     "value" : [ "","define ","TupleOfDecimalsIsTupleOfIntegers",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -910,6 +1022,14 @@ module.exports['IsChoiceType'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "19",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -927,7 +1047,27 @@ module.exports['IsChoiceType'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -951,7 +1091,7 @@ module.exports['IsChoiceType'] = {
                "s" : {
                   "r" : "7",
                   "s" : [ {
-                     "value" : [ "define ","IntegerIsChoiceOfIntegersAndDecimals",": " ]
+                     "value" : [ "","define ","IntegerIsChoiceOfIntegersAndDecimals",": " ]
                   }, {
                      "r" : "6",
                      "s" : [ {
@@ -1013,7 +1153,7 @@ module.exports['IsChoiceType'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "define ","DecimalIsChoiceOfIntegersAndDecimals",": " ]
+                     "value" : [ "","define ","DecimalIsChoiceOfIntegersAndDecimals",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -1075,7 +1215,7 @@ module.exports['IsChoiceType'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","StringIsChoiceOfIntegersAndDecimals",": " ]
+                     "value" : [ "","define ","StringIsChoiceOfIntegersAndDecimals",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -1152,6 +1292,14 @@ module.exports['IsCustomDataModelType'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "26",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1169,7 +1317,27 @@ module.exports['IsCustomDataModelType'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1193,7 +1361,7 @@ module.exports['IsCustomDataModelType'] = {
                "s" : {
                   "r" : "6",
                   "s" : [ {
-                     "value" : [ "define ","EncounterIsEncounter",": " ]
+                     "value" : [ "","define ","EncounterIsEncounter",": " ]
                   }, {
                      "r" : "5",
                      "s" : [ {
@@ -1247,7 +1415,7 @@ module.exports['IsCustomDataModelType'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","EncounterIsRecord",": " ]
+                     "value" : [ "","define ","EncounterIsRecord",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -1301,7 +1469,7 @@ module.exports['IsCustomDataModelType'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","EncounterIsAny",": " ]
+                     "value" : [ "","define ","EncounterIsAny",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -1355,7 +1523,7 @@ module.exports['IsCustomDataModelType'] = {
                "s" : {
                   "r" : "21",
                   "s" : [ {
-                     "value" : [ "define ","EncounterIsCondition",": " ]
+                     "value" : [ "","define ","EncounterIsCondition",": " ]
                   }, {
                      "r" : "20",
                      "s" : [ {
@@ -1409,7 +1577,7 @@ module.exports['IsCustomDataModelType'] = {
                "s" : {
                   "r" : "26",
                   "s" : [ {
-                     "value" : [ "define ","EncounterIsString",": " ]
+                     "value" : [ "","define ","EncounterIsString",": " ]
                   }, {
                      "r" : "25",
                      "s" : [ {
@@ -1484,6 +1652,14 @@ module.exports['AsSystemType'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "82",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -1501,7 +1677,27 @@ module.exports['AsSystemType'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -1526,7 +1722,7 @@ module.exports['AsSystemType'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define function ","Echo","(","Val"," " ]
+                     "value" : [ "","define function ","Echo","(","Val"," " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -1568,7 +1764,7 @@ module.exports['AsSystemType'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "define ","FiveAsInteger",": " ]
+                     "value" : [ "// fool CQL-to-ELM into letting the casts compile","define ","FiveAsInteger",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -1619,7 +1815,7 @@ module.exports['AsSystemType'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "define ","FiveAsString",": " ]
+                     "value" : [ "","define ","FiveAsString",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -1670,7 +1866,7 @@ module.exports['AsSystemType'] = {
                "s" : {
                   "r" : "19",
                   "s" : [ {
-                     "value" : [ "define ","StringFiveAsInteger",": " ]
+                     "value" : [ "","define ","StringFiveAsInteger",": " ]
                   }, {
                      "r" : "18",
                      "s" : [ {
@@ -1727,7 +1923,7 @@ module.exports['AsSystemType'] = {
                "s" : {
                   "r" : "24",
                   "s" : [ {
-                     "value" : [ "define ","StringFiveAsString",": " ]
+                     "value" : [ "","define ","StringFiveAsString",": " ]
                   }, {
                      "r" : "23",
                      "s" : [ {
@@ -1784,7 +1980,7 @@ module.exports['AsSystemType'] = {
                "s" : {
                   "r" : "30",
                   "s" : [ {
-                     "value" : [ "define ","ListAsInteger",": " ]
+                     "value" : [ "","define ","ListAsInteger",": " ]
                   }, {
                      "r" : "29",
                      "s" : [ {
@@ -1846,7 +2042,7 @@ module.exports['AsSystemType'] = {
                "s" : {
                   "r" : "37",
                   "s" : [ {
-                     "value" : [ "define ","IntervalAsInteger",": " ]
+                     "value" : [ "","define ","IntervalAsInteger",": " ]
                   }, {
                      "r" : "36",
                      "s" : [ {
@@ -1916,7 +2112,7 @@ module.exports['AsSystemType'] = {
                "s" : {
                   "r" : "43",
                   "s" : [ {
-                     "value" : [ "define ","TupleAsInteger",": " ]
+                     "value" : [ "","define ","TupleAsInteger",": " ]
                   }, {
                      "r" : "42",
                      "s" : [ {
@@ -1987,7 +2183,7 @@ module.exports['AsSystemType'] = {
                "s" : {
                   "r" : "48",
                   "s" : [ {
-                     "value" : [ "define ","CastFiveAsInteger",": " ]
+                     "value" : [ "","define ","CastFiveAsInteger",": " ]
                   }, {
                      "r" : "47",
                      "s" : [ {
@@ -2040,7 +2236,7 @@ module.exports['AsSystemType'] = {
                "s" : {
                   "r" : "53",
                   "s" : [ {
-                     "value" : [ "define ","CastFiveAsString",": " ]
+                     "value" : [ "","define ","CastFiveAsString",": " ]
                   }, {
                      "r" : "52",
                      "s" : [ {
@@ -2093,7 +2289,7 @@ module.exports['AsSystemType'] = {
                "s" : {
                   "r" : "58",
                   "s" : [ {
-                     "value" : [ "define ","CastStringFiveAsInteger",": " ]
+                     "value" : [ "","define ","CastStringFiveAsInteger",": " ]
                   }, {
                      "r" : "57",
                      "s" : [ {
@@ -2152,7 +2348,7 @@ module.exports['AsSystemType'] = {
                "s" : {
                   "r" : "63",
                   "s" : [ {
-                     "value" : [ "define ","CastStringFiveAsString",": " ]
+                     "value" : [ "","define ","CastStringFiveAsString",": " ]
                   }, {
                      "r" : "62",
                      "s" : [ {
@@ -2211,7 +2407,7 @@ module.exports['AsSystemType'] = {
                "s" : {
                   "r" : "69",
                   "s" : [ {
-                     "value" : [ "define ","CastListAsInteger",": " ]
+                     "value" : [ "","define ","CastListAsInteger",": " ]
                   }, {
                      "r" : "68",
                      "s" : [ {
@@ -2275,7 +2471,7 @@ module.exports['AsSystemType'] = {
                "s" : {
                   "r" : "76",
                   "s" : [ {
-                     "value" : [ "define ","CastIntervalAsInteger",": " ]
+                     "value" : [ "","define ","CastIntervalAsInteger",": " ]
                   }, {
                      "r" : "75",
                      "s" : [ {
@@ -2347,7 +2543,7 @@ module.exports['AsSystemType'] = {
                "s" : {
                   "r" : "82",
                   "s" : [ {
-                     "value" : [ "define ","CastTupleAsInteger",": " ]
+                     "value" : [ "","define ","CastTupleAsInteger",": " ]
                   }, {
                      "r" : "81",
                      "s" : [ {
@@ -2437,6 +2633,14 @@ module.exports['AsListType'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "88",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -2454,7 +2658,27 @@ module.exports['AsListType'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -2479,7 +2703,7 @@ module.exports['AsListType'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define function ","Echo","(","Val"," " ]
+                     "value" : [ "","define function ","Echo","(","Val"," " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -2521,7 +2745,7 @@ module.exports['AsListType'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","ListOfIntegersAsListOfIntegers",": " ]
+                     "value" : [ "// fool CQL-to-ELM into letting the casts compile","define ","ListOfIntegersAsListOfIntegers",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -2614,7 +2838,7 @@ module.exports['AsListType'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","ListOfStringsAsListOfIntegers",": " ]
+                     "value" : [ "","define ","ListOfStringsAsListOfIntegers",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -2729,7 +2953,7 @@ module.exports['AsListType'] = {
                "s" : {
                   "r" : "31",
                   "s" : [ {
-                     "value" : [ "define ","IntegerAsListOfIntegers",": " ]
+                     "value" : [ "","define ","IntegerAsListOfIntegers",": " ]
                   }, {
                      "r" : "30",
                      "s" : [ {
@@ -2791,7 +3015,7 @@ module.exports['AsListType'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","IntervalAsListOfIntegers",": " ]
+                     "value" : [ "","define ","IntervalAsListOfIntegers",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -2872,7 +3096,7 @@ module.exports['AsListType'] = {
                "s" : {
                   "r" : "46",
                   "s" : [ {
-                     "value" : [ "define ","TupleAsListOfIntegers",": " ]
+                     "value" : [ "","define ","TupleAsListOfIntegers",": " ]
                   }, {
                      "r" : "45",
                      "s" : [ {
@@ -2954,7 +3178,7 @@ module.exports['AsListType'] = {
                "s" : {
                   "r" : "57",
                   "s" : [ {
-                     "value" : [ "define ","CastListOfIntegersAsListOfIntegers",": " ]
+                     "value" : [ "","define ","CastListOfIntegersAsListOfIntegers",": " ]
                   }, {
                      "r" : "56",
                      "s" : [ {
@@ -3049,7 +3273,7 @@ module.exports['AsListType'] = {
                "s" : {
                   "r" : "67",
                   "s" : [ {
-                     "value" : [ "define ","CastListOfStringsAsListOfIntegers",": " ]
+                     "value" : [ "","define ","CastListOfStringsAsListOfIntegers",": " ]
                   }, {
                      "r" : "66",
                      "s" : [ {
@@ -3166,7 +3390,7 @@ module.exports['AsListType'] = {
                "s" : {
                   "r" : "73",
                   "s" : [ {
-                     "value" : [ "define ","CastIntegerAsListOfIntegers",": " ]
+                     "value" : [ "","define ","CastIntegerAsListOfIntegers",": " ]
                   }, {
                      "r" : "72",
                      "s" : [ {
@@ -3230,7 +3454,7 @@ module.exports['AsListType'] = {
                "s" : {
                   "r" : "81",
                   "s" : [ {
-                     "value" : [ "define ","CastIntervalAsListOfIntegers",": " ]
+                     "value" : [ "","define ","CastIntervalAsListOfIntegers",": " ]
                   }, {
                      "r" : "80",
                      "s" : [ {
@@ -3313,7 +3537,7 @@ module.exports['AsListType'] = {
                "s" : {
                   "r" : "88",
                   "s" : [ {
-                     "value" : [ "define ","CastTupleAsListOfIntegers",": " ]
+                     "value" : [ "","define ","CastTupleAsListOfIntegers",": " ]
                   }, {
                      "r" : "87",
                      "s" : [ {
@@ -3414,6 +3638,14 @@ module.exports['AsIntervalType'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "84",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -3431,7 +3663,27 @@ module.exports['AsIntervalType'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -3456,7 +3708,7 @@ module.exports['AsIntervalType'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define function ","Echo","(","Val"," " ]
+                     "value" : [ "","define function ","Echo","(","Val"," " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -3498,7 +3750,7 @@ module.exports['AsIntervalType'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "define ","IntervalOfIntegersAsIntervalOfIntegers",": " ]
+                     "value" : [ "// fool CQL-to-ELM into letting the casts compile","define ","IntervalOfIntegersAsIntervalOfIntegers",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -3579,7 +3831,7 @@ module.exports['AsIntervalType'] = {
                "s" : {
                   "r" : "20",
                   "s" : [ {
-                     "value" : [ "define ","IntervalOfDatesAsIntervalOfIntegers",": " ]
+                     "value" : [ "","define ","IntervalOfDatesAsIntervalOfIntegers",": " ]
                   }, {
                      "r" : "19",
                      "s" : [ {
@@ -3686,7 +3938,7 @@ module.exports['AsIntervalType'] = {
                "s" : {
                   "r" : "26",
                   "s" : [ {
-                     "value" : [ "define ","IntegerAsIntervalOfIntegers",": " ]
+                     "value" : [ "","define ","IntegerAsIntervalOfIntegers",": " ]
                   }, {
                      "r" : "25",
                      "s" : [ {
@@ -3748,7 +4000,7 @@ module.exports['AsIntervalType'] = {
                "s" : {
                   "r" : "37",
                   "s" : [ {
-                     "value" : [ "define ","ListAsIntervalOfIntegers",": " ]
+                     "value" : [ "","define ","ListAsIntervalOfIntegers",": " ]
                   }, {
                      "r" : "36",
                      "s" : [ {
@@ -3841,7 +4093,7 @@ module.exports['AsIntervalType'] = {
                "s" : {
                   "r" : "44",
                   "s" : [ {
-                     "value" : [ "define ","TupleAsIntervalOfIntegers",": " ]
+                     "value" : [ "","define ","TupleAsIntervalOfIntegers",": " ]
                   }, {
                      "r" : "43",
                      "s" : [ {
@@ -3923,7 +4175,7 @@ module.exports['AsIntervalType'] = {
                "s" : {
                   "r" : "52",
                   "s" : [ {
-                     "value" : [ "define ","CastIntervalOfIntegersAsIntervalOfIntegers",": " ]
+                     "value" : [ "","define ","CastIntervalOfIntegersAsIntervalOfIntegers",": " ]
                   }, {
                      "r" : "51",
                      "s" : [ {
@@ -4006,7 +4258,7 @@ module.exports['AsIntervalType'] = {
                "s" : {
                   "r" : "60",
                   "s" : [ {
-                     "value" : [ "define ","CastIntervalOfDatesAsIntervalOfIntegers",": " ]
+                     "value" : [ "","define ","CastIntervalOfDatesAsIntervalOfIntegers",": " ]
                   }, {
                      "r" : "59",
                      "s" : [ {
@@ -4115,7 +4367,7 @@ module.exports['AsIntervalType'] = {
                "s" : {
                   "r" : "66",
                   "s" : [ {
-                     "value" : [ "define ","CastIntegerAsIntervalOfIntegers",": " ]
+                     "value" : [ "","define ","CastIntegerAsIntervalOfIntegers",": " ]
                   }, {
                      "r" : "65",
                      "s" : [ {
@@ -4179,7 +4431,7 @@ module.exports['AsIntervalType'] = {
                "s" : {
                   "r" : "77",
                   "s" : [ {
-                     "value" : [ "define ","CastListAsIntervalOfIntegers",": " ]
+                     "value" : [ "","define ","CastListAsIntervalOfIntegers",": " ]
                   }, {
                      "r" : "76",
                      "s" : [ {
@@ -4274,7 +4526,7 @@ module.exports['AsIntervalType'] = {
                "s" : {
                   "r" : "84",
                   "s" : [ {
-                     "value" : [ "define ","CastTupleAsIntervalOfIntegers",": " ]
+                     "value" : [ "","define ","CastTupleAsIntervalOfIntegers",": " ]
                   }, {
                      "r" : "83",
                      "s" : [ {
@@ -4375,6 +4627,14 @@ module.exports['AsTupleType'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "96",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -4392,7 +4652,27 @@ module.exports['AsTupleType'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -4417,7 +4697,7 @@ module.exports['AsTupleType'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define function ","Echo","(","Val"," " ]
+                     "value" : [ "","define function ","Echo","(","Val"," " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -4459,7 +4739,7 @@ module.exports['AsTupleType'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "define ","TupleOfAIntegerBStringAsTupleOfAIntegerBString",": " ]
+                     "value" : [ "// fool CQL-to-ELM into letting the casts compile","define ","TupleOfAIntegerBStringAsTupleOfAIntegerBString",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -4589,7 +4869,7 @@ module.exports['AsTupleType'] = {
                "s" : {
                   "r" : "26",
                   "s" : [ {
-                     "value" : [ "define ","TupleOfAStringBIntegerAsTupleOfAIntegerBString",": " ]
+                     "value" : [ "","define ","TupleOfAStringBIntegerAsTupleOfAIntegerBString",": " ]
                   }, {
                      "r" : "25",
                      "s" : [ {
@@ -4719,7 +4999,7 @@ module.exports['AsTupleType'] = {
                "s" : {
                   "r" : "33",
                   "s" : [ {
-                     "value" : [ "define ","IntegerAsTupleOfInteger",": " ]
+                     "value" : [ "","define ","IntegerAsTupleOfInteger",": " ]
                   }, {
                      "r" : "32",
                      "s" : [ {
@@ -4790,7 +5070,7 @@ module.exports['AsTupleType'] = {
                "s" : {
                   "r" : "41",
                   "s" : [ {
-                     "value" : [ "define ","ListAsTupleOfInteger",": " ]
+                     "value" : [ "","define ","ListAsTupleOfInteger",": " ]
                   }, {
                      "r" : "40",
                      "s" : [ {
@@ -4872,7 +5152,7 @@ module.exports['AsTupleType'] = {
                "s" : {
                   "r" : "50",
                   "s" : [ {
-                     "value" : [ "define ","IntervalAsTupleOfInteger",": " ]
+                     "value" : [ "","define ","IntervalAsTupleOfInteger",": " ]
                   }, {
                      "r" : "49",
                      "s" : [ {
@@ -4962,7 +5242,7 @@ module.exports['AsTupleType'] = {
                "s" : {
                   "r" : "61",
                   "s" : [ {
-                     "value" : [ "define ","CastTupleOfAIntegerBStringAsTupleOfAIntegerBString",": " ]
+                     "value" : [ "","define ","CastTupleOfAIntegerBStringAsTupleOfAIntegerBString",": " ]
                   }, {
                      "r" : "60",
                      "s" : [ {
@@ -5094,7 +5374,7 @@ module.exports['AsTupleType'] = {
                "s" : {
                   "r" : "72",
                   "s" : [ {
-                     "value" : [ "define ","CastTupleOfAStringBIntegerAsTupleOfAIntegerBString",": " ]
+                     "value" : [ "","define ","CastTupleOfAStringBIntegerAsTupleOfAIntegerBString",": " ]
                   }, {
                      "r" : "71",
                      "s" : [ {
@@ -5226,7 +5506,7 @@ module.exports['AsTupleType'] = {
                "s" : {
                   "r" : "79",
                   "s" : [ {
-                     "value" : [ "define ","CastIntegerAsTupleOfInteger",": " ]
+                     "value" : [ "","define ","CastIntegerAsTupleOfInteger",": " ]
                   }, {
                      "r" : "78",
                      "s" : [ {
@@ -5299,7 +5579,7 @@ module.exports['AsTupleType'] = {
                "s" : {
                   "r" : "87",
                   "s" : [ {
-                     "value" : [ "define ","CastListAsTupleOfInteger",": " ]
+                     "value" : [ "","define ","CastListAsTupleOfInteger",": " ]
                   }, {
                      "r" : "86",
                      "s" : [ {
@@ -5383,7 +5663,7 @@ module.exports['AsTupleType'] = {
                "s" : {
                   "r" : "96",
                   "s" : [ {
-                     "value" : [ "define ","CastIntervalAsTupleOfInteger",": " ]
+                     "value" : [ "","define ","CastIntervalAsTupleOfInteger",": " ]
                   }, {
                      "r" : "95",
                      "s" : [ {
@@ -5494,6 +5774,14 @@ module.exports['AsChoiceType'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "100",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -5511,7 +5799,27 @@ module.exports['AsChoiceType'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -5536,7 +5844,7 @@ module.exports['AsChoiceType'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define function ","Echo","(","Val"," " ]
+                     "value" : [ "","define function ","Echo","(","Val"," " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -5578,7 +5886,7 @@ module.exports['AsChoiceType'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "define ","IntegerAsChoiceOfIntegersAndStrings",": " ]
+                     "value" : [ "// fool CQL-to-ELM into letting the casts compile","define ","IntegerAsChoiceOfIntegersAndStrings",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -5651,7 +5959,7 @@ module.exports['AsChoiceType'] = {
                "s" : {
                   "r" : "18",
                   "s" : [ {
-                     "value" : [ "define ","StringAsChoiceOfIntegersAndStrings",": " ]
+                     "value" : [ "","define ","StringAsChoiceOfIntegersAndStrings",": " ]
                   }, {
                      "r" : "17",
                      "s" : [ {
@@ -5730,7 +6038,7 @@ module.exports['AsChoiceType'] = {
                "s" : {
                   "r" : "25",
                   "s" : [ {
-                     "value" : [ "define ","DecimalAsChoiceOfIntegersAndStrings",": " ]
+                     "value" : [ "","define ","DecimalAsChoiceOfIntegersAndStrings",": " ]
                   }, {
                      "r" : "24",
                      "s" : [ {
@@ -5803,7 +6111,7 @@ module.exports['AsChoiceType'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","ListAsChoiceOfIntegersAndStrings",": " ]
+                     "value" : [ "","define ","ListAsChoiceOfIntegersAndStrings",": " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -5899,7 +6207,7 @@ module.exports['AsChoiceType'] = {
                "s" : {
                   "r" : "43",
                   "s" : [ {
-                     "value" : [ "define ","IntervalAsChoiceOfIntegersAndStrings",": " ]
+                     "value" : [ "","define ","IntervalAsChoiceOfIntegersAndStrings",": " ]
                   }, {
                      "r" : "42",
                      "s" : [ {
@@ -5991,7 +6299,7 @@ module.exports['AsChoiceType'] = {
                "s" : {
                   "r" : "52",
                   "s" : [ {
-                     "value" : [ "define ","TupleAsChoiceOfIntegersAndStrings",": " ]
+                     "value" : [ "","define ","TupleAsChoiceOfIntegersAndStrings",": " ]
                   }, {
                      "r" : "51",
                      "s" : [ {
@@ -6103,7 +6411,7 @@ module.exports['AsChoiceType'] = {
                "s" : {
                   "r" : "59",
                   "s" : [ {
-                     "value" : [ "define ","CastIntegerAsChoiceOfIntegersAndStrings",": " ]
+                     "value" : [ "","define ","CastIntegerAsChoiceOfIntegersAndStrings",": " ]
                   }, {
                      "r" : "58",
                      "s" : [ {
@@ -6178,7 +6486,7 @@ module.exports['AsChoiceType'] = {
                "s" : {
                   "r" : "66",
                   "s" : [ {
-                     "value" : [ "define ","CastStringAsChoiceOfIntegersAndStrings",": " ]
+                     "value" : [ "","define ","CastStringAsChoiceOfIntegersAndStrings",": " ]
                   }, {
                      "r" : "65",
                      "s" : [ {
@@ -6259,7 +6567,7 @@ module.exports['AsChoiceType'] = {
                "s" : {
                   "r" : "73",
                   "s" : [ {
-                     "value" : [ "define ","CastDecimalAsChoiceOfIntegersAndStrings",": " ]
+                     "value" : [ "","define ","CastDecimalAsChoiceOfIntegersAndStrings",": " ]
                   }, {
                      "r" : "72",
                      "s" : [ {
@@ -6334,7 +6642,7 @@ module.exports['AsChoiceType'] = {
                "s" : {
                   "r" : "82",
                   "s" : [ {
-                     "value" : [ "define ","CastListAsChoiceOfIntegersAndStrings",": " ]
+                     "value" : [ "","define ","CastListAsChoiceOfIntegersAndStrings",": " ]
                   }, {
                      "r" : "81",
                      "s" : [ {
@@ -6432,7 +6740,7 @@ module.exports['AsChoiceType'] = {
                "s" : {
                   "r" : "91",
                   "s" : [ {
-                     "value" : [ "define ","CastIntervalAsChoiceOfIntegersAndStrings",": " ]
+                     "value" : [ "","define ","CastIntervalAsChoiceOfIntegersAndStrings",": " ]
                   }, {
                      "r" : "90",
                      "s" : [ {
@@ -6526,7 +6834,7 @@ module.exports['AsChoiceType'] = {
                "s" : {
                   "r" : "100",
                   "s" : [ {
-                     "value" : [ "define ","CastTupleAsChoiceOfIntegersAndStrings",": " ]
+                     "value" : [ "","define ","CastTupleAsChoiceOfIntegersAndStrings",": " ]
                   }, {
                      "r" : "99",
                      "s" : [ {
@@ -6665,6 +6973,14 @@ module.exports['AsCustomDataModelType'] = {
       "annotation" : [ {
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "112",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
       } ],
       "identifier" : {
          "id" : "TestSnippet",
@@ -6682,7 +6998,27 @@ module.exports['AsCustomDataModelType'] = {
             "localId" : "1",
             "localIdentifier" : "Simple",
             "uri" : "https://github.com/cqframework/cql-execution/simple",
-            "version" : "1.0.0"
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -6707,7 +7043,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "4",
                   "s" : [ {
-                     "value" : [ "define function ","Echo","(","Val"," " ]
+                     "value" : [ "","define function ","Echo","(","Val"," " ]
                   }, {
                      "r" : "2",
                      "s" : [ {
@@ -6749,7 +7085,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "define ","EncounterAsEncounter",": " ]
+                     "value" : [ "// fool CQL-to-ELM into letting the casts compile","define ","EncounterAsEncounter",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {
@@ -6816,7 +7152,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "16",
                   "s" : [ {
-                     "value" : [ "define ","EncounterAsRecord",": " ]
+                     "value" : [ "","define ","EncounterAsRecord",": " ]
                   }, {
                      "r" : "15",
                      "s" : [ {
@@ -6883,7 +7219,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "22",
                   "s" : [ {
-                     "value" : [ "define ","EncounterAsAny",": " ]
+                     "value" : [ "","define ","EncounterAsAny",": " ]
                   }, {
                      "r" : "21",
                      "s" : [ {
@@ -6950,7 +7286,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "28",
                   "s" : [ {
-                     "value" : [ "define ","EncounterAsCondition",": " ]
+                     "value" : [ "","define ","EncounterAsCondition",": " ]
                   }, {
                      "r" : "27",
                      "s" : [ {
@@ -7017,7 +7353,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "34",
                   "s" : [ {
-                     "value" : [ "define ","EncounterAsString",": " ]
+                     "value" : [ "","define ","EncounterAsString",": " ]
                   }, {
                      "r" : "33",
                      "s" : [ {
@@ -7084,7 +7420,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "39",
                   "s" : [ {
-                     "value" : [ "define ","ListAsEncounter",": " ]
+                     "value" : [ "","define ","ListAsEncounter",": " ]
                   }, {
                      "r" : "38",
                      "s" : [ {
@@ -7140,7 +7476,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "46",
                   "s" : [ {
-                     "value" : [ "define ","IntervalAsEncounter",": " ]
+                     "value" : [ "","define ","IntervalAsEncounter",": " ]
                   }, {
                      "r" : "45",
                      "s" : [ {
@@ -7210,7 +7546,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "52",
                   "s" : [ {
-                     "value" : [ "define ","TupleAsEncounter",": " ]
+                     "value" : [ "","define ","TupleAsEncounter",": " ]
                   }, {
                      "r" : "51",
                      "s" : [ {
@@ -7285,7 +7621,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "58",
                   "s" : [ {
-                     "value" : [ "define ","NamedTupleAsEncounter",": " ]
+                     "value" : [ "","define ","NamedTupleAsEncounter",": " ]
                   }, {
                      "r" : "57",
                      "s" : [ {
@@ -7361,7 +7697,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "64",
                   "s" : [ {
-                     "value" : [ "define ","CastEncounterAsEncounter",": " ]
+                     "value" : [ "","define ","CastEncounterAsEncounter",": " ]
                   }, {
                      "r" : "63",
                      "s" : [ {
@@ -7430,7 +7766,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "70",
                   "s" : [ {
-                     "value" : [ "define ","CastEncounterAsRecord",": " ]
+                     "value" : [ "","define ","CastEncounterAsRecord",": " ]
                   }, {
                      "r" : "69",
                      "s" : [ {
@@ -7499,7 +7835,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "76",
                   "s" : [ {
-                     "value" : [ "define ","CastEncounterAsAny",": " ]
+                     "value" : [ "","define ","CastEncounterAsAny",": " ]
                   }, {
                      "r" : "75",
                      "s" : [ {
@@ -7568,7 +7904,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "82",
                   "s" : [ {
-                     "value" : [ "define ","CastEncounterAsCondition",": " ]
+                     "value" : [ "","define ","CastEncounterAsCondition",": " ]
                   }, {
                      "r" : "81",
                      "s" : [ {
@@ -7637,7 +7973,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "88",
                   "s" : [ {
-                     "value" : [ "define ","CastEncounterAsString",": " ]
+                     "value" : [ "","define ","CastEncounterAsString",": " ]
                   }, {
                      "r" : "87",
                      "s" : [ {
@@ -7706,7 +8042,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "93",
                   "s" : [ {
-                     "value" : [ "define ","CastListAsEncounter",": " ]
+                     "value" : [ "","define ","CastListAsEncounter",": " ]
                   }, {
                      "r" : "92",
                      "s" : [ {
@@ -7764,7 +8100,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "100",
                   "s" : [ {
-                     "value" : [ "define ","CastIntervalAsEncounter",": " ]
+                     "value" : [ "","define ","CastIntervalAsEncounter",": " ]
                   }, {
                      "r" : "99",
                      "s" : [ {
@@ -7836,7 +8172,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "106",
                   "s" : [ {
-                     "value" : [ "define ","CastTupleAsEncounter",": " ]
+                     "value" : [ "","define ","CastTupleAsEncounter",": " ]
                   }, {
                      "r" : "105",
                      "s" : [ {
@@ -7913,7 +8249,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "112",
                   "s" : [ {
-                     "value" : [ "define ","CastNamedTupleAsEncounter",": " ]
+                     "value" : [ "","define ","CastNamedTupleAsEncounter",": " ]
                   }, {
                      "r" : "111",
                      "s" : [ {

--- a/test/generator/build.gradle
+++ b/test/generator/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'info.cqframework', name: 'cql-to-elm', version: '1.4.9'
+    implementation group: 'info.cqframework', name: 'cql-to-elm', version: '1.5.2'
     implementation group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.7'
 }
 

--- a/test/generator/build.gradle
+++ b/test/generator/build.gradle
@@ -29,5 +29,5 @@ task watchTestData (dependsOn: 'classes', type: JavaExec) {
 task generateSpecTestData(dependsOn: 'classes', type: JavaExec) {
   classpath = sourceSets.main.runtimeClasspath
   main = 'org.cqframework.cql.cql2elm.CqlTranslator'
-  args '--input', "${projectDir}/../spec-tests/cql", '--model', "${projectDir}/../../src/simple-modelinfo.xml", '--format', 'JSON'
+  args '--input', "${projectDir}/../spec-tests/cql", '--format', 'JSON'
 }

--- a/test/spec-tests/cql/CqlAggregateFunctionsTest.cql
+++ b/test/spec-tests/cql/CqlAggregateFunctionsTest.cql
@@ -1,5 +1,5 @@
 library CqlAggregateFunctionsTest version '1.4.0'
-using Simple
+using QUICK version '3.3.0'
 context Patient
 
 define "AllTrue": Tuple{

--- a/test/spec-tests/cql/CqlAggregateFunctionsTest.json
+++ b/test/spec-tests/cql/CqlAggregateFunctionsTest.json
@@ -17,8 +17,14 @@
             "localIdentifier" : "System",
             "uri" : "urn:hl7-org:elm-types:r1"
          }, {
-            "localIdentifier" : "Simple",
-            "uri" : "https://github.com/cqframework/cql-execution/simple"
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir/us/qicore",
+            "version" : "3.3.0"
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -28,7 +34,8 @@
             "expression" : {
                "type" : "SingletonFrom",
                "operand" : {
-                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "dataType" : "{http://hl7.org/fhir/us/qicore}Patient",
+                  "templateId" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
                   "type" : "Retrieve"
                }
             }

--- a/test/spec-tests/cql/CqlArithmeticFunctionsTest.cql
+++ b/test/spec-tests/cql/CqlArithmeticFunctionsTest.cql
@@ -1,5 +1,5 @@
 library CqlArithmeticFunctionsTest version '1.4.0'
-using Simple
+using QUICK version '3.3.0'
 context Patient
 
 define "Abs": Tuple{

--- a/test/spec-tests/cql/CqlArithmeticFunctionsTest.json
+++ b/test/spec-tests/cql/CqlArithmeticFunctionsTest.json
@@ -17,8 +17,14 @@
             "localIdentifier" : "System",
             "uri" : "urn:hl7-org:elm-types:r1"
          }, {
-            "localIdentifier" : "Simple",
-            "uri" : "https://github.com/cqframework/cql-execution/simple"
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir/us/qicore",
+            "version" : "3.3.0"
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -28,7 +34,8 @@
             "expression" : {
                "type" : "SingletonFrom",
                "operand" : {
-                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "dataType" : "{http://hl7.org/fhir/us/qicore}Patient",
+                  "templateId" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
                   "type" : "Retrieve"
                }
             }

--- a/test/spec-tests/cql/CqlComparisonOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlComparisonOperatorsTest.cql
@@ -1,5 +1,5 @@
 library CqlComparisonOperatorsTest version '1.4.0'
-using Simple
+using QUICK version '3.3.0'
 context Patient
 
 define "Between": Tuple{

--- a/test/spec-tests/cql/CqlComparisonOperatorsTest.json
+++ b/test/spec-tests/cql/CqlComparisonOperatorsTest.json
@@ -17,8 +17,14 @@
             "localIdentifier" : "System",
             "uri" : "urn:hl7-org:elm-types:r1"
          }, {
-            "localIdentifier" : "Simple",
-            "uri" : "https://github.com/cqframework/cql-execution/simple"
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir/us/qicore",
+            "version" : "3.3.0"
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -28,7 +34,8 @@
             "expression" : {
                "type" : "SingletonFrom",
                "operand" : {
-                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "dataType" : "{http://hl7.org/fhir/us/qicore}Patient",
+                  "templateId" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
                   "type" : "Retrieve"
                }
             }

--- a/test/spec-tests/cql/CqlConditionalOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlConditionalOperatorsTest.cql
@@ -1,5 +1,5 @@
 library CqlConditionalOperatorsTest version '1.4.0'
-using Simple
+using QUICK version '3.3.0'
 context Patient
 
 define "if-then-else": Tuple{

--- a/test/spec-tests/cql/CqlConditionalOperatorsTest.json
+++ b/test/spec-tests/cql/CqlConditionalOperatorsTest.json
@@ -17,8 +17,14 @@
             "localIdentifier" : "System",
             "uri" : "urn:hl7-org:elm-types:r1"
          }, {
-            "localIdentifier" : "Simple",
-            "uri" : "https://github.com/cqframework/cql-execution/simple"
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir/us/qicore",
+            "version" : "3.3.0"
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -28,7 +34,8 @@
             "expression" : {
                "type" : "SingletonFrom",
                "operand" : {
-                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "dataType" : "{http://hl7.org/fhir/us/qicore}Patient",
+                  "templateId" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
                   "type" : "Retrieve"
                }
             }
@@ -47,20 +54,16 @@
                         "value" : {
                            "type" : "If",
                            "condition" : {
-                              "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                              "type" : "As",
-                              "operand" : {
-                                 "type" : "Greater",
-                                 "operand" : [ {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "10",
-                                    "type" : "Literal"
-                                 }, {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "5",
-                                    "type" : "Literal"
-                                 } ]
-                              }
+                              "type" : "Greater",
+                              "operand" : [ {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "10",
+                                 "type" : "Literal"
+                              }, {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "5",
+                                 "type" : "Literal"
+                              } ]
                            },
                            "then" : {
                               "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -91,20 +94,16 @@
                         "value" : {
                            "type" : "If",
                            "condition" : {
-                              "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                              "type" : "As",
-                              "operand" : {
-                                 "type" : "Equal",
-                                 "operand" : [ {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "10",
-                                    "type" : "Literal"
-                                 }, {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "5",
-                                    "type" : "Literal"
-                                 } ]
-                              }
+                              "type" : "Equal",
+                              "operand" : [ {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "10",
+                                 "type" : "Literal"
+                              }, {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "5",
+                                 "type" : "Literal"
+                              } ]
                            },
                            "then" : {
                               "type" : "Add",
@@ -149,22 +148,18 @@
                         "value" : {
                            "type" : "If",
                            "condition" : {
-                              "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                              "type" : "As",
-                              "operand" : {
-                                 "type" : "Equal",
-                                 "operand" : [ {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "10",
-                                    "type" : "Literal"
-                                 }, {
-                                    "asType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "type" : "As",
-                                    "operand" : {
-                                       "type" : "Null"
-                                    }
-                                 } ]
-                              }
+                              "type" : "Equal",
+                              "operand" : [ {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "10",
+                                 "type" : "Literal"
+                              }, {
+                                 "asType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "type" : "As",
+                                 "operand" : {
+                                    "type" : "Null"
+                                 }
+                              } ]
                            },
                            "then" : {
                               "valueType" : "{urn:hl7-org:elm-types:r1}Integer",

--- a/test/spec-tests/cql/CqlDateTimeOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlDateTimeOperatorsTest.cql
@@ -1,5 +1,5 @@
 library CqlDateTimeOperatorsTest version '1.4.0'
-using Simple
+using QUICK version '3.3.0'
 context Patient
 
 define "Add": Tuple{

--- a/test/spec-tests/cql/CqlDateTimeOperatorsTest.json
+++ b/test/spec-tests/cql/CqlDateTimeOperatorsTest.json
@@ -17,8 +17,14 @@
             "localIdentifier" : "System",
             "uri" : "urn:hl7-org:elm-types:r1"
          }, {
-            "localIdentifier" : "Simple",
-            "uri" : "https://github.com/cqframework/cql-execution/simple"
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir/us/qicore",
+            "version" : "3.3.0"
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -28,7 +34,8 @@
             "expression" : {
                "type" : "SingletonFrom",
                "operand" : {
-                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "dataType" : "{http://hl7.org/fhir/us/qicore}Patient",
+                  "templateId" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
                   "type" : "Retrieve"
                }
             }

--- a/test/spec-tests/cql/CqlErrorsAndMessagingOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlErrorsAndMessagingOperatorsTest.cql
@@ -1,5 +1,5 @@
 library CqlErrorsAndMessagingOperatorsTest version '1.4.0'
-using Simple
+using QUICK version '3.3.0'
 context Patient
 
 define "Group1": Tuple{

--- a/test/spec-tests/cql/CqlErrorsAndMessagingOperatorsTest.json
+++ b/test/spec-tests/cql/CqlErrorsAndMessagingOperatorsTest.json
@@ -17,8 +17,14 @@
             "localIdentifier" : "System",
             "uri" : "urn:hl7-org:elm-types:r1"
          }, {
-            "localIdentifier" : "Simple",
-            "uri" : "https://github.com/cqframework/cql-execution/simple"
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir/us/qicore",
+            "version" : "3.3.0"
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -28,7 +34,8 @@
             "expression" : {
                "type" : "SingletonFrom",
                "operand" : {
-                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "dataType" : "{http://hl7.org/fhir/us/qicore}Patient",
+                  "templateId" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
                   "type" : "Retrieve"
                }
             }

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
@@ -1,5 +1,5 @@
 library CqlIntervalOperatorsTest version '1.4.0'
-using Simple
+using QUICK version '3.3.0'
 context Patient
 
 define "After": Tuple{

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.json
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.json
@@ -17,8 +17,14 @@
             "localIdentifier" : "System",
             "uri" : "urn:hl7-org:elm-types:r1"
          }, {
-            "localIdentifier" : "Simple",
-            "uri" : "https://github.com/cqframework/cql-execution/simple"
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir/us/qicore",
+            "version" : "3.3.0"
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -28,7 +34,8 @@
             "expression" : {
                "type" : "SingletonFrom",
                "operand" : {
-                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "dataType" : "{http://hl7.org/fhir/us/qicore}Patient",
+                  "templateId" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
                   "type" : "Retrieve"
                }
             }
@@ -154,18 +161,39 @@
                         "value" : {
                            "type" : "After",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "12",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "12",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "12",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "12",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "12",
+                                    "type" : "Literal"
+                                 }
                               }
                            }, {
                               "lowClosed" : true,
@@ -201,18 +229,39 @@
                         "value" : {
                            "type" : "After",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "9",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "9",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "9",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "9",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "9",
+                                    "type" : "Literal"
+                                 }
                               }
                            }, {
                               "lowClosed" : true,
@@ -262,18 +311,39 @@
                                  "type" : "Literal"
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "5",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "5",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "5",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "5",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "5",
+                                    "type" : "Literal"
+                                 }
                               }
                            } ]
                         }
@@ -309,18 +379,39 @@
                                  "type" : "Literal"
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "12",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "12",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "12",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "12",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "12",
+                                    "type" : "Literal"
+                                 }
                               }
                            } ]
                         }
@@ -436,18 +527,39 @@
                         "value" : {
                            "type" : "After",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "12.0",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "12.0",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "12.0",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "12.0",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "12.0",
+                                    "type" : "Literal"
+                                 }
                               }
                            }, {
                               "lowClosed" : true,
@@ -483,18 +595,39 @@
                         "value" : {
                            "type" : "After",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "9.0",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "9.0",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "9.0",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "9.0",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "9.0",
+                                    "type" : "Literal"
+                                 }
                               }
                            }, {
                               "lowClosed" : true,
@@ -544,18 +677,39 @@
                                  "type" : "Literal"
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "5.0",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "5.0",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "5.0",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "5.0",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "5.0",
+                                    "type" : "Literal"
+                                 }
                               }
                            } ]
                         }
@@ -591,18 +745,39 @@
                                  "type" : "Literal"
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "12.0",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "12.0",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "12.0",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "12.0",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "12.0",
+                                    "type" : "Literal"
+                                 }
                               }
                            } ]
                         }
@@ -718,18 +893,39 @@
                         "value" : {
                            "type" : "After",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "value" : 12.0,
-                                 "unit" : "g",
-                                 "type" : "Quantity"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "value" : 12.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 }
                               },
-                              "high" : {
-                                 "value" : 12.0,
-                                 "unit" : "g",
-                                 "type" : "Quantity"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "value" : 12.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 },
+                                 "high" : {
+                                    "value" : 12.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 }
                               }
                            }, {
                               "lowClosed" : true,
@@ -765,18 +961,39 @@
                         "value" : {
                            "type" : "After",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "value" : 9.0,
-                                 "unit" : "g",
-                                 "type" : "Quantity"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "value" : 9.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 }
                               },
-                              "high" : {
-                                 "value" : 9.0,
-                                 "unit" : "g",
-                                 "type" : "Quantity"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "value" : 9.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 },
+                                 "high" : {
+                                    "value" : 9.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 }
                               }
                            }, {
                               "lowClosed" : true,
@@ -826,18 +1043,39 @@
                                  "type" : "Quantity"
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "value" : 5.0,
-                                 "unit" : "g",
-                                 "type" : "Quantity"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "value" : 5.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 }
                               },
-                              "high" : {
-                                 "value" : 5.0,
-                                 "unit" : "g",
-                                 "type" : "Quantity"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "value" : 5.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 },
+                                 "high" : {
+                                    "value" : 5.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 }
                               }
                            } ]
                         }
@@ -873,18 +1111,39 @@
                                  "type" : "Quantity"
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "value" : 12.0,
-                                 "unit" : "g",
-                                 "type" : "Quantity"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "value" : 12.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 }
                               },
-                              "high" : {
-                                 "value" : 12.0,
-                                 "unit" : "g",
-                                 "type" : "Quantity"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "value" : 12.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 },
+                                 "high" : {
+                                    "value" : 12.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 }
                               }
                            } ]
                         }
@@ -946,43 +1205,77 @@
                                  }
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "type" : "DateTime",
-                                 "year" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2011",
-                                    "type" : "Literal"
-                                 },
-                                 "month" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "12",
-                                    "type" : "Literal"
-                                 },
-                                 "day" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "31",
-                                    "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "type" : "DateTime",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2011",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "12",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "31",
+                                       "type" : "Literal"
+                                    }
                                  }
                               },
-                              "high" : {
-                                 "type" : "DateTime",
-                                 "year" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2011",
-                                    "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "DateTime",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2011",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "12",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "31",
+                                       "type" : "Literal"
+                                    }
                                  },
-                                 "month" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "12",
-                                    "type" : "Literal"
-                                 },
-                                 "day" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "31",
-                                    "type" : "Literal"
+                                 "high" : {
+                                    "type" : "DateTime",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2011",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "12",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "31",
+                                       "type" : "Literal"
+                                    }
                                  }
                               }
                            } ]
@@ -1045,43 +1338,77 @@
                                  }
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "type" : "DateTime",
-                                 "year" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2012",
-                                    "type" : "Literal"
-                                 },
-                                 "month" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "12",
-                                    "type" : "Literal"
-                                 },
-                                 "day" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "31",
-                                    "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "type" : "DateTime",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "12",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "31",
+                                       "type" : "Literal"
+                                    }
                                  }
                               },
-                              "high" : {
-                                 "type" : "DateTime",
-                                 "year" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2012",
-                                    "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "DateTime",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "12",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "31",
+                                       "type" : "Literal"
+                                    }
                                  },
-                                 "month" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "12",
-                                    "type" : "Literal"
-                                 },
-                                 "day" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "31",
-                                    "type" : "Literal"
+                                 "high" : {
+                                    "type" : "DateTime",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "12",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "31",
+                                       "type" : "Literal"
+                                    }
                                  }
                               }
                            } ]
@@ -1154,53 +1481,92 @@
                                  }
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "type" : "Time",
-                                 "hour" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "12",
-                                    "type" : "Literal"
-                                 },
-                                 "minute" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "59",
-                                    "type" : "Literal"
-                                 },
-                                 "second" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "59",
-                                    "type" : "Literal"
-                                 },
-                                 "millisecond" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "999",
-                                    "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "type" : "Time",
+                                    "hour" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "12",
+                                       "type" : "Literal"
+                                    },
+                                    "minute" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "second" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "millisecond" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "999",
+                                       "type" : "Literal"
+                                    }
                                  }
                               },
-                              "high" : {
-                                 "type" : "Time",
-                                 "hour" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "12",
-                                    "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Time",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "Time",
+                                    "hour" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "12",
+                                       "type" : "Literal"
+                                    },
+                                    "minute" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "second" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "millisecond" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "999",
+                                       "type" : "Literal"
+                                    }
                                  },
-                                 "minute" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "59",
-                                    "type" : "Literal"
-                                 },
-                                 "second" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "59",
-                                    "type" : "Literal"
-                                 },
-                                 "millisecond" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "999",
-                                    "type" : "Literal"
+                                 "high" : {
+                                    "type" : "Time",
+                                    "hour" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "12",
+                                       "type" : "Literal"
+                                    },
+                                    "minute" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "second" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "millisecond" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "999",
+                                       "type" : "Literal"
+                                    }
                                  }
                               }
                            } ]
@@ -1273,53 +1639,92 @@
                                  }
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "type" : "Time",
-                                 "hour" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "17",
-                                    "type" : "Literal"
-                                 },
-                                 "minute" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "59",
-                                    "type" : "Literal"
-                                 },
-                                 "second" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "59",
-                                    "type" : "Literal"
-                                 },
-                                 "millisecond" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "999",
-                                    "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "type" : "Time",
+                                    "hour" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "17",
+                                       "type" : "Literal"
+                                    },
+                                    "minute" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "second" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "millisecond" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "999",
+                                       "type" : "Literal"
+                                    }
                                  }
                               },
-                              "high" : {
-                                 "type" : "Time",
-                                 "hour" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "17",
-                                    "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Time",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "Time",
+                                    "hour" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "17",
+                                       "type" : "Literal"
+                                    },
+                                    "minute" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "second" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "millisecond" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "999",
+                                       "type" : "Literal"
+                                    }
                                  },
-                                 "minute" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "59",
-                                    "type" : "Literal"
-                                 },
-                                 "second" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "59",
-                                    "type" : "Literal"
-                                 },
-                                 "millisecond" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "999",
-                                    "type" : "Literal"
+                                 "high" : {
+                                    "type" : "Time",
+                                    "hour" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "17",
+                                       "type" : "Literal"
+                                    },
+                                    "minute" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "second" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "millisecond" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "999",
+                                       "type" : "Literal"
+                                    }
                                  }
                               }
                            } ]
@@ -1457,18 +1862,39 @@
                         "value" : {
                            "type" : "Before",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "9",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "9",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "9",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "9",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "9",
+                                    "type" : "Literal"
+                                 }
                               }
                            }, {
                               "lowClosed" : true,
@@ -1504,18 +1930,39 @@
                         "value" : {
                            "type" : "Before",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "9",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "9",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "9",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "9",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "9",
+                                    "type" : "Literal"
+                                 }
                               }
                            }, {
                               "lowClosed" : true,
@@ -1565,18 +2012,39 @@
                                  "type" : "Literal"
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "11",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "11",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "11",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "11",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "11",
+                                    "type" : "Literal"
+                                 }
                               }
                            } ]
                         }
@@ -1612,18 +2080,39 @@
                                  "type" : "Literal"
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "8",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "8",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "8",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "8",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "8",
+                                    "type" : "Literal"
+                                 }
                               }
                            } ]
                         }
@@ -1739,18 +2228,39 @@
                         "value" : {
                            "type" : "Before",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "9.0",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "9.0",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "9.0",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "9.0",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "9.0",
+                                    "type" : "Literal"
+                                 }
                               }
                            }, {
                               "lowClosed" : true,
@@ -1786,18 +2296,39 @@
                         "value" : {
                            "type" : "Before",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "9.0",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "9.0",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "9.0",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "9.0",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "9.0",
+                                    "type" : "Literal"
+                                 }
                               }
                            }, {
                               "lowClosed" : true,
@@ -1847,18 +2378,39 @@
                                  "type" : "Literal"
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "11.0",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "11.0",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "11.0",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "11.0",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "11.0",
+                                    "type" : "Literal"
+                                 }
                               }
                            } ]
                         }
@@ -1894,18 +2446,39 @@
                                  "type" : "Literal"
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "8.0",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "8.0",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "8.0",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "8.0",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "8.0",
+                                    "type" : "Literal"
+                                 }
                               }
                            } ]
                         }
@@ -2035,18 +2608,39 @@
                                  "type" : "Quantity"
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "value" : 12.0,
-                                 "unit" : "g",
-                                 "type" : "Quantity"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "value" : 12.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 }
                               },
-                              "high" : {
-                                 "value" : 12.0,
-                                 "unit" : "g",
-                                 "type" : "Quantity"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "value" : 12.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 },
+                                 "high" : {
+                                    "value" : 12.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 }
                               }
                            } ]
                         }
@@ -2082,18 +2676,39 @@
                                  "type" : "Quantity"
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "value" : 9.0,
-                                 "unit" : "g",
-                                 "type" : "Quantity"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "value" : 9.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 }
                               },
-                              "high" : {
-                                 "value" : 9.0,
-                                 "unit" : "g",
-                                 "type" : "Quantity"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "value" : 9.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 },
+                                 "high" : {
+                                    "value" : 9.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 }
                               }
                            } ]
                         }
@@ -2115,18 +2730,39 @@
                         "value" : {
                            "type" : "Before",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "value" : 5.0,
-                                 "unit" : "g",
-                                 "type" : "Quantity"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "value" : 5.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 }
                               },
-                              "high" : {
-                                 "value" : 5.0,
-                                 "unit" : "g",
-                                 "type" : "Quantity"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "value" : 5.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 },
+                                 "high" : {
+                                    "value" : 5.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 }
                               }
                            }, {
                               "lowClosed" : true,
@@ -2162,18 +2798,39 @@
                         "value" : {
                            "type" : "Before",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "value" : 12.0,
-                                 "unit" : "g",
-                                 "type" : "Quantity"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "value" : 12.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 }
                               },
-                              "high" : {
-                                 "value" : 12.0,
-                                 "unit" : "g",
-                                 "type" : "Quantity"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "value" : 12.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 },
+                                 "high" : {
+                                    "value" : 12.0,
+                                    "unit" : "g",
+                                    "type" : "Quantity"
+                                 }
                               }
                            }, {
                               "lowClosed" : true,
@@ -2249,43 +2906,77 @@
                                  }
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "type" : "DateTime",
-                                 "year" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2012",
-                                    "type" : "Literal"
-                                 },
-                                 "month" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2",
-                                    "type" : "Literal"
-                                 },
-                                 "day" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "27",
-                                    "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "type" : "DateTime",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "27",
+                                       "type" : "Literal"
+                                    }
                                  }
                               },
-                              "high" : {
-                                 "type" : "DateTime",
-                                 "year" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2012",
-                                    "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "DateTime",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "27",
+                                       "type" : "Literal"
+                                    }
                                  },
-                                 "month" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2",
-                                    "type" : "Literal"
-                                 },
-                                 "day" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "27",
-                                    "type" : "Literal"
+                                 "high" : {
+                                    "type" : "DateTime",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "27",
+                                       "type" : "Literal"
+                                    }
                                  }
                               }
                            } ]
@@ -2348,43 +3039,77 @@
                                  }
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "type" : "DateTime",
-                                 "year" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2011",
-                                    "type" : "Literal"
-                                 },
-                                 "month" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "12",
-                                    "type" : "Literal"
-                                 },
-                                 "day" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "31",
-                                    "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "type" : "DateTime",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2011",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "12",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "31",
+                                       "type" : "Literal"
+                                    }
                                  }
                               },
-                              "high" : {
-                                 "type" : "DateTime",
-                                 "year" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2011",
-                                    "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "DateTime",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2011",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "12",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "31",
+                                       "type" : "Literal"
+                                    }
                                  },
-                                 "month" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "12",
-                                    "type" : "Literal"
-                                 },
-                                 "day" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "31",
-                                    "type" : "Literal"
+                                 "high" : {
+                                    "type" : "DateTime",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2011",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "12",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "31",
+                                       "type" : "Literal"
+                                    }
                                  }
                               }
                            } ]
@@ -2457,53 +3182,92 @@
                                  }
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "type" : "Time",
-                                 "hour" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "22",
-                                    "type" : "Literal"
-                                 },
-                                 "minute" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "59",
-                                    "type" : "Literal"
-                                 },
-                                 "second" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "59",
-                                    "type" : "Literal"
-                                 },
-                                 "millisecond" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "999",
-                                    "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "type" : "Time",
+                                    "hour" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "22",
+                                       "type" : "Literal"
+                                    },
+                                    "minute" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "second" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "millisecond" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "999",
+                                       "type" : "Literal"
+                                    }
                                  }
                               },
-                              "high" : {
-                                 "type" : "Time",
-                                 "hour" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "22",
-                                    "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Time",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "Time",
+                                    "hour" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "22",
+                                       "type" : "Literal"
+                                    },
+                                    "minute" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "second" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "millisecond" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "999",
+                                       "type" : "Literal"
+                                    }
                                  },
-                                 "minute" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "59",
-                                    "type" : "Literal"
-                                 },
-                                 "second" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "59",
-                                    "type" : "Literal"
-                                 },
-                                 "millisecond" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "999",
-                                    "type" : "Literal"
+                                 "high" : {
+                                    "type" : "Time",
+                                    "hour" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "22",
+                                       "type" : "Literal"
+                                    },
+                                    "minute" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "second" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "millisecond" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "999",
+                                       "type" : "Literal"
+                                    }
                                  }
                               }
                            } ]
@@ -2576,53 +3340,92 @@
                                  }
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "type" : "Time",
-                                 "hour" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "10",
-                                    "type" : "Literal"
-                                 },
-                                 "minute" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "59",
-                                    "type" : "Literal"
-                                 },
-                                 "second" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "59",
-                                    "type" : "Literal"
-                                 },
-                                 "millisecond" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "999",
-                                    "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "type" : "Time",
+                                    "hour" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "10",
+                                       "type" : "Literal"
+                                    },
+                                    "minute" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "second" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "millisecond" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "999",
+                                       "type" : "Literal"
+                                    }
                                  }
                               },
-                              "high" : {
-                                 "type" : "Time",
-                                 "hour" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "10",
-                                    "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Time",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "Time",
+                                    "hour" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "10",
+                                       "type" : "Literal"
+                                    },
+                                    "minute" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "second" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "millisecond" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "999",
+                                       "type" : "Literal"
+                                    }
                                  },
-                                 "minute" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "59",
-                                    "type" : "Literal"
-                                 },
-                                 "second" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "59",
-                                    "type" : "Literal"
-                                 },
-                                 "millisecond" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "999",
-                                    "type" : "Literal"
+                                 "high" : {
+                                    "type" : "Time",
+                                    "hour" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "10",
+                                       "type" : "Literal"
+                                    },
+                                    "minute" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "second" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "59",
+                                       "type" : "Literal"
+                                    },
+                                    "millisecond" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "999",
+                                       "type" : "Literal"
+                                    }
                                  }
                               }
                            } ]
@@ -4685,21 +5488,18 @@
                         "value" : {
                            "type" : "Expand",
                            "operand" : [ {
-                              "type" : "ToList",
-                              "operand" : {
-                                 "lowClosed" : true,
-                                 "highClosed" : true,
-                                 "type" : "Interval",
-                                 "low" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "1",
-                                    "type" : "Literal"
-                                 },
-                                 "high" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "10",
-                                    "type" : "Literal"
-                                 }
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "1",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "10",
+                                 "type" : "Literal"
                               }
                            }, {
                               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Quantity",
@@ -4863,21 +5663,18 @@
                         "value" : {
                            "type" : "Expand",
                            "operand" : [ {
-                              "type" : "ToList",
-                              "operand" : {
-                                 "lowClosed" : true,
-                                 "highClosed" : true,
-                                 "type" : "Interval",
-                                 "low" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "1",
-                                    "type" : "Literal"
-                                 },
-                                 "high" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "10",
-                                    "type" : "Literal"
-                                 }
+                              "lowClosed" : true,
+                              "highClosed" : true,
+                              "type" : "Interval",
+                              "low" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "1",
+                                 "type" : "Literal"
+                              },
+                              "high" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "10",
+                                 "type" : "Literal"
                               }
                            }, {
                               "type" : "ToQuantity",
@@ -16822,43 +17619,77 @@
                                  }
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "type" : "Date",
-                                 "year" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2012",
-                                    "type" : "Literal"
-                                 },
-                                 "month" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "11",
-                                    "type" : "Literal"
-                                 },
-                                 "day" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "15",
-                                    "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "type" : "Date",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "11",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "15",
+                                       "type" : "Literal"
+                                    }
                                  }
                               },
-                              "high" : {
-                                 "type" : "Date",
-                                 "year" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2012",
-                                    "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Date",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "Date",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "11",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "15",
+                                       "type" : "Literal"
+                                    }
                                  },
-                                 "month" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "11",
-                                    "type" : "Literal"
-                                 },
-                                 "day" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "15",
-                                    "type" : "Literal"
+                                 "high" : {
+                                    "type" : "Date",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "11",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "15",
+                                       "type" : "Literal"
+                                    }
                                  }
                               }
                            } ]
@@ -16882,43 +17713,77 @@
                            "precision" : "Month",
                            "type" : "SameOrAfter",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "type" : "Date",
-                                 "year" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2012",
-                                    "type" : "Literal"
-                                 },
-                                 "month" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "11",
-                                    "type" : "Literal"
-                                 },
-                                 "day" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "15",
-                                    "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "type" : "Date",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "11",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "15",
+                                       "type" : "Literal"
+                                    }
                                  }
                               },
-                              "high" : {
-                                 "type" : "Date",
-                                 "year" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2012",
-                                    "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Date",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "Date",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "11",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "15",
+                                       "type" : "Literal"
+                                    }
                                  },
-                                 "month" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "11",
-                                    "type" : "Literal"
-                                 },
-                                 "day" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "15",
-                                    "type" : "Literal"
+                                 "high" : {
+                                    "type" : "Date",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "11",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "15",
+                                       "type" : "Literal"
+                                    }
                                  }
                               }
                            }, {
@@ -17235,18 +18100,39 @@
                                  "type" : "Literal"
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "6",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "6",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "6",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "6",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "6",
+                                    "type" : "Literal"
+                                 }
                               }
                            } ]
                         }
@@ -17268,18 +18154,39 @@
                         "value" : {
                            "type" : "SameOrAfter",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "2.5",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "2.5",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "2.5",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "2.5",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "2.5",
+                                    "type" : "Literal"
+                                 }
                               }
                            }, {
                               "lowClosed" : true,
@@ -17315,18 +18222,39 @@
                         "value" : {
                            "type" : "SameOrAfter",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "value" : 2.5,
-                                 "unit" : "mg",
-                                 "type" : "Quantity"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "value" : 2.5,
+                                    "unit" : "mg",
+                                    "type" : "Quantity"
+                                 }
                               },
-                              "high" : {
-                                 "value" : 2.5,
-                                 "unit" : "mg",
-                                 "type" : "Quantity"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "value" : 2.5,
+                                    "unit" : "mg",
+                                    "type" : "Quantity"
+                                 },
+                                 "high" : {
+                                    "value" : 2.5,
+                                    "unit" : "mg",
+                                    "type" : "Quantity"
+                                 }
                               }
                            }, {
                               "lowClosed" : true,
@@ -17481,43 +18409,77 @@
                                  }
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "type" : "Date",
-                                 "year" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2012",
-                                    "type" : "Literal"
-                                 },
-                                 "month" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "11",
-                                    "type" : "Literal"
-                                 },
-                                 "day" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "15",
-                                    "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "type" : "Date",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "11",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "15",
+                                       "type" : "Literal"
+                                    }
                                  }
                               },
-                              "high" : {
-                                 "type" : "Date",
-                                 "year" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2012",
-                                    "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Date",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "Date",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "11",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "15",
+                                       "type" : "Literal"
+                                    }
                                  },
-                                 "month" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "11",
-                                    "type" : "Literal"
-                                 },
-                                 "day" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "15",
-                                    "type" : "Literal"
+                                 "high" : {
+                                    "type" : "Date",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "11",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "15",
+                                       "type" : "Literal"
+                                    }
                                  }
                               }
                            } ]
@@ -17541,43 +18503,77 @@
                            "precision" : "Month",
                            "type" : "SameOrBefore",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "type" : "Date",
-                                 "year" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2012",
-                                    "type" : "Literal"
-                                 },
-                                 "month" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "11",
-                                    "type" : "Literal"
-                                 },
-                                 "day" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "15",
-                                    "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "type" : "Date",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "11",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "15",
+                                       "type" : "Literal"
+                                    }
                                  }
                               },
-                              "high" : {
-                                 "type" : "Date",
-                                 "year" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "2012",
-                                    "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Date",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "type" : "Date",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "11",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "15",
+                                       "type" : "Literal"
+                                    }
                                  },
-                                 "month" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "11",
-                                    "type" : "Literal"
-                                 },
-                                 "day" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "15",
-                                    "type" : "Literal"
+                                 "high" : {
+                                    "type" : "Date",
+                                    "year" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "2012",
+                                       "type" : "Literal"
+                                    },
+                                    "month" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "11",
+                                       "type" : "Literal"
+                                    },
+                                    "day" : {
+                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "value" : "15",
+                                       "type" : "Literal"
+                                    }
                                  }
                               }
                            }, {
@@ -17894,18 +18890,39 @@
                                  "type" : "Literal"
                               }
                            }, {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "6",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "6",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "6",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "6",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "6",
+                                    "type" : "Literal"
+                                 }
                               }
                            } ]
                         }
@@ -17927,18 +18944,39 @@
                         "value" : {
                            "type" : "SameOrBefore",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "1.6667",
-                                 "type" : "Literal"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "1.6667",
+                                    "type" : "Literal"
+                                 }
                               },
-                              "high" : {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                                 "value" : "1.6667",
-                                 "type" : "Literal"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "1.6667",
+                                    "type" : "Literal"
+                                 },
+                                 "high" : {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                    "value" : "1.6667",
+                                    "type" : "Literal"
+                                 }
                               }
                            }, {
                               "lowClosed" : true,
@@ -17974,18 +19012,39 @@
                         "value" : {
                            "type" : "SameOrBefore",
                            "operand" : [ {
-                              "lowClosed" : true,
-                              "highClosed" : true,
-                              "type" : "Interval",
-                              "low" : {
-                                 "value" : 1.666,
-                                 "unit" : "mg",
-                                 "type" : "Quantity"
+                              "type" : "If",
+                              "condition" : {
+                                 "type" : "IsNull",
+                                 "operand" : {
+                                    "value" : 1.666,
+                                    "unit" : "mg",
+                                    "type" : "Quantity"
+                                 }
                               },
-                              "high" : {
-                                 "value" : 1.666,
-                                 "unit" : "mg",
-                                 "type" : "Quantity"
+                              "then" : {
+                                 "type" : "Null",
+                                 "resultTypeSpecifier" : {
+                                    "type" : "IntervalTypeSpecifier",
+                                    "pointType" : {
+                                       "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                                       "type" : "NamedTypeSpecifier"
+                                    }
+                                 }
+                              },
+                              "else" : {
+                                 "lowClosed" : true,
+                                 "highClosed" : true,
+                                 "type" : "Interval",
+                                 "low" : {
+                                    "value" : 1.666,
+                                    "unit" : "mg",
+                                    "type" : "Quantity"
+                                 },
+                                 "high" : {
+                                    "value" : 1.666,
+                                    "unit" : "mg",
+                                    "type" : "Quantity"
+                                 }
                               }
                            }, {
                               "lowClosed" : true,

--- a/test/spec-tests/cql/CqlListOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlListOperatorsTest.cql
@@ -1,5 +1,5 @@
 library CqlListOperatorsTest version '1.4.0'
-using Simple
+using QUICK version '3.3.0'
 context Patient
 
 define "Sort": Tuple{

--- a/test/spec-tests/cql/CqlListOperatorsTest.json
+++ b/test/spec-tests/cql/CqlListOperatorsTest.json
@@ -171,8 +171,14 @@
             "localIdentifier" : "System",
             "uri" : "urn:hl7-org:elm-types:r1"
          }, {
-            "localIdentifier" : "Simple",
-            "uri" : "https://github.com/cqframework/cql-execution/simple"
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir/us/qicore",
+            "version" : "3.3.0"
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -182,7 +188,8 @@
             "expression" : {
                "type" : "SingletonFrom",
                "operand" : {
-                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "dataType" : "{http://hl7.org/fhir/us/qicore}Patient",
+                  "templateId" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
                   "type" : "Retrieve"
                }
             }

--- a/test/spec-tests/cql/CqlLogicalOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlLogicalOperatorsTest.cql
@@ -1,5 +1,5 @@
 library CqlLogicalOperatorsTest version '1.4.0'
-using Simple
+using QUICK version '3.3.0'
 context Patient
 
 define "And": Tuple{

--- a/test/spec-tests/cql/CqlLogicalOperatorsTest.json
+++ b/test/spec-tests/cql/CqlLogicalOperatorsTest.json
@@ -17,8 +17,14 @@
             "localIdentifier" : "System",
             "uri" : "urn:hl7-org:elm-types:r1"
          }, {
-            "localIdentifier" : "Simple",
-            "uri" : "https://github.com/cqframework/cql-execution/simple"
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir/us/qicore",
+            "version" : "3.3.0"
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -28,7 +34,8 @@
             "expression" : {
                "type" : "SingletonFrom",
                "operand" : {
-                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "dataType" : "{http://hl7.org/fhir/us/qicore}Patient",
+                  "templateId" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
                   "type" : "Retrieve"
                }
             }

--- a/test/spec-tests/cql/CqlNullologicalOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlNullologicalOperatorsTest.cql
@@ -1,5 +1,5 @@
 library CqlNullologicalOperatorsTest version '1.4.0'
-using Simple
+using QUICK version '3.3.0'
 context Patient
 
 define "Coalesce": Tuple{

--- a/test/spec-tests/cql/CqlNullologicalOperatorsTest.json
+++ b/test/spec-tests/cql/CqlNullologicalOperatorsTest.json
@@ -17,8 +17,14 @@
             "localIdentifier" : "System",
             "uri" : "urn:hl7-org:elm-types:r1"
          }, {
-            "localIdentifier" : "Simple",
-            "uri" : "https://github.com/cqframework/cql-execution/simple"
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir/us/qicore",
+            "version" : "3.3.0"
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -28,7 +34,8 @@
             "expression" : {
                "type" : "SingletonFrom",
                "operand" : {
-                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "dataType" : "{http://hl7.org/fhir/us/qicore}Patient",
+                  "templateId" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
                   "type" : "Retrieve"
                }
             }

--- a/test/spec-tests/cql/CqlStringOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlStringOperatorsTest.cql
@@ -1,5 +1,5 @@
 library CqlStringOperatorsTest version '1.4.0'
-using Simple
+using QUICK version '3.3.0'
 context Patient
 
 define "Combine": Tuple{

--- a/test/spec-tests/cql/CqlStringOperatorsTest.json
+++ b/test/spec-tests/cql/CqlStringOperatorsTest.json
@@ -17,8 +17,14 @@
             "localIdentifier" : "System",
             "uri" : "urn:hl7-org:elm-types:r1"
          }, {
-            "localIdentifier" : "Simple",
-            "uri" : "https://github.com/cqframework/cql-execution/simple"
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir/us/qicore",
+            "version" : "3.3.0"
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -28,7 +34,8 @@
             "expression" : {
                "type" : "SingletonFrom",
                "operand" : {
-                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "dataType" : "{http://hl7.org/fhir/us/qicore}Patient",
+                  "templateId" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
                   "type" : "Retrieve"
                }
             }

--- a/test/spec-tests/cql/CqlTypeOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlTypeOperatorsTest.cql
@@ -1,5 +1,5 @@
 library CqlTypeOperatorsTest version '1.4.0'
-using Simple
+using QUICK version '3.3.0'
 context Patient
 
 define "As": Tuple{

--- a/test/spec-tests/cql/CqlTypeOperatorsTest.json
+++ b/test/spec-tests/cql/CqlTypeOperatorsTest.json
@@ -17,8 +17,14 @@
             "localIdentifier" : "System",
             "uri" : "urn:hl7-org:elm-types:r1"
          }, {
-            "localIdentifier" : "Simple",
-            "uri" : "https://github.com/cqframework/cql-execution/simple"
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir/us/qicore",
+            "version" : "3.3.0"
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -28,7 +34,8 @@
             "expression" : {
                "type" : "SingletonFrom",
                "operand" : {
-                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "dataType" : "{http://hl7.org/fhir/us/qicore}Patient",
+                  "templateId" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
                   "type" : "Retrieve"
                }
             }

--- a/test/spec-tests/cql/CqlTypesTest.cql
+++ b/test/spec-tests/cql/CqlTypesTest.cql
@@ -1,5 +1,5 @@
 library CqlTypesTest version '1.4.0'
-using Simple
+using QUICK version '3.3.0'
 context Patient
 
 define "Any": Tuple{

--- a/test/spec-tests/cql/CqlTypesTest.json
+++ b/test/spec-tests/cql/CqlTypesTest.json
@@ -17,8 +17,14 @@
             "localIdentifier" : "System",
             "uri" : "urn:hl7-org:elm-types:r1"
          }, {
-            "localIdentifier" : "Simple",
-            "uri" : "https://github.com/cqframework/cql-execution/simple"
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir/us/qicore",
+            "version" : "3.3.0"
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -28,7 +34,8 @@
             "expression" : {
                "type" : "SingletonFrom",
                "operand" : {
-                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "dataType" : "{http://hl7.org/fhir/us/qicore}Patient",
+                  "templateId" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
                   "type" : "Retrieve"
                }
             }

--- a/test/spec-tests/cql/ValueLiteralsAndSelectors.cql
+++ b/test/spec-tests/cql/ValueLiteralsAndSelectors.cql
@@ -1,5 +1,5 @@
 library ValueLiteralsAndSelectors version '1.4.0'
-using Simple
+using QUICK version '3.3.0'
 context Patient
 
 define "Null": Tuple{

--- a/test/spec-tests/cql/ValueLiteralsAndSelectors.json
+++ b/test/spec-tests/cql/ValueLiteralsAndSelectors.json
@@ -17,8 +17,14 @@
             "localIdentifier" : "System",
             "uri" : "urn:hl7-org:elm-types:r1"
          }, {
-            "localIdentifier" : "Simple",
-            "uri" : "https://github.com/cqframework/cql-execution/simple"
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir/us/qicore",
+            "version" : "3.3.0"
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
          } ]
       },
       "statements" : {
@@ -28,7 +34,8 @@
             "expression" : {
                "type" : "SingletonFrom",
                "operand" : {
-                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "dataType" : "{http://hl7.org/fhir/us/qicore}Patient",
+                  "templateId" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
                   "type" : "Retrieve"
                }
             }

--- a/test/spec-tests/generate-cql.js
+++ b/test/spec-tests/generate-cql.js
@@ -61,7 +61,7 @@ fs.readdirSync(path.join(__dirname, 'xml')).forEach(file => {
 
   // Construct the CQL
   const suiteName = xmlJS.tests._attributes.name;
-  let cql = `library ${suiteName} version '1.4.0'\nusing Simple\ncontext Patient\n`;
+  let cql = `library ${suiteName} version '1.4.0'\nusing QUICK version '3.3.0'\ncontext Patient\n`;
   xmlJS.tests.group.forEach((group, i) => {
     // Some groups have all their tests commented out.  In that case, don't generate the group at all.
     if (group.test == null || group.test.length === 0) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,537 +3,444 @@
 
 
 "@babel/cli@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.10.4.tgz#ba38ad6d0b4b772a67b106934b7c33d656031896"
-  integrity sha512-xX99K4V1BzGJdQANK5cwK+EpF1vP9gvqhn+iWvG+TubCjecplW7RSQimJ2jcCvu6fnK5pY6mZMdu6EWTj32QVA==
+  version "7.13.14"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.13.14.tgz#c395bc89ec4760c91f2027fa8b26f8b2bf42238f"
+  integrity sha512-zmEFV8WBRsW+mPQumO1/4b34QNALBVReaiHJOkxhUsdo/AvYM62c+SKSuLi2aZ42t3ocK6OI0uwUXRvrIbREZw==
   dependencies:
     commander "^4.0.1"
     convert-source-map "^1.1.0"
     fs-readdir-recursive "^1.1.0"
     glob "^7.0.0"
-    lodash "^4.17.13"
+    lodash "^4.17.19"
     make-dir "^2.1.0"
     slash "^2.0.0"
     source-map "^0.5.0"
   optionalDependencies:
-    chokidar "^2.1.8"
+    "@nicolo-ribaudo/chokidar-2" "2.1.8-no-fsevents"
+    chokidar "^3.4.0"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
-  integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
+"@babel/code-frame@7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
+  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
-  integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
+"@babel/code-frame@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
+  integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
   dependencies:
-    "@babel/highlight" "^7.8.3"
+    "@babel/highlight" "^7.12.13"
 
-"@babel/compat-data@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.10.4.tgz#706a6484ee6f910b719b696a9194f8da7d7ac241"
-  integrity sha512-t+rjExOrSVvjQQXNp5zAIYDp00KjdvGl/TpDX5REPr0S9IAIPQMTilcfG6q8c0QFmj9lSTVySV2VTsyggvtNIw==
-  dependencies:
-    browserslist "^4.12.0"
-    invariant "^2.2.4"
-    semver "^5.5.0"
+"@babel/compat-data@^7.13.0", "@babel/compat-data@^7.13.12", "@babel/compat-data@^7.13.8":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.13.12.tgz#a8a5ccac19c200f9dd49624cac6e19d7be1236a1"
+  integrity sha512-3eJJ841uKxeV8dcN/2yGEUy+RfgQspPEgQat85umsE1rotuquQ2AbIub4S6j7c50a2d+4myc+zSlnXeIHrOnhQ==
 
-"@babel/core@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.10.4.tgz#780e8b83e496152f8dd7df63892b2e052bf1d51d"
-  integrity sha512-3A0tS0HWpy4XujGc7QtOIHTeNwUgWaZc/WuS5YQrfhU67jnVmsD6OGPc1AKHH0LJHQICGncy3+YUjIhVlfDdcA==
+"@babel/core@^7.10.4", "@babel/core@^7.7.5":
+  version "7.13.14"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.13.14.tgz#8e46ebbaca460a63497c797e574038ab04ae6d06"
+  integrity sha512-wZso/vyF4ki0l0znlgM4inxbdrUvCb+cVz8grxDq+6C9k6qbqoIJteQOKicaKjCipU3ISV+XedCqpL2RJJVehA==
   dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.10.4"
-    "@babel/helper-module-transforms" "^7.10.4"
-    "@babel/helpers" "^7.10.4"
-    "@babel/parser" "^7.10.4"
-    "@babel/template" "^7.10.4"
-    "@babel/traverse" "^7.10.4"
-    "@babel/types" "^7.10.4"
+    "@babel/code-frame" "^7.12.13"
+    "@babel/generator" "^7.13.9"
+    "@babel/helper-compilation-targets" "^7.13.13"
+    "@babel/helper-module-transforms" "^7.13.14"
+    "@babel/helpers" "^7.13.10"
+    "@babel/parser" "^7.13.13"
+    "@babel/template" "^7.12.13"
+    "@babel/traverse" "^7.13.13"
+    "@babel/types" "^7.13.14"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
-    gensync "^1.0.0-beta.1"
+    gensync "^1.0.0-beta.2"
     json5 "^2.1.2"
-    lodash "^4.17.13"
-    resolve "^1.3.2"
-    semver "^5.4.1"
+    semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/core@^7.7.5":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.6.tgz#d9aa1f580abf3b2286ef40b6904d390904c63376"
-  integrity sha512-nD3deLvbsApbHAHttzIssYqgb883yU/d9roe4RZymBCDaZryMJDbptVpEpeQuRh4BJ+SYI8le9YGxKvFEvl1Wg==
+"@babel/generator@^7.13.9":
+  version "7.13.9"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.13.9.tgz#3a7aa96f9efb8e2be42d38d80e2ceb4c64d8de39"
+  integrity sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==
   dependencies:
-    "@babel/code-frame" "^7.8.3"
-    "@babel/generator" "^7.9.6"
-    "@babel/helper-module-transforms" "^7.9.0"
-    "@babel/helpers" "^7.9.6"
-    "@babel/parser" "^7.9.6"
-    "@babel/template" "^7.8.6"
-    "@babel/traverse" "^7.9.6"
-    "@babel/types" "^7.9.6"
-    convert-source-map "^1.7.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.1"
-    json5 "^2.1.2"
-    lodash "^4.17.13"
-    resolve "^1.3.2"
-    semver "^5.4.1"
-    source-map "^0.5.0"
-
-"@babel/generator@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.10.4.tgz#e49eeed9fe114b62fa5b181856a43a5e32f5f243"
-  integrity sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==
-  dependencies:
-    "@babel/types" "^7.10.4"
+    "@babel/types" "^7.13.0"
     jsesc "^2.5.1"
-    lodash "^4.17.13"
     source-map "^0.5.0"
 
-"@babel/generator@^7.9.6":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.6.tgz#5408c82ac5de98cda0d77d8124e99fa1f2170a43"
-  integrity sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==
+"@babel/helper-annotate-as-pure@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.13.tgz#0f58e86dfc4bb3b1fcd7db806570e177d439b6ab"
+  integrity sha512-7YXfX5wQ5aYM/BOlbSccHDbuXXFPxeoUmfWtz8le2yTkTZc+BxsiEnENFoi2SlmA8ewDkG2LgIMIVzzn2h8kfw==
   dependencies:
-    "@babel/types" "^7.9.6"
-    jsesc "^2.5.1"
-    lodash "^4.17.13"
-    source-map "^0.5.0"
+    "@babel/types" "^7.12.13"
 
-"@babel/helper-annotate-as-pure@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz#5bf0d495a3f757ac3bda48b5bf3b3ba309c72ba3"
-  integrity sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==
+"@babel/helper-builder-binary-assignment-operator-visitor@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.12.13.tgz#6bc20361c88b0a74d05137a65cac8d3cbf6f61fc"
+  integrity sha512-CZOv9tGphhDRlVjVkAgm8Nhklm9RzSmWpX2my+t7Ua/KT616pEzXsQCjinzvkRvHWJ9itO4f296efroX23XCMA==
   dependencies:
-    "@babel/types" "^7.10.4"
+    "@babel/helper-explode-assignable-expression" "^7.12.13"
+    "@babel/types" "^7.12.13"
 
-"@babel/helper-builder-binary-assignment-operator-visitor@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz#bb0b75f31bf98cbf9ff143c1ae578b87274ae1a3"
-  integrity sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==
+"@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.13.10", "@babel/helper-compilation-targets@^7.13.13", "@babel/helper-compilation-targets@^7.13.8":
+  version "7.13.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz#2b2972a0926474853f41e4adbc69338f520600e5"
+  integrity sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==
   dependencies:
-    "@babel/helper-explode-assignable-expression" "^7.10.4"
-    "@babel/types" "^7.10.4"
+    "@babel/compat-data" "^7.13.12"
+    "@babel/helper-validator-option" "^7.12.17"
+    browserslist "^4.14.5"
+    semver "^6.3.0"
 
-"@babel/helper-compilation-targets@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.4.tgz#804ae8e3f04376607cc791b9d47d540276332bd2"
-  integrity sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==
+"@babel/helper-create-class-features-plugin@^7.13.0":
+  version "7.13.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.11.tgz#30d30a005bca2c953f5653fc25091a492177f4f6"
+  integrity sha512-ays0I7XYq9xbjCSvT+EvysLgfc3tOkwCULHjrnscGT3A9qD4sk3wXnJ3of0MAWsWGjdinFvajHU2smYuqXKMrw==
   dependencies:
-    "@babel/compat-data" "^7.10.4"
-    browserslist "^4.12.0"
-    invariant "^2.2.4"
-    levenary "^1.1.1"
-    semver "^5.5.0"
+    "@babel/helper-function-name" "^7.12.13"
+    "@babel/helper-member-expression-to-functions" "^7.13.0"
+    "@babel/helper-optimise-call-expression" "^7.12.13"
+    "@babel/helper-replace-supers" "^7.13.0"
+    "@babel/helper-split-export-declaration" "^7.12.13"
 
-"@babel/helper-create-class-features-plugin@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.4.tgz#2d4015d0136bd314103a70d84a7183e4b344a355"
-  integrity sha512-9raUiOsXPxzzLjCXeosApJItoMnX3uyT4QdM2UldffuGApNrF8e938MwNpDCK9CPoyxrEoCgT+hObJc3mZa6lQ==
+"@babel/helper-create-regexp-features-plugin@^7.12.13":
+  version "7.12.17"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.17.tgz#a2ac87e9e319269ac655b8d4415e94d38d663cb7"
+  integrity sha512-p2VGmBu9oefLZ2nQpgnEnG0ZlRPvL8gAGvPUMQwUdaE8k49rOMuZpOwdQoy5qJf6K8jL3bcAMhVUlHAjIgJHUg==
   dependencies:
-    "@babel/helper-function-name" "^7.10.4"
-    "@babel/helper-member-expression-to-functions" "^7.10.4"
-    "@babel/helper-optimise-call-expression" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-replace-supers" "^7.10.4"
-    "@babel/helper-split-export-declaration" "^7.10.4"
+    "@babel/helper-annotate-as-pure" "^7.12.13"
+    regexpu-core "^4.7.1"
 
-"@babel/helper-create-regexp-features-plugin@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz#fdd60d88524659a0b6959c0579925e425714f3b8"
-  integrity sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==
+"@babel/helper-define-polyfill-provider@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.1.5.tgz#3c2f91b7971b9fc11fe779c945c014065dea340e"
+  integrity sha512-nXuzCSwlJ/WKr8qxzW816gwyT6VZgiJG17zR40fou70yfAcqjoNyTLl/DQ+FExw5Hx5KNqshmN8Ldl/r2N7cTg==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.10.4"
-    "@babel/helper-regex" "^7.10.4"
-    regexpu-core "^4.7.0"
+    "@babel/helper-compilation-targets" "^7.13.0"
+    "@babel/helper-module-imports" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/traverse" "^7.13.0"
+    debug "^4.1.1"
+    lodash.debounce "^4.0.8"
+    resolve "^1.14.2"
+    semver "^6.1.2"
 
-"@babel/helper-define-map@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.10.4.tgz#f037ad794264f729eda1889f4ee210b870999092"
-  integrity sha512-nIij0oKErfCnLUCWaCaHW0Bmtl2RO9cN7+u2QT8yqTywgALKlyUVOvHDElh+b5DwVC6YB1FOYFOTWcN/+41EDA==
+"@babel/helper-explode-assignable-expression@^7.12.13":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.13.0.tgz#17b5c59ff473d9f956f40ef570cf3a76ca12657f"
+  integrity sha512-qS0peLTDP8kOisG1blKbaoBg/o9OSa1qoumMjTK5pM+KDTtpxpsiubnCGP34vK8BXGcb2M9eigwgvoJryrzwWA==
   dependencies:
-    "@babel/helper-function-name" "^7.10.4"
-    "@babel/types" "^7.10.4"
-    lodash "^4.17.13"
+    "@babel/types" "^7.13.0"
 
-"@babel/helper-explode-assignable-expression@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.4.tgz#40a1cd917bff1288f699a94a75b37a1a2dbd8c7c"
-  integrity sha512-4K71RyRQNPRrR85sr5QY4X3VwG4wtVoXZB9+L3r1Gp38DhELyHCtovqydRi7c1Ovb17eRGiQ/FD5s8JdU0Uy5A==
+"@babel/helper-function-name@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz#93ad656db3c3c2232559fd7b2c3dbdcbe0eb377a"
+  integrity sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==
   dependencies:
-    "@babel/traverse" "^7.10.4"
-    "@babel/types" "^7.10.4"
+    "@babel/helper-get-function-arity" "^7.12.13"
+    "@babel/template" "^7.12.13"
+    "@babel/types" "^7.12.13"
 
-"@babel/helper-function-name@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz#d2d3b20c59ad8c47112fa7d2a94bc09d5ef82f1a"
-  integrity sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==
+"@babel/helper-get-function-arity@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz#bc63451d403a3b3082b97e1d8b3fe5bd4091e583"
+  integrity sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==
   dependencies:
-    "@babel/helper-get-function-arity" "^7.10.4"
-    "@babel/template" "^7.10.4"
-    "@babel/types" "^7.10.4"
+    "@babel/types" "^7.12.13"
 
-"@babel/helper-function-name@^7.9.5":
-  version "7.9.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz#2b53820d35275120e1874a82e5aabe1376920a5c"
-  integrity sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==
+"@babel/helper-hoist-variables@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.0.tgz#5d5882e855b5c5eda91e0cadc26c6e7a2c8593d8"
+  integrity sha512-0kBzvXiIKfsCA0y6cFEIJf4OdzfpRuNk4+YTeHZpGGc666SATFKTz6sRncwFnQk7/ugJ4dSrCj6iJuvW4Qwr2g==
   dependencies:
-    "@babel/helper-get-function-arity" "^7.8.3"
-    "@babel/template" "^7.8.3"
-    "@babel/types" "^7.9.5"
+    "@babel/traverse" "^7.13.0"
+    "@babel/types" "^7.13.0"
 
-"@babel/helper-get-function-arity@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz#98c1cbea0e2332f33f9a4661b8ce1505b2c19ba2"
-  integrity sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==
+"@babel/helper-member-expression-to-functions@^7.13.0", "@babel/helper-member-expression-to-functions@^7.13.12":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz#dfe368f26d426a07299d8d6513821768216e6d72"
+  integrity sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==
   dependencies:
-    "@babel/types" "^7.10.4"
+    "@babel/types" "^7.13.12"
 
-"@babel/helper-get-function-arity@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz#b894b947bd004381ce63ea1db9f08547e920abd5"
-  integrity sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==
+"@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.13.12":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz#c6a369a6f3621cb25da014078684da9196b61977"
+  integrity sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
   dependencies:
-    "@babel/types" "^7.8.3"
+    "@babel/types" "^7.13.12"
 
-"@babel/helper-hoist-variables@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz#d49b001d1d5a68ca5e6604dda01a6297f7c9381e"
-  integrity sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==
+"@babel/helper-module-transforms@^7.13.0", "@babel/helper-module-transforms@^7.13.14":
+  version "7.13.14"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz#e600652ba48ccb1641775413cb32cfa4e8b495ef"
+  integrity sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==
   dependencies:
-    "@babel/types" "^7.10.4"
+    "@babel/helper-module-imports" "^7.13.12"
+    "@babel/helper-replace-supers" "^7.13.12"
+    "@babel/helper-simple-access" "^7.13.12"
+    "@babel/helper-split-export-declaration" "^7.12.13"
+    "@babel/helper-validator-identifier" "^7.12.11"
+    "@babel/template" "^7.12.13"
+    "@babel/traverse" "^7.13.13"
+    "@babel/types" "^7.13.14"
 
-"@babel/helper-member-expression-to-functions@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz#7cd04b57dfcf82fce9aeae7d4e4452fa31b8c7c4"
-  integrity sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==
+"@babel/helper-optimise-call-expression@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz#5c02d171b4c8615b1e7163f888c1c81c30a2aaea"
+  integrity sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==
   dependencies:
-    "@babel/types" "^7.10.4"
+    "@babel/types" "^7.12.13"
 
-"@babel/helper-member-expression-to-functions@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz#659b710498ea6c1d9907e0c73f206eee7dadc24c"
-  integrity sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz#806526ce125aed03373bc416a828321e3a6a33af"
+  integrity sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==
+
+"@babel/helper-remap-async-to-generator@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.13.0.tgz#376a760d9f7b4b2077a9dd05aa9c3927cadb2209"
+  integrity sha512-pUQpFBE9JvC9lrQbpX0TmeNIy5s7GnZjna2lhhcHC7DzgBs6fWn722Y5cfwgrtrqc7NAJwMvOa0mKhq6XaE4jg==
   dependencies:
-    "@babel/types" "^7.8.3"
+    "@babel/helper-annotate-as-pure" "^7.12.13"
+    "@babel/helper-wrap-function" "^7.13.0"
+    "@babel/types" "^7.13.0"
 
-"@babel/helper-module-imports@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz#4c5c54be04bd31670a7382797d75b9fa2e5b5620"
-  integrity sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==
+"@babel/helper-replace-supers@^7.12.13", "@babel/helper-replace-supers@^7.13.0", "@babel/helper-replace-supers@^7.13.12":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz#6442f4c1ad912502481a564a7386de0c77ff3804"
+  integrity sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==
   dependencies:
-    "@babel/types" "^7.10.4"
+    "@babel/helper-member-expression-to-functions" "^7.13.12"
+    "@babel/helper-optimise-call-expression" "^7.12.13"
+    "@babel/traverse" "^7.13.0"
+    "@babel/types" "^7.13.12"
 
-"@babel/helper-module-imports@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz#7fe39589b39c016331b6b8c3f441e8f0b1419498"
-  integrity sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
+"@babel/helper-simple-access@^7.12.13", "@babel/helper-simple-access@^7.13.12":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz#dd6c538afb61819d205a012c31792a39c7a5eaf6"
+  integrity sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==
   dependencies:
-    "@babel/types" "^7.8.3"
+    "@babel/types" "^7.13.12"
 
-"@babel/helper-module-transforms@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.10.4.tgz#ca1f01fdb84e48c24d7506bb818c961f1da8805d"
-  integrity sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==
+"@babel/helper-skip-transparent-expression-wrappers@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz#462dc63a7e435ade8468385c63d2b84cce4b3cbf"
+  integrity sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==
   dependencies:
-    "@babel/helper-module-imports" "^7.10.4"
-    "@babel/helper-replace-supers" "^7.10.4"
-    "@babel/helper-simple-access" "^7.10.4"
-    "@babel/helper-split-export-declaration" "^7.10.4"
-    "@babel/template" "^7.10.4"
-    "@babel/types" "^7.10.4"
-    lodash "^4.17.13"
+    "@babel/types" "^7.12.1"
 
-"@babel/helper-module-transforms@^7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz#43b34dfe15961918707d247327431388e9fe96e5"
-  integrity sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==
+"@babel/helper-split-export-declaration@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz#e9430be00baf3e88b0e13e6f9d4eaf2136372b05"
+  integrity sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==
   dependencies:
-    "@babel/helper-module-imports" "^7.8.3"
-    "@babel/helper-replace-supers" "^7.8.6"
-    "@babel/helper-simple-access" "^7.8.3"
-    "@babel/helper-split-export-declaration" "^7.8.3"
-    "@babel/template" "^7.8.6"
-    "@babel/types" "^7.9.0"
-    lodash "^4.17.13"
+    "@babel/types" "^7.12.13"
 
-"@babel/helper-optimise-call-expression@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz#50dc96413d594f995a77905905b05893cd779673"
-  integrity sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==
+"@babel/helper-validator-identifier@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
+  integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
+
+"@babel/helper-validator-option@^7.12.17":
+  version "7.12.17"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz#d1fbf012e1a79b7eebbfdc6d270baaf8d9eb9831"
+  integrity sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==
+
+"@babel/helper-wrap-function@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.13.0.tgz#bdb5c66fda8526ec235ab894ad53a1235c79fcc4"
+  integrity sha512-1UX9F7K3BS42fI6qd2A4BjKzgGjToscyZTdp1DjknHLCIvpgne6918io+aL5LXFcER/8QWiwpoY902pVEqgTXA==
   dependencies:
-    "@babel/types" "^7.10.4"
+    "@babel/helper-function-name" "^7.12.13"
+    "@babel/template" "^7.12.13"
+    "@babel/traverse" "^7.13.0"
+    "@babel/types" "^7.13.0"
 
-"@babel/helper-optimise-call-expression@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz#7ed071813d09c75298ef4f208956006b6111ecb9"
-  integrity sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==
+"@babel/helpers@^7.13.10":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.13.10.tgz#fd8e2ba7488533cdeac45cc158e9ebca5e3c7df8"
+  integrity sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==
   dependencies:
-    "@babel/types" "^7.8.3"
+    "@babel/template" "^7.12.13"
+    "@babel/traverse" "^7.13.0"
+    "@babel/types" "^7.13.0"
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.8.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
-  integrity sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
-
-"@babel/helper-regex@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.10.4.tgz#59b373daaf3458e5747dece71bbaf45f9676af6d"
-  integrity sha512-inWpnHGgtg5NOF0eyHlC0/74/VkdRITY9dtTpB2PrxKKn+AkVMRiZz/Adrx+Ssg+MLDesi2zohBW6MVq6b4pOQ==
+"@babel/highlight@^7.10.4", "@babel/highlight@^7.12.13":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.13.10.tgz#a8b2a66148f5b27d666b15d81774347a731d52d1"
+  integrity sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==
   dependencies:
-    lodash "^4.17.13"
-
-"@babel/helper-remap-async-to-generator@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.4.tgz#fce8bea4e9690bbe923056ded21e54b4e8b68ed5"
-  integrity sha512-86Lsr6NNw3qTNl+TBcF1oRZMaVzJtbWTyTko+CQL/tvNvcGYEFKbLXDPxtW0HKk3McNOk4KzY55itGWCAGK5tg==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.10.4"
-    "@babel/helper-wrap-function" "^7.10.4"
-    "@babel/template" "^7.10.4"
-    "@babel/traverse" "^7.10.4"
-    "@babel/types" "^7.10.4"
-
-"@babel/helper-replace-supers@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz#d585cd9388ea06e6031e4cd44b6713cbead9e6cf"
-  integrity sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==
-  dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.10.4"
-    "@babel/helper-optimise-call-expression" "^7.10.4"
-    "@babel/traverse" "^7.10.4"
-    "@babel/types" "^7.10.4"
-
-"@babel/helper-replace-supers@^7.8.6":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.9.6.tgz#03149d7e6a5586ab6764996cd31d6981a17e1444"
-  integrity sha512-qX+chbxkbArLyCImk3bWV+jB5gTNU/rsze+JlcF6Nf8tVTigPJSI1o1oBow/9Resa1yehUO9lIipsmu9oG4RzA==
-  dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.8.3"
-    "@babel/helper-optimise-call-expression" "^7.8.3"
-    "@babel/traverse" "^7.9.6"
-    "@babel/types" "^7.9.6"
-
-"@babel/helper-simple-access@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz#0f5ccda2945277a2a7a2d3a821e15395edcf3461"
-  integrity sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==
-  dependencies:
-    "@babel/template" "^7.10.4"
-    "@babel/types" "^7.10.4"
-
-"@babel/helper-simple-access@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz#7f8109928b4dab4654076986af575231deb639ae"
-  integrity sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==
-  dependencies:
-    "@babel/template" "^7.8.3"
-    "@babel/types" "^7.8.3"
-
-"@babel/helper-split-export-declaration@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz#2c70576eaa3b5609b24cb99db2888cc3fc4251d1"
-  integrity sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==
-  dependencies:
-    "@babel/types" "^7.10.4"
-
-"@babel/helper-split-export-declaration@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
-  integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
-  dependencies:
-    "@babel/types" "^7.8.3"
-
-"@babel/helper-validator-identifier@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
-  integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
-
-"@babel/helper-validator-identifier@^7.9.0", "@babel/helper-validator-identifier@^7.9.5":
-  version "7.9.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
-  integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
-
-"@babel/helper-wrap-function@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz#8a6f701eab0ff39f765b5a1cfef409990e624b87"
-  integrity sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==
-  dependencies:
-    "@babel/helper-function-name" "^7.10.4"
-    "@babel/template" "^7.10.4"
-    "@babel/traverse" "^7.10.4"
-    "@babel/types" "^7.10.4"
-
-"@babel/helpers@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.10.4.tgz#2abeb0d721aff7c0a97376b9e1f6f65d7a475044"
-  integrity sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==
-  dependencies:
-    "@babel/template" "^7.10.4"
-    "@babel/traverse" "^7.10.4"
-    "@babel/types" "^7.10.4"
-
-"@babel/helpers@^7.9.6":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.9.6.tgz#092c774743471d0bb6c7de3ad465ab3d3486d580"
-  integrity sha512-tI4bUbldloLcHWoRUMAj4g1bF313M/o6fBKhIsb3QnGVPwRm9JsNf/gqMkQ7zjqReABiffPV6RWj7hEglID5Iw==
-  dependencies:
-    "@babel/template" "^7.8.3"
-    "@babel/traverse" "^7.9.6"
-    "@babel/types" "^7.9.6"
-
-"@babel/highlight@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
-  integrity sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.10.4"
+    "@babel/helper-validator-identifier" "^7.12.11"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/highlight@^7.8.3":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.9.0.tgz#4e9b45ccb82b79607271b2979ad82c7b68163079"
-  integrity sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==
+"@babel/parser@^7.12.13", "@babel/parser@^7.13.13":
+  version "7.13.13"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.13.tgz#42f03862f4aed50461e543270916b47dd501f0df"
+  integrity sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==
+
+"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.13.12":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.13.12.tgz#a3484d84d0b549f3fc916b99ee4783f26fabad2a"
+  integrity sha512-d0u3zWKcoZf379fOeJdr1a5WPDny4aOFZ6hlfKivgK0LY7ZxNfoaHL2fWwdGtHyVvra38FC+HVYkO+byfSA8AQ==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.9.0"
-    chalk "^2.0.0"
-    js-tokens "^4.0.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
+    "@babel/plugin-proposal-optional-chaining" "^7.13.12"
 
-"@babel/parser@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.4.tgz#9eedf27e1998d87739fb5028a5120557c06a1a64"
-  integrity sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==
-
-"@babel/parser@^7.8.6", "@babel/parser@^7.9.6":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.6.tgz#3b1bbb30dabe600cd72db58720998376ff653bc7"
-  integrity sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==
-
-"@babel/plugin-proposal-async-generator-functions@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.4.tgz#4b65abb3d9bacc6c657aaa413e56696f9f170fc6"
-  integrity sha512-MJbxGSmejEFVOANAezdO39SObkURO5o/8b6fSH6D1pi9RZQt+ldppKPXfqgUWpSQ9asM6xaSaSJIaeWMDRP0Zg==
+"@babel/plugin-proposal-async-generator-functions@^7.13.8":
+  version "7.13.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.8.tgz#87aacb574b3bc4b5603f6fe41458d72a5a2ec4b1"
+  integrity sha512-rPBnhj+WgoSmgq+4gQUtXx/vOcU+UYtjy1AA/aeD61Hwj410fwYyqfUcRP3lR8ucgliVJL/G7sXcNUecC75IXA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-remap-async-to-generator" "^7.10.4"
-    "@babel/plugin-syntax-async-generators" "^7.8.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-remap-async-to-generator" "^7.13.0"
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
 
-"@babel/plugin-proposal-class-properties@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz#a33bf632da390a59c7a8c570045d1115cd778807"
-  integrity sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==
+"@babel/plugin-proposal-class-properties@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.13.0.tgz#146376000b94efd001e57a40a88a525afaab9f37"
+  integrity sha512-KnTDjFNC1g+45ka0myZNvSBFLhNCLN+GeGYLDEA8Oq7MZ6yMgfLoIRh86GRT0FjtJhZw8JyUskP9uvj5pHM9Zg==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-create-class-features-plugin" "^7.13.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
-"@babel/plugin-proposal-dynamic-import@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.4.tgz#ba57a26cb98b37741e9d5bca1b8b0ddf8291f17e"
-  integrity sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==
+"@babel/plugin-proposal-dynamic-import@^7.13.8":
+  version "7.13.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.13.8.tgz#876a1f6966e1dec332e8c9451afda3bebcdf2e1d"
+  integrity sha512-ONWKj0H6+wIRCkZi9zSbZtE/r73uOhMVHh256ys0UzfM7I3d4n+spZNWjOnJv2gzopumP2Wxi186vI8N0Y2JyQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-dynamic-import" "^7.8.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
 
-"@babel/plugin-proposal-json-strings@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.4.tgz#593e59c63528160233bd321b1aebe0820c2341db"
-  integrity sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==
+"@babel/plugin-proposal-export-namespace-from@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.13.tgz#393be47a4acd03fa2af6e3cde9b06e33de1b446d"
+  integrity sha512-INAgtFo4OnLN3Y/j0VwAgw3HDXcDtX+C/erMvWzuV9v71r7urb6iyMXu7eM9IgLr1ElLlOkaHjJ0SbCmdOQ3Iw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-json-strings" "^7.8.0"
+    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
 
-"@babel/plugin-proposal-nullish-coalescing-operator@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz#02a7e961fc32e6d5b2db0649e01bf80ddee7e04a"
-  integrity sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==
+"@babel/plugin-proposal-json-strings@^7.13.8":
+  version "7.13.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.13.8.tgz#bf1fb362547075afda3634ed31571c5901afef7b"
+  integrity sha512-w4zOPKUFPX1mgvTmL/fcEqy34hrQ1CRcGxdphBc6snDnnqJ47EZDIyop6IwXzAC8G916hsIuXB2ZMBCExC5k7Q==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/plugin-syntax-json-strings" "^7.8.3"
 
-"@babel/plugin-proposal-numeric-separator@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz#ce1590ff0a65ad12970a609d78855e9a4c1aef06"
-  integrity sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==
+"@babel/plugin-proposal-logical-assignment-operators@^7.13.8":
+  version "7.13.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.13.8.tgz#93fa78d63857c40ce3c8c3315220fd00bfbb4e1a"
+  integrity sha512-aul6znYB4N4HGweImqKn59Su9RS8lbUIqxtXTOcAGtNIDczoEFv+l1EhmX8rUBp3G1jMjKJm8m0jXVp63ZpS4A==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
+
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.13.8":
+  version "7.13.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.13.8.tgz#3730a31dafd3c10d8ccd10648ed80a2ac5472ef3"
+  integrity sha512-iePlDPBn//UhxExyS9KyeYU7RM9WScAG+D3Hhno0PLJebAEpDZMocbDe64eqynhNAnwz/vZoL/q/QB2T1OH39A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
+
+"@babel/plugin-proposal-numeric-separator@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.13.tgz#bd9da3188e787b5120b4f9d465a8261ce67ed1db"
+  integrity sha512-O1jFia9R8BUCl3ZGB7eitaAPu62TXJRHn7rh+ojNERCFyqRwJMTmhz+tJ+k0CwI6CLjX/ee4qW74FSqlq9I35w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.12.13"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
 
-"@babel/plugin-proposal-object-rest-spread@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.4.tgz#50129ac216b9a6a55b3853fdd923e74bf553a4c0"
-  integrity sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==
+"@babel/plugin-proposal-object-rest-spread@^7.13.8":
+  version "7.13.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.13.8.tgz#5d210a4d727d6ce3b18f9de82cc99a3964eed60a"
+  integrity sha512-DhB2EuB1Ih7S3/IRX5AFVgZ16k3EzfRbq97CxAVI1KSYcW+lexV8VZb7G7L8zuPVSdQMRn0kiBpf/Yzu9ZKH0g==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
-    "@babel/plugin-transform-parameters" "^7.10.4"
+    "@babel/compat-data" "^7.13.8"
+    "@babel/helper-compilation-targets" "^7.13.8"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-transform-parameters" "^7.13.0"
 
-"@babel/plugin-proposal-optional-catch-binding@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz#31c938309d24a78a49d68fdabffaa863758554dd"
-  integrity sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==
+"@babel/plugin-proposal-optional-catch-binding@^7.13.8":
+  version "7.13.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.13.8.tgz#3ad6bd5901506ea996fc31bdcf3ccfa2bed71107"
+  integrity sha512-0wS/4DUF1CuTmGo+NiaHfHcVSeSLj5S3e6RivPTg/2k3wOv3jO35tZ6/ZWsQhQMvdgI7CwphjQa/ccarLymHVA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
 
-"@babel/plugin-proposal-optional-chaining@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.10.4.tgz#750f1255e930a1f82d8cdde45031f81a0d0adff7"
-  integrity sha512-ZIhQIEeavTgouyMSdZRap4VPPHqJJ3NEs2cuHs5p0erH+iz6khB0qfgU8g7UuJkG88+fBMy23ZiU+nuHvekJeQ==
+"@babel/plugin-proposal-optional-chaining@^7.13.12":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.12.tgz#ba9feb601d422e0adea6760c2bd6bbb7bfec4866"
+  integrity sha512-fcEdKOkIB7Tf4IxrgEVeFC4zeJSTr78no9wTdBuZZbqF64kzllU0ybo2zrzm7gUQfxGhBgq4E39oRs8Zx/RMYQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
 
-"@babel/plugin-proposal-private-methods@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.10.4.tgz#b160d972b8fdba5c7d111a145fc8c421fc2a6909"
-  integrity sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==
+"@babel/plugin-proposal-private-methods@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.13.0.tgz#04bd4c6d40f6e6bbfa2f57e2d8094bad900ef787"
+  integrity sha512-MXyyKQd9inhx1kDYPkFRVOBXQ20ES8Pto3T7UZ92xj2mY0EVD8oAVzeyYuVfy/mxAdTSIayOvg+aVzcHV2bn6Q==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-create-class-features-plugin" "^7.13.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
-"@babel/plugin-proposal-unicode-property-regex@^7.10.4", "@babel/plugin-proposal-unicode-property-regex@^7.4.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.4.tgz#4483cda53041ce3413b7fe2f00022665ddfaa75d"
-  integrity sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==
+"@babel/plugin-proposal-unicode-property-regex@^7.12.13", "@babel/plugin-proposal-unicode-property-regex@^7.4.4":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.13.tgz#bebde51339be829c17aaaaced18641deb62b39ba"
+  integrity sha512-XyJmZidNfofEkqFV5VC/bLabGmO5QzenPO/YOfGuEbgU+2sSwMmio3YLb4WtBgcmmdwZHyVyv8on77IUjQ5Gvg==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-create-regexp-features-plugin" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-syntax-async-generators@^7.8.0":
+"@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz#a983fb1aeb2ec3f6ed042a210f640e90e786fe0d"
   integrity sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-class-properties@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz#6644e6a0baa55a61f9e3231f6c9eeb6ee46c124c"
-  integrity sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==
+"@babel/plugin-syntax-class-properties@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz#b5c987274c4a3a82b89714796931a6b53544ae10"
+  integrity sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-syntax-dynamic-import@^7.8.0":
+"@babel/plugin-syntax-dynamic-import@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz#62bf98b2da3cd21d626154fc96ee5b3cb68eacb3"
   integrity sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-json-strings@^7.8.0":
+"@babel/plugin-syntax-export-namespace-from@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz#028964a9ba80dbc094c915c487ad7c4e7a66465a"
+  integrity sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+
+"@babel/plugin-syntax-json-strings@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz#01ca21b668cd8218c9e640cb6dd88c5412b2c96a"
   integrity sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.0":
+"@babel/plugin-syntax-logical-assignment-operators@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz#ca91ef46303530448b906652bac2e9fe9941f699"
+  integrity sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz#167ed70368886081f74b5c36c65a88c03b66d1a9"
   integrity sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
@@ -547,359 +454,361 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-syntax-object-rest-spread@^7.8.0":
+"@babel/plugin-syntax-object-rest-spread@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
   integrity sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-optional-catch-binding@^7.8.0":
+"@babel/plugin-syntax-optional-catch-binding@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz#6111a265bcfb020eb9efd0fdfd7d26402b9ed6c1"
   integrity sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-optional-chaining@^7.8.0":
+"@babel/plugin-syntax-optional-chaining@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz#4f69c2ab95167e0180cd5336613f8c5788f7d48a"
   integrity sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-top-level-await@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz#4bbeb8917b54fcf768364e0a81f560e33a3ef57d"
-  integrity sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==
+"@babel/plugin-syntax-top-level-await@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.13.tgz#c5f0fa6e249f5b739727f923540cf7a806130178"
+  integrity sha512-A81F9pDwyS7yM//KwbCSDqy3Uj4NMIurtplxphWxoYtNPov7cJsDkAFNNyVlIZ3jwGycVsurZ+LtOA8gZ376iQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-arrow-functions@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz#e22960d77e697c74f41c501d44d73dbf8a6a64cd"
-  integrity sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==
+"@babel/plugin-transform-arrow-functions@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.13.0.tgz#10a59bebad52d637a027afa692e8d5ceff5e3dae"
+  integrity sha512-96lgJagobeVmazXFaDrbmCLQxBysKu7U6Do3mLsx27gf5Dk85ezysrs2BZUpXD703U/Su1xTBDxxar2oa4jAGg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
-"@babel/plugin-transform-async-to-generator@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz#41a5017e49eb6f3cda9392a51eef29405b245a37"
-  integrity sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==
+"@babel/plugin-transform-async-to-generator@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.13.0.tgz#8e112bf6771b82bf1e974e5e26806c5c99aa516f"
+  integrity sha512-3j6E004Dx0K3eGmhxVJxwwI89CTJrce7lg3UrtFuDAVQ/2+SJ/h/aSFOeE6/n0WB1GsOffsJp6MnPQNQ8nmwhg==
   dependencies:
-    "@babel/helper-module-imports" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-remap-async-to-generator" "^7.10.4"
+    "@babel/helper-module-imports" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-remap-async-to-generator" "^7.13.0"
 
-"@babel/plugin-transform-block-scoped-functions@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz#1afa595744f75e43a91af73b0d998ecfe4ebc2e8"
-  integrity sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==
+"@babel/plugin-transform-block-scoped-functions@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.13.tgz#a9bf1836f2a39b4eb6cf09967739de29ea4bf4c4"
+  integrity sha512-zNyFqbc3kI/fVpqwfqkg6RvBgFpC4J18aKKMmv7KdQ/1GgREapSJAykLMVNwfRGO3BtHj3YQZl8kxCXPcVMVeg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-block-scoping@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.4.tgz#a670d1364bb5019a621b9ea2001482876d734787"
-  integrity sha512-J3b5CluMg3hPUii2onJDRiaVbPtKFPLEaV5dOPY5OeAbDi1iU/UbbFFTgwb7WnanaDy7bjU35kc26W3eM5Qa0A==
+"@babel/plugin-transform-block-scoping@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.13.tgz#f36e55076d06f41dfd78557ea039c1b581642e61"
+  integrity sha512-Pxwe0iqWJX4fOOM2kEZeUuAxHMWb9nK+9oh5d11bsLoB0xMg+mkDpt0eYuDZB7ETrY9bbcVlKUGTOGWy7BHsMQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    lodash "^4.17.13"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-classes@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz#405136af2b3e218bc4a1926228bc917ab1a0adc7"
-  integrity sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==
+"@babel/plugin-transform-classes@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.13.0.tgz#0265155075c42918bf4d3a4053134176ad9b533b"
+  integrity sha512-9BtHCPUARyVH1oXGcSJD3YpsqRLROJx5ZNP6tN5vnk17N0SVf9WCtf8Nuh1CFmgByKKAIMstitKduoCmsaDK5g==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.10.4"
-    "@babel/helper-define-map" "^7.10.4"
-    "@babel/helper-function-name" "^7.10.4"
-    "@babel/helper-optimise-call-expression" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-replace-supers" "^7.10.4"
-    "@babel/helper-split-export-declaration" "^7.10.4"
+    "@babel/helper-annotate-as-pure" "^7.12.13"
+    "@babel/helper-function-name" "^7.12.13"
+    "@babel/helper-optimise-call-expression" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-replace-supers" "^7.13.0"
+    "@babel/helper-split-export-declaration" "^7.12.13"
     globals "^11.1.0"
 
-"@babel/plugin-transform-computed-properties@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz#9ded83a816e82ded28d52d4b4ecbdd810cdfc0eb"
-  integrity sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==
+"@babel/plugin-transform-computed-properties@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.13.0.tgz#845c6e8b9bb55376b1fa0b92ef0bdc8ea06644ed"
+  integrity sha512-RRqTYTeZkZAz8WbieLTvKUEUxZlUTdmL5KGMyZj7FnMfLNKV4+r5549aORG/mgojRmFlQMJDUupwAMiF2Q7OUg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
-"@babel/plugin-transform-destructuring@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz#70ddd2b3d1bea83d01509e9bb25ddb3a74fc85e5"
-  integrity sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==
+"@babel/plugin-transform-destructuring@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.13.0.tgz#c5dce270014d4e1ebb1d806116694c12b7028963"
+  integrity sha512-zym5em7tePoNT9s964c0/KU3JPPnuq7VhIxPRefJ4/s82cD+q1mgKfuGRDMCPL0HTyKz4dISuQlCusfgCJ86HA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
-"@babel/plugin-transform-dotall-regex@^7.10.4", "@babel/plugin-transform-dotall-regex@^7.4.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.4.tgz#469c2062105c1eb6a040eaf4fac4b488078395ee"
-  integrity sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==
+"@babel/plugin-transform-dotall-regex@^7.12.13", "@babel/plugin-transform-dotall-regex@^7.4.4":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.13.tgz#3f1601cc29905bfcb67f53910f197aeafebb25ad"
+  integrity sha512-foDrozE65ZFdUC2OfgeOCrEPTxdB3yjqxpXh8CH+ipd9CHd4s/iq81kcUpyH8ACGNEPdFqbtzfgzbT/ZGlbDeQ==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-create-regexp-features-plugin" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-duplicate-keys@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.4.tgz#697e50c9fee14380fe843d1f306b295617431e47"
-  integrity sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==
+"@babel/plugin-transform-duplicate-keys@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.13.tgz#6f06b87a8b803fd928e54b81c258f0a0033904de"
+  integrity sha512-NfADJiiHdhLBW3pulJlJI2NB0t4cci4WTZ8FtdIuNc2+8pslXdPtRRAEWqUY+m9kNOk2eRYbTAOipAxlrOcwwQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-exponentiation-operator@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.4.tgz#5ae338c57f8cf4001bdb35607ae66b92d665af2e"
-  integrity sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==
+"@babel/plugin-transform-exponentiation-operator@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.13.tgz#4d52390b9a273e651e4aba6aee49ef40e80cd0a1"
+  integrity sha512-fbUelkM1apvqez/yYx1/oICVnGo2KM5s63mhGylrmXUxK/IAXSIf87QIxVfZldWf4QsOafY6vV3bX8aMHSvNrA==
   dependencies:
-    "@babel/helper-builder-binary-assignment-operator-visitor" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-builder-binary-assignment-operator-visitor" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-for-of@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz#c08892e8819d3a5db29031b115af511dbbfebae9"
-  integrity sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
+"@babel/plugin-transform-for-of@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.13.0.tgz#c799f881a8091ac26b54867a845c3e97d2696062"
+  integrity sha512-IHKT00mwUVYE0zzbkDgNRP6SRzvfGCYsOxIRz8KsiaaHCcT9BWIkO+H9QRJseHBLOGBZkHUdHiqj6r0POsdytg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
-"@babel/plugin-transform-function-name@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz#6a467880e0fc9638514ba369111811ddbe2644b7"
-  integrity sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==
+"@babel/plugin-transform-function-name@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.13.tgz#bb024452f9aaed861d374c8e7a24252ce3a50051"
+  integrity sha512-6K7gZycG0cmIwwF7uMK/ZqeCikCGVBdyP2J5SKNCXO5EOHcqi+z7Jwf8AmyDNcBgxET8DrEtCt/mPKPyAzXyqQ==
   dependencies:
-    "@babel/helper-function-name" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-function-name" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-literals@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz#9f42ba0841100a135f22712d0e391c462f571f3c"
-  integrity sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==
+"@babel/plugin-transform-literals@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.13.tgz#2ca45bafe4a820197cf315794a4d26560fe4bdb9"
+  integrity sha512-FW+WPjSR7hiUxMcKqyNjP05tQ2kmBCdpEpZHY1ARm96tGQCCBvXKnpjILtDplUnJ/eHZ0lALLM+d2lMFSpYJrQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-member-expression-literals@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz#b1ec44fcf195afcb8db2c62cd8e551c881baf8b7"
-  integrity sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==
+"@babel/plugin-transform-member-expression-literals@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.13.tgz#5ffa66cd59b9e191314c9f1f803b938e8c081e40"
+  integrity sha512-kxLkOsg8yir4YeEPHLuO2tXP9R/gTjpuTOjshqSpELUN3ZAg2jfDnKUvzzJxObun38sw3wm4Uu69sX/zA7iRvg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-modules-amd@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.4.tgz#cb407c68b862e4c1d13a2fc738c7ec5ed75fc520"
-  integrity sha512-3Fw+H3WLUrTlzi3zMiZWp3AR4xadAEMv6XRCYnd5jAlLM61Rn+CRJaZMaNvIpcJpQ3vs1kyifYvEVPFfoSkKOA==
+"@babel/plugin-transform-modules-amd@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.13.0.tgz#19f511d60e3d8753cc5a6d4e775d3a5184866cc3"
+  integrity sha512-EKy/E2NHhY/6Vw5d1k3rgoobftcNUmp9fGjb9XZwQLtTctsRBOTRO7RHHxfIky1ogMN5BxN7p9uMA3SzPfotMQ==
   dependencies:
-    "@babel/helper-module-transforms" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-module-transforms" "^7.13.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
     babel-plugin-dynamic-import-node "^2.3.3"
 
-"@babel/plugin-transform-modules-commonjs@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz#66667c3eeda1ebf7896d41f1f16b17105a2fbca0"
-  integrity sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==
+"@babel/plugin-transform-modules-commonjs@^7.13.8":
+  version "7.13.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.13.8.tgz#7b01ad7c2dcf2275b06fa1781e00d13d420b3e1b"
+  integrity sha512-9QiOx4MEGglfYZ4XOnU79OHr6vIWUakIj9b4mioN8eQIoEh+pf5p/zEB36JpDFWA12nNMiRf7bfoRvl9Rn79Bw==
   dependencies:
-    "@babel/helper-module-transforms" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-simple-access" "^7.10.4"
+    "@babel/helper-module-transforms" "^7.13.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-simple-access" "^7.12.13"
     babel-plugin-dynamic-import-node "^2.3.3"
 
-"@babel/plugin-transform-modules-systemjs@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.4.tgz#8f576afd943ac2f789b35ded0a6312f929c633f9"
-  integrity sha512-Tb28LlfxrTiOTGtZFsvkjpyjCl9IoaRI52AEU/VIwOwvDQWtbNJsAqTXzh+5R7i74e/OZHH2c2w2fsOqAfnQYQ==
+"@babel/plugin-transform-modules-systemjs@^7.13.8":
+  version "7.13.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.13.8.tgz#6d066ee2bff3c7b3d60bf28dec169ad993831ae3"
+  integrity sha512-hwqctPYjhM6cWvVIlOIe27jCIBgHCsdH2xCJVAYQm7V5yTMoilbVMi9f6wKg0rpQAOn6ZG4AOyvCqFF/hUh6+A==
   dependencies:
-    "@babel/helper-hoist-variables" "^7.10.4"
-    "@babel/helper-module-transforms" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-hoist-variables" "^7.13.0"
+    "@babel/helper-module-transforms" "^7.13.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-validator-identifier" "^7.12.11"
     babel-plugin-dynamic-import-node "^2.3.3"
 
-"@babel/plugin-transform-modules-umd@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.4.tgz#9a8481fe81b824654b3a0b65da3df89f3d21839e"
-  integrity sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==
+"@babel/plugin-transform-modules-umd@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.13.0.tgz#8a3d96a97d199705b9fd021580082af81c06e70b"
+  integrity sha512-D/ILzAh6uyvkWjKKyFE/W0FzWwasv6vPTSqPcjxFqn6QpX3u8DjRVliq4F2BamO2Wee/om06Vyy+vPkNrd4wxw==
   dependencies:
-    "@babel/helper-module-transforms" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-module-transforms" "^7.13.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
-"@babel/plugin-transform-named-capturing-groups-regex@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.10.4.tgz#78b4d978810b6f3bcf03f9e318f2fc0ed41aecb6"
-  integrity sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==
+"@babel/plugin-transform-named-capturing-groups-regex@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.13.tgz#2213725a5f5bbbe364b50c3ba5998c9599c5c9d9"
+  integrity sha512-Xsm8P2hr5hAxyYblrfACXpQKdQbx4m2df9/ZZSQ8MAhsadw06+jW7s9zsSw6he+mJZXRlVMyEnVktJo4zjk1WA==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.10.4"
+    "@babel/helper-create-regexp-features-plugin" "^7.12.13"
 
-"@babel/plugin-transform-new-target@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.4.tgz#9097d753cb7b024cb7381a3b2e52e9513a9c6888"
-  integrity sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==
+"@babel/plugin-transform-new-target@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.13.tgz#e22d8c3af24b150dd528cbd6e685e799bf1c351c"
+  integrity sha512-/KY2hbLxrG5GTQ9zzZSc3xWiOy379pIETEhbtzwZcw9rvuaVV4Fqy7BYGYOWZnaoXIQYbbJ0ziXLa/sKcGCYEQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-object-super@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz#d7146c4d139433e7a6526f888c667e314a093894"
-  integrity sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==
+"@babel/plugin-transform-object-super@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.13.tgz#b4416a2d63b8f7be314f3d349bd55a9c1b5171f7"
+  integrity sha512-JzYIcj3XtYspZDV8j9ulnoMPZZnF/Cj0LUxPOjR89BdBVx+zYJI9MdMIlUZjbXDX+6YVeS6I3e8op+qQ3BYBoQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-replace-supers" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-replace-supers" "^7.12.13"
 
-"@babel/plugin-transform-parameters@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.4.tgz#7b4d137c87ea7adc2a0f3ebf53266871daa6fced"
-  integrity sha512-RurVtZ/D5nYfEg0iVERXYKEgDFeesHrHfx8RT05Sq57ucj2eOYAP6eu5fynL4Adju4I/mP/I6SO0DqNWAXjfLQ==
+"@babel/plugin-transform-parameters@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.13.0.tgz#8fa7603e3097f9c0b7ca1a4821bc2fb52e9e5007"
+  integrity sha512-Jt8k/h/mIwE2JFEOb3lURoY5C85ETcYPnbuAJ96zRBzh1XHtQZfs62ChZ6EP22QlC8c7Xqr9q+e1SU5qttwwjw==
   dependencies:
-    "@babel/helper-get-function-arity" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
-"@babel/plugin-transform-property-literals@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz#f6fe54b6590352298785b83edd815d214c42e3c0"
-  integrity sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==
+"@babel/plugin-transform-property-literals@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.13.tgz#4e6a9e37864d8f1b3bc0e2dce7bf8857db8b1a81"
+  integrity sha512-nqVigwVan+lR+g8Fj8Exl0UQX2kymtjcWfMOYM1vTYEKujeyv2SkMgazf2qNcK7l4SDiKyTA/nHCPqL4e2zo1A==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-regenerator@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz#2015e59d839074e76838de2159db421966fd8b63"
-  integrity sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==
+"@babel/plugin-transform-regenerator@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.13.tgz#b628bcc9c85260ac1aeb05b45bde25210194a2f5"
+  integrity sha512-lxb2ZAvSLyJ2PEe47hoGWPmW22v7CtSl9jW8mingV4H2sEX/JOcrAj2nPuGWi56ERUm2bUpjKzONAuT6HCn2EA==
   dependencies:
     regenerator-transform "^0.14.2"
 
-"@babel/plugin-transform-reserved-words@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.4.tgz#8f2682bcdcef9ed327e1b0861585d7013f8a54dd"
-  integrity sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==
+"@babel/plugin-transform-reserved-words@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.13.tgz#7d9988d4f06e0fe697ea1d9803188aa18b472695"
+  integrity sha512-xhUPzDXxZN1QfiOy/I5tyye+TRz6lA7z6xaT4CLOjPRMVg1ldRf0LHw0TDBpYL4vG78556WuHdyO9oi5UmzZBg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-shorthand-properties@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz#9fd25ec5cdd555bb7f473e5e6ee1c971eede4dd6"
-  integrity sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==
+"@babel/plugin-transform-shorthand-properties@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.13.tgz#db755732b70c539d504c6390d9ce90fe64aff7ad"
+  integrity sha512-xpL49pqPnLtf0tVluuqvzWIgLEhuPpZzvs2yabUHSKRNlN7ScYU7aMlmavOeyXJZKgZKQRBlh8rHbKiJDraTSw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-spread@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.10.4.tgz#4e2c85ea0d6abaee1b24dcfbbae426fe8d674cff"
-  integrity sha512-1e/51G/Ni+7uH5gktbWv+eCED9pP8ZpRhZB3jOaI3mmzfvJTWHkuyYTv0Z5PYtyM+Tr2Ccr9kUdQxn60fI5WuQ==
+"@babel/plugin-transform-spread@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.13.0.tgz#84887710e273c1815ace7ae459f6f42a5d31d5fd"
+  integrity sha512-V6vkiXijjzYeFmQTr3dBxPtZYLPcUfY34DebOU27jIl2M/Y8Egm52Hw82CSjjPqd54GTlJs5x+CR7HeNr24ckg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
 
-"@babel/plugin-transform-sticky-regex@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.4.tgz#8f3889ee8657581130a29d9cc91d7c73b7c4a28d"
-  integrity sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==
+"@babel/plugin-transform-sticky-regex@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.13.tgz#760ffd936face73f860ae646fb86ee82f3d06d1f"
+  integrity sha512-Jc3JSaaWT8+fr7GRvQP02fKDsYk4K/lYwWq38r/UGfaxo89ajud321NH28KRQ7xy1Ybc0VUE5Pz8psjNNDUglg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-regex" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-template-literals@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.4.tgz#e6375407b30fcb7fcfdbba3bb98ef3e9d36df7bc"
-  integrity sha512-4NErciJkAYe+xI5cqfS8pV/0ntlY5N5Ske/4ImxAVX7mk9Rxt2bwDTGv1Msc2BRJvWQcmYEC+yoMLdX22aE4VQ==
+"@babel/plugin-transform-template-literals@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.13.0.tgz#a36049127977ad94438dee7443598d1cefdf409d"
+  integrity sha512-d67umW6nlfmr1iehCcBv69eSUSySk1EsIS8aTDX4Xo9qajAh6mYtcl4kJrBkGXuxZPEgVr7RVfAvNW6YQkd4Mw==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
-"@babel/plugin-transform-typeof-symbol@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.4.tgz#9509f1a7eec31c4edbffe137c16cc33ff0bc5bfc"
-  integrity sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==
+"@babel/plugin-transform-typeof-symbol@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.13.tgz#785dd67a1f2ea579d9c2be722de8c84cb85f5a7f"
+  integrity sha512-eKv/LmUJpMnu4npgfvs3LiHhJua5fo/CysENxa45YCQXZwKnGCQKAg87bvoqSW1fFT+HA32l03Qxsm8ouTY3ZQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-unicode-escapes@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.10.4.tgz#feae523391c7651ddac115dae0a9d06857892007"
-  integrity sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==
+"@babel/plugin-transform-unicode-escapes@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.13.tgz#840ced3b816d3b5127dd1d12dcedc5dead1a5e74"
+  integrity sha512-0bHEkdwJ/sN/ikBHfSmOXPypN/beiGqjo+o4/5K+vxEFNPRPdImhviPakMKG4x96l85emoa0Z6cDflsdBusZbw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-unicode-regex@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz#e56d71f9282fac6db09c82742055576d5e6d80a8"
-  integrity sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==
+"@babel/plugin-transform-unicode-regex@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.13.tgz#b52521685804e155b1202e83fc188d34bb70f5ac"
+  integrity sha512-mDRzSNY7/zopwisPZ5kM9XKCfhchqIYwAKRERtEnhYscZB79VRekuRSoYbN0+KVe3y8+q1h6A4svXtP7N+UoCA==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-create-regexp-features-plugin" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.12.13"
 
 "@babel/preset-env@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.10.4.tgz#fbf57f9a803afd97f4f32e4f798bb62e4b2bef5f"
-  integrity sha512-tcmuQ6vupfMZPrLrc38d0sF2OjLT3/bZ0dry5HchNCQbrokoQi4reXqclvkkAT5b+gWc23meVWpve5P/7+w/zw==
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.13.12.tgz#6dff470478290582ac282fb77780eadf32480237"
+  integrity sha512-JzElc6jk3Ko6zuZgBtjOd01pf9yYDEIH8BcqVuYIuOkzOwDesoa/Nz4gIo4lBG6K861KTV9TvIgmFuT6ytOaAA==
   dependencies:
-    "@babel/compat-data" "^7.10.4"
-    "@babel/helper-compilation-targets" "^7.10.4"
-    "@babel/helper-module-imports" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-proposal-async-generator-functions" "^7.10.4"
-    "@babel/plugin-proposal-class-properties" "^7.10.4"
-    "@babel/plugin-proposal-dynamic-import" "^7.10.4"
-    "@babel/plugin-proposal-json-strings" "^7.10.4"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.10.4"
-    "@babel/plugin-proposal-numeric-separator" "^7.10.4"
-    "@babel/plugin-proposal-object-rest-spread" "^7.10.4"
-    "@babel/plugin-proposal-optional-catch-binding" "^7.10.4"
-    "@babel/plugin-proposal-optional-chaining" "^7.10.4"
-    "@babel/plugin-proposal-private-methods" "^7.10.4"
-    "@babel/plugin-proposal-unicode-property-regex" "^7.10.4"
-    "@babel/plugin-syntax-async-generators" "^7.8.0"
-    "@babel/plugin-syntax-class-properties" "^7.10.4"
-    "@babel/plugin-syntax-dynamic-import" "^7.8.0"
-    "@babel/plugin-syntax-json-strings" "^7.8.0"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+    "@babel/compat-data" "^7.13.12"
+    "@babel/helper-compilation-targets" "^7.13.10"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-validator-option" "^7.12.17"
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.13.12"
+    "@babel/plugin-proposal-async-generator-functions" "^7.13.8"
+    "@babel/plugin-proposal-class-properties" "^7.13.0"
+    "@babel/plugin-proposal-dynamic-import" "^7.13.8"
+    "@babel/plugin-proposal-export-namespace-from" "^7.12.13"
+    "@babel/plugin-proposal-json-strings" "^7.13.8"
+    "@babel/plugin-proposal-logical-assignment-operators" "^7.13.8"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.13.8"
+    "@babel/plugin-proposal-numeric-separator" "^7.12.13"
+    "@babel/plugin-proposal-object-rest-spread" "^7.13.8"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.13.8"
+    "@babel/plugin-proposal-optional-chaining" "^7.13.12"
+    "@babel/plugin-proposal-private-methods" "^7.13.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.12.13"
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
+    "@babel/plugin-syntax-class-properties" "^7.12.13"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
+    "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
+    "@babel/plugin-syntax-json-strings" "^7.8.3"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
-    "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
-    "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
-    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
-    "@babel/plugin-syntax-top-level-await" "^7.10.4"
-    "@babel/plugin-transform-arrow-functions" "^7.10.4"
-    "@babel/plugin-transform-async-to-generator" "^7.10.4"
-    "@babel/plugin-transform-block-scoped-functions" "^7.10.4"
-    "@babel/plugin-transform-block-scoping" "^7.10.4"
-    "@babel/plugin-transform-classes" "^7.10.4"
-    "@babel/plugin-transform-computed-properties" "^7.10.4"
-    "@babel/plugin-transform-destructuring" "^7.10.4"
-    "@babel/plugin-transform-dotall-regex" "^7.10.4"
-    "@babel/plugin-transform-duplicate-keys" "^7.10.4"
-    "@babel/plugin-transform-exponentiation-operator" "^7.10.4"
-    "@babel/plugin-transform-for-of" "^7.10.4"
-    "@babel/plugin-transform-function-name" "^7.10.4"
-    "@babel/plugin-transform-literals" "^7.10.4"
-    "@babel/plugin-transform-member-expression-literals" "^7.10.4"
-    "@babel/plugin-transform-modules-amd" "^7.10.4"
-    "@babel/plugin-transform-modules-commonjs" "^7.10.4"
-    "@babel/plugin-transform-modules-systemjs" "^7.10.4"
-    "@babel/plugin-transform-modules-umd" "^7.10.4"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.10.4"
-    "@babel/plugin-transform-new-target" "^7.10.4"
-    "@babel/plugin-transform-object-super" "^7.10.4"
-    "@babel/plugin-transform-parameters" "^7.10.4"
-    "@babel/plugin-transform-property-literals" "^7.10.4"
-    "@babel/plugin-transform-regenerator" "^7.10.4"
-    "@babel/plugin-transform-reserved-words" "^7.10.4"
-    "@babel/plugin-transform-shorthand-properties" "^7.10.4"
-    "@babel/plugin-transform-spread" "^7.10.4"
-    "@babel/plugin-transform-sticky-regex" "^7.10.4"
-    "@babel/plugin-transform-template-literals" "^7.10.4"
-    "@babel/plugin-transform-typeof-symbol" "^7.10.4"
-    "@babel/plugin-transform-unicode-escapes" "^7.10.4"
-    "@babel/plugin-transform-unicode-regex" "^7.10.4"
-    "@babel/preset-modules" "^0.1.3"
-    "@babel/types" "^7.10.4"
-    browserslist "^4.12.0"
-    core-js-compat "^3.6.2"
-    invariant "^2.2.2"
-    levenary "^1.1.1"
-    semver "^5.5.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
+    "@babel/plugin-syntax-top-level-await" "^7.12.13"
+    "@babel/plugin-transform-arrow-functions" "^7.13.0"
+    "@babel/plugin-transform-async-to-generator" "^7.13.0"
+    "@babel/plugin-transform-block-scoped-functions" "^7.12.13"
+    "@babel/plugin-transform-block-scoping" "^7.12.13"
+    "@babel/plugin-transform-classes" "^7.13.0"
+    "@babel/plugin-transform-computed-properties" "^7.13.0"
+    "@babel/plugin-transform-destructuring" "^7.13.0"
+    "@babel/plugin-transform-dotall-regex" "^7.12.13"
+    "@babel/plugin-transform-duplicate-keys" "^7.12.13"
+    "@babel/plugin-transform-exponentiation-operator" "^7.12.13"
+    "@babel/plugin-transform-for-of" "^7.13.0"
+    "@babel/plugin-transform-function-name" "^7.12.13"
+    "@babel/plugin-transform-literals" "^7.12.13"
+    "@babel/plugin-transform-member-expression-literals" "^7.12.13"
+    "@babel/plugin-transform-modules-amd" "^7.13.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.13.8"
+    "@babel/plugin-transform-modules-systemjs" "^7.13.8"
+    "@babel/plugin-transform-modules-umd" "^7.13.0"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.12.13"
+    "@babel/plugin-transform-new-target" "^7.12.13"
+    "@babel/plugin-transform-object-super" "^7.12.13"
+    "@babel/plugin-transform-parameters" "^7.13.0"
+    "@babel/plugin-transform-property-literals" "^7.12.13"
+    "@babel/plugin-transform-regenerator" "^7.12.13"
+    "@babel/plugin-transform-reserved-words" "^7.12.13"
+    "@babel/plugin-transform-shorthand-properties" "^7.12.13"
+    "@babel/plugin-transform-spread" "^7.13.0"
+    "@babel/plugin-transform-sticky-regex" "^7.12.13"
+    "@babel/plugin-transform-template-literals" "^7.13.0"
+    "@babel/plugin-transform-typeof-symbol" "^7.12.13"
+    "@babel/plugin-transform-unicode-escapes" "^7.12.13"
+    "@babel/plugin-transform-unicode-regex" "^7.12.13"
+    "@babel/preset-modules" "^0.1.4"
+    "@babel/types" "^7.13.12"
+    babel-plugin-polyfill-corejs2 "^0.1.4"
+    babel-plugin-polyfill-corejs3 "^0.1.3"
+    babel-plugin-polyfill-regenerator "^0.1.2"
+    core-js-compat "^3.9.0"
+    semver "^6.3.0"
 
-"@babel/preset-modules@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.3.tgz#13242b53b5ef8c883c3cf7dddd55b36ce80fbc72"
-  integrity sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==
+"@babel/preset-modules@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.4.tgz#362f2b68c662842970fdb5e254ffc8fc1c2e415e"
+  integrity sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-proposal-unicode-property-regex" "^7.4.4"
@@ -908,77 +817,58 @@
     esutils "^2.0.2"
 
 "@babel/runtime@^7.8.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.4.tgz#a6724f1a6b8d2f6ea5236dbfe58c7d7ea9c5eb99"
-  integrity sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
+  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
-  integrity sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
+"@babel/template@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
+  integrity sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==
   dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/parser" "^7.10.4"
-    "@babel/types" "^7.10.4"
+    "@babel/code-frame" "^7.12.13"
+    "@babel/parser" "^7.12.13"
+    "@babel/types" "^7.12.13"
 
-"@babel/template@^7.8.3", "@babel/template@^7.8.6":
-  version "7.8.6"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
-  integrity sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==
+"@babel/traverse@^7.13.0", "@babel/traverse@^7.13.13":
+  version "7.13.13"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.13.13.tgz#39aa9c21aab69f74d948a486dd28a2dbdbf5114d"
+  integrity sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==
   dependencies:
-    "@babel/code-frame" "^7.8.3"
-    "@babel/parser" "^7.8.6"
-    "@babel/types" "^7.8.6"
-
-"@babel/traverse@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.10.4.tgz#e642e5395a3b09cc95c8e74a27432b484b697818"
-  integrity sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.10.4"
-    "@babel/helper-function-name" "^7.10.4"
-    "@babel/helper-split-export-declaration" "^7.10.4"
-    "@babel/parser" "^7.10.4"
-    "@babel/types" "^7.10.4"
+    "@babel/code-frame" "^7.12.13"
+    "@babel/generator" "^7.13.9"
+    "@babel/helper-function-name" "^7.12.13"
+    "@babel/helper-split-export-declaration" "^7.12.13"
+    "@babel/parser" "^7.13.13"
+    "@babel/types" "^7.13.13"
     debug "^4.1.0"
     globals "^11.1.0"
-    lodash "^4.17.13"
 
-"@babel/traverse@^7.9.6":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.6.tgz#5540d7577697bf619cc57b92aa0f1c231a94f442"
-  integrity sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==
+"@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.13", "@babel/types@^7.13.14", "@babel/types@^7.4.4":
+  version "7.13.14"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.14.tgz#c35a4abb15c7cd45a2746d78ab328e362cbace0d"
+  integrity sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==
   dependencies:
-    "@babel/code-frame" "^7.8.3"
-    "@babel/generator" "^7.9.6"
-    "@babel/helper-function-name" "^7.9.5"
-    "@babel/helper-split-export-declaration" "^7.8.3"
-    "@babel/parser" "^7.9.6"
-    "@babel/types" "^7.9.6"
-    debug "^4.1.0"
-    globals "^11.1.0"
-    lodash "^4.17.13"
-
-"@babel/types@^7.10.4", "@babel/types@^7.4.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.4.tgz#369517188352e18219981efd156bfdb199fff1ee"
-  integrity sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.10.4"
-    lodash "^4.17.13"
+    "@babel/helper-validator-identifier" "^7.12.11"
+    lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0", "@babel/types@^7.9.5", "@babel/types@^7.9.6":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.6.tgz#2c5502b427251e9de1bd2dff95add646d95cc9f7"
-  integrity sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==
+"@eslint/eslintrc@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
+  integrity sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.9.5"
-    lodash "^4.17.13"
-    to-fast-properties "^2.0.0"
+    ajv "^6.12.4"
+    debug "^4.1.1"
+    espree "^7.3.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.2.1"
+    js-yaml "^3.13.1"
+    minimatch "^3.0.4"
+    strip-json-comments "^3.1.1"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -992,19 +882,18 @@
     resolve-from "^5.0.0"
 
 "@istanbuljs/schema@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
-  integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
+  integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
 "@lhncbc/ucum-lhc@^4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@lhncbc/ucum-lhc/-/ucum-lhc-4.1.3.tgz#cc76e277753cfc5e30497ef6e76c9d75df4702ba"
-  integrity sha512-F49BJBDr5lE+AkbyJVRE4b/cog3mP5xK+SlxSyztUk2Wzak5bX5vydQhdCmyRZupgtDQlFAvEr7TmIuUmNHH8g==
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@lhncbc/ucum-lhc/-/ucum-lhc-4.1.4.tgz#763d26a1e2d58b204fc645ae5128262c8cdc56bc"
+  integrity sha512-ErlXJv6lrerZbthxc33SWTKrZv4KjMIaCN2lNxsNrGZW4PqyVFEKDie6lok//SvC6QeEoAC1mWN8xD87r72qPQ==
   dependencies:
     csv-parse "^4.4.6"
     csv-stringify "^1.0.4"
     escape-html "^1.0.3"
-    grunt-extract-sourcemap "^0.1.19"
     is-integer "^1.0.6"
     jsonfile "^2.2.3"
     stream "0.0.2"
@@ -1012,10 +901,27 @@
     string-to-stream "^1.1.0"
     xmldoc "^0.4.0"
 
-"@types/color-name@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
-  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+"@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents":
+  version "2.1.8-no-fsevents"
+  resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.tgz#da7c3996b8e6e19ebd14d82eaced2313e7769f9b"
+  integrity sha512-+nb9vWloHNNMFHjGofEam3wopE3m1yuambrrd/fnPc+lFOMB9ROTqQlche9ByFWNkdNqfSgR/kkQtQ8DzEWt2w==
+  dependencies:
+    anymatch "^2.0.0"
+    async-each "^1.0.1"
+    braces "^2.3.2"
+    glob-parent "^3.1.0"
+    inherits "^2.0.3"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    normalize-path "^3.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.2.1"
+    upath "^1.1.1"
+
+"@ungap/promise-all-settled@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
+  integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
 JSONStream@^1.0.3:
   version "1.3.5"
@@ -1025,10 +931,10 @@ JSONStream@^1.0.3:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-acorn-jsx@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
-  integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
+acorn-jsx@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
+  integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
 acorn-node@^1.2.0, acorn-node@^1.3.0, acorn-node@^1.5.2, acorn-node@^1.6.1:
   version "1.8.2"
@@ -1044,37 +950,37 @@ acorn-walk@^7.0.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn@^7.0.0, acorn@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
-  integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
+acorn@^7.0.0, acorn@^7.4.0:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 aggregate-error@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
-  integrity sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
+  integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
   dependencies:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@^6.10.0, ajv@^6.10.2:
-  version "6.12.3"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
-  integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
+ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^6.5.5:
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
-  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
+ajv@^8.0.1:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.0.2.tgz#1396e27f208ed56dd5638ab5a251edeb1c91d402"
+  integrity sha512-V0HGxJd0PiDF0ecHYIesTOqfd1gJguwQUOYfMfAWnRsWQEXfc5ifbUFhD3Wjc+O+y7VAqL+g07prq9gHQ/JOZQ==
   dependencies:
-    fast-deep-equal "^2.0.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ansi-colors@4.1.1, ansi-colors@^4.1.1:
@@ -1087,17 +993,12 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
-
 ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
-ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -1105,11 +1006,10 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
     color-convert "^1.9.0"
 
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
-  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
-    "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
 
 anymatch@^2.0.0:
@@ -1147,6 +1047,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -1167,24 +1072,15 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
-array.prototype.map@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/array.prototype.map/-/array.prototype.map-1.0.2.tgz#9a4159f416458a23e9483078de1106b2ef68f8ec"
-  integrity sha512-Az3OYxgsa1g7xDYp86l0nnN4bcmuEITGe1rbdEBVkrqkzMgDcbdQ2R7r41pNzti+4NMces3H8gMmuioZUilLgw==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    es-array-method-boxes-properly "^1.0.0"
-    is-string "^1.0.4"
-
-asn1.js@^4.0.0:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
-  integrity sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==
+asn1.js@^5.2.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"
+  integrity sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==
   dependencies:
     bn.js "^4.0.0"
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
+    safer-buffer "^2.1.0"
 
 asn1@~0.2.3:
   version "0.2.4"
@@ -1211,10 +1107,10 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-astral-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
-  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
+astral-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
+  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 async-each@^1.0.1:
   version "1.0.3"
@@ -1237,9 +1133,9 @@ aws-sign2@~0.7.0:
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
 aws4@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
-  integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
+  integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
@@ -1248,15 +1144,39 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
+babel-plugin-polyfill-corejs2@^0.1.4:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.1.10.tgz#a2c5c245f56c0cac3dbddbf0726a46b24f0f81d1"
+  integrity sha512-DO95wD4g0A8KRaHKi0D51NdGXzvpqVLnLu5BTvDlpqUEpTmeEtypgC1xqesORaWmiUOQI14UHKlzNd9iZ2G3ZA==
+  dependencies:
+    "@babel/compat-data" "^7.13.0"
+    "@babel/helper-define-polyfill-provider" "^0.1.5"
+    semver "^6.1.1"
+
+babel-plugin-polyfill-corejs3@^0.1.3:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.7.tgz#80449d9d6f2274912e05d9e182b54816904befd0"
+  integrity sha512-u+gbS9bbPhZWEeyy1oR/YaaSpod/KDT07arZHb80aTpl8H5ZBq+uN1nN9/xtX7jQyfLdPfoqI4Rue/MQSWJquw==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.1.5"
+    core-js-compat "^3.8.1"
+
+babel-plugin-polyfill-regenerator@^0.1.2:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.1.6.tgz#0fe06a026fe0faa628ccc8ba3302da0a6ce02f3f"
+  integrity sha512-OUrYG9iKPKz8NxswXbRAdSwF0GhRdIEMTloQATJi4bDuFqrXaXcCUT/VGNrr8pBcjMh1RxZ7Xt9cytVJTJfvMg==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.1.5"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
 base64-js@^1.0.2:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
-  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 base@^0.11.1:
   version "0.11.2"
@@ -1284,26 +1204,19 @@ binary-extensions@^1.0.0:
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
 binary-extensions@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
-  integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
-
-bindings@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
-  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
-  dependencies:
-    file-uri-to-path "1.0.0"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
+  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
 
-bn.js@^5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.2.tgz#c9686902d3c9a27729f43ab10f9d79c2004da7b0"
-  integrity sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==
+bn.js@^5.0.0, bn.js@^5.1.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
+  integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1353,12 +1266,12 @@ browser-pack@^6.0.1:
     through2 "^2.0.0"
     umd "^3.0.0"
 
-browser-resolve@^1.11.0, browser-resolve@^1.7.0:
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
-  integrity sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==
+browser-resolve@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-2.0.0.tgz#99b7304cb392f8d73dba741bb2d7da28c6d7842b"
+  integrity sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==
   dependencies:
-    resolve "1.1.7"
+    resolve "^1.17.0"
 
 browser-stdout@1.3.1:
   version "1.3.1"
@@ -1397,23 +1310,23 @@ browserify-des@^1.0.0:
     safe-buffer "^5.1.2"
 
 browserify-rsa@^4.0.0, browserify-rsa@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.0.1.tgz#21e0abfaf6f2029cf2fafb133567a701d4135524"
-  integrity sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.1.0.tgz#b2fd06b5b75ae297f7ce2dc651f918f5be158c8d"
+  integrity sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==
   dependencies:
-    bn.js "^4.1.0"
+    bn.js "^5.0.0"
     randombytes "^2.0.1"
 
 browserify-sign@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.2.0.tgz#545d0b1b07e6b2c99211082bf1b12cce7a0b0e11"
-  integrity sha512-hEZC1KEeYuoHRqhGhTy6gWrpJA3ZDjFWv0DE61643ZnOXAKJb3u7yWcrU0mMc9SwAqK1n7myPGndkp0dFG7NFA==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.2.1.tgz#eaf4add46dd54be3bb3b36c0cf15abbeba7956c3"
+  integrity sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==
   dependencies:
     bn.js "^5.1.1"
     browserify-rsa "^4.0.1"
     create-hash "^1.2.0"
     create-hmac "^1.1.7"
-    elliptic "^6.5.2"
+    elliptic "^6.5.3"
     inherits "^2.0.4"
     parse-asn1 "^5.1.5"
     readable-stream "^3.6.0"
@@ -1427,14 +1340,14 @@ browserify-zlib@~0.2.0:
     pako "~1.0.5"
 
 browserify@^16.5.1:
-  version "16.5.1"
-  resolved "https://registry.yarnpkg.com/browserify/-/browserify-16.5.1.tgz#3c13c97436802930d5c3ae28658ddc33bfd37dc2"
-  integrity sha512-EQX0h59Pp+0GtSRb5rL6OTfrttlzv+uyaUVlK6GX3w11SQ0jKPKyjC/54RhPR2ib2KmfcELM06e8FxcI5XNU2A==
+  version "16.5.2"
+  resolved "https://registry.yarnpkg.com/browserify/-/browserify-16.5.2.tgz#d926835e9280fa5fd57f5bc301f2ef24a972ddfe"
+  integrity sha512-TkOR1cQGdmXU9zW4YukWzWVSJwrxmNdADFbqbE3HFgQWe5wqZmOawqZ7J/8MPCwk/W8yY7Y0h+7mOtcZxLP23g==
   dependencies:
     JSONStream "^1.0.3"
     assert "^1.4.0"
     browser-pack "^6.0.1"
-    browser-resolve "^1.11.0"
+    browser-resolve "^2.0.0"
     browserify-zlib "~0.2.0"
     buffer "~5.2.1"
     cached-path-relative "^1.0.0"
@@ -1455,7 +1368,7 @@ browserify@^16.5.1:
     insert-module-globals "^7.0.0"
     labeled-stream-splicer "^2.0.0"
     mkdirp-classic "^0.5.2"
-    module-deps "^6.0.0"
+    module-deps "^6.2.3"
     os-browserify "~0.3.0"
     parents "^1.0.1"
     path-browserify "~0.0.0"
@@ -1480,15 +1393,16 @@ browserify@^16.5.1:
     vm-browserify "^1.0.0"
     xtend "^4.0.0"
 
-browserslist@^4.12.0, browserslist@^4.8.5:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.13.0.tgz#42556cba011e1b0a2775b611cba6a8eca18e940d"
-  integrity sha512-MINatJ5ZNrLnQ6blGvePd/QOz9Xtu+Ne+x29iQSCHfkU5BugKVJwZKn/iiL8UbpIpa3JhviKjz+XxMo0m2caFQ==
+browserslist@^4.14.5, browserslist@^4.16.3:
+  version "4.16.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.3.tgz#340aa46940d7db878748567c5dea24a48ddf3717"
+  integrity sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==
   dependencies:
-    caniuse-lite "^1.0.30001093"
-    electron-to-chromium "^1.3.488"
-    escalade "^3.0.1"
-    node-releases "^1.1.58"
+    caniuse-lite "^1.0.30001181"
+    colorette "^1.2.1"
+    electron-to-chromium "^1.3.649"
+    escalade "^3.1.1"
+    node-releases "^1.1.70"
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -1543,6 +1457,14 @@ caching-transform@^4.0.0:
     package-hash "^4.0.0"
     write-file-atomic "^3.0.0"
 
+call-bind@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -1553,10 +1475,15 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-caniuse-lite@^1.0.30001093:
-  version "1.0.30001177"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001177.tgz"
-  integrity sha512-6Ld7t3ifCL02jTj3MxPMM5wAYjbo4h/TAQGFTgv1inihP1tWnWp8mxxT4ut4JBEHLbpFXEXJJQ119JCJTBkYDw==
+camelcase@^6.0.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
+  integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
+
+caniuse-lite@^1.0.30001181:
+  version "1.0.30001205"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz#d79bf6a6fb13196b4bb46e5143a22ca0242e0ef8"
+  integrity sha512-TL1GrS5V6LElbitPazidkBMD9sa448bQDDLrumDqaggmKFcuU2JW1wTOHJPukAcOMtEmLcmDJEzfRrf+GjM0Og==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1580,10 +1507,10 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chokidar@3.4.2:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.2.tgz#38dc8e658dec3809741eb3ef7bb0a47fe424232d"
-  integrity sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==
+chokidar@3.5.1, chokidar@^3.4.0:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
   dependencies:
     anymatch "~3.1.1"
     braces "~3.0.2"
@@ -1591,28 +1518,9 @@ chokidar@3.4.2:
     is-binary-path "~2.1.0"
     is-glob "~4.0.1"
     normalize-path "~3.0.0"
-    readdirp "~3.4.0"
+    readdirp "~3.5.0"
   optionalDependencies:
-    fsevents "~2.1.2"
-
-chokidar@^2.1.8:
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
-  integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
-  dependencies:
-    anymatch "^2.0.0"
-    async-each "^1.0.1"
-    braces "^2.3.2"
-    glob-parent "^3.1.0"
-    inherits "^2.0.3"
-    is-binary-path "^1.0.0"
-    is-glob "^4.0.0"
-    normalize-path "^3.0.0"
-    path-is-absolute "^1.0.0"
-    readdirp "^2.2.1"
-    upath "^1.1.1"
-  optionalDependencies:
-    fsevents "^1.2.7"
+    fsevents "~2.3.1"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -1637,15 +1545,6 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
-cliui@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
-  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
-  dependencies:
-    string-width "^3.1.0"
-    strip-ansi "^5.2.0"
-    wrap-ansi "^5.1.0"
-
 cliui@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
@@ -1655,10 +1554,14 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
-coffee-script@~1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.10.0.tgz#12938bcf9be1948fa006f92e0c4c9e81705108c0"
-  integrity sha1-EpOLz5vhlI+gBvkuDEyegXBRCMA=
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -1692,6 +1595,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+colorette@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
+  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
+
 combine-source-map@^0.8.0, combine-source-map@~0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/combine-source-map/-/combine-source-map-0.8.0.tgz#a58d0df042c186fcf822a8e8015f5450d2d79a8b"
@@ -1703,9 +1611,9 @@ combine-source-map@^0.8.0, combine-source-map@~0.8.0:
     source-map "~0.5.3"
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
-  integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
 
@@ -1766,17 +1674,18 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js-compat@^3.6.2:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.6.5.tgz#2a51d9a4e25dfd6e690251aa81f99e3c05481f1c"
-  integrity sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==
+core-js-compat@^3.8.1, core-js-compat@^3.9.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.10.0.tgz#3600dc72869673c110215ee7a005a8609dea0fe1"
+  integrity sha512-9yVewub2MXNYyGvuLnMHcN1k9RkvB7/ofktpeKTIaASyB88YYqGzUnu0ywMMhJrDHOMiTjSHWGzR+i7Wb9Z1kQ==
   dependencies:
-    browserslist "^4.8.5"
+    browserslist "^4.16.3"
     semver "7.0.0"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+  integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
 coveralls@^3.1.0:
   version "3.1.0"
@@ -1790,12 +1699,12 @@ coveralls@^3.1.0:
     request "^2.88.2"
 
 create-ecdh@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
-  integrity sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
+  integrity sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==
   dependencies:
     bn.js "^4.1.0"
-    elliptic "^6.0.0"
+    elliptic "^6.5.3"
 
 create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
@@ -1820,16 +1729,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-spawn@^7.0.0:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.2.tgz#d0d7dcfa74e89115c7619f4f721a94e1fdb716d6"
-  integrity sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==
-  dependencies:
-    path-key "^3.1.0"
-    shebang-command "^2.0.0"
-    which "^2.0.1"
-
-cross-spawn@^7.0.2:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -1856,9 +1756,9 @@ crypto-browserify@^3.0.0:
     randomfill "^1.0.3"
 
 csv-parse@^4.4.6:
-  version "4.15.0"
-  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.15.0.tgz#d86d447e88d5f9a539e8768874f89a8d86d8fd78"
-  integrity sha512-y2wGeU/ybvUlyw6F+eanM6lxxE4JthCuHuaoTgPXdw6ImmfYXqtP0nrCLqd6Ew/a0FgPEz36y5HznI0W5oJ+cg==
+  version "4.15.3"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.15.3.tgz#8a62759617a920c328cb31c351b05053b8f92b10"
+  integrity sha512-jlTqDvLdHnYMSr08ynNfk4IAUSJgJjTKy2U5CQBSu4cN9vQOJonLVZP4Qo4gKKrIgIQ5dr07UwOJdi+lRqT12w==
 
 csv-stringify@^1.0.4:
   version "1.1.2"
@@ -1879,12 +1779,12 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@4.1.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+debug@4.3.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
   dependencies:
-    ms "^2.1.1"
+    ms "2.1.2"
 
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -1897,6 +1797,11 @@ decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+decamelize@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
+  integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -1915,7 +1820,7 @@ default-require-extensions@^3.0.0:
   dependencies:
     strip-bom "^4.0.0"
 
-define-properties@^1.1.2, define-properties@^1.1.3:
+define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
@@ -1981,10 +1886,10 @@ detective@^5.2.0:
     defined "^1.0.0"
     minimist "^1.1.1"
 
-diff@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+diff@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -2022,12 +1927,12 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-electron-to-chromium@^1.3.488:
-  version "1.3.496"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.496.tgz#3f43d32930481d82ad3663d79658e7c59a58af0b"
-  integrity sha512-TXY4mwoyowwi4Lsrq9vcTUYBThyc1b2hXaTZI13p8/FRhY2CTaq5lK+DVjhYkKiTLsKt569Xes+0J5JsVXFurQ==
+electron-to-chromium@^1.3.649:
+  version "1.3.703"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.703.tgz#6d9b9a75c42a40775f5930329e642b22b227317f"
+  integrity sha512-SVBVhNB+4zPL+rvtWLw7PZQkw/Eqj1HQZs22xtcqW36+xoifzEOEEDEpkxSMfB6RFeSIOcG00w6z5mSqLr1Y6w==
 
-elliptic@^6.0.0, elliptic@^6.5.2:
+elliptic@^6.5.3:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
@@ -2045,11 +1950,6 @@ emitter-component@^1.1.1:
   resolved "https://registry.yarnpkg.com/emitter-component/-/emitter-component-1.1.1.tgz#065e2dbed6959bf470679edabeaf7981d1003ab6"
   integrity sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY=
 
-emoji-regex@^7.0.1:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
-  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
-
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -2062,59 +1962,15 @@ enquirer@^2.3.5:
   dependencies:
     ansi-colors "^4.1.1"
 
-es-abstract@^1.17.0-next.1, es-abstract@^1.17.4, es-abstract@^1.17.5:
-  version "1.17.6"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.6.tgz#9142071707857b2cacc7b89ecb670316c3e2d52a"
-  integrity sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
-  dependencies:
-    es-to-primitive "^1.2.1"
-    function-bind "^1.1.1"
-    has "^1.0.3"
-    has-symbols "^1.0.1"
-    is-callable "^1.2.0"
-    is-regex "^1.1.0"
-    object-inspect "^1.7.0"
-    object-keys "^1.1.1"
-    object.assign "^4.1.0"
-    string.prototype.trimend "^1.0.1"
-    string.prototype.trimstart "^1.0.1"
-
-es-array-method-boxes-properly@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
-  integrity sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==
-
-es-get-iterator@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.0.tgz#bb98ad9d6d63b31aacdc8f89d5d0ee57bcb5b4c8"
-  integrity sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==
-  dependencies:
-    es-abstract "^1.17.4"
-    has-symbols "^1.0.1"
-    is-arguments "^1.0.4"
-    is-map "^2.0.1"
-    is-set "^2.0.1"
-    is-string "^1.0.5"
-    isarray "^2.0.5"
-
-es-to-primitive@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
-  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
-  dependencies:
-    is-callable "^1.1.4"
-    is-date-object "^1.0.1"
-    is-symbol "^1.0.2"
-
 es6-error@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
-escalade@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.0.1.tgz#52568a77443f6927cd0ab9c73129137533c965ed"
-  integrity sha512-DR6NO3h9niOT+MZs7bjxlj2a1k+POu5RN8CLTPX2+i78bRi9eLe7+0zXgUHMnGXWybYcL61E9hGhPKqedy8tQA==
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
 escape-html@^1.0.3:
   version "1.0.3"
@@ -2132,54 +1988,60 @@ escape-string-regexp@^1.0.5:
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
 eslint-config-prettier@^6.11.0:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz#f6d2238c1290d01c859a8b5c1f7d352a0b0da8b1"
-  integrity sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz#7f93f6cb7d45a92f1537a70ecc06366e1ac6fed9"
+  integrity sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-scope@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.0.tgz#d0f971dfe59c69e0cada684b23d49dbf82600ce5"
-  integrity sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==
+eslint-scope@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
   dependencies:
-    esrecurse "^4.1.0"
+    esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-utils@^2.0.0:
+eslint-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.2.0:
+eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
+eslint-visitor-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
+  integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
+
 eslint@^7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.4.0.tgz#4e35a2697e6c1972f9d6ef2b690ad319f80f206f"
-  integrity sha512-gU+lxhlPHu45H3JkEGgYhWhkR9wLHHEXC9FbWFnTlEkbKyZKWgWRLgf61E8zWmBuI6g5xKBph9ltg3NtZMVF8g==
+  version "7.23.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.23.0.tgz#8d029d252f6e8cf45894b4bee08f5493f8e94325"
+  integrity sha512-kqvNVbdkjzpFy0XOszNwjkKzZ+6TcwCQ/h+ozlcIWwaimBBuhlQ4nN6kbiM2L+OjDcznkTJxzYfRFH92sx4a0Q==
   dependencies:
-    "@babel/code-frame" "^7.0.0"
+    "@babel/code-frame" "7.12.11"
+    "@eslint/eslintrc" "^0.4.0"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
     debug "^4.0.1"
     doctrine "^3.0.0"
     enquirer "^2.3.5"
-    eslint-scope "^5.1.0"
-    eslint-utils "^2.0.0"
-    eslint-visitor-keys "^1.2.0"
-    espree "^7.1.0"
-    esquery "^1.2.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^2.1.0"
+    eslint-visitor-keys "^2.0.0"
+    espree "^7.3.1"
+    esquery "^1.4.0"
     esutils "^2.0.2"
-    file-entry-cache "^5.0.1"
+    file-entry-cache "^6.0.1"
     functional-red-black-tree "^1.0.1"
     glob-parent "^5.0.0"
-    globals "^12.1.0"
+    globals "^13.6.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
@@ -2187,7 +2049,7 @@ eslint@^7.4.0:
     js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
-    lodash "^4.17.14"
+    lodash "^4.17.21"
     minimatch "^3.0.4"
     natural-compare "^1.4.0"
     optionator "^0.9.1"
@@ -2196,47 +2058,47 @@ eslint@^7.4.0:
     semver "^7.2.1"
     strip-ansi "^6.0.0"
     strip-json-comments "^3.1.0"
-    table "^5.2.3"
+    table "^6.0.4"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-7.1.0.tgz#a9c7f18a752056735bf1ba14cb1b70adc3a5ce1c"
-  integrity sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==
+espree@^7.3.0, espree@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
+  integrity sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
   dependencies:
-    acorn "^7.2.0"
-    acorn-jsx "^5.2.0"
-    eslint-visitor-keys "^1.2.0"
+    acorn "^7.4.0"
+    acorn-jsx "^5.3.1"
+    eslint-visitor-keys "^1.3.0"
 
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.3.1.tgz#b78b5828aa8e214e29fb74c4d5b752e1c033da57"
-  integrity sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==
+esquery@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
   dependencies:
     estraverse "^5.1.0"
 
-esrecurse@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
-  integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
+esrecurse@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
-    estraverse "^4.1.0"
+    estraverse "^5.2.0"
 
-estraverse@^4.1.0, estraverse@^4.1.1:
+estraverse@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.1.0.tgz#374309d39fd935ae500e7b92e8a6b4c720e59642"
-  integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
+estraverse@^5.1.0, estraverse@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
+  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -2313,20 +2175,15 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
-  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
-
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-json-stable-stringify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
-  integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-levenshtein@^2.0.6:
   version "2.0.6"
@@ -2338,17 +2195,12 @@ fast-safe-stringify@^2.0.7:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
   integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
 
-file-entry-cache@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
-  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
+file-entry-cache@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
-    flat-cache "^2.0.1"
-
-file-uri-to-path@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
-  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+    flat-cache "^3.0.4"
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -2384,13 +2236,6 @@ find-up@5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
-find-up@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
-  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
-  dependencies:
-    locate-path "^3.0.0"
-
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -2399,26 +2244,23 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-flat-cache@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
-  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+flat-cache@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
   dependencies:
-    flatted "^2.0.0"
-    rimraf "2.6.3"
-    write "1.0.3"
+    flatted "^3.1.0"
+    rimraf "^3.0.2"
 
-flat@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/flat/-/flat-4.1.0.tgz#090bec8b05e39cba309747f1d588f04dbaf98db2"
-  integrity sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==
-  dependencies:
-    is-buffer "~2.0.3"
+flat@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
+  integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
-flatted@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
-  integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+flatted@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
+  integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -2455,9 +2297,9 @@ fragment-cache@^0.2.1:
     map-cache "^0.2.2"
 
 fromentries@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fromentries/-/fromentries-1.2.0.tgz#e6aa06f240d6267f913cea422075ef88b63e7897"
-  integrity sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/fromentries/-/fromentries-1.3.2.tgz#e4bca6808816bf8f93b52750f1127f5a6fd86e3a"
+  integrity sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==
 
 fs-readdir-recursive@^1.1.0:
   version "1.1.0"
@@ -2469,18 +2311,10 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@^1.2.7:
-  version "1.2.13"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.13.tgz#f325cb0455592428bcf11b383370ef70e3bfcc38"
-  integrity sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==
-  dependencies:
-    bindings "^1.5.0"
-    nan "^2.12.1"
-
-fsevents@~2.1.2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
-  integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+fsevents@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -2492,20 +2326,29 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-gensync@^1.0.0-beta.1:
-  version "1.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
-  integrity sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==
+gensync@^1.0.0-beta.2:
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
+  integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
 get-assigned-identifiers@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz#6dbf411de648cbaf8d9169ebb0d2d576191e2ff1"
   integrity sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-intrinsic@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
 
 get-package-type@^0.1.0:
   version "0.1.0"
@@ -2538,9 +2381,9 @@ glob-parent@^3.1.0:
     path-dirname "^1.0.0"
 
 glob-parent@^5.0.0, glob-parent@~5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
-  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
@@ -2568,28 +2411,22 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.6:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
-  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+globals@^13.6.0:
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.7.0.tgz#aed3bcefd80ad3ec0f0be2cf0c895110c0591795"
+  integrity sha512-Aipsz6ZKRxa/xQkZhNg0qIWXT6x6rD46f6x/PCnBomlttdIyAPak4YD9jTmKpZ72uROSMU87qJtcgpgHaVchiA==
+  dependencies:
+    type-fest "^0.20.2"
 
-graceful-fs@^4.1.15:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
-  integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.6:
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
+  integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
 growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
-
-grunt-extract-sourcemap@^0.1.19:
-  version "0.1.19"
-  resolved "https://registry.yarnpkg.com/grunt-extract-sourcemap/-/grunt-extract-sourcemap-0.1.19.tgz#bd4630125d56875c7cb3b70003ca30137245a692"
-  integrity sha1-vUYwEl1Wh1x8s7cAA8owE3JFppI=
-  dependencies:
-    coffee-script "~1.10.0"
-    lazy.js "~0.4.2"
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -2597,11 +2434,11 @@ har-schema@^2.0.0:
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
 har-validator@~5.1.3:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
-  integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
+  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
   dependencies:
-    ajv "^6.5.5"
+    ajv "^6.12.3"
     har-schema "^2.0.0"
 
 has-flag@^3.0.0:
@@ -2614,10 +2451,10 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-symbols@^1.0.0, has-symbols@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
-  integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
+has-symbols@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
+  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -2675,9 +2512,9 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     minimalistic-assert "^1.0.1"
 
 hasha@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/hasha/-/hasha-5.2.0.tgz#33094d1f69c40a4a6ac7be53d5fe3ff95a269e0c"
-  integrity sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/hasha/-/hasha-5.2.2.tgz#a48477989b3b327aea3c04f53096d816d97522a1"
+  integrity sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==
   dependencies:
     is-stream "^2.0.0"
     type-fest "^0.8.0"
@@ -2721,19 +2558,19 @@ https-browserify@^1.0.0:
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
 ieee754@^1.1.4:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
-  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-import-fresh@^3.0.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
-  integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
+import-fresh@^3.0.0, import-fresh@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
+  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
@@ -2779,9 +2616,9 @@ inline-source-map@~0.6.0:
     source-map "~0.5.3"
 
 insert-module-globals@^7.0.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/insert-module-globals/-/insert-module-globals-7.2.0.tgz#ec87e5b42728479e327bd5c5c71611ddfb4752ba"
-  integrity sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/insert-module-globals/-/insert-module-globals-7.2.1.tgz#d5e33185181a4e1f33b15f7bf100ee91890d5cb3"
+  integrity sha512-ufS5Qq9RZN+Bu899eA9QCAYThY+gGW7oRkmb0vC93Vlyu/CFGcH0OYPEjVkDXA5FEbTt1+VWzdoOD3Ny9N+8tg==
   dependencies:
     JSONStream "^1.0.3"
     acorn-node "^1.5.2"
@@ -2793,13 +2630,6 @@ insert-module-globals@^7.0.0:
     through2 "^2.0.0"
     undeclared-identifiers "^1.1.2"
     xtend "^4.0.0"
-
-invariant@^2.2.2, invariant@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
-  dependencies:
-    loose-envify "^1.0.0"
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -2815,11 +2645,6 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
-is-arguments@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz#3faf966c7cba0ff437fb31f6250082fcf0448cf3"
-  integrity sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==
-
 is-binary-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
@@ -2834,19 +2659,24 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
+is-boolean-object@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.0.tgz#e2aaad3a3a8fca34c28f6eee135b156ed2587ff0"
+  integrity sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==
+  dependencies:
+    call-bind "^1.0.0"
+
 is-buffer@^1.1.0, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-buffer@~2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
-  integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
-
-is-callable@^1.1.4, is-callable@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
-  integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
+is-core-module@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
+  integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
+  dependencies:
+    has "^1.0.3"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -2861,11 +2691,6 @@ is-data-descriptor@^1.0.0:
   integrity sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
   dependencies:
     kind-of "^6.0.0"
-
-is-date-object@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
-  integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -2938,10 +2763,10 @@ is-integer@^1.0.6:
   dependencies:
     is-finite "^1.0.0"
 
-is-map@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.1.tgz#520dafc4307bb8ebc33b813de5ce7c9400d644a1"
-  integrity sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==
+is-number-object@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.4.tgz#36ac95e741cf18b283fc1ddf5e83da798e3ec197"
+  integrity sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==
 
 is-number@^3.0.0:
   version "3.0.0"
@@ -2955,10 +2780,10 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-plain-obj@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
-  integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
+is-plain-obj@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
@@ -2967,34 +2792,15 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-regex@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.0.tgz#ece38e389e490df0dc21caea2bd596f987f767ff"
-  integrity sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==
-  dependencies:
-    has-symbols "^1.0.1"
-
-is-set@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.1.tgz#d1604afdab1724986d30091575f54945da7e5f43"
-  integrity sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==
-
 is-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
-is-string@^1.0.4, is-string@^1.0.5:
+is-string@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
   integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
-
-is-symbol@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
-  integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
-  dependencies:
-    has-symbols "^1.0.1"
 
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
@@ -3009,11 +2815,7 @@ is-windows@^1.0.2:
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-
-isarray@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
-  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
+  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -3098,36 +2900,22 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-iterate-iterator@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/iterate-iterator/-/iterate-iterator-1.0.1.tgz#1693a768c1ddd79c969051459453f082fe82e9f6"
-  integrity sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw==
-
-iterate-value@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/iterate-value/-/iterate-value-1.0.2.tgz#935115bd37d006a52046535ebc8d07e9c9337f57"
-  integrity sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==
-  dependencies:
-    es-get-iterator "^1.0.2"
-    iterate-iterator "^1.0.1"
-
-"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
+js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@3.14.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
-  integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
+js-yaml@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
+  integrity sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
   dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
+    argparse "^2.0.1"
 
 js-yaml@^3.13.1:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
-  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
+  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -3152,6 +2940,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -3175,9 +2968,9 @@ json-stringify-safe@~5.0.1:
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
 json5@^2.1.2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
-  integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
     minimist "^1.2.5"
 
@@ -3240,27 +3033,10 @@ labeled-stream-splicer@^2.0.0:
     inherits "^2.0.1"
     stream-splicer "^2.0.0"
 
-lazy.js@~0.4.2:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/lazy.js/-/lazy.js-0.4.3.tgz#87f67a07ad36555121e4fff1520df31be66786d8"
-  integrity sha1-h/Z6B602VVEh5P/xUg3zG+Znhtg=
-
 lcov-parse@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-1.0.0.tgz#eb0d46b54111ebc561acb4c408ef9363bdc8f7e0"
   integrity sha1-6w1GtUER68VhrLTECO+TY73I9+A=
-
-leven@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
-  integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
-
-levenary@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/levenary/-/levenary-1.1.1.tgz#842a9ee98d2075aa7faeedbe32679e9205f46f77"
-  integrity sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==
-  dependencies:
-    leven "^3.1.0"
 
 levn@^0.4.1:
   version "0.4.1"
@@ -3269,14 +3045,6 @@ levn@^0.4.1:
   dependencies:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
-
-locate-path@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
-  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
-  dependencies:
-    p-locate "^3.0.0"
-    path-exists "^3.0.0"
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -3291,6 +3059,21 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
@@ -3307,10 +3090,15 @@ lodash.memoize@~3.0.3:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
   integrity sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=
 
-lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.19:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
+
+lodash@^4.17.19, lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-driver@^1.2.7:
   version "1.2.7"
@@ -3324,17 +3112,17 @@ log-symbols@4.0.0:
   dependencies:
     chalk "^4.0.0"
 
-loose-envify@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
-  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
-    js-tokens "^3.0.0 || ^4.0.0"
+    yallist "^4.0.0"
 
 luxon@^1.25.0:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.25.0.tgz#d86219e90bc0102c0eb299d65b2f5e95efe1fe72"
-  integrity sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ==
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.26.0.tgz#d3692361fda51473948252061d0f8561df02b578"
+  integrity sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A==
 
 make-dir@^2.1.0:
   version "2.1.0"
@@ -3399,17 +3187,17 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.40.0:
-  version "1.40.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
-  integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
+mime-db@1.46.0:
+  version "1.46.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.46.0.tgz#6267748a7f799594de3cbc8cde91def349661cee"
+  integrity sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==
 
 mime-types@^2.1.12, mime-types@~2.1.19:
-  version "2.1.24"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
-  integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
+  version "2.1.29"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.29.tgz#1d4ab77da64b91f5f72489df29236563754bb1b2"
+  integrity sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==
   dependencies:
-    mime-db "1.40.0"
+    mime-db "1.46.0"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -3428,7 +3216,7 @@ minimatch@3.0.4, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.5:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -3446,51 +3234,44 @@ mkdirp-classic@^0.5.2:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-mkdirp@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-  dependencies:
-    minimist "0.0.8"
-
 mocha@^8.1.3:
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-8.1.3.tgz#5e93f873e35dfdd69617ea75f9c68c2ca61c2ac5"
-  integrity sha512-ZbaYib4hT4PpF4bdSO2DohooKXIn4lDeiYqB+vTmCdr6l2woW0b6H3pf5x4sM5nwQMru9RvjjHYWVGltR50ZBw==
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-8.3.2.tgz#53406f195fa86fbdebe71f8b1c6fb23221d69fcc"
+  integrity sha512-UdmISwr/5w+uXLPKspgoV7/RXZwKRTiTjJ2/AC5ZiEztIoOYdfKb19+9jNmEInzx5pBsCyJQzarAxqIGBNYJhg==
   dependencies:
+    "@ungap/promise-all-settled" "1.1.2"
     ansi-colors "4.1.1"
     browser-stdout "1.3.1"
-    chokidar "3.4.2"
-    debug "4.1.1"
-    diff "4.0.2"
+    chokidar "3.5.1"
+    debug "4.3.1"
+    diff "5.0.0"
     escape-string-regexp "4.0.0"
     find-up "5.0.0"
     glob "7.1.6"
     growl "1.10.5"
     he "1.2.0"
-    js-yaml "3.14.0"
+    js-yaml "4.0.0"
     log-symbols "4.0.0"
     minimatch "3.0.4"
-    ms "2.1.2"
-    object.assign "4.1.0"
-    promise.allsettled "1.0.2"
-    serialize-javascript "4.0.0"
-    strip-json-comments "3.0.1"
-    supports-color "7.1.0"
+    ms "2.1.3"
+    nanoid "3.1.20"
+    serialize-javascript "5.0.1"
+    strip-json-comments "3.1.1"
+    supports-color "8.1.1"
     which "2.0.2"
     wide-align "1.1.3"
-    workerpool "6.0.0"
-    yargs "13.3.2"
-    yargs-parser "13.1.2"
-    yargs-unparser "1.6.1"
+    workerpool "6.1.0"
+    yargs "16.2.0"
+    yargs-parser "20.2.4"
+    yargs-unparser "2.0.0"
 
-module-deps@^6.0.0:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/module-deps/-/module-deps-6.2.2.tgz#d8a15c2265dfc119153c29bb47386987d0ee423b"
-  integrity sha512-a9y6yDv5u5I4A+IPHTnqFxcaKr4p50/zxTjcQJaX2ws9tN/W6J6YXnEKhqRyPhl494dkcxx951onSKVezmI+3w==
+module-deps@^6.2.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/module-deps/-/module-deps-6.2.3.tgz#15490bc02af4b56cf62299c7c17cba32d71a96ee"
+  integrity sha512-fg7OZaQBcL4/L+AK5f4iVqf9OMbCclXfy/znXRxTVhJSeW5AIlS9AwheYwDaXM3lVW7OBeaeUEY3gbaC6cLlSA==
   dependencies:
     JSONStream "^1.0.3"
-    browser-resolve "^1.7.0"
+    browser-resolve "^2.0.0"
     cached-path-relative "^1.0.2"
     concat-stream "~1.6.0"
     defined "^1.0.0"
@@ -3510,15 +3291,20 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@2.1.2, ms@^2.1.1:
+ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-nan@^2.12.1:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
-  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
+ms@2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+nanoid@3.1.20:
+  version "3.1.20"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
+  integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -3549,10 +3335,10 @@ node-preload@^0.2.1:
   dependencies:
     process-on-spawn "^1.0.0"
 
-node-releases@^1.1.58:
-  version "1.1.59"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.59.tgz#4d648330641cec704bff10f8e4fe28e453ab8e8e"
-  integrity sha512-H3JrdUczbdiwxN5FuJPyCHnGHIFqQ0wWxo+9j1kAXAzqNMAHlo+4I/sYYxpyK0irQ73HgdiyzD32oqQDcU2Osw==
+node-releases@^1.1.70:
+  version "1.1.71"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
+  integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
 
 normalize-path@^2.1.1:
   version "2.1.1"
@@ -3618,12 +3404,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
-  integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
-
-object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
+object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -3635,15 +3416,15 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@4.1.0, object.assign@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
-  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+object.assign@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
+  integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
   dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.1"
-    has-symbols "^1.0.0"
-    object-keys "^1.0.11"
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -3676,7 +3457,7 @@ os-browserify@~0.3.0:
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
   integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
 
-p-limit@^2.0.0, p-limit@^2.2.0:
+p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -3684,18 +3465,11 @@ p-limit@^2.0.0, p-limit@^2.2.0:
     p-try "^2.0.0"
 
 p-limit@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.0.2.tgz#1664e010af3cadc681baafd3e2a437be7b0fb5fe"
-  integrity sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
-    p-try "^2.0.0"
-
-p-locate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
-  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
-  dependencies:
-    p-limit "^2.0.0"
+    yocto-queue "^0.1.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -3753,13 +3527,12 @@ parents@^1.0.0, parents@^1.0.1:
     path-platform "~0.11.15"
 
 parse-asn1@^5.0.0, parse-asn1@^5.1.5:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.5.tgz#003271343da58dc94cace494faef3d2147ecea0e"
-  integrity sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.6.tgz#385080a3ec13cb62a62d39409cb3e88844cdaed4"
+  integrity sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==
   dependencies:
-    asn1.js "^4.0.0"
+    asn1.js "^5.2.0"
     browserify-aes "^1.0.0"
-    create-hash "^1.1.0"
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
@@ -3779,11 +3552,6 @@ path-dirname@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
   integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
 
-path-exists@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
-  integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
-
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
@@ -3792,6 +3560,7 @@ path-exists@^4.0.0:
 path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
 path-key@^3.1.0:
   version "3.1.1"
@@ -3852,14 +3621,14 @@ prelude-ls@^1.2.1:
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
 prettier@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.1.tgz#d9485dd5e499daa6cb547023b87a6cf51bee37d6"
-  integrity sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 process-nextick-args@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
-  integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
 process-on-spawn@^1.0.0:
   version "1.0.0"
@@ -3877,17 +3646,6 @@ progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
-
-promise.allsettled@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/promise.allsettled/-/promise.allsettled-1.0.2.tgz#d66f78fbb600e83e863d893e98b3d4376a9c47c9"
-  integrity sha512-UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==
-  dependencies:
-    array.prototype.map "^1.0.1"
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    function-bind "^1.1.1"
-    iterate-value "^1.0.0"
 
 psl@^1.1.28:
   version "1.8.0"
@@ -3958,20 +3716,7 @@ read-only-stream@^2.0.0:
   dependencies:
     readable-stream "^2.0.2"
 
-readable-stream@^2.0.2:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
-  integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.1.0, readable-stream@^2.2.2, readable-stream@~2.3.6:
+readable-stream@^2.0.2, readable-stream@^2.1.0, readable-stream@^2.2.2, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -4002,10 +3747,10 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
-readdirp@~3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.4.0.tgz#9fdccdf9e9155805449221ac645e8303ab5b9ada"
-  integrity sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==
+readdirp@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
+  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
   dependencies:
     picomatch "^2.2.1"
 
@@ -4017,14 +3762,14 @@ regenerate-unicode-properties@^8.2.0:
     regenerate "^1.4.0"
 
 regenerate@^1.4.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.1.tgz#cad92ad8e6b591773485fbe05a485caf4f457e6f"
-  integrity sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
+  integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
 regenerator-runtime@^0.13.4:
-  version "0.13.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
-  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
 regenerator-transform@^0.14.2:
   version "0.14.5"
@@ -4046,10 +3791,10 @@ regexpp@^3.1.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
 
-regexpu-core@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.7.0.tgz#fcbf458c50431b0bb7b45d6967b8192d91f3d938"
-  integrity sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==
+regexpu-core@^4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.7.1.tgz#2dea5a9a07233298fbf0db91fa9abc4c6e0f8ad6"
+  integrity sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==
   dependencies:
     regenerate "^1.4.0"
     regenerate-unicode-properties "^8.2.0"
@@ -4064,9 +3809,9 @@ regjsgen@^0.5.1:
   integrity sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==
 
 regjsparser@^0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.4.tgz#a769f8684308401a66e9b529d2436ff4d0666272"
-  integrity sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==
+  version "0.6.9"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.9.tgz#b489eef7c9a2ce43727627011429cf833a7183e6"
+  integrity sha512-ZqbNRz1SNjLAiYuwY0zoXW8Ne675IX5q+YHioAGbCw4X96Mjl2+dcX9B2ciaeyYjViDAfvIjFpQjJgLttTEERQ==
   dependencies:
     jsesc "~0.5.0"
 
@@ -4123,6 +3868,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
@@ -4143,16 +3893,12 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
-  integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
-
-resolve@^1.1.4, resolve@^1.3.2, resolve@^1.4.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
-  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
+resolve@^1.1.4, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.4.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
+  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
   dependencies:
+    is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
 ret@~0.1.10:
@@ -4160,14 +3906,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rimraf@2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -4182,17 +3921,12 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-safe-buffer@^5.0.1:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
-  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
-
-safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -4224,25 +3958,27 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.0.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@^7.2.1:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
 
-serialize-javascript@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
-  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+serialize-javascript@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
+  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
   dependencies:
     randombytes "^2.1.0"
 
@@ -4317,8 +4053,9 @@ should-format@^3.0.3:
     should-type-adaptors "^1.0.1"
 
 should-type-adaptors@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/should-type-adaptors/-/should-type-adaptors-1.0.1.tgz#efe5553cdf68cff66e5c5f51b712dc351c77beaa"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz#401e7f33b5533033944d5cd8bf2b65027792e27a"
+  integrity sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==
   dependencies:
     should-type "^1.3.0"
     should-util "^1.0.0"
@@ -4326,10 +4063,12 @@ should-type-adaptors@^1.0.1:
 should-type@^1.3.0, should-type@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/should-type/-/should-type-1.4.0.tgz#0756d8ce846dfd09843a6947719dfa0d4cff5cf3"
+  integrity sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=
 
 should-util@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/should-util/-/should-util-1.0.0.tgz#c98cda374aa6b190df8ba87c9889c2b4db620063"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/should-util/-/should-util-1.0.1.tgz#fb0d71338f532a3a149213639e2d32cbea8bcb28"
+  integrity sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==
 
 should@^13.2.3:
   version "13.2.3"
@@ -4343,28 +4082,28 @@ should@^13.2.3:
     should-util "^1.0.0"
 
 signal-exit@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
-  integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
+  integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
 simple-concat@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
-  integrity sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
 
 slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
-slice-ansi@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
-  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
   dependencies:
-    ansi-styles "^3.2.0"
-    astral-regex "^1.0.0"
-    is-fullwidth-code-point "^2.0.0"
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -4408,9 +4147,9 @@ source-map-resolve@^0.5.0:
     urix "^0.1.0"
 
 source-map-url@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
-  integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.1.tgz#0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
+  integrity sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
 
 source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.3:
   version "0.5.7"
@@ -4531,39 +4270,14 @@ string-to-stream@^1.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^3.0.0, string-width@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
-  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
-  dependencies:
-    emoji-regex "^7.0.1"
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^5.1.0"
-
 string-width@^4.1.0, string-width@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
-  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
+  integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
   dependencies:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
-
-string.prototype.trimend@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
-  integrity sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
-
-string.prototype.trimstart@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
-  integrity sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
 
 string_decoder@^1.1.1:
   version "1.3.0"
@@ -4586,13 +4300,6 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
-  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
-  dependencies:
-    ansi-regex "^4.1.0"
-
 strip-ansi@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
@@ -4605,15 +4312,10 @@ strip-bom@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
   integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
 
-strip-json-comments@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
-  integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
-
-strip-json-comments@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.0.tgz#7638d31422129ecf4457440009fba03f9f9ac180"
-  integrity sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
+strip-json-comments@3.1.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 subarg@^1.0.0:
   version "1.0.0"
@@ -4622,10 +4324,10 @@ subarg@^1.0.0:
   dependencies:
     minimist "^1.1.0"
 
-supports-color@7.1.0, supports-color@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
-  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+supports-color@8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
 
@@ -4636,6 +4338,13 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
 syntax-error@^1.1.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/syntax-error/-/syntax-error-1.4.0.tgz#2d9d4ff5c064acb711594a3e3b95054ad51d907c"
@@ -4643,15 +4352,20 @@ syntax-error@^1.1.1:
   dependencies:
     acorn-node "^1.2.0"
 
-table@^5.2.3:
-  version "5.4.6"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
-  integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
+table@^6.0.4:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.0.9.tgz#790a12bf1e09b87b30e60419bafd6a1fd85536fb"
+  integrity sha512-F3cLs9a3hL1Z7N4+EkSscsel3z55XT950AvB05bwayrNg5T1/gykXtigioTAjbltvbMSJvvhFCbnf6mX+ntnJQ==
   dependencies:
-    ajv "^6.10.2"
-    lodash "^4.17.14"
-    slice-ansi "^2.1.0"
-    string-width "^3.0.0"
+    ajv "^8.0.1"
+    is-boolean-object "^1.1.0"
+    is-number-object "^1.0.4"
+    is-string "^1.0.5"
+    lodash.clonedeep "^4.5.0"
+    lodash.flatten "^4.4.0"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.0"
 
 test-exclude@^6.0.0:
   version "6.0.0"
@@ -4756,6 +4470,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
 type-fest@^0.8.0, type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
@@ -4836,9 +4555,9 @@ upath@^1.1.1:
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
 uri-js@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
-  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
 
@@ -4879,20 +4598,15 @@ util@~0.10.1:
   dependencies:
     inherits "2.0.3"
 
-uuid@^3.3.2:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
-  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
-
-uuid@^3.3.3:
+uuid@^3.3.2, uuid@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 v8-compile-cache@^2.0.3:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
-  integrity sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
+  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
 verror@1.10.0:
   version "1.10.0"
@@ -4932,24 +4646,24 @@ word-wrap@^1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-workerpool@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.0.0.tgz#85aad67fa1a2c8ef9386a1b43539900f61d03d58"
-  integrity sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA==
-
-wrap-ansi@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
-  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
-  dependencies:
-    ansi-styles "^3.2.0"
-    string-width "^3.0.0"
-    strip-ansi "^5.0.0"
+workerpool@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.0.tgz#a8e038b4c94569596852de7a8ea4228eefdeb37b"
+  integrity sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==
 
 wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -4969,13 +4683,6 @@ write-file-atomic@^3.0.0:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
-
-write@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
-  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
-  dependencies:
-    mkdirp "^0.5.1"
 
 xml-js@^1.6.11:
   version "1.6.11"
@@ -4997,27 +4704,26 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
+  integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
+
+y18n@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
+  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
+
+yallist@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yargs-parser@13.1.2, yargs-parser@^13.1.2:
-  version "13.1.2"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
-  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
+yargs-parser@20.2.4:
+  version "20.2.4"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
-yargs-parser@^15.0.1:
-  version "15.0.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
-  integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^18.1.1:
+yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
@@ -5025,54 +4731,38 @@ yargs-parser@^18.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-unparser@1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-1.6.1.tgz#bd4b0ee05b4c94d058929c32cb09e3fce71d3c5f"
-  integrity sha512-qZV14lK9MWsGCmcr7u5oXGH0dbGqZAIxTDrWXZDo5zUr6b6iUmelNKO6x6R1dQT24AH3LgRxJpr8meWy2unolA==
-  dependencies:
-    camelcase "^5.3.1"
-    decamelize "^1.2.0"
-    flat "^4.1.0"
-    is-plain-obj "^1.1.0"
-    yargs "^14.2.3"
+yargs-parser@^20.2.2:
+  version "20.2.7"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
+  integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
 
-yargs@13.3.2:
-  version "13.3.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
-  integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
+yargs-unparser@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz#f131f9226911ae5d9ad38c432fe809366c2325eb"
+  integrity sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==
   dependencies:
-    cliui "^5.0.0"
-    find-up "^3.0.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^3.0.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^13.1.2"
+    camelcase "^6.0.0"
+    decamelize "^4.0.0"
+    flat "^5.0.2"
+    is-plain-obj "^2.1.0"
 
-yargs@^14.2.3:
-  version "14.2.3"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
-  integrity sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==
+yargs@16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
   dependencies:
-    cliui "^5.0.0"
-    decamelize "^1.2.0"
-    find-up "^3.0.0"
-    get-caller-file "^2.0.1"
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
     require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^3.0.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^15.0.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yargs@^15.0.2:
-  version "15.3.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
-  integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
+  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
   dependencies:
     cliui "^6.0.0"
     decamelize "^1.2.0"
@@ -5084,4 +4774,9 @@ yargs@^15.0.2:
     string-width "^4.2.0"
     which-module "^2.0.0"
     y18n "^4.0.0"
-    yargs-parser "^18.1.1"
+    yargs-parser "^18.1.2"
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==


### PR DESCRIPTION
As the title says this PR is for bumping the version of cql-to-elm to version 1.5.2. This is  to allow for functionality that is contained within CQL 1.5.x to be developed within the execution engine. 

Changes made to cql-to-elm 1.5.2 caused the functionality to load model files to no longer to work .  Contained in this PR is a fix to JavaScriptTestDataGenerator to deal with those changes and allow for the custom data model to be loaded for use in the tests. 

This also includes a regeneration of the test data based off of the 1.5.2 version of the library.  

This also includes an update to a dependency to take care of a yarn audit issue that presented while creating the PR. 

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository.
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- N/A Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `yarn run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `yarn run build:browserify` if source changed.

**Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
