### PR TITLE
Fixing issue related to issue #238

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -9431,8 +9431,18 @@ var Union = /*#__PURE__*/function (_Expression4) {
           a = _this$execArgs4[0],
           b = _this$execArgs4[1];
 
-      if (a == null || b == null) {
+      if (a == null && b == null) {
         return null;
+      }
+
+      if (a == null || b == null) {
+        var notNull = a || b;
+
+        if (typeIsArray(notNull)) {
+          return notNull;
+        } else {
+          return null;
+        }
       }
 
       var lib = typeIsArray(a) ? LIST : IVL;

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -9441,7 +9441,7 @@ var Union = /*#__PURE__*/function (_Expression4) {
         if (typeIsArray(notNull)) {
           return notNull;
         } else {
-          return null;
+          return [];
         }
       }
 

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -9451,7 +9451,7 @@ var Union = /*#__PURE__*/function (_Expression4) {
   }, {
     key: "listTypeArgs",
     value: function listTypeArgs() {
-      return this.args.every(function (arg) {
+      return this.args.some(function (arg) {
         return arg.asTypeSpecifier != null && arg.asTypeSpecifier.type === 'ListTypeSpecifier';
       });
     }

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -9432,7 +9432,7 @@ var Union = /*#__PURE__*/function (_Expression4) {
           b = _this$execArgs4[1];
 
       if (a == null && b == null) {
-        return null;
+        return this.listTypeArgs() ? [] : null;
       }
 
       if (a == null || b == null) {
@@ -9441,12 +9441,19 @@ var Union = /*#__PURE__*/function (_Expression4) {
         if (typeIsArray(notNull)) {
           return notNull;
         } else {
-          return [];
+          return null;
         }
       }
 
       var lib = typeIsArray(a) ? LIST : IVL;
       return lib.doUnion(a, b);
+    }
+  }, {
+    key: "listTypeArgs",
+    value: function listTypeArgs() {
+      return this.args.every(function (arg) {
+        return arg.asTypeSpecifier != null && arg.asTypeSpecifier.type === 'ListTypeSpecifier';
+      });
     }
   }]);
 

--- a/src/elm/overloaded.js
+++ b/src/elm/overloaded.js
@@ -60,18 +60,24 @@ class Union extends Expression {
   exec(ctx) {
     const [a, b] = this.execArgs(ctx);
     if (a == null && b == null) {
-      return null;
+      return this.listTypeArgs() ? [] : null;
     }
     if (a == null || b == null) {
       const notNull = a || b;
       if (typeIsArray(notNull)) {
         return notNull;
       } else {
-        return [];
+        return null;
       }
     }
     const lib = typeIsArray(a) ? LIST : IVL;
     return lib.doUnion(a, b);
+  }
+
+  listTypeArgs() {
+    return this.args.every(arg => {
+      return arg.asTypeSpecifier != null && arg.asTypeSpecifier.type === 'ListTypeSpecifier';
+    });
   }
 }
 

--- a/src/elm/overloaded.js
+++ b/src/elm/overloaded.js
@@ -59,8 +59,16 @@ class Union extends Expression {
 
   exec(ctx) {
     const [a, b] = this.execArgs(ctx);
-    if (a == null || b == null) {
+    if (a == null && b == null) {
       return null;
+    }
+    if (a == null || b == null) {
+      const notNull = a || b;
+      if (typeIsArray(notNull)) {
+        return notNull;
+      } else {
+        return null;
+      }
     }
     const lib = typeIsArray(a) ? LIST : IVL;
     return lib.doUnion(a, b);

--- a/src/elm/overloaded.js
+++ b/src/elm/overloaded.js
@@ -75,7 +75,7 @@ class Union extends Expression {
   }
 
   listTypeArgs() {
-    return this.args.every(arg => {
+    return this.args.some(arg => {
       return arg.asTypeSpecifier != null && arg.asTypeSpecifier.type === 'ListTypeSpecifier';
     });
   }

--- a/src/elm/overloaded.js
+++ b/src/elm/overloaded.js
@@ -67,7 +67,7 @@ class Union extends Expression {
       if (typeIsArray(notNull)) {
         return notNull;
       } else {
-        return null;
+        return [];
       }
     }
     const lib = typeIsArray(a) ? LIST : IVL;

--- a/test/elm/interval/data.cql
+++ b/test/elm/interval/data.cql
@@ -844,6 +844,8 @@ define IntOverlapsUnion: Interval[0,7] union Interval[3,10]
 define IntBeginsUnion: Interval[0,5] union Interval[0,10]
 define IntDuringUnion: Interval[3,5] union Interval[0,10]
 define IntEndsUnion: Interval[5,10] union Interval[0,10]
+define NullUnion: null union Interval[0,10]
+define UnionNull: Interval[5,10] union null
 
 // @Test: DateTimeIntervalUnion
 define DateTimeFullInterval: Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2013, 1, 1, 0, 0, 0, 0)]

--- a/test/elm/interval/data.cql
+++ b/test/elm/interval/data.cql
@@ -846,6 +846,7 @@ define IntDuringUnion: Interval[3,5] union Interval[0,10]
 define IntEndsUnion: Interval[5,10] union Interval[0,10]
 define NullUnion: null union Interval[0,10]
 define UnionNull: Interval[5,10] union null
+define NullUnionNull: (null as Interval<Integer>) union (null as Interval<Integer>)
 
 // @Test: DateTimeIntervalUnion
 define DateTimeFullInterval: Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2013, 1, 1, 0, 0, 0, 0)]

--- a/test/elm/interval/interval-test.js
+++ b/test/elm/interval/interval-test.js
@@ -1566,6 +1566,11 @@ describe('IntegerIntervalUnion', () => {
     const y = this.intEndsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
+
+  it('should properly handle null unions', function () {
+    should(this.nullUnion.exec(this.ctx)).be.null();
+    should(this.unionNull.exec(this.ctx)).be.null();
+  });
 });
 
 // TODO

--- a/test/elm/interval/interval-test.js
+++ b/test/elm/interval/interval-test.js
@@ -1568,8 +1568,8 @@ describe('IntegerIntervalUnion', () => {
   });
 
   it('should properly handle null unions', function () {
-    should(this.nullUnion.exec(this.ctx)).be.null();
-    should(this.unionNull.exec(this.ctx)).be.null();
+    this.nullUnion.exec(this.ctx).should.eql([]);
+    this.unionNull.exec(this.ctx).should.eql([]);
   });
 });
 

--- a/test/elm/interval/interval-test.js
+++ b/test/elm/interval/interval-test.js
@@ -1568,8 +1568,8 @@ describe('IntegerIntervalUnion', () => {
   });
 
   it('should properly handle null unions', function () {
-    this.nullUnion.exec(this.ctx).should.eql([]);
-    this.unionNull.exec(this.ctx).should.eql([]);
+    should(this.nullUnion.exec(this.ctx)).be.null();
+    should(this.unionNull.exec(this.ctx)).be.null();
   });
 });
 

