### PR TITLE
Add CQL 1.5 tests to spec-tests

### DIFF
--- a/test/spec-tests/cql/CqlAggregateTest.cql
+++ b/test/spec-tests/cql/CqlAggregateTest.cql
@@ -4,11 +4,9 @@ context Patient
 
 define "AggregateTests": Tuple{
   "FactorialOfFive": Tuple{
-    skipped: 'Query aggregation not implemented'
-    /*
     expression: ({ 1, 2, 3, 4, 5 }) Num aggregate Result starting 1: Result * Num,
     output: 120
-    */  },
+  },
   "RolledOutIntervals": Tuple{
     skipped: 'Translation Error: Could not resolve identifier MedicationRequestIntervals in the current library.'
     /*

--- a/test/spec-tests/cql/CqlAggregateTest.cql
+++ b/test/spec-tests/cql/CqlAggregateTest.cql
@@ -1,0 +1,24 @@
+library CqlAggregateTest version '1.4.0'
+using QUICK version '3.3.0'
+context Patient
+
+define "AggregateTests": Tuple{
+  "FactorialOfFive": Tuple{
+    skipped: 'Query aggregation not implemented'
+    /*
+    expression: ({ 1, 2, 3, 4, 5 }) Num aggregate Result starting 1: Result * Num,
+    output: 120
+    */  },
+  "RolledOutIntervals": Tuple{
+    skipped: 'Translation Error: Could not resolve identifier MedicationRequestIntervals in the current library.'
+    /*
+    expression: MedicationRequestIntervals M
+    aggregate R starting (null as List<Interval<DateTime>>): R union ({
+      M X
+        let S: Max({ end of Last(R) + 1 day, start of X }),
+          E: S + duration in days of X
+        return Interval[S, E]
+    }),
+    output: TODO
+    */  }
+}

--- a/test/spec-tests/cql/CqlAggregateTest.json
+++ b/test/spec-tests/cql/CqlAggregateTest.json
@@ -50,10 +50,61 @@
                   "value" : {
                      "type" : "Tuple",
                      "element" : [ {
-                        "name" : "skipped",
+                        "name" : "expression",
                         "value" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "Query aggregation not implemented",
+                           "type" : "Query",
+                           "source" : [ {
+                              "alias" : "Num",
+                              "expression" : {
+                                 "type" : "List",
+                                 "element" : [ {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "1",
+                                    "type" : "Literal"
+                                 }, {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "2",
+                                    "type" : "Literal"
+                                 }, {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "3",
+                                    "type" : "Literal"
+                                 }, {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "4",
+                                    "type" : "Literal"
+                                 }, {
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "5",
+                                    "type" : "Literal"
+                                 } ]
+                              }
+                           } ],
+                           "relationship" : [ ],
+                           "aggregate" : {
+                              "identifier" : "Result",
+                              "expression" : {
+                                 "type" : "Multiply",
+                                 "operand" : [ {
+                                    "name" : "Result",
+                                    "type" : "QueryLetRef"
+                                 }, {
+                                    "name" : "Num",
+                                    "type" : "AliasRef"
+                                 } ]
+                              },
+                              "starting" : {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "1",
+                                 "type" : "Literal"
+                              }
+                           }
+                        }
+                     }, {
+                        "name" : "output",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "120",
                            "type" : "Literal"
                         }
                      } ]

--- a/test/spec-tests/cql/CqlAggregateTest.json
+++ b/test/spec-tests/cql/CqlAggregateTest.json
@@ -1,0 +1,80 @@
+{
+   "library" : {
+      "annotation" : [ {
+         "translatorOptions" : "",
+         "type" : "CqlToElmInfo"
+      } ],
+      "identifier" : {
+         "id" : "CqlAggregateTest",
+         "version" : "1.4.0"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir/us/qicore",
+            "version" : "3.3.0"
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir/us/qicore}Patient",
+                  "templateId" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "AggregateTests",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Tuple",
+               "element" : [ {
+                  "name" : "FactorialOfFive",
+                  "value" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "skipped",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Query aggregation not implemented",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }
+               }, {
+                  "name" : "RolledOutIntervals",
+                  "value" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "skipped",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Translation Error: Could not resolve identifier MedicationRequestIntervals in the current library.",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }
+               } ]
+            }
+         } ]
+      }
+   }
+}
+

