### PR TITLE
Update Test Framework to use CQL Translator 2.x

### DIFF
--- a/test/elm/aggregate/data.js
+++ b/test/elm/aggregate/data.js
@@ -21,6 +21,7 @@ define is_null: Count(null as List<Integer>)
 module.exports['Count'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -322,6 +323,7 @@ define IncompatibleUnitsNull: Sum({1 'mg/d', 0.002 '/d'})
 module.exports['Sum'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1123,6 +1125,7 @@ define IncompatibleUnitsNull: Min({1 'mg/d', 0.002 '/d'})
 module.exports['Min'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2560,6 +2563,7 @@ define MaxIsAlsoNull: Max(null as List<Decimal>)
 module.exports['Max'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3947,6 +3951,7 @@ define IncompatibleUnitsNull: Avg({1 'mg/d', 0.002 '/d'})
 module.exports['Avg'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -4674,6 +4679,7 @@ define IncompatibleUnitsNull: Median({1 'mg/d', 0.002 '/d'})
 module.exports['Median'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -6045,6 +6051,7 @@ define IncompatibleUnitsNull: Mode({1 'mg/d', 0.002 '/d'})
 module.exports['Mode'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -6533,6 +6540,7 @@ define IncompatibleUnitsNull: Variance({1 'mg/d', 0.002 '/d'})
 module.exports['Variance'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -7023,6 +7031,7 @@ define IncompatibleUnitsNull: PopulationVariance({1 'mg/d', 0.002 '/d'})
 module.exports['PopulationVariance'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -7498,6 +7507,7 @@ define IncompatibleUnitsNull: StdDev({1 'mg/d', 0.002 '/d'})
 module.exports['StdDev'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -8080,6 +8090,7 @@ define IncompatibleUnitsNull: PopulationStdDev({1 'mg/d', 0.002 '/d'})
 module.exports['PopulationStdDev'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -8573,6 +8584,7 @@ define IncompatibleUnitsNull: Product({1 'mg/d', 0.002 '/d'})
 module.exports['Product'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -9431,6 +9443,7 @@ define also_null_geometric_mean: GeometricMean(null as List<Decimal>)
 module.exports['GeometricMean'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -9810,6 +9823,7 @@ define atfwn: AllTrue({true,true,null,null,true,false})
 module.exports['AllTrue'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -10142,6 +10156,7 @@ define atfwn: AnyTrue({false,false,null,null,false,false})
 module.exports['AnyTrue'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/arithmetic/data.js
+++ b/test/elm/arithmetic/data.js
@@ -28,6 +28,7 @@ define AddNumberAndUncertainty: 10 + UncertaintyZeroToTwelve
 module.exports['Add'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -682,6 +683,7 @@ define SubtractUncertaintyFromNumber: 10 - UncertaintySixToEighteen
 module.exports['Subtract'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1197,6 +1199,7 @@ define MultiplyNumberAndUncertainty: 10 * UncertaintyTwoToFourteen
 module.exports['Multiply'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1728,6 +1731,7 @@ define DivideNumberByUncertainty: 36 / UncertaintySixToEighteen
 module.exports['Divide'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2317,6 +2321,7 @@ define NegativeOne: -1
 module.exports['Negate'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2424,6 +2429,7 @@ define Parenthetical: (1 + 5) * (10 - 15) / 3
 module.exports['MathPrecedence'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2687,6 +2693,7 @@ define Pow: 3 ^ 4
 module.exports['Power'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2802,6 +2809,7 @@ define MinWrongType: minimum Quantity
 module.exports['MinValue'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3027,6 +3035,7 @@ define MaxWrongType: maximum Quantity
 module.exports['MaxValue'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3249,6 +3258,7 @@ define Even: 9 div 3
 module.exports['TruncatedDivide'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3395,6 +3405,7 @@ define Mod: 3 mod 2
 module.exports['Modulo'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3507,6 +3518,7 @@ define Even: Ceiling(10)
 module.exports['Ceiling'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3647,6 +3659,7 @@ define Even: Floor(10)
 module.exports['Floor'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3787,6 +3800,7 @@ define Even: Truncate(10)
 module.exports['Truncate'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3928,6 +3942,7 @@ define Zero: Abs(0)
 module.exports['Abs'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -4108,6 +4123,7 @@ define Down_percent: Round(4.43,1)
 module.exports['Round'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -4316,6 +4332,7 @@ define ln: Ln(4)
 module.exports['Ln'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -4425,6 +4442,7 @@ define log: Log(10,10000)
 module.exports['Log'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -4552,6 +4570,7 @@ define max_date: successor of DateTime(9999,12,31,23,59,59,999)
 module.exports['Successor'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -5202,6 +5221,7 @@ define min_date: predecessor of DateTime(0001,01,01,0,0,0,0)
 module.exports['Predecessor'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -5873,6 +5893,7 @@ define SubtractUcum: (25 'km' - 5 'm') = 24995 'm'
 module.exports['Quantity'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -7059,6 +7080,7 @@ define ExpOverflow: Exp(maximum Decimal)
 module.exports['OutOfBounds'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/clinical/data.js
+++ b/test/elm/clinical/data.js
@@ -21,6 +21,7 @@ define Foo: 'Bar'
 module.exports['ValueSetDef'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -169,6 +170,7 @@ define Foo: "Acute Pharyngitis"
 module.exports['ValueSetRef'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -269,6 +271,7 @@ module.exports['ValueSetRef'] = {
             "expression" : {
                "localId" : "3",
                "name" : "Acute Pharyngitis",
+               "preserve" : true,
                "type" : "ValueSetRef"
             }
          } ]
@@ -310,6 +313,7 @@ define ListOfCodesNull: (null as List<Code>) in "Female"
 module.exports['InValueSet'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -472,7 +476,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "7",
                   "name" : "Female",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -516,7 +520,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "11",
                   "name" : "SharedCodes",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -560,7 +564,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "15",
                   "name" : "SharedCodes",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -604,7 +608,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "19",
                   "name" : "ImproperSharedCodes",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -648,7 +652,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "23",
                   "name" : "Versioned Female",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -711,7 +715,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "28",
                   "name" : "Female",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -793,7 +797,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "34",
                   "name" : "Female",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -894,7 +898,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "41",
                   "name" : "Female",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -938,7 +942,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "45",
                   "name" : "Female",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -982,7 +986,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "49",
                   "name" : "Versioned Female",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -1045,7 +1049,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "54",
                   "name" : "Female",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -1127,7 +1131,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "60",
                   "name" : "Female",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -1228,7 +1232,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "67",
                   "name" : "Female",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -1327,7 +1331,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "74",
                   "name" : "Female",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -1470,7 +1474,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "84",
                   "name" : "Female",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -1742,7 +1746,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "103",
                   "name" : "Female",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -1785,7 +1789,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "107",
                   "name" : "Female",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -1942,7 +1946,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "119",
                   "name" : "Female",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          }, {
@@ -2018,7 +2022,7 @@ module.exports['InValueSet'] = {
                "valueset" : {
                   "localId" : "126",
                   "name" : "Female",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          } ]
@@ -2037,6 +2041,7 @@ define IsFemale: Patient.gender in "Female"
 module.exports['Patient Property In ValueSet'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2170,7 +2175,7 @@ module.exports['Patient Property In ValueSet'] = {
                "valueset" : {
                   "localId" : "5",
                   "name" : "Female",
-                  "type" : "ValueSetRef"
+                  "preserve" : true
                }
             }
          } ]
@@ -2190,6 +2195,7 @@ define Foo: 'Bar'
 module.exports['CodeDef'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2339,6 +2345,7 @@ define Foo: "Tobacco smoking status code"
 module.exports['CodeRef'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2488,6 +2495,7 @@ define Foo: 'Bar'
 module.exports['ConceptDef'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2666,6 +2674,7 @@ define Foo: "Tobacco smoking status"
 module.exports['ConceptRef'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2846,6 +2855,7 @@ define Seconds: AgeInSeconds()
 module.exports['CalculateAge: Fully Specified Birth Date'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3158,6 +3168,7 @@ define Seconds: AgeInSeconds()
 module.exports['CalculateAge: Fully Specified Birth Date on Today'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3470,6 +3481,7 @@ define Seconds: AgeInSeconds()
 module.exports['CalculateAge: Date-Only Birth Date as DateTime'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3782,6 +3794,7 @@ define Seconds: AgeInSeconds()
 module.exports['CalculateAge: Date-Only Birth Date as DateTime on Today'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -4094,6 +4107,7 @@ define Seconds: AgeInSeconds()
 module.exports['CalculateAge: Date-Only Birth Date as Date'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -4406,6 +4420,7 @@ define Seconds: AgeInSeconds()
 module.exports['CalculateAge: Date-Only Birth Date as Date on Today'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -4718,6 +4733,7 @@ define CalculateAgeInYearsDateArg: CalculateAgeInYearsAt(@1994-12-01T23:59:00.00
 module.exports['CalculateAgeAt'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/comparison/data.js
+++ b/test/elm/comparison/data.js
@@ -54,6 +54,7 @@ define UneqRatios: 10 'mg' : 2 'dL' = 15 'mg' : 4 'dL'
 module.exports['Equal'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3298,6 +3299,7 @@ define ALtB_Quantity_incompatible: 5 'Cel' != 40 'm'
 module.exports['NotEqual'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -6528,6 +6530,7 @@ define DateTimeAndDateUncertainFalse: DateTime(2000, 3, 13, 2, 4, 23) ~ Date(200
 module.exports['Equivalent'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -7519,7 +7522,7 @@ module.exports['Equivalent'] = {
                "s" : {
                   "r" : "94",
                   "s" : [ {
-                     "value" : [ "// define EmptyTuples: { : } ~ { : } // TODO: We don't seem to support this format","define ","SameTuples",": " ]
+                     "value" : [ "// define EmptyTuples: { : } ~ { : } // TODO: We don't seem to support this format\n","define ","SameTuples",": " ]
                   }, {
                      "r" : "93",
                      "s" : [ {
@@ -11811,6 +11814,7 @@ define ALtB_Quantity_incompatible: 5 'Cel' < 40 'm'
 module.exports['Less'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -12399,6 +12403,7 @@ define ALtB_Quantity_incompatible: 5 'Cel' <= 40 'm'
 module.exports['LessOrEqual'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -12987,6 +12992,7 @@ define ALtB_Quantity_incompatible: 5 'Cel' > 40 'm'
 module.exports['Greater'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -13577,6 +13583,7 @@ define DivideUcum: (100 'mg' / 2 '[lb_av]') > 49 'mg/[lb_av]'
 module.exports['GreaterOrEqual'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/conditional/data.js
+++ b/test/elm/conditional/data.js
@@ -19,6 +19,7 @@ define exp: if var then 'true return' else 'false return'
 module.exports['If'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -197,6 +198,7 @@ define standard:
 module.exports['Case'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/convert/data.js
+++ b/test/elm/convert/data.js
@@ -36,6 +36,7 @@ define TimezoneTime: convert '14:30:00.0-07:00' to Time // 2:30PM Mountain Stand
 module.exports['FromString'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -793,7 +794,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "72",
                   "s" : [ {
-                     "value" : [ "// January 1st, 2014, 2:30PM UTC","define ","TimezoneDateTime",": " ]
+                     "value" : [ "// January 1st, 2014, 2:30PM UTC\n","define ","TimezoneDateTime",": " ]
                   }, {
                      "r" : "71",
                      "s" : [ {
@@ -834,7 +835,7 @@ module.exports['FromString'] = {
                "s" : {
                   "r" : "76",
                   "s" : [ {
-                     "value" : [ "// January 1st, 2014, 2:30PM Mountain Standard (GMT-7:00)","define ","TimezoneTime",": " ]
+                     "value" : [ "// January 1st, 2014, 2:30PM Mountain Standard (GMT-7:00)\n","define ","TimezoneTime",": " ]
                   }, {
                      "r" : "75",
                      "s" : [ {
@@ -883,6 +884,7 @@ define intInt: convert 10 to Integer
 module.exports['FromInteger'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1097,6 +1099,7 @@ define quantityQuantity: convert 10 'A' to Quantity
 module.exports['FromQuantity'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1350,6 +1353,7 @@ define booleanFalseBool: convert false to Boolean
 module.exports['FromBoolean'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1560,6 +1564,7 @@ define dateTimeToDateTime: convert @2015-01-02T12:01:02.321-06:00 to DateTime
 module.exports['FromDateTime'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1855,6 +1860,7 @@ define dateToStr: convert @2015-01-01 to String
 module.exports['FromDate'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2153,6 +2159,7 @@ define timeTime: convert @T11:57 to Time
 module.exports['FromTime'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2315,6 +2322,7 @@ define foo: 'bar'
 module.exports['FromCode'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2552,6 +2560,7 @@ define WrongFormat: ToDecimal('+.1')
 module.exports['ToDecimal'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2943,6 +2952,7 @@ define BooleanFalse: ToInteger(false)
 module.exports['ToInteger'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3268,6 +3278,7 @@ define NullArg: ToQuantity((null as String))
 module.exports['ToQuantity'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3762,6 +3773,7 @@ define InvalidDenominator: ToRatio('1.0 \'mg\':2.0 \'cc\'')
 module.exports['ToRatio'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -4084,6 +4096,7 @@ define SecondTooHigh: ToTime('23:59:60')
 module.exports['ToTime'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -4551,6 +4564,7 @@ define IsNull: ToBoolean('falsetto')
 module.exports['ToBoolean'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -5024,6 +5038,7 @@ define IsNull: ToConcept(null as Code)
 module.exports['ToConcept'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -5169,7 +5184,7 @@ module.exports['ToConcept'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "// Concept { codes: { Code { system: 'http://loinc.org', code: '8480-6' } } }","define ","IsNull",": " ]
+                     "value" : [ "// Concept { codes: { Code { system: 'http://loinc.org', code: '8480-6' } } }\n","define ","IsNull",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -5227,6 +5242,7 @@ define ToDateDateTimeString: ToDate(@2014-01-01T12:30:00)
 module.exports['ToDate'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -5527,6 +5543,7 @@ define IsNull: ConvertsToBoolean(null as String)
 module.exports['ConvertsToBoolean'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -5763,6 +5780,7 @@ define IsNull: ConvertsToDate(null as Date)
 module.exports['ConvertsToDate'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -5964,6 +5982,7 @@ define IsNull: ConvertsToDateTime(null as DateTime)
 module.exports['ConvertsToDateTime'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -6207,6 +6226,7 @@ define IsNull: ConvertsToDecimal(null as Decimal)
 module.exports['ConvertsToDecimal'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -6409,6 +6429,7 @@ define IsNull: ConvertsToInteger(null as Integer)
 module.exports['ConvertsToInteger'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -6672,6 +6693,7 @@ define IsNull: ConvertsToQuantity(null as String)
 module.exports['ConvertsToQuantity'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -6969,6 +6991,7 @@ define IsNull: ConvertsToRatio(null as String)
 module.exports['ConvertsToRatio'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -7205,6 +7228,7 @@ define IsNull: ConvertsToString(null as String)
 module.exports['ConvertsToString'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -7437,6 +7461,7 @@ define IsNull: ConvertsToTime(null as String)
 module.exports['ConvertsToTime'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -7639,6 +7664,7 @@ define NullConvertQuantity: ConvertQuantity(5 'mg', 'fox')
 module.exports['ConvertQuantity'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -7950,6 +7976,7 @@ define CanConvertQuantityNullSecondNUll: CanConvertQuantity(5 'mg', null)
 module.exports['CanConvertQuantity'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/date/data.js
+++ b/test/elm/date/data.js
@@ -20,6 +20,7 @@ define Day: Date(2012, 2, 15)
 module.exports['Date'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -214,6 +215,7 @@ define NullDate: year from (null as Date)
 module.exports['DateComponentFrom'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -646,6 +648,7 @@ define NullBoth: (null as Date) same as null
 module.exports['SameAs'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1745,6 +1748,7 @@ define NullBoth: (null as Date) same or after null
 module.exports['SameOrAfter'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3441,6 +3445,7 @@ define NullBoth: (null as Date) same or before null
 module.exports['SameOrBefore'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -5134,6 +5139,7 @@ define NullBoth: (null as Date) after null
 module.exports['After'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -6587,6 +6593,7 @@ define NullBoth: (null as Date) before null
 module.exports['Before'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -8033,6 +8040,7 @@ define DaysBetweenUncertainty: difference in days between NewYear2014 and Januar
 module.exports['DifferenceBetween'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -8608,6 +8616,7 @@ define TwentyFiveDaysGreaterThanDaysBetween: 25 > difference in days between New
 module.exports['DifferenceBetween Comparisons'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -9852,6 +9861,7 @@ define DaysBetweenUncertainty: days between JanOne2015 and January2015
 module.exports['DurationBetween'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -10416,6 +10426,7 @@ define MinusTwentyDays: June15th2013 - 20 days
 module.exports['DateMath'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/datetime/data.js
+++ b/test/elm/datetime/data.js
@@ -25,6 +25,7 @@ define TimezoneOffset: DateTime(2012, 2, 15, 12, 10, 59, 456, -8.0)
 module.exports['DateTime'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -524,6 +525,7 @@ define Millisecond: Time(12, 10, 59, 456)
 module.exports['Time'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -756,6 +758,7 @@ define TodayVar: Today()
 module.exports['Today'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -855,6 +858,7 @@ define NowVar: Now()
 module.exports['Now'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -954,6 +958,7 @@ define TimeOfDayVar: TimeOfDay()
 module.exports['TimeOfDay'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1071,6 +1076,7 @@ define NullDate: year from (null as DateTime)
 module.exports['DateTimeComponentFrom'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1785,6 +1791,7 @@ define NullDate: date from (null as DateTime)
 module.exports['DateFrom'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2046,6 +2053,7 @@ define NullDate: time from null
 module.exports['TimeFrom'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2297,6 +2305,7 @@ define NullDate: timezoneoffset from (null as DateTime)
 module.exports['TimezoneOffsetFrom'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2713,6 +2722,7 @@ define NullBoth: (null as DateTime) same as null
 module.exports['SameAs'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -7076,6 +7086,7 @@ define NullBothAOO: (null as DateTime) after or on null
 module.exports['SameOrAfter'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -12387,7 +12398,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "693",
                   "s" : [ {
-                     "value" : [ "// On Or After:","define ","SameOOA",": " ]
+                     "value" : [ "// On Or After:\n","define ","SameOOA",": " ]
                   }, {
                      "r" : "692",
                      "s" : [ {
@@ -13109,7 +13120,7 @@ module.exports['SameOrAfter'] = {
                "s" : {
                   "r" : "783",
                   "s" : [ {
-                     "value" : [ "// After Or On:","define ","SameAOO",": " ]
+                     "value" : [ "// After Or On:\n","define ","SameAOO",": " ]
                   }, {
                      "r" : "782",
                      "s" : [ {
@@ -13885,6 +13896,7 @@ define NullBothBOO: (null as DateTime) before or on null
 module.exports['SameOrBefore'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -19196,7 +19208,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "693",
                   "s" : [ {
-                     "value" : [ "// On Or Before:","define ","SameOOB",": " ]
+                     "value" : [ "// On Or Before:\n","define ","SameOOB",": " ]
                   }, {
                      "r" : "692",
                      "s" : [ {
@@ -19918,7 +19930,7 @@ module.exports['SameOrBefore'] = {
                "s" : {
                   "r" : "783",
                   "s" : [ {
-                     "value" : [ "// Before Or On:","define ","SameBOO",": " ]
+                     "value" : [ "// Before Or On:\n","define ","SameBOO",": " ]
                   }, {
                      "r" : "782",
                      "s" : [ {
@@ -20677,6 +20689,7 @@ define NullBoth: (null as DateTime) after null
 module.exports['After'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -25557,6 +25570,7 @@ define NullBoth: (null as DateTime) before null
 module.exports['Before'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -30427,6 +30441,7 @@ define HoursBetween1and3CrossingFallDST: difference in hours between DateTime(20
 module.exports['DifferenceBetween'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -31832,6 +31847,7 @@ define BonnieTestCaseZulu: difference in months between DateTime(2012, 9, 13, 14
 module.exports['DifferenceBetween Comparisons'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -33448,6 +33464,7 @@ define HoursBetween1and3CrossingFallDST: hours between DateTime(2017, 11, 5, 1, 
 module.exports['DurationBetween'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -34848,6 +34865,7 @@ define MinusThreeMilliseconds: June15th2013 - 3 milliseconds
 module.exports['DateMath'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/executor/data.js
+++ b/test/elm/executor/data.js
@@ -34,6 +34,7 @@ define AgeSumRef : AgeSum
 module.exports['Age'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/external/data.js
+++ b/test/elm/external/data.js
@@ -34,6 +34,7 @@ define ConditionsByDate: [Condition] C where C.period during Interval[@2013-03-0
 module.exports['Retrieve'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -341,6 +342,7 @@ module.exports['Retrieve'] = {
                "type" : "Retrieve",
                "codes" : {
                   "name" : "Ambulatory/ED Visit",
+                  "preserve" : true,
                   "type" : "ValueSetRef"
                }
             }
@@ -383,6 +385,7 @@ module.exports['Retrieve'] = {
                "type" : "Retrieve",
                "codes" : {
                   "name" : "Ambulatory/ED Visit",
+                  "preserve" : true,
                   "type" : "ValueSetRef"
                }
             }
@@ -419,6 +422,7 @@ module.exports['Retrieve'] = {
                "type" : "Retrieve",
                "codes" : {
                   "name" : "Ambulatory/ED Visit",
+                  "preserve" : true,
                   "type" : "ValueSetRef"
                }
             }
@@ -461,6 +465,7 @@ module.exports['Retrieve'] = {
                "type" : "Retrieve",
                "codes" : {
                   "name" : "Ambulatory/ED Visit",
+                  "preserve" : true,
                   "type" : "ValueSetRef"
                }
             }
@@ -724,6 +729,7 @@ valueset "Acute Pharyngitis": '2.16.840.1.113883.3.464.1003.102.12.1011'
 module.exports['Included'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/instance/data.js
+++ b/test/elm/instance/data.js
@@ -45,6 +45,7 @@ define val: QuantityA.value
 module.exports['Instance'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/library/data.js
+++ b/test/elm/library/data.js
@@ -22,6 +22,7 @@ AgeInYearsAt(start of MeasurementPeriod) >= 2 and AgeInYearsAt(start of Measurem
 module.exports['In Age Demographic'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -328,6 +329,7 @@ define SupportLibDef:
 module.exports['CommonLib'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -863,6 +865,7 @@ define supportLibCode: common."directReferenceCode"
 module.exports['Using CommonLib'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1250,6 +1253,7 @@ define SortUsingFunction:
 module.exports['CommonLib2'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2003,6 +2007,7 @@ define ExprSortsOnFunc: common2.SortUsingFunction
 module.exports['Using CommonLib2'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2519,6 +2524,7 @@ define testCommon2Lib: common2.SortUsingFunction
 module.exports['Using CommonLib and CommonLib2'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/list/data.js
+++ b/test/elm/list/data.js
@@ -22,6 +22,7 @@ define EmptyList: List<Integer>{}
 module.exports['List'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -329,6 +330,7 @@ define NullExists: exists (null)
 module.exports['Exists'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -766,6 +768,7 @@ define BothListsHaveNull: List<Integer>{(null as Integer)} = List<Integer>{(null
 module.exports['Equal'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2150,6 +2153,7 @@ define UnequalTupleList: List<Any>{ Tuple{a: 1, b: Tuple{c: 1}}, Tuple{x: 'y', z
 module.exports['NotEqual'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3188,12 +3192,13 @@ define nullUnionNull: (null as List<String>) union (null as List<String>)
 module.exports['Union'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
          "type" : "Annotation",
          "s" : {
-            "r" : "96",
+            "r" : "97",
             "s" : [ {
                "value" : [ "","library TestSnippet version '1'" ]
             } ]
@@ -3580,20 +3585,20 @@ module.exports['Union'] = {
                } ]
             }
          }, {
-            "localId" : "72",
+            "localId" : "73",
             "name" : "NestedToFifteen",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "72",
+                  "r" : "73",
                   "s" : [ {
                      "value" : [ "","define ","NestedToFifteen",": " ]
                   }, {
-                     "r" : "71",
+                     "r" : "72",
                      "s" : [ {
-                        "r" : "66",
+                        "r" : "67",
                         "s" : [ {
                            "r" : "61",
                            "s" : [ {
@@ -3634,9 +3639,9 @@ module.exports['Union'] = {
                      }, {
                         "value" : [ " union " ]
                      }, {
-                        "r" : "70",
+                        "r" : "71",
                         "s" : [ {
-                           "r" : "67",
+                           "r" : "68",
                            "value" : [ "{","13",", ","14",", ","15","}" ]
                         } ]
                      } ]
@@ -3644,10 +3649,10 @@ module.exports['Union'] = {
                }
             } ],
             "expression" : {
-               "localId" : "71",
+               "localId" : "72",
                "type" : "Union",
                "operand" : [ {
-                  "localId" : "66",
+                  "localId" : "67",
                   "type" : "Union",
                   "operand" : [ {
                      "localId" : "56",
@@ -3692,6 +3697,7 @@ module.exports['Union'] = {
                         } ]
                      } ]
                   }, {
+                     "localId" : "66",
                      "type" : "Union",
                      "operand" : [ {
                         "localId" : "60",
@@ -3734,20 +3740,20 @@ module.exports['Union'] = {
                      } ]
                   } ]
                }, {
-                  "localId" : "70",
+                  "localId" : "71",
                   "type" : "List",
                   "element" : [ {
-                     "localId" : "67",
+                     "localId" : "68",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "13",
                      "type" : "Literal"
                   }, {
-                     "localId" : "68",
+                     "localId" : "69",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "14",
                      "type" : "Literal"
                   }, {
-                     "localId" : "69",
+                     "localId" : "70",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "15",
                      "type" : "Literal"
@@ -3755,25 +3761,25 @@ module.exports['Union'] = {
                } ]
             }
          }, {
-            "localId" : "79",
+            "localId" : "80",
             "name" : "NullUnion",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "79",
+                  "r" : "80",
                   "s" : [ {
                      "value" : [ "","define ","NullUnion",": " ]
                   }, {
-                     "r" : "78",
+                     "r" : "79",
                      "s" : [ {
-                        "r" : "73",
+                        "r" : "74",
                         "value" : [ "null"," union " ]
                      }, {
-                        "r" : "77",
+                        "r" : "78",
                         "s" : [ {
-                           "r" : "74",
+                           "r" : "75",
                            "value" : [ "{","1",", ","2",", ","3","}" ]
                         } ]
                      } ]
@@ -3781,12 +3787,12 @@ module.exports['Union'] = {
                }
             } ],
             "expression" : {
-               "localId" : "78",
+               "localId" : "79",
                "type" : "Union",
                "operand" : [ {
                   "type" : "As",
                   "operand" : {
-                     "localId" : "73",
+                     "localId" : "74",
                      "type" : "Null"
                   },
                   "asTypeSpecifier" : {
@@ -3797,20 +3803,20 @@ module.exports['Union'] = {
                      }
                   }
                }, {
-                  "localId" : "77",
+                  "localId" : "78",
                   "type" : "List",
                   "element" : [ {
-                     "localId" : "74",
+                     "localId" : "75",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
                      "type" : "Literal"
                   }, {
-                     "localId" : "75",
+                     "localId" : "76",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2",
                      "type" : "Literal"
                   }, {
-                     "localId" : "76",
+                     "localId" : "77",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "3",
                      "type" : "Literal"
@@ -3818,49 +3824,49 @@ module.exports['Union'] = {
                } ]
             }
          }, {
-            "localId" : "86",
+            "localId" : "87",
             "name" : "UnionNull",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "86",
+                  "r" : "87",
                   "s" : [ {
                      "value" : [ "","define ","UnionNull",": " ]
                   }, {
-                     "r" : "85",
+                     "r" : "86",
                      "s" : [ {
-                        "r" : "83",
+                        "r" : "84",
                         "s" : [ {
-                           "r" : "80",
+                           "r" : "81",
                            "value" : [ "{","1",", ","2",", ","3","}" ]
                         } ]
                      }, {
-                        "r" : "84",
+                        "r" : "85",
                         "value" : [ " union ","null" ]
                      } ]
                   } ]
                }
             } ],
             "expression" : {
-               "localId" : "85",
+               "localId" : "86",
                "type" : "Union",
                "operand" : [ {
-                  "localId" : "83",
+                  "localId" : "84",
                   "type" : "List",
                   "element" : [ {
-                     "localId" : "80",
+                     "localId" : "81",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
                      "type" : "Literal"
                   }, {
-                     "localId" : "81",
+                     "localId" : "82",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2",
                      "type" : "Literal"
                   }, {
-                     "localId" : "82",
+                     "localId" : "83",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "3",
                      "type" : "Literal"
@@ -3868,7 +3874,7 @@ module.exports['Union'] = {
                }, {
                   "type" : "As",
                   "operand" : {
-                     "localId" : "84",
+                     "localId" : "85",
                      "type" : "Null"
                   },
                   "asTypeSpecifier" : {
@@ -3881,33 +3887,33 @@ module.exports['Union'] = {
                } ]
             }
          }, {
-            "localId" : "96",
+            "localId" : "97",
             "name" : "nullUnionNull",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "96",
+                  "r" : "97",
                   "s" : [ {
                      "value" : [ "","define ","nullUnionNull",": " ]
                   }, {
-                     "r" : "95",
+                     "r" : "96",
                      "s" : [ {
-                        "r" : "90",
+                        "r" : "91",
                         "s" : [ {
                            "value" : [ "(" ]
                         }, {
-                           "r" : "90",
+                           "r" : "91",
                            "s" : [ {
-                              "r" : "87",
+                              "r" : "88",
                               "value" : [ "null"," as " ]
                            }, {
-                              "r" : "89",
+                              "r" : "90",
                               "s" : [ {
                                  "value" : [ "List<" ]
                               }, {
-                                 "r" : "88",
+                                 "r" : "89",
                                  "s" : [ {
                                     "value" : [ "String" ]
                                  } ]
@@ -3921,20 +3927,20 @@ module.exports['Union'] = {
                      }, {
                         "value" : [ " union " ]
                      }, {
-                        "r" : "94",
+                        "r" : "95",
                         "s" : [ {
                            "value" : [ "(" ]
                         }, {
-                           "r" : "94",
+                           "r" : "95",
                            "s" : [ {
-                              "r" : "91",
+                              "r" : "92",
                               "value" : [ "null"," as " ]
                            }, {
-                              "r" : "93",
+                              "r" : "94",
                               "s" : [ {
                                  "value" : [ "List<" ]
                               }, {
-                                 "r" : "92",
+                                 "r" : "93",
                                  "s" : [ {
                                     "value" : [ "String" ]
                                  } ]
@@ -3950,38 +3956,38 @@ module.exports['Union'] = {
                }
             } ],
             "expression" : {
-               "localId" : "95",
+               "localId" : "96",
                "type" : "Union",
                "operand" : [ {
-                  "localId" : "90",
+                  "localId" : "91",
                   "strict" : false,
                   "type" : "As",
                   "operand" : {
-                     "localId" : "87",
+                     "localId" : "88",
                      "type" : "Null"
                   },
                   "asTypeSpecifier" : {
-                     "localId" : "89",
+                     "localId" : "90",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "88",
+                        "localId" : "89",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
-                  "localId" : "94",
+                  "localId" : "95",
                   "strict" : false,
                   "type" : "As",
                   "operand" : {
-                     "localId" : "91",
+                     "localId" : "92",
                      "type" : "Null"
                   },
                   "asTypeSpecifier" : {
-                     "localId" : "93",
+                     "localId" : "94",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "92",
+                        "localId" : "93",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
@@ -4014,6 +4020,7 @@ define NullExcept: null except {1, 2, 3, 4, 5}
 module.exports['Except'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -5064,6 +5071,7 @@ define MultipleNullInListIntersect: {1, 2, 3, null} intersect {null, 3}
 module.exports['Intersect'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -6366,6 +6374,7 @@ define ListWrongCodeSystem: IndexOf({Code{code: 'F', system: '1.16.840.1.113883.
 module.exports['IndexOf'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -7763,6 +7772,7 @@ define NullIndexer: {'a', 'b', 'c', 'd'}[null]
 module.exports['Indexer'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -8267,6 +8277,7 @@ define NullNotIn: null in {1, 2, 3}
 module.exports['In'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -9045,6 +9056,7 @@ define NullNotIn: {1, 2, 3} contains null
 module.exports['Contains'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -9859,6 +9871,7 @@ define QuantityNotInList: { ToQuantity('100 \'m\''), ToQuantity('1.995 \'m\''), 
 module.exports['Includes'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -11777,6 +11790,7 @@ define QuantityNotInList: ToQuantity('100 \'m\'') included in { ToQuantity('1 \'
 module.exports['IncludedIn'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -13678,6 +13692,7 @@ define NullIncludes: null properly includes {1, 2, 3, 4, 5}
 module.exports['ProperIncludes'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -14885,6 +14900,7 @@ define NullIncluded: (null as List<Integer>) properly included in {1, 2, 3, 4, 5
 module.exports['ProperIncludedIn'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -16100,6 +16116,7 @@ define NullValue: flatten null
 module.exports['Flatten'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -16416,6 +16433,7 @@ define DuplicateNulls: distinct {null, 1, 2, null, 3, 4, 5, null}
 module.exports['Distinct'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -17012,6 +17030,7 @@ define NullValue: First(null as List<Integer>)
 module.exports['First'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -17655,6 +17674,7 @@ define NullValue: Last(null as List<Integer>)
 module.exports['Last'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -18296,6 +18316,7 @@ define NullValue: Length(null as List<Integer>)
 module.exports['Length'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -18827,6 +18848,7 @@ define LengthOfNull: Length(null as Integer) // CQL-to-ELM will promote the null
 module.exports['ToList'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -18936,7 +18958,7 @@ module.exports['ToList'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "// CQL-to-ELM will promote the second 5 to a list via ToList","define ","FourInFive",": " ]
+                     "value" : [ "// CQL-to-ELM will promote the second 5 to a list via ToList\n","define ","FourInFive",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -18974,7 +18996,7 @@ module.exports['ToList'] = {
                "s" : {
                   "r" : "14",
                   "s" : [ {
-                     "value" : [ "// CQL-to-ELM will promote the 5 to a list via ToList","define ","LengthOfNull",": " ]
+                     "value" : [ "// CQL-to-ELM will promote the 5 to a list via ToList\n","define ","LengthOfNull",": " ]
                   }, {
                      "r" : "13",
                      "s" : [ {
@@ -19035,6 +19057,7 @@ define SkipIsNull: Skip(null, 2)
 module.exports['Skip'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -19370,6 +19393,7 @@ define TailIsNull: Tail(null)
 module.exports['Tail'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -19598,6 +19622,7 @@ define TakeIsNull: Take(null, 2)
 module.exports['Take'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/literal/data.js
+++ b/test/elm/literal/data.js
@@ -24,6 +24,7 @@ define TimeX: @T12:10:59.456
 module.exports['Literal'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -315,6 +316,7 @@ define Unicode: '\u0048'
 module.exports['Escape'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/logical/data.js
+++ b/test/elm/logical/data.js
@@ -26,6 +26,7 @@ define NF: null and false
 module.exports['And'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -437,6 +438,7 @@ define NF: null or false
 module.exports['Or'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -848,6 +850,7 @@ define NF: null xor false
 module.exports['XOr'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1253,6 +1256,7 @@ define NotNull: not null
 module.exports['Not'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1423,6 +1427,7 @@ define NullIsTrue: null is true
 module.exports['IsTrue'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1593,6 +1598,7 @@ define NullIsFalse: null is false
 module.exports['IsFalse'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/message/data.js
+++ b/test/elm/message/data.js
@@ -21,6 +21,7 @@ define oneOverZero: DoDivide(1, 0)
 module.exports['Message'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/nullological/data.js
+++ b/test/elm/nullological/data.js
@@ -18,6 +18,7 @@ define Nil: null
 module.exports['Nil'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -118,6 +119,7 @@ define NonNullVarIsNull: One is null
 module.exports['IsNull'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -371,6 +373,7 @@ define UnionAsList: Coalesce(ListA union ListWithNull)
 module.exports['Coalesce'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/parameters/data.js
+++ b/test/elm/parameters/data.js
@@ -22,6 +22,7 @@ define foo: 'bar'
 module.exports['ParameterDef'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -378,6 +379,7 @@ define Foo: FooP
 module.exports['ParameterRef'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -508,6 +510,7 @@ define Foo2: FooDP
 module.exports['BooleanParameterTypes'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -681,6 +684,7 @@ define Foo2: FooDP
 module.exports['DecimalParameterTypes'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -854,6 +858,7 @@ define Foo2: FooDP
 module.exports['IntegerParameterTypes'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1027,6 +1032,7 @@ define Foo2: FooDP
 module.exports['StringParameterTypes'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1205,6 +1211,7 @@ define Foo2: FooDP
 module.exports['CodeParameterTypes'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1411,6 +1418,7 @@ define Foo2: FooDP
 module.exports['ConceptParameterTypes'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1624,6 +1632,7 @@ define Foo2: FooDP
 module.exports['DateTimeParameterTypes'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1825,6 +1834,7 @@ define Foo2: FooDP
 module.exports['DateParameterTypes'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2011,6 +2021,7 @@ define Foo2: FooDP
 module.exports['QuantityParameterTypes'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2188,6 +2199,7 @@ define Foo2: FooDP
 module.exports['TimeParameterTypes'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2374,6 +2386,7 @@ define Foo2: FooDP
 module.exports['ListParameterTypes'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2597,6 +2610,7 @@ define Foo2: FooDP
 module.exports['IntervalParameterTypes'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2798,6 +2812,7 @@ define Foo2: FooDP
 module.exports['TupleParameterTypes'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3048,6 +3063,7 @@ define Foo2: FooWithDefault
 module.exports['DefaultAndNoDefault'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3219,6 +3235,7 @@ define MeasurementPeriod: Interval[DateTime(2011, 1, 1), DateTime(2013, 1, 1)] o
 module.exports['MeasurementPeriodParameter'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/query/data.js
+++ b/test/elm/query/data.js
@@ -22,6 +22,7 @@ define AmbulatoryEncountersIncludedInMP: [Encounter: "Ambulatory/ED Visit"] E wh
 module.exports['DateRangeOptimizedQuery'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -358,6 +359,7 @@ module.exports['DateRangeOptimizedQuery'] = {
                      "type" : "Retrieve",
                      "codes" : {
                         "name" : "Ambulatory/ED Visit",
+                        "preserve" : true,
                         "type" : "ValueSetRef"
                      },
                      "dateRange" : {
@@ -455,6 +457,7 @@ module.exports['DateRangeOptimizedQuery'] = {
                      "type" : "Retrieve",
                      "codes" : {
                         "name" : "Ambulatory/ED Visit",
+                        "preserve" : true,
                         "type" : "ValueSetRef"
                      },
                      "dateRange" : {
@@ -482,6 +485,7 @@ define queryWithThis: "FunctionWithThis"([Encounter] E) > 0
 module.exports['FunctionQuery'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -770,6 +774,7 @@ define MPIncludedAmbulatoryEncounters: [Encounter: "Ambulatory/ED Visit"] E wher
 module.exports['IncludesQuery'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1020,6 +1025,7 @@ module.exports['IncludesQuery'] = {
                      "type" : "Retrieve",
                      "codes" : {
                         "name" : "Ambulatory/ED Visit",
+                        "preserve" : true,
                         "type" : "ValueSetRef"
                      }
                   }
@@ -1063,6 +1069,7 @@ define msQuery: from [Encounter] E, [Condition] C return {E: E, C:C}
 module.exports['MultiSourceQuery'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1666,6 +1673,7 @@ without [Condition] C such that C.id = 'http://cqframework.org/3/2'
 module.exports['QueryRelationship'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2212,6 +2220,7 @@ return {E: E, a:a}
 module.exports['QueryLet'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2415,6 +2424,7 @@ define query:  [Encounter] E return {id: E.id, thing: E.status}
 module.exports['Tuple'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2615,6 +2625,7 @@ define query:  (List{null, 'One', null, 'Two', null}) I where I is not null
 module.exports['QueryFilterNulls'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2841,6 +2852,7 @@ define sortWithDescendingKeyword: ({8, 6, 7, 5, 3, 0, 9}) N return N sort descen
 module.exports['Sorting'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -5514,6 +5526,7 @@ define allTuples: ({Tuple{a: 1, b:2}, Tuple{a: 2, b: 3}, Tuple{a: 1, b: 2}}) T r
 module.exports['Distinct'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -7003,6 +7016,7 @@ define singleAliasReturnList: firstEncounter E return {'foo', 'bar', 'baz', 'bar
 module.exports['SingleObjectAlias'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -8260,7 +8274,7 @@ module.exports['SingleObjectAlias'] = {
                "s" : {
                   "r" : "111",
                   "s" : [ {
-                     "value" : [ "//define singleAliasWith: firstEncounter E with [Condition] C\n//                         such that C.id = 'http://cqframework.org/3/2'\n//define singleAliasWithNull: firstEncounter E with conditions C\n//                        such that C.id is null","define ","singleAliasReturnTuple",": " ]
+                     "value" : [ "//define singleAliasWith: firstEncounter E with [Condition] C\n//                         such that C.id = 'http://cqframework.org/3/2'\n//define singleAliasWithNull: firstEncounter E with conditions C\n//                        such that C.id is null\n","define ","singleAliasReturnTuple",": " ]
                   }, {
                      "r" : "110",
                      "s" : [ {
@@ -8490,6 +8504,7 @@ define distinctAggregation:
 module.exports['AggregateQuery'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/reusable/data.js
+++ b/test/elm/reusable/data.js
@@ -18,6 +18,7 @@ define Foo: 'Bar'
 module.exports['ExpressionDef'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -120,6 +121,7 @@ define Foo: Life
 module.exports['ExpressionRef'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -244,6 +246,7 @@ define testValue: "foo bar"(1,2)
 module.exports['FunctionDefinitions'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -438,6 +441,7 @@ define testValue2: process('World')
 module.exports['FunctionOverloadsWithSingleArgument'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -709,6 +713,7 @@ define testValue2: process(true, 'World')
 module.exports['FunctionOverloadsWithMultipleArguments'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1120,6 +1125,7 @@ define testValue3: process('World', false)
 module.exports['FunctionOverloadsWithDifferentNumberOfArguments'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1554,6 +1560,7 @@ define testValue2: process(First([Condition]))
 module.exports['FunctionOverloadsWithArgumentsFromCustomDataModel'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/string/data.js
+++ b/test/elm/string/data.js
@@ -29,6 +29,7 @@ define AndHelloWorldVariables: Hello & World
 module.exports['Concat'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1340,6 +1341,7 @@ define CombineEmptyNull: Combine({}, ';')
 module.exports['Combine'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1868,6 +1870,7 @@ define SeparateUsingNull: Split('a,b,c', null)
 module.exports['Split'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2137,6 +2140,7 @@ define SplitOnMatchesAllNull: SplitOnMatches(null, null)
 module.exports['SplitOnMatches'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2491,6 +2495,7 @@ define NullString: Length(null as String)
 module.exports['Length'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2656,6 +2661,7 @@ define NullString: Upper(null)
 module.exports['Upper'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2875,6 +2881,7 @@ define NullString: Lower(null)
 module.exports['Lower'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3095,6 +3102,7 @@ define NullIndex: 'HelloWorld'[null]
 module.exports['Indexer'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3398,6 +3406,7 @@ define MatchesAllNull: Matches(null, null)
 module.exports['Matches'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3700,6 +3709,7 @@ define NullString: PositionOf('cde', null)
 module.exports['PositionOf'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3967,6 +3977,7 @@ define NullString: LastPositionOf('ABCDE', null)  // null
 module.exports['LastPositionOf'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -4087,7 +4098,7 @@ module.exports['LastPositionOf'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "// 7","define ","NotFound",": " ]
+                     "value" : [ "// 7\n","define ","NotFound",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -4136,7 +4147,7 @@ module.exports['LastPositionOf'] = {
                "s" : {
                   "r" : "13",
                   "s" : [ {
-                     "value" : [ "// -1","define ","NullPattern",": " ]
+                     "value" : [ "// -1\n","define ","NullPattern",": " ]
                   }, {
                      "r" : "12",
                      "s" : [ {
@@ -4181,7 +4192,7 @@ module.exports['LastPositionOf'] = {
                "s" : {
                   "r" : "17",
                   "s" : [ {
-                     "value" : [ "// null","define ","NullString",": " ]
+                     "value" : [ "// null\n","define ","NullString",": " ]
                   }, {
                      "r" : "16",
                      "s" : [ {
@@ -4239,6 +4250,7 @@ define NullStart: Substring('HelloWorld', null)
 module.exports['Substring'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -4753,6 +4765,7 @@ define NullAsStringStartsWith: StartsWith(null as String, 'Foo')
 module.exports['StartsWith'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -5240,6 +5253,7 @@ define NullAsStringEndsWith: EndsWith(null as String, 'Foo')
 module.exports['EndsWith'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -5749,6 +5763,7 @@ define ReplaceSubstitutionIsNull: ReplaceMatches('Foo', 'Bar', null)
 module.exports['ReplaceMatches'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/structured/data.js
+++ b/test/elm/structured/data.js
@@ -19,6 +19,7 @@ define emptyTup: {:}
 module.exports['Tuple'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/elm/type/data.js
+++ b/test/elm/type/data.js
@@ -21,6 +21,7 @@ define StringFiveIsString: '5' is String
 module.exports['IsSystemType'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -266,6 +267,7 @@ define ListOfDecimalsIsListOfIntegers: {1.5, 2.5, 3.5, 4.5, 5.5} is List<Integer
 module.exports['IsListType'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -503,6 +505,7 @@ define IntervalOfDecimalsIsIntervalOfIntegers: Interval[1.5, 5.5] is Interval<In
 module.exports['IsIntervalType'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -716,6 +719,7 @@ define TupleOfDecimalsIsTupleOfIntegers: Tuple{ a: 1.5, b: 2.5 } is Tuple{a Inte
 module.exports['IsTupleType'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1020,6 +1024,7 @@ define StringIsChoiceOfIntegersAndDecimals: 'Foo' is Choice<Integer, Decimal>
 module.exports['IsChoiceType'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1290,6 +1295,7 @@ define EncounterIsString: First([Encounter]) is System.String
 module.exports['IsCustomDataModelType'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1650,6 +1656,7 @@ define CastTupleAsInteger: cast Echo(Tuple{A: 5}) as Integer
 module.exports['AsSystemType'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -1764,7 +1771,7 @@ module.exports['AsSystemType'] = {
                "s" : {
                   "r" : "9",
                   "s" : [ {
-                     "value" : [ "// fool CQL-to-ELM into letting the casts compile","define ","FiveAsInteger",": " ]
+                     "value" : [ "// fool CQL-to-ELM into letting the casts compile\n","define ","FiveAsInteger",": " ]
                   }, {
                      "r" : "8",
                      "s" : [ {
@@ -2631,6 +2638,7 @@ define CastTupleAsListOfIntegers: cast Echo(Tuple{A: 5}) as List<Integer>
 module.exports['AsListType'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -2745,7 +2753,7 @@ module.exports['AsListType'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "// fool CQL-to-ELM into letting the casts compile","define ","ListOfIntegersAsListOfIntegers",": " ]
+                     "value" : [ "// fool CQL-to-ELM into letting the casts compile\n","define ","ListOfIntegersAsListOfIntegers",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -3636,6 +3644,7 @@ define CastTupleAsIntervalOfIntegers: cast Echo(Tuple{A: 5}) as Interval<Integer
 module.exports['AsIntervalType'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -3750,7 +3759,7 @@ module.exports['AsIntervalType'] = {
                "s" : {
                   "r" : "12",
                   "s" : [ {
-                     "value" : [ "// fool CQL-to-ELM into letting the casts compile","define ","IntervalOfIntegersAsIntervalOfIntegers",": " ]
+                     "value" : [ "// fool CQL-to-ELM into letting the casts compile\n","define ","IntervalOfIntegersAsIntervalOfIntegers",": " ]
                   }, {
                      "r" : "11",
                      "s" : [ {
@@ -4625,6 +4634,7 @@ define CastIntervalAsTupleOfInteger: cast Echo(Interval[1, 5]) as Tuple{A Intege
 module.exports['AsTupleType'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -4739,7 +4749,7 @@ module.exports['AsTupleType'] = {
                "s" : {
                   "r" : "15",
                   "s" : [ {
-                     "value" : [ "// fool CQL-to-ELM into letting the casts compile","define ","TupleOfAIntegerBStringAsTupleOfAIntegerBString",": " ]
+                     "value" : [ "// fool CQL-to-ELM into letting the casts compile\n","define ","TupleOfAIntegerBStringAsTupleOfAIntegerBString",": " ]
                   }, {
                      "r" : "14",
                      "s" : [ {
@@ -5772,6 +5782,7 @@ define CastTupleAsChoiceOfIntegersAndStrings: cast Echo(Tuple{A: 1, B: '2'}) as 
 module.exports['AsChoiceType'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -5886,7 +5897,7 @@ module.exports['AsChoiceType'] = {
                "s" : {
                   "r" : "11",
                   "s" : [ {
-                     "value" : [ "// fool CQL-to-ELM into letting the casts compile","define ","IntegerAsChoiceOfIntegersAndStrings",": " ]
+                     "value" : [ "// fool CQL-to-ELM into letting the casts compile\n","define ","IntegerAsChoiceOfIntegersAndStrings",": " ]
                   }, {
                      "r" : "10",
                      "s" : [ {
@@ -6971,6 +6982,7 @@ define CastNamedTupleAsEncounter: Echo(Encounter {id: '1'}) as Simple.Encounter
 module.exports['AsCustomDataModelType'] = {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
          "type" : "CqlToElmInfo"
       }, {
@@ -7085,7 +7097,7 @@ module.exports['AsCustomDataModelType'] = {
                "s" : {
                   "r" : "10",
                   "s" : [ {
-                     "value" : [ "// fool CQL-to-ELM into letting the casts compile","define ","EncounterAsEncounter",": " ]
+                     "value" : [ "// fool CQL-to-ELM into letting the casts compile\n","define ","EncounterAsEncounter",": " ]
                   }, {
                      "r" : "9",
                      "s" : [ {

--- a/test/generator/build.gradle
+++ b/test/generator/build.gradle
@@ -1,6 +1,6 @@
 apply plugin:'java'
 
-sourceCompatibility = '1.8'
+sourceCompatibility = '11'
 
 repositories {
     mavenCentral()
@@ -10,8 +10,12 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'info.cqframework', name: 'cql-to-elm', version: '1.5.2'
+    implementation group: 'info.cqframework', name: 'cql-to-elm-cli', version: '2.3.0'
+    implementation group: 'info.cqframework', name: 'cql-to-elm', version: '2.3.0'
+    implementation group: 'info.cqframework', name: 'model-jaxb', version: '2.3.0'
+    implementation group: 'info.cqframework', name: 'elm-jaxb', version: '2.3.0'
     implementation group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.7'
+    runtimeOnly group: 'org.eclipse.persistence', name: 'org.eclipse.persistence.moxy', version: '2.7.7'
 }
 
 task generateTestData (dependsOn: 'classes', type: JavaExec) {
@@ -28,6 +32,6 @@ task watchTestData (dependsOn: 'classes', type: JavaExec) {
 
 task generateSpecTestData(dependsOn: 'classes', type: JavaExec) {
   classpath = sourceSets.main.runtimeClasspath
-  main = 'org.cqframework.cql.cql2elm.CqlTranslator'
+  main = 'org.cqframework.cql.cql2elm.cli.CqlTranslator'
   args '--input', "${projectDir}/../spec-tests/cql", '--format', 'JSON'
 }

--- a/test/generator/src/main/java/JavaScriptTestDataGenerator.java
+++ b/test/generator/src/main/java/JavaScriptTestDataGenerator.java
@@ -80,7 +80,6 @@ public class JavaScriptTestDataGenerator {
             final ModelInfo modelInfo = ModelInfoReaderFactory.getReader("application/xml").read(modelInfoXML);
             final ModelIdentifier modelId = new ModelIdentifier().withId(modelInfo.getName()).withVersion(modelInfo.getVersion());
             final ModelInfoProvider modelProvider = (ModelIdentifier modelIdentifier) -> modelInfo;
-            final ModelInfoLoader modelInfoLoader = new ModelInfoLoader();
             modelManager.getModelInfoLoader().registerModelInfoProvider(modelProvider);
         } catch (IOException e) {
             e.printStackTrace();

--- a/test/generator/src/main/java/JavaScriptTestDataGenerator.java
+++ b/test/generator/src/main/java/JavaScriptTestDataGenerator.java
@@ -3,6 +3,11 @@ import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import org.cqframework.cql.cql2elm.*;
 import org.cqframework.cql.elm.tracking.TrackBack;
+import org.hl7.cql.model.ModelIdentifier;
+import org.hl7.cql.model.ModelInfoProvider;
+import org.hl7.elm.r1.VersionedIdentifier;
+import org.hl7.elm_modelinfo.r1.ModelInfo;
+import org.hl7.elm_modelinfo.r1.serializing.ModelInfoReaderFactory;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -26,9 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.hl7.elm.r1.VersionedIdentifier;
-import org.hl7.elm_modelinfo.r1.ModelInfo;
 
 import javax.xml.bind.*;
 
@@ -74,10 +76,16 @@ public class JavaScriptTestDataGenerator {
     }
 
     public static void loadModelInfo(File modelInfoXML, ModelManager modelManager) {
-        final ModelInfo modelInfo = JAXB.unmarshal(modelInfoXML, ModelInfo.class);
-        final VersionedIdentifier modelId = new VersionedIdentifier().withId(modelInfo.getName()).withVersion(modelInfo.getVersion());
-        final ModelInfoProvider modelProvider = (VersionedIdentifier modelIdentifier) -> modelInfo;
-        modelManager.getModelInfoLoader().registerModelInfoProvider(modelProvider);
+        try {
+            final ModelInfo modelInfo = ModelInfoReaderFactory.getReader("application/xml").read(modelInfoXML);
+            final ModelIdentifier modelId = new ModelIdentifier().withId(modelInfo.getName()).withVersion(modelInfo.getVersion());
+            final ModelInfoProvider modelProvider = (ModelIdentifier modelIdentifier) -> modelInfo;
+            final ModelInfoLoader modelInfoLoader = new ModelInfoLoader();
+            modelManager.getModelInfoLoader().registerModelInfoProvider(modelProvider);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return;
+        }
     }
 
     private static void writeSnippetsToJavaScriptFile(Map<String,StringBuilder> snippets, Path file) throws IOException {
@@ -106,12 +114,17 @@ public class JavaScriptTestDataGenerator {
                 JavaScriptTestDataGenerator.loadModelInfo(new File("../../src/simple-modelinfo.xml"), modelManager);
                 LibraryManager libraryManager = new LibraryManager(modelManager);
                 libraryManager.getLibrarySourceLoader().registerProvider(new DefaultLibrarySourceProvider(file.getParent()));
-                CqlTranslator.Options[] options = {CqlTranslator.Options.EnableDateRangeOptimization, CqlTranslator.Options.EnableAnnotations};
-                CqlTranslator cqlt = CqlTranslator.fromText(snippet, modelManager, libraryManager, options);
+                CqlTranslator cqlt = CqlTranslator.fromText(
+                    snippet,
+                    modelManager,
+                    libraryManager,
+                    CqlTranslatorOptions.Options.EnableDateRangeOptimization,
+                    CqlTranslatorOptions.Options.EnableAnnotations
+                );
                 if (! cqlt.getErrors().isEmpty()) {
                     pw.println("/*");
                     pw.println("Translation Error(s):");
-                    for (CqlTranslatorException e : cqlt.getErrors()) {
+                    for (CqlCompilerException e : cqlt.getErrors()) {
                         TrackBack tb = e.getLocator();
                         String lines = tb == null ? "[n/a]" : String.format("[%d:%d, %d:%d]",
                                 tb.getStartLine(), tb.getStartChar(), tb.getEndLine(), tb.getEndChar());
@@ -175,7 +188,7 @@ public class JavaScriptTestDataGenerator {
     }
 
     public static void main(String[] args) throws IOException, InterruptedException {
-        
+
         OptionParser parser = new OptionParser();
         OptionSpec<File> input = parser.accepts("input").withRequiredArg().ofType(File.class).required();
         OptionSpec recursive = parser.accepts("recursive");

--- a/test/spec-tests/cql/CqlAggregateFunctionsTest.json
+++ b/test/spec-tests/cql/CqlAggregateFunctionsTest.json
@@ -1,6 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "",
          "type" : "CqlToElmInfo"
       } ],

--- a/test/spec-tests/cql/CqlAggregateTest.json
+++ b/test/spec-tests/cql/CqlAggregateTest.json
@@ -1,6 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "",
          "type" : "CqlToElmInfo"
       } ],

--- a/test/spec-tests/cql/CqlArithmeticFunctionsTest.json
+++ b/test/spec-tests/cql/CqlArithmeticFunctionsTest.json
@@ -1,6 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "",
          "type" : "CqlToElmInfo"
       } ],
@@ -365,11 +366,11 @@
                            "type" : "Add",
                            "operand" : [ {
                               "valueType" : "{urn:hl7-org:elm-types:r1}Long",
-                              "value" : "",
+                              "value" : "1",
                               "type" : "Literal"
                            }, {
                               "valueType" : "{urn:hl7-org:elm-types:r1}Long",
-                              "value" : "",
+                              "value" : "1",
                               "type" : "Literal"
                            } ]
                         }
@@ -377,7 +378,7 @@
                         "name" : "output",
                         "value" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}Long",
-                           "value" : "",
+                           "value" : "2",
                            "type" : "Literal"
                         }
                      } ]

--- a/test/spec-tests/cql/CqlComparisonOperatorsTest.json
+++ b/test/spec-tests/cql/CqlComparisonOperatorsTest.json
@@ -1,6 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "",
          "type" : "CqlToElmInfo"
       } ],

--- a/test/spec-tests/cql/CqlConditionalOperatorsTest.json
+++ b/test/spec-tests/cql/CqlConditionalOperatorsTest.json
@@ -1,6 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "",
          "type" : "CqlToElmInfo"
       } ],

--- a/test/spec-tests/cql/CqlDateTimeOperatorsTest.json
+++ b/test/spec-tests/cql/CqlDateTimeOperatorsTest.json
@@ -1,6 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "",
          "type" : "CqlToElmInfo"
       } ],

--- a/test/spec-tests/cql/CqlErrorsAndMessagingOperatorsTest.json
+++ b/test/spec-tests/cql/CqlErrorsAndMessagingOperatorsTest.json
@@ -1,6 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "",
          "type" : "CqlToElmInfo"
       } ],

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.json
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.json
@@ -1,6 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "",
          "type" : "CqlToElmInfo"
       } ],

--- a/test/spec-tests/cql/CqlListOperatorsTest.json
+++ b/test/spec-tests/cql/CqlListOperatorsTest.json
@@ -1,6 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "",
          "type" : "CqlToElmInfo"
       }, {

--- a/test/spec-tests/cql/CqlLogicalOperatorsTest.json
+++ b/test/spec-tests/cql/CqlLogicalOperatorsTest.json
@@ -1,6 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "",
          "type" : "CqlToElmInfo"
       } ],

--- a/test/spec-tests/cql/CqlNullologicalOperatorsTest.json
+++ b/test/spec-tests/cql/CqlNullologicalOperatorsTest.json
@@ -1,6 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "",
          "type" : "CqlToElmInfo"
       } ],

--- a/test/spec-tests/cql/CqlStringOperatorsTest.json
+++ b/test/spec-tests/cql/CqlStringOperatorsTest.json
@@ -1,6 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "",
          "type" : "CqlToElmInfo"
       } ],

--- a/test/spec-tests/cql/CqlTypeOperatorsTest.json
+++ b/test/spec-tests/cql/CqlTypeOperatorsTest.json
@@ -1,6 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "",
          "type" : "CqlToElmInfo"
       } ],

--- a/test/spec-tests/cql/CqlTypesTest.json
+++ b/test/spec-tests/cql/CqlTypesTest.json
@@ -1,6 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "",
          "type" : "CqlToElmInfo"
       } ],

--- a/test/spec-tests/cql/ValueLiteralsAndSelectors.json
+++ b/test/spec-tests/cql/ValueLiteralsAndSelectors.json
@@ -1,6 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
+         "translatorVersion" : "2.3.0",
          "translatorOptions" : "",
          "type" : "CqlToElmInfo"
       } ],


### PR DESCRIPTION
Most new development of the CQL Translator is now happening on the 2.x line. This PR updates the test generation code to use the new CQL Translator 2.3.0. This included updating the custom Java generator code to align w/ refactored bits of the API.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [ ] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
