### PR TITLE
fixed collapseIntervals error on null intervals

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -5175,17 +5175,17 @@ exports.Collapse = Collapse;
 function collapseIntervals(intervals, perWidth) {
     // Clone intervals so this function remains idempotent
     const intervalsClone = [];
+    // If the list is null, return null
+    if (intervals == null) {
+        return null;
+    }
     for (const interval of intervals) {
         // The spec says to ignore null intervals
         if (interval != null) {
             intervalsClone.push(interval.copy());
         }
     }
-    // If the list is null, return null
-    if (intervals == null) {
-        return null;
-    }
-    else if (intervalsClone.length <= 1) {
+    if (intervalsClone.length <= 1) {
         return intervalsClone;
     }
     else {

--- a/src/elm/interval.ts
+++ b/src/elm/interval.ts
@@ -650,6 +650,12 @@ export class Collapse extends Expression {
 function collapseIntervals(intervals: any, perWidth: any) {
   // Clone intervals so this function remains idempotent
   const intervalsClone = [];
+
+  // If the list is null, return null
+  if (intervals == null) {
+    return null;
+  }
+
   for (const interval of intervals) {
     // The spec says to ignore null intervals
     if (interval != null) {
@@ -657,10 +663,7 @@ function collapseIntervals(intervals: any, perWidth: any) {
     }
   }
 
-  // If the list is null, return null
-  if (intervals == null) {
-    return null;
-  } else if (intervalsClone.length <= 1) {
+  if (intervalsClone.length <= 1) {
     return intervalsClone;
   } else {
     // If the per argument is null, the default unit interval for the point type

--- a/src/elm/interval.ts
+++ b/src/elm/interval.ts
@@ -650,12 +650,10 @@ export class Collapse extends Expression {
 function collapseIntervals(intervals: any, perWidth: any) {
   // Clone intervals so this function remains idempotent
   const intervalsClone = [];
-
   // If the list is null, return null
   if (intervals == null) {
     return null;
   }
-
   for (const interval of intervals) {
     // The spec says to ignore null intervals
     if (interval != null) {

--- a/test/elm/interval/data.cql
+++ b/test/elm/interval/data.cql
@@ -1034,7 +1034,7 @@ define CollapseNullHighIntervalList: collapse NullHighIntervalList
 define ExpectedNullHighIntervalCollapse: { Interval[1, null] }
 define NullInCollapse: collapse { Interval[1,3], null }
 define ExpectedResultWithNull: { Interval[1,3] }
-// define NullCollapse: collapse null // Translation Error
+define NullCollapse: collapse null
 define NullPerCollapse: collapse { Interval[1,4], Interval[4,7] } per null
 define ExpectedResultNullPer: { Interval[1,7] }
 define DateTime5_NullInterval: Interval[DateTime(2012, 1, 5, 0, 0, 0, 0), null]

--- a/test/elm/interval/data.cql
+++ b/test/elm/interval/data.cql
@@ -1034,7 +1034,7 @@ define CollapseNullHighIntervalList: collapse NullHighIntervalList
 define ExpectedNullHighIntervalCollapse: { Interval[1, null] }
 define NullInCollapse: collapse { Interval[1,3], null }
 define ExpectedResultWithNull: { Interval[1,3] }
-define NullCollapse: collapse null
+define NullCollapse: collapse null as List<Interval<Integer>>
 define NullPerCollapse: collapse { Interval[1,4], Interval[4,7] } per null
 define ExpectedResultNullPer: { Interval[1,7] }
 define DateTime5_NullInterval: Interval[DateTime(2012, 1, 5, 0, 0, 0, 0), null]

--- a/test/elm/interval/interval-test.ts
+++ b/test/elm/interval/interval-test.ts
@@ -2140,8 +2140,7 @@ describe('Collapse', () => {
     this.nullInCollapse.exec(this.ctx).should.eql(this.expectedResultWithNull.exec(this.ctx));
   });
 
-  it.skip('should return null if list is null', function () {
-    // TODO: Translation Error
+  it('should return null if list is null', function () {
     should.not.exist(this.nullCollapse.exec(this.ctx));
   });
 


### PR DESCRIPTION
Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository.
It is strongly recommended to include a person from each of those projects as a reviewer.

Submitted in conjunction with @elsaperelli
## Summary
`collapseIntervals` function previously threw `intervals is not iterable` error when `intervals` argument was null. Moved the `intervals == null` check to catch null values before entering the `for` loop. Restored existing testing for this case. Fixes [fqm-execution issue 227]( https://github.com/projecttacoma/fqm-execution/issues/227).


**Submitter:**
- [✔] This pull request describes why these changes were made
- [✔] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [✔] Tests are included and test edge cases
- [✔] Tests have been run locally and pass
- [✔] Code coverage has not gone down and all code touched or added is covered.
- [✔] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [✔] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [✔] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