--- a/test/spec-tests/cql/CqlArithmeticFunctionsTest.cql
+++ b/test/spec-tests/cql/CqlArithmeticFunctionsTest.cql
@@ -26,7 +26,13 @@ define "Abs": Tuple{
   "Abs1cm": Tuple{
     expression: Abs(-1.0'cm'),
     output: 1.0'cm'
-  }
+  },
+  "AbsLong": Tuple{
+    skipped: 'Long not implemented'
+    /*
+    expression: Abs(-1L),
+    output: 1L
+    */  }
 }
 
 define "Add": Tuple{
@@ -49,6 +55,10 @@ define "Add": Tuple{
   "AddIAndD": Tuple{
     expression: 1 + 2.0,
     output: 3.0
+  },
+  "Add1L1L": Tuple{
+    expression: 1L + 1L,
+    output: 2L
   }
 }
 
@@ -317,6 +327,12 @@ define "MinValue": Tuple{
     expression: minimum Integer,
     output: -2147483648
   },
+  "LongMinValue": Tuple{
+    skipped: 'Long not implemented'
+    /*
+    expression: minimum Long,
+    output: -9223372036854775808
+    */  },
   "DecimalMinValue": Tuple{
     expression: minimum Decimal,
     output: -99999999999999999999.99999999
@@ -340,6 +356,12 @@ define "MaxValue": Tuple{
     expression: maximum Integer,
     output: 2147483647
   },
+  "LongMaxValue": Tuple{
+    skipped: 'Long not implemented'
+    /*
+    expression: maximum Long,
+    output: 9223372036854775807
+    */  },
   "DecimalMaxValue": Tuple{
     expression: maximum Decimal,
     output: 99999999999999999999.99999999
@@ -371,6 +393,12 @@ define "Modulo": Tuple{
     expression: 4 mod 2,
     output: 0
   },
+  "Modulo4LBy2L": Tuple{
+    skipped: 'Long not implemented'
+    /*
+    expression: 4L mod 2L,
+    output: 0L
+    */  },
   "Modulo4DBy2D": Tuple{
     expression: 4.0 mod 2.0,
     output: 0.0
@@ -390,7 +418,13 @@ define "Modulo": Tuple{
   "ModuloDResult": Tuple{
     expression: 3.5 mod 3,
     output: 0.5
-  }
+  },
+  "ModuloQuantity": Tuple{
+    skipped: 'Modulo not implemented for Quantity'
+    /*
+    expression: 3.5 'cm' mod 3 'cm',
+    output: 0.5 'cm'
+    */  }
 }
 
 define "Multiply": Tuple{
@@ -406,6 +440,12 @@ define "Multiply": Tuple{
     expression: 1.0 * 2.0,
     output: 2.0
   },
+  "Multiply1By1L": Tuple{
+    skipped: 'Long not implemented'
+    /*
+    expression: 1 * 1L,
+    output: 1L
+    */  },
   "Multiply1IBy2D": Tuple{
     expression: 1 * 2.0,
     output: 2.0
@@ -437,6 +477,12 @@ define "Negate": Tuple{
     expression: -(-1),
     output: 1
   },
+  "NegateNeg1L": Tuple{
+    skipped: 'Long not implemented'
+    /*
+    expression: -(-1L),
+    output: 1L
+    */  },
   "Negate0D": Tuple{
     expression: -(0.0),
     output: 0.0
@@ -505,6 +551,12 @@ define "Predecessor": Tuple{
     expression: predecessor of 1,
     output: 0
   },
+  "PredecessorOf1L": Tuple{
+    skipped: 'Long not implemented'
+    /*
+    expression: predecessor of 1L,
+    output: 0L
+    */  },
   "PredecessorOf1D": Tuple{
     skipped: 'Wrong answer (doesn\'t recognize 1.0 as decimal)'
     /*
@@ -560,6 +612,12 @@ define "Power": Tuple{
     expression: Power(2, -2),
     output: 0.25
   },
+  "Power2LTo2L": Tuple{
+    skipped: 'Long not implemented'
+    /*
+    expression: Power(2L, 2L),
+    output: 4L
+    */  },
   "Power2DTo2D": Tuple{
     expression: Power(2.0, 2.0),
     output: 4.0
@@ -650,6 +708,12 @@ define "Subtract": Tuple{
     expression: 1 - 1,
     output: 0
   },
+  "Subtract1LAnd1L": Tuple{
+    skipped: 'Long not implemented'
+    /*
+    expression: 1L - 1L,
+    output: 0L
+    */  },
   "Subtract1DAnd2D": Tuple{
     expression: 1.0 - 2.0,
     output: -1.0
@@ -677,6 +741,12 @@ define "Successor": Tuple{
     expression: successor of 1,
     output: 2
   },
+  "SuccessorOf1L": Tuple{
+    skipped: 'Long not implemented'
+    /*
+    expression: successor of 1L,
+    output: 2L
+    */  },
   "SuccessorOf1D": Tuple{
     skipped: 'Wrong answer (doesn\'t recognize 1.0 as decimal)'
     /*
@@ -769,6 +839,12 @@ define "Truncated Divide": Tuple{
     expression: 10 div 3,
     output: 3
   },
+  "TruncatedDivide10LBy3L": Tuple{
+    skipped: 'Long not implemented'
+    /*
+    expression: 10L div 3L,
+    output: 3L
+    */  },
   "TruncatedDivide10d1By3D1": Tuple{
     expression: 10.1 div 3.1,
     output: 3.0
@@ -812,5 +888,11 @@ define "Truncated Divide": Tuple{
   "TruncatedDivide10By5D": Tuple{
     expression: 10 div 5.0,
     output: 2.0
-  }
+  },
+  "TruncatedDivide10d1ByNeg3D1Quantity": Tuple{
+    skipped: 'Truncated divide not implemented for Quantity'
+    /*
+    expression: 10.1 'cm' div -3.1 'cm',
+    output: -3.0 'cm'
+    */  }
 }

--- a/test/spec-tests/cql/CqlArithmeticFunctionsTest.json
+++ b/test/spec-tests/cql/CqlArithmeticFunctionsTest.json
@@ -196,6 +196,19 @@
                         }
                      } ]
                   }
+               }, {
+                  "name" : "AbsLong",
+                  "value" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "skipped",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Long not implemented",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }
                } ]
             }
          }, {
@@ -338,6 +351,33 @@
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
                            "value" : "3.0",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }
