### PR TITLE
Do not perform tz offset with precision of year, month and day

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -672,8 +672,14 @@ var AbstractDate = /** @class */ (function () {
             throw new Error("Invalid precision: ".concat(precision));
         }
         // make a copy of other in the correct timezone offset if they don't match.
-        if (this.timezoneOffset !== other.timezoneOffset) {
-            other = other.convertToTimezoneOffset(this.timezoneOffset);
+        // When comparing DateTime values with different timezone offsets, implementations
+        // should normalize to the timezone offset of the evaluation request timestamp,
+        // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
+        // @ts-ignore
+        if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+            if (this.timezoneOffset !== other.timezoneOffset) {
+                other = other.convertToTimezoneOffset(this.timezoneOffset);
+            }
         }
         // @ts-ignore
         for (var _i = 0, _a = this.constructor.FIELDS; _i < _a.length; _i++) {
@@ -725,8 +731,14 @@ var AbstractDate = /** @class */ (function () {
             throw new Error("Invalid precision: ".concat(precision));
         }
         // make a copy of other in the correct timezone offset if they don't match.
-        if (this.timezoneOffset !== other.timezoneOffset) {
-            other = other.convertToTimezoneOffset(this.timezoneOffset);
+        // When comparing DateTime values with different timezone offsets, implementations
+        // should normalize to the timezone offset of the evaluation request timestamp,
+        // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
+        // @ts-ignore
+        if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+            if (this.timezoneOffset !== other.timezoneOffset) {
+                other = other.convertToTimezoneOffset(this.timezoneOffset);
+            }
         }
         // @ts-ignore
         for (var _i = 0, _a = this.constructor.FIELDS; _i < _a.length; _i++) {
@@ -784,8 +796,14 @@ var AbstractDate = /** @class */ (function () {
             throw new Error("Invalid precision: ".concat(precision));
         }
         // make a copy of other in the correct timezone offset if they don't match.
-        if (this.timezoneOffset !== other.timezoneOffset) {
-            other = other.convertToTimezoneOffset(this.timezoneOffset);
+        // When comparing DateTime values with different timezone offsets, implementations
+        // should normalize to the timezone offset of the evaluation request timestamp,
+        // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
+        // @ts-ignore
+        if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+            if (this.timezoneOffset !== other.timezoneOffset) {
+                other = other.convertToTimezoneOffset(this.timezoneOffset);
+            }
         }
         // @ts-ignore
         for (var _i = 0, _a = this.constructor.FIELDS; _i < _a.length; _i++) {
@@ -843,8 +861,14 @@ var AbstractDate = /** @class */ (function () {
             throw new Error("Invalid precision: ".concat(precision));
         }
         // make a copy of other in the correct timezone offset if they don't match.
-        if (this.timezoneOffset !== other.timezoneOffset) {
-            other = other.convertToTimezoneOffset(this.timezoneOffset);
+        // When comparing DateTime values with different timezone offsets, implementations
+        // should normalize to the timezone offset of the evaluation request timestamp,
+        // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
+        // @ts-ignore
+        if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+            if (this.timezoneOffset !== other.timezoneOffset) {
+                other = other.convertToTimezoneOffset(this.timezoneOffset);
+            }
         }
         // @ts-ignore
         for (var _i = 0, _a = this.constructor.FIELDS; _i < _a.length; _i++) {
@@ -902,8 +926,14 @@ var AbstractDate = /** @class */ (function () {
             throw new Error("Invalid precision: ".concat(precision));
         }
         // make a copy of other in the correct timezone offset if they don't match.
-        if (this.timezoneOffset !== other.timezoneOffset) {
-            other = other.convertToTimezoneOffset(this.timezoneOffset);
+        // When comparing DateTime values with different timezone offsets, implementations
+        // should normalize to the timezone offset of the evaluation request timestamp,
+        // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
+        // @ts-ignore
+        if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+            if (this.timezoneOffset !== other.timezoneOffset) {
+                other = other.convertToTimezoneOffset(this.timezoneOffset);
+            }
         }
         // @ts-ignore
         for (var _i = 0, _a = this.constructor.FIELDS; _i < _a.length; _i++) {

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -675,7 +675,6 @@ var AbstractDate = /** @class */ (function () {
         // When comparing DateTime values with different timezone offsets, implementations
         // should normalize to the timezone offset of the evaluation request timestamp,
         // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
-        // @ts-ignore
         if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
             if (this.timezoneOffset !== other.timezoneOffset) {
                 other = other.convertToTimezoneOffset(this.timezoneOffset);
@@ -734,7 +733,6 @@ var AbstractDate = /** @class */ (function () {
         // When comparing DateTime values with different timezone offsets, implementations
         // should normalize to the timezone offset of the evaluation request timestamp,
         // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
-        // @ts-ignore
         if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
             if (this.timezoneOffset !== other.timezoneOffset) {
                 other = other.convertToTimezoneOffset(this.timezoneOffset);
@@ -799,7 +797,6 @@ var AbstractDate = /** @class */ (function () {
         // When comparing DateTime values with different timezone offsets, implementations
         // should normalize to the timezone offset of the evaluation request timestamp,
         // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
-        // @ts-ignore
         if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
             if (this.timezoneOffset !== other.timezoneOffset) {
                 other = other.convertToTimezoneOffset(this.timezoneOffset);
@@ -864,7 +861,6 @@ var AbstractDate = /** @class */ (function () {
         // When comparing DateTime values with different timezone offsets, implementations
         // should normalize to the timezone offset of the evaluation request timestamp,
         // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
-        // @ts-ignore
         if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
             if (this.timezoneOffset !== other.timezoneOffset) {
                 other = other.convertToTimezoneOffset(this.timezoneOffset);
@@ -929,7 +925,6 @@ var AbstractDate = /** @class */ (function () {
         // When comparing DateTime values with different timezone offsets, implementations
         // should normalize to the timezone offset of the evaluation request timestamp,
         // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
-        // @ts-ignore
         if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
             if (this.timezoneOffset !== other.timezoneOffset) {
                 other = other.convertToTimezoneOffset(this.timezoneOffset);
@@ -1749,7 +1744,7 @@ function isValidDateTimeStringFormat(string) {
     }
     return formats.some(function (fmt) { return luxon_1.DateTime.fromFormat(string, fmt).isValid; });
 }
-// Will return true if provided precision is unspecified or if 
+// Will return true if provided precision is unspecified or if
 // precision is hours, minutes, seconds, or milliseconds
 function isPrecisionUnspecifiedOrGreaterThanDay(precision) {
     return precision == null || /^h|mi|s/.test(precision);

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -676,7 +676,7 @@ var AbstractDate = /** @class */ (function () {
         // should normalize to the timezone offset of the evaluation request timestamp,
         // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
         // @ts-ignore
-        if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+        if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
             if (this.timezoneOffset !== other.timezoneOffset) {
                 other = other.convertToTimezoneOffset(this.timezoneOffset);
             }
@@ -735,7 +735,7 @@ var AbstractDate = /** @class */ (function () {
         // should normalize to the timezone offset of the evaluation request timestamp,
         // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
         // @ts-ignore
-        if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+        if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
             if (this.timezoneOffset !== other.timezoneOffset) {
                 other = other.convertToTimezoneOffset(this.timezoneOffset);
             }
@@ -800,7 +800,7 @@ var AbstractDate = /** @class */ (function () {
         // should normalize to the timezone offset of the evaluation request timestamp,
         // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
         // @ts-ignore
-        if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+        if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
             if (this.timezoneOffset !== other.timezoneOffset) {
                 other = other.convertToTimezoneOffset(this.timezoneOffset);
             }
@@ -865,7 +865,7 @@ var AbstractDate = /** @class */ (function () {
         // should normalize to the timezone offset of the evaluation request timestamp,
         // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
         // @ts-ignore
-        if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+        if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
             if (this.timezoneOffset !== other.timezoneOffset) {
                 other = other.convertToTimezoneOffset(this.timezoneOffset);
             }
@@ -930,7 +930,7 @@ var AbstractDate = /** @class */ (function () {
         // should normalize to the timezone offset of the evaluation request timestamp,
         // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
         // @ts-ignore
-        if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+        if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
             if (this.timezoneOffset !== other.timezoneOffset) {
                 other = other.convertToTimezoneOffset(this.timezoneOffset);
             }
@@ -1748,6 +1748,11 @@ function isValidDateTimeStringFormat(string) {
         return false;
     }
     return formats.some(function (fmt) { return luxon_1.DateTime.fromFormat(string, fmt).isValid; });
+}
+// Will return true if provided precision is unspecified or if 
+// precision is hours, minutes, seconds, or milliseconds
+function isPrecisionUnspecifiedOrGreaterThanDay(precision) {
+    return precision == null || /^h|mi|s/.test(precision);
 }
 
 },{"../util/util":55,"./uncertainty":13,"luxon":72}],8:[function(require,module,exports){

--- a/src/datatypes/datetime.ts
+++ b/src/datatypes/datetime.ts
@@ -178,7 +178,7 @@ abstract class AbstractDate {
     // should normalize to the timezone offset of the evaluation request timestamp,
     // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
     // @ts-ignore
-    if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+    if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
       if ((this as any).timezoneOffset !== other.timezoneOffset) {
         other = other.convertToTimezoneOffset((this as any).timezoneOffset);
       }
@@ -239,7 +239,7 @@ abstract class AbstractDate {
     // should normalize to the timezone offset of the evaluation request timestamp,
     // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
     // @ts-ignore
-    if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+    if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
       if ((this as any).timezoneOffset !== other.timezoneOffset) {
         other = other.convertToTimezoneOffset((this as any).timezoneOffset);
       }
@@ -305,7 +305,7 @@ abstract class AbstractDate {
     // should normalize to the timezone offset of the evaluation request timestamp,
     // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
     // @ts-ignore
-    if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+    if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
       if ((this as any).timezoneOffset !== other.timezoneOffset) {
         other = other.convertToTimezoneOffset((this as any).timezoneOffset);
       }
@@ -371,7 +371,7 @@ abstract class AbstractDate {
     // should normalize to the timezone offset of the evaluation request timestamp,
     // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
     // @ts-ignore
-    if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+    if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
       if ((this as any).timezoneOffset !== other.timezoneOffset) {
         other = other.convertToTimezoneOffset((this as any).timezoneOffset);
       }
@@ -437,7 +437,7 @@ abstract class AbstractDate {
     // should normalize to the timezone offset of the evaluation request timestamp,
     // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
     // @ts-ignore
-    if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+    if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
       if ((this as any).timezoneOffset !== other.timezoneOffset) {
         other = other.convertToTimezoneOffset((this as any).timezoneOffset);
       }
@@ -1345,4 +1345,10 @@ function isValidDateTimeStringFormat(string: any) {
   }
 
   return formats.some((fmt: any) => LuxonDateTime.fromFormat(string, fmt).isValid);
+}
+
+// Will return true if provided precision is unspecified or if
+// precision is hours, minutes, seconds, or milliseconds
+function isPrecisionUnspecifiedOrGreaterThanDay(precision: any) {
+  return precision == null || /^h|mi|s/.test(precision);
 }

--- a/src/datatypes/datetime.ts
+++ b/src/datatypes/datetime.ts
@@ -174,8 +174,14 @@ abstract class AbstractDate {
     }
 
     // make a copy of other in the correct timezone offset if they don't match.
-    if ((this as any).timezoneOffset !== other.timezoneOffset) {
-      other = other.convertToTimezoneOffset((this as any).timezoneOffset);
+    // When comparing DateTime values with different timezone offsets, implementations
+    // should normalize to the timezone offset of the evaluation request timestamp,
+    // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
+    // @ts-ignore
+    if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+      if ((this as any).timezoneOffset !== other.timezoneOffset) {
+        other = other.convertToTimezoneOffset((this as any).timezoneOffset);
+      }
     }
 
     // @ts-ignore
@@ -229,8 +235,14 @@ abstract class AbstractDate {
     }
 
     // make a copy of other in the correct timezone offset if they don't match.
-    if ((this as any).timezoneOffset !== other.timezoneOffset) {
-      other = other.convertToTimezoneOffset((this as any).timezoneOffset);
+    // When comparing DateTime values with different timezone offsets, implementations
+    // should normalize to the timezone offset of the evaluation request timestamp,
+    // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
+    // @ts-ignore
+    if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+      if ((this as any).timezoneOffset !== other.timezoneOffset) {
+        other = other.convertToTimezoneOffset((this as any).timezoneOffset);
+      }
     }
 
     // @ts-ignore
@@ -289,8 +301,14 @@ abstract class AbstractDate {
     }
 
     // make a copy of other in the correct timezone offset if they don't match.
-    if ((this as any).timezoneOffset !== other.timezoneOffset) {
-      other = other.convertToTimezoneOffset((this as any).timezoneOffset);
+    // When comparing DateTime values with different timezone offsets, implementations
+    // should normalize to the timezone offset of the evaluation request timestamp,
+    // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
+    // @ts-ignore
+    if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+      if ((this as any).timezoneOffset !== other.timezoneOffset) {
+        other = other.convertToTimezoneOffset((this as any).timezoneOffset);
+      }
     }
 
     // @ts-ignore
@@ -349,8 +367,14 @@ abstract class AbstractDate {
     }
 
     // make a copy of other in the correct timezone offset if they don't match.
-    if ((this as any).timezoneOffset !== other.timezoneOffset) {
-      other = other.convertToTimezoneOffset((this as any).timezoneOffset);
+    // When comparing DateTime values with different timezone offsets, implementations
+    // should normalize to the timezone offset of the evaluation request timestamp,
+    // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
+    // @ts-ignore
+    if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+      if ((this as any).timezoneOffset !== other.timezoneOffset) {
+        other = other.convertToTimezoneOffset((this as any).timezoneOffset);
+      }
     }
 
     // @ts-ignore
@@ -409,8 +433,14 @@ abstract class AbstractDate {
     }
 
     // make a copy of other in the correct timezone offset if they don't match.
-    if ((this as any).timezoneOffset !== other.timezoneOffset) {
-      other = other.convertToTimezoneOffset((this as any).timezoneOffset);
+    // When comparing DateTime values with different timezone offsets, implementations
+    // should normalize to the timezone offset of the evaluation request timestamp,
+    // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
+    // @ts-ignore
+    if (precision == null || this.constructor.FIELDS.indexOf(precision) > 2) {
+      if ((this as any).timezoneOffset !== other.timezoneOffset) {
+        other = other.convertToTimezoneOffset((this as any).timezoneOffset);
+      }
     }
 
     // @ts-ignore

--- a/src/datatypes/datetime.ts
+++ b/src/datatypes/datetime.ts
@@ -177,7 +177,6 @@ abstract class AbstractDate {
     // When comparing DateTime values with different timezone offsets, implementations
     // should normalize to the timezone offset of the evaluation request timestamp,
     // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
-    // @ts-ignore
     if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
       if ((this as any).timezoneOffset !== other.timezoneOffset) {
         other = other.convertToTimezoneOffset((this as any).timezoneOffset);
@@ -238,7 +237,6 @@ abstract class AbstractDate {
     // When comparing DateTime values with different timezone offsets, implementations
     // should normalize to the timezone offset of the evaluation request timestamp,
     // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
-    // @ts-ignore
     if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
       if ((this as any).timezoneOffset !== other.timezoneOffset) {
         other = other.convertToTimezoneOffset((this as any).timezoneOffset);
@@ -304,7 +302,6 @@ abstract class AbstractDate {
     // When comparing DateTime values with different timezone offsets, implementations
     // should normalize to the timezone offset of the evaluation request timestamp,
     // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
-    // @ts-ignore
     if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
       if ((this as any).timezoneOffset !== other.timezoneOffset) {
         other = other.convertToTimezoneOffset((this as any).timezoneOffset);
@@ -370,7 +367,6 @@ abstract class AbstractDate {
     // When comparing DateTime values with different timezone offsets, implementations
     // should normalize to the timezone offset of the evaluation request timestamp,
     // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
-    // @ts-ignore
     if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
       if ((this as any).timezoneOffset !== other.timezoneOffset) {
         other = other.convertToTimezoneOffset((this as any).timezoneOffset);
@@ -436,7 +432,6 @@ abstract class AbstractDate {
     // When comparing DateTime values with different timezone offsets, implementations
     // should normalize to the timezone offset of the evaluation request timestamp,
     // but only when the comparison precision is hours, minutes, seconds, or milliseconds.
-    // @ts-ignore
     if (isPrecisionUnspecifiedOrGreaterThanDay(precision)) {
       if ((this as any).timezoneOffset !== other.timezoneOffset) {
         other = other.convertToTimezoneOffset((this as any).timezoneOffset);

--- a/test/datatypes/datetime-test.ts
+++ b/test/datatypes/datetime-test.ts
@@ -1615,13 +1615,13 @@ describe('DateTime.sameAs', () => {
       .should.be.true();
     DateTime.parse('2000-12-31T19:35:45.123+00:00')
       .sameAs(DateTime.parse('2001-01-01T00:05:45.123+04:30'), DateTime.Unit.DAY)
-      .should.be.true();
+      .should.be.false();
     DateTime.parse('2000-12-31T19:35:45.123+00:00')
       .sameAs(DateTime.parse('2001-01-01T00:05:45.123+04:30'), DateTime.Unit.MONTH)
-      .should.be.true();
+      .should.be.false();
     DateTime.parse('2000-12-31T19:35:45.123+00:00')
       .sameAs(DateTime.parse('2001-01-01T00:05:45.123+04:30'), DateTime.Unit.YEAR)
-      .should.be.true();
+      .should.be.false();
   });
 
   it('should handle imprecision correctly with missing milliseconds', () => {


### PR DESCRIPTION
https://cql.hl7.org/09-b-cqlreference.html#same-as-1
When comparing DateTime values with different timezone offsets, implementations should normalize to the timezone offset of the evaluation request timestamp, but only when the comparison precision is hours, minutes, seconds, or milliseconds.

Previously, the timezone offset was being normalized for all comparisons.

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository.
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