--- a/test/elm/list/data.cql
+++ b/test/elm/list/data.cql
@@ -44,6 +44,8 @@ define Disjoint: {1, 2} union {4, 5}
 define NestedToFifteen: {1, 2, 3} union {4, 5, 6} union {7 ,8 , 9} union {10, 11, 12} union {13, 14, 15}
 define NullUnion: null union {1, 2, 3}
 define UnionNull: {1, 2, 3} union null
+define nullUnionNull: (null as List<String>) union (null as List<String>)
+
 
 // @Test: Except
 define ExceptThreeFour: {1, 2, 3, 4, 5} except {3, 4}

--- a/test/elm/list/data.js
+++ b/test/elm/list/data.js
@@ -3182,6 +3182,7 @@ define Disjoint: {1, 2} union {4, 5}
 define NestedToFifteen: {1, 2, 3} union {4, 5, 6} union {7 ,8 , 9} union {10, 11, 12} union {13, 14, 15}
 define NullUnion: null union {1, 2, 3}
 define UnionNull: {1, 2, 3} union null
+define nullUnionNull: (null as List<String>) union (null as List<String>)
 */
 
 module.exports['Union'] = {
@@ -3192,7 +3193,7 @@ module.exports['Union'] = {
       }, {
          "type" : "Annotation",
          "s" : {
-            "r" : "86",
+            "r" : "96",
             "s" : [ {
                "value" : [ "","library TestSnippet version '1'" ]
             } ]
@@ -3874,6 +3875,114 @@ module.exports['Union'] = {
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
                         "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }
+               } ]
+            }
+         }, {
+            "localId" : "96",
+            "name" : "nullUnionNull",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "96",
+                  "s" : [ {
+                     "value" : [ "","define ","nullUnionNull",": " ]
+                  }, {
+                     "r" : "95",
+                     "s" : [ {
+                        "r" : "90",
+                        "s" : [ {
+                           "value" : [ "(" ]
+                        }, {
+                           "r" : "90",
+                           "s" : [ {
+                              "r" : "87",
+                              "value" : [ "null"," as " ]
+                           }, {
+                              "r" : "89",
+                              "s" : [ {
+                                 "value" : [ "List<" ]
+                              }, {
+                                 "r" : "88",
+                                 "s" : [ {
+                                    "value" : [ "String" ]
+                                 } ]
+                              }, {
+                                 "value" : [ ">" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     }, {
+                        "value" : [ " union " ]
+                     }, {
+                        "r" : "94",
+                        "s" : [ {
+                           "value" : [ "(" ]
+                        }, {
+                           "r" : "94",
+                           "s" : [ {
+                              "r" : "91",
+                              "value" : [ "null"," as " ]
+                           }, {
+                              "r" : "93",
+                              "s" : [ {
+                                 "value" : [ "List<" ]
+                              }, {
+                                 "r" : "92",
+                                 "s" : [ {
+                                    "value" : [ "String" ]
+                                 } ]
+                              }, {
+                                 "value" : [ ">" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "95",
+               "type" : "Union",
+               "operand" : [ {
+                  "localId" : "90",
+                  "strict" : false,
+                  "type" : "As",
+                  "operand" : {
+                     "localId" : "87",
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "localId" : "89",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "88",
+                        "name" : "{urn:hl7-org:elm-types:r1}String",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }
+               }, {
+                  "localId" : "94",
+                  "strict" : false,
+                  "type" : "As",
+                  "operand" : {
+                     "localId" : "91",
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "localId" : "93",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "92",
+                        "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }

--- a/test/elm/list/list-test.js
+++ b/test/elm/list/list-test.js
@@ -174,6 +174,10 @@ describe('Union', () => {
     should(this.unionNull.exec(this.ctx)).be.eql([1, 2, 3]);
     should(this.nullUnion.exec(this.ctx)).be.eql([1, 2, 3]);
   });
+
+  it('should return an empty list if both args are null but expected to be lists', function () {
+    this.nullUnionNull.exec(this.ctx).should.be.eql([]);
+  });
 });
 
 describe('Except', () => {

--- a/test/elm/list/list-test.js
+++ b/test/elm/list/list-test.js
@@ -170,9 +170,9 @@ describe('Union', () => {
       .should.eql([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
   });
 
-  it('should return null if either arg is null', function () {
-    should(this.unionNull.exec(this.ctx)).be.null();
-    should(this.nullUnion.exec(this.ctx)).be.null();
+  it('should return other list if either arg is null', function () {
+    should(this.unionNull.exec(this.ctx)).be.eql([1, 2, 3]);
+    should(this.nullUnion.exec(this.ctx)).be.eql([1, 2, 3]);
   });
 });
 


### PR DESCRIPTION
This fixes the issue with performing unions between lists when one of the lists is null as identified in #238 
Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository.
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `yarn run test:plus` to run tests, lint, and prettier)
- [n/a] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `yarn run build:browserify` if source changed.

**Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