+               }, {
+                  "name" : "Add1L1L",
+                  "value" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "expression",
+                        "value" : {
+                           "type" : "Add",
+                           "operand" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}Long",
+                              "value" : "",
+                              "type" : "Literal"
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}Long",
+                              "value" : "",
+                              "type" : "Literal"
+                           } ]
+                        }
+                     }, {
+                        "name" : "output",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Long",
+                           "value" : "",
                            "type" : "Literal"
                         }
                      } ]
@@ -1861,6 +1901,19 @@
                      } ]
                   }
                }, {
+                  "name" : "LongMinValue",
+                  "value" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "skipped",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Long not implemented",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }
+               }, {
                   "name" : "DecimalMinValue",
                   "value" : {
                      "type" : "Tuple",
@@ -2026,6 +2079,19 @@
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "2147483647",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }
+               }, {
+                  "name" : "LongMaxValue",
+                  "value" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "skipped",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Long not implemented",
                            "type" : "Literal"
                         }
                      } ]
@@ -2258,6 +2324,19 @@
                      } ]
                   }
                }, {
+                  "name" : "Modulo4LBy2L",
+                  "value" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "skipped",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Long not implemented",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }
+               }, {
                   "name" : "Modulo4DBy2D",
                   "value" : {
                      "type" : "Tuple",
@@ -2398,6 +2477,19 @@
                         }
                      } ]
                   }
+               }, {
+                  "name" : "ModuloQuantity",
+                  "value" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "skipped",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Modulo not implemented for Quantity",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }
                } ]
             }
          }, {
@@ -2483,6 +2575,19 @@
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
                            "value" : "2.0",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }
+               }, {
+                  "name" : "Multiply1By1L",
+                  "value" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "skipped",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Long not implemented",
                            "type" : "Literal"
                         }
                      } ]
@@ -2676,6 +2781,19 @@
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "1",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }
+               }, {
+                  "name" : "NegateNeg1L",
+                  "value" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "skipped",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Long not implemented",
                            "type" : "Literal"
                         }
                      } ]
@@ -2960,6 +3078,19 @@
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "0",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }
+               }, {
+                  "name" : "PredecessorOf1L",
+                  "value" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "skipped",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Long not implemented",
                            "type" : "Literal"
                         }
                      } ]
@@ -3373,6 +3504,19 @@
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
                            "value" : "0.25",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }
+               }, {
+                  "name" : "Power2LTo2L",
+                  "value" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "skipped",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Long not implemented",
                            "type" : "Literal"
                         }
                      } ]
@@ -3984,6 +4128,19 @@
                      } ]
                   }
                }, {
+                  "name" : "Subtract1LAnd1L",
+                  "value" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "skipped",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Long not implemented",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }
+               }, {
                   "name" : "Subtract1DAnd2D",
                   "value" : {
                      "type" : "Tuple",
@@ -4150,6 +4307,19 @@
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "2",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }
+               }, {
+                  "name" : "SuccessorOf1L",
+                  "value" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "skipped",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Long not implemented",
                            "type" : "Literal"
                         }
                      } ]
@@ -4816,6 +4986,19 @@
                      } ]
                   }
                }, {
+                  "name" : "TruncatedDivide10LBy3L",
+                  "value" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "skipped",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Long not implemented",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }
+               }, {
                   "name" : "TruncatedDivide10d1By3D1",
                   "value" : {
                      "type" : "Tuple",
@@ -5165,6 +5348,19 @@
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
                            "value" : "2.0",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }
+               }, {
+                  "name" : "TruncatedDivide10d1ByNeg3D1Quantity",
+                  "value" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "skipped",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "Truncated divide not implemented for Quantity",
                            "type" : "Literal"
                         }
                      } ]

--- a/test/spec-tests/skip-list.txt
+++ b/test/spec-tests/skip-list.txt
@@ -14,6 +14,7 @@ CqlLogicalOperatorsTest.Implies.FalseImpliesNull    Translation Error: Could not
 CqlLogicalOperatorsTest.Implies.NullImpliesTrue     Translation Error: Could not resolve call to operator Implies with signature (System.Any,System.Boolean).
 CqlLogicalOperatorsTest.Implies.NullImpliesFalse    Translation Error: Could not resolve call to operator Implies with signature (System.Any,System.Boolean).
 CqlLogicalOperatorsTest.Implies.NullImpliesNull     Translation Error: Could not resolve call to operator Implies with signature (System.Any,System.Any).
+CqlAggregateTest.AggregateTests.RolledOutIntervals  Translation Error: Could not resolve identifier MedicationRequestIntervals in the current library.
 CqlIntervalOperatorsTest.Expand.ExpandPer1          Translation Error: Could not resolve call to operator Expand with signature (list<interval<System.Decimal>>,System.Integer).
 CqlIntervalOperatorsTest.Expand.ExpandPer0D1        Translation Error: Could not resolve call to operator Expand with signature (list<interval<System.Integer>>,System.Decimal).
 CqlTypeOperatorsTest.ToDateTime.ToDateTime4         @2014-01-01T12:05:05.955+01:30 Parsed with offset 1 (should be 1.5)
@@ -58,6 +59,22 @@ CqlListOperatorsTest.Sort                 Sort not implemented
 CqlListOperatorsTest.Descendents          Descendents not implemented
 CqlListOperatorsTest.ProperContains       ProperContains not implemented
 CqlListOperatorsTest.ProperIn             ProperIn not implemented
+
+# Unimplemented (New in CQL 1.5)
+CqlArithmeticFunctionsTest.Abs.AbsLong                                Long not implemented
+CqlArithmeticFunctionsTest.MinValue.LongMinValue                      Long not implemented
+CqlArithmeticFunctionsTest.MaxValue.LongMaxValue                      Long not implemented
+CqlArithmeticFunctionsTest.Modulo.Modulo4LBy2L                        Long not implemented
+CqlArithmeticFunctionsTest.Multiply.Multiply1By1L                     Long not implemented
+CqlArithmeticFunctionsTest.Negate.NegateNeg1L                         Long not implemented
+CqlArithmeticFunctionsTest.Predecessor.PredecessorOf1L                Long not implemented
+CqlArithmeticFunctionsTest.Power.Power2LTo2L                          Long not implemented
+CqlArithmeticFunctionsTest.Subtract.Subtract1LAnd1L                   Long not implemented
+CqlArithmeticFunctionsTest.Successor.SuccessorOf1L                    Long not implemented
+"CqlArithmeticFunctionsTest.Truncated Divide.TruncatedDivide10LBy3L"  Long not implemented
+CqlAggregateTest.AggregateTests.FactorialOfFive                       Query aggregation not implemented
+CqlArithmeticFunctionsTest.Modulo.ModuloQuantity                      Modulo not implemented for Quantity
+"CqlArithmeticFunctionsTest.Truncated Divide.TruncatedDivide10d1ByNeg3D1Quantity"     Truncated divide not implemented for Quantity
 
 # Awaiting feedback from Bryn
 

--- a/test/spec-tests/skip-list.txt
+++ b/test/spec-tests/skip-list.txt
@@ -72,7 +72,6 @@ CqlArithmeticFunctionsTest.Power.Power2LTo2L                          Long not i
 CqlArithmeticFunctionsTest.Subtract.Subtract1LAnd1L                   Long not implemented
 CqlArithmeticFunctionsTest.Successor.SuccessorOf1L                    Long not implemented
 "CqlArithmeticFunctionsTest.Truncated Divide.TruncatedDivide10LBy3L"  Long not implemented
-CqlAggregateTest.AggregateTests.FactorialOfFive                       Query aggregation not implemented
 CqlArithmeticFunctionsTest.Modulo.ModuloQuantity                      Modulo not implemented for Quantity
 "CqlArithmeticFunctionsTest.Truncated Divide.TruncatedDivide10d1ByNeg3D1Quantity"     Truncated divide not implemented for Quantity
 

--- a/test/spec-tests/xml/CqlAggregateTest.xml
+++ b/test/spec-tests/xml/CqlAggregateTest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://hl7.org/fhirpath/tests" xsi:schemaLocation="http://hl7.org/fhirpath/tests ../../testSchema/testSchema.xsd"
+  name="CqlAggregateTest" reference="http://build.fhir.org/ig/HL7/cql/03-developersguide.html#aggregate-queries">
+	<group name="AggregateTests">
+		<test name="FactorialOfFive">
+			<expression>({ 1, 2, 3, 4, 5 }) Num aggregate Result starting 1: Result * Num</expression>
+			<output>120</output>
+		</test>
+    <test name="RolledOutIntervals">
+      <expression>MedicationRequestIntervals M
+    aggregate R starting (null as List&lt;Interval&lt;DateTime>>): R union ({
+      M X
+        let S: Max({ end of Last(R) + 1 day, start of X }),
+          E: S + duration in days of X
+        return Interval[S, E]
+    })</expression>
+      <output>TODO</output>
+      <!-- Translation Error: Could not resolve identifier MedicationRequestIntervals in the current library. -->
+    </test>
+  </group>
+</tests>

--- a/test/spec-tests/xml/CqlArithmeticFunctionsTest.xml
+++ b/test/spec-tests/xml/CqlArithmeticFunctionsTest.xml
@@ -26,6 +26,10 @@
 			<expression>Abs(-1.0'cm')</expression>
 			<output>1.0'cm'</output>
 		</test>
+		<test name="AbsLong">
+			<expression>Abs(-1L)</expression>
+			<output>1L</output>
+		</test>
 	</group>
 	<group name="Add">
 		<test name="AddNull">
@@ -47,6 +51,10 @@
 		<test name="AddIAndD">
 			<expression>1 + 2.0</expression>
 			<output>3.0</output>
+		</test>
+		<test name="Add1L1L">
+			<expression>1L + 1L</expression>
+			<output>2L</output>
 		</test>
 	</group>
 	<group name="Ceiling">
@@ -302,6 +310,10 @@
 			<output>-2147483648</output>
 			<!-- TODO: make Engine parse -2147483648 holistically not as a negated positive -->
 		</test>
+		<test name="LongMinValue">
+			<expression>minimum Long</expression>
+			<output>-9223372036854775808</output>
+		</test>
 		<test name="DecimalMinValue">
 			<expression>minimum Decimal</expression>
 			<output>-99999999999999999999.99999999</output>
@@ -324,6 +336,10 @@
 		<test name="IntegerMaxValue">
 			<expression>maximum Integer</expression>
 			<output>2147483647</output>
+		</test>
+		<test name="LongMaxValue">
+			<expression>maximum Long</expression>
+			<output>9223372036854775807</output>
 		</test>
 		<test name="DecimalMaxValue">
 			<expression>maximum Decimal</expression>
@@ -356,6 +372,10 @@
 			<expression>4 mod 2</expression>
 			<output>0</output>
 		</test>
+		<test name="Modulo4LBy2L">
+			<expression>4L mod 2L</expression>
+			<output>0L</output>
+		</test>
 		<test name="Modulo4DBy2D">
 			<expression>4.0 mod 2.0</expression>
 			<output>0.0</output>
@@ -376,6 +396,10 @@
 			<expression>3.5 mod 3</expression>
 			<output>0.5</output>
 		</test>
+		<test name="ModuloQuantity">
+			<expression>3.5 'cm' mod 3 'cm'</expression>
+			<output>0.5 'cm'</output>
+		</test>
 	</group>
 	<group name="Multiply">
 		<test name="MultiplyNull">
@@ -389,6 +413,10 @@
 		<test name="Multiply1DBy2D">
 			<expression>1.0 * 2.0</expression>
 			<output>2.0</output>
+		</test>
+		<test name="Multiply1By1L">
+			<expression>1 * 1L</expression>
+			<output>1L</output>
 		</test>
 		<test name="Multiply1IBy2D">
 			<expression>1 * 2.0</expression>
@@ -420,6 +448,10 @@
 		<test name="NegateNeg1">
 			<expression>-(-1)</expression>
 			<output>1</output>
+		</test>
+		<test name="NegateNeg1L">
+			<expression>-(-1L)</expression>
+			<output>1L</output>
 		</test>
 		<test name="Negate0D">
 			<expression>-(0.0)</expression>
@@ -477,6 +509,10 @@
 			<expression>predecessor of 1</expression>
 			<output>0</output>
 		</test>
+		<test name="PredecessorOf1L">
+			<expression>predecessor of 1L</expression>
+			<output>0L</output>
+		</test>
 		<test name="PredecessorOf1D">
 			<expression>predecessor of 1.0</expression>
 			<output>0.99999999</output>
@@ -526,6 +562,10 @@
 		<test name="Power2ToNeg2">
 			<expression>Power(2, -2)</expression>
 			<output>0.25</output>
+		</test>
+		<test name="Power2LTo2L">
+			<expression>Power(2L, 2L)</expression>
+			<output>4L</output>
 		</test>
 		<test name="Power2DTo2D">
 			<expression>Power(2.0, 2.0)</expression>
@@ -615,6 +655,10 @@
 			<expression>1 - 1</expression>
 			<output>0</output>
 		</test>
+		<test name="Subtract1LAnd1L">
+			<expression>1L - 1L</expression>
+			<output>0L</output>
+		</test>
 		<test name="Subtract1DAnd2D">
 			<expression>1.0 - 2.0</expression>
 			<output>-1.0</output>
@@ -640,6 +684,10 @@
 		<test name="SuccessorOf1">
 			<expression>successor of 1</expression>
 			<output>2</output>
+		</test>
+		<test name="SuccessorOf1L">
+			<expression>successor of 1L</expression>
+			<output>2L</output>
 		</test>
 		<test name="SuccessorOf1D">
 			<expression>successor of 1.0</expression>
@@ -729,6 +777,10 @@
 			<expression>10 div 3</expression>
 			<output>3</output>
 		</test>
+		<test name="TruncatedDivide10LBy3L">
+			<expression>10L div 3L</expression>
+			<output>3L</output>
+		</test>
 		<test name="TruncatedDivide10d1By3D1">
 			<expression>10.1 div 3.1</expression>
 			<output>3.0</output>
@@ -772,6 +824,10 @@
 		<test name="TruncatedDivide10By5D">
 			<expression>10 div 5.0</expression>
 			<output>2.0</output>
+		</test>
+		<test name="TruncatedDivide10d1ByNeg3D1Quantity">
+			<expression>10.1 'cm' div -3.1 'cm'</expression>
+			<output>-3.0 'cm'</output>
 		</test>
 	</group>
 </tests>


### PR DESCRIPTION
This adds back in the CQL 1.5-specific tests to the spec tests and skips the ones that are not yet implemented.

**Submitter:**
- [x] This pull request describes why these changes were made
- [n/a] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `yarn run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [n/a] `cql4browsers.js` built with `yarn run build:browserify` if source changed.

**Reviewer:**

Name:
- [n/a] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
