### PR TITLE
Changed use of exec to execute for expressions

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -5659,7 +5659,7 @@ class First extends expression_1.Expression {
         this.source = (0, builder_1.build)(json.source);
     }
     async exec(ctx) {
-        const src = await this.source.exec(ctx);
+        const src = await this.source.execute(ctx);
         if (src != null && (0, util_1.typeIsArray)(src) && src.length > 0) {
             return src[0];
         }
@@ -5675,7 +5675,7 @@ class Last extends expression_1.Expression {
         this.source = (0, builder_1.build)(json.source);
     }
     async exec(ctx) {
-        const src = await this.source.exec(ctx);
+        const src = await this.source.execute(ctx);
         if (src != null && (0, util_1.typeIsArray)(src) && src.length > 0) {
             return src[src.length - 1];
         }
@@ -5693,10 +5693,10 @@ class Slice extends expression_1.Expression {
         this.endIndex = (0, builder_1.build)(json.endIndex);
     }
     async exec(ctx) {
-        const src = await this.source.exec(ctx);
+        const src = await this.source.execute(ctx);
         if (src != null && (0, util_1.typeIsArray)(src)) {
-            const startIndex = await this.startIndex.exec(ctx);
-            const endIndex = await this.endIndex.exec(ctx);
+            const startIndex = await this.startIndex.execute(ctx);
+            const endIndex = await this.endIndex.execute(ctx);
             const start = startIndex != null ? startIndex : 0;
             const end = endIndex != null ? endIndex : src.length;
             if (src.length === 0 || start < 0 || end < 0 || end < start) {
@@ -6559,7 +6559,7 @@ class AggregateClause extends expression_1.Expression {
         this.distinct = json.distinct != null ? json.distinct : true;
     }
     async aggregate(returnedValues, ctx) {
-        let aggregateValue = this.starting != null ? await this.starting.exec(ctx) : null;
+        let aggregateValue = this.starting != null ? await this.starting.execute(ctx) : null;
         for (const contextValues of returnedValues) {
             const childContext = ctx.childContext(contextValues);
             childContext.set(this.identifier, aggregateValue);

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -3751,7 +3751,7 @@ class AnyInValueSet extends expression_1.Expression {
         if (valueset == null || !valueset.isValueSet) {
             throw new Error('ValueSet must be provided to InValueSet function');
         }
-        const codes = await this.codes.exec(ctx);
+        const codes = await this.codes.execute(ctx);
         return codes != null && codes.some((code) => valueset.hasMatch(code));
     }
 }

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -6563,7 +6563,7 @@ class AggregateClause extends expression_1.Expression {
         for (const contextValues of returnedValues) {
             const childContext = ctx.childContext(contextValues);
             childContext.set(this.identifier, aggregateValue);
-            aggregateValue = await this.expression.exec(childContext);
+            aggregateValue = await this.expression.execute(childContext);
         }
         return aggregateValue;
     }

--- a/src/elm/clinical.ts
+++ b/src/elm/clinical.ts
@@ -62,7 +62,7 @@ export class AnyInValueSet extends Expression {
       throw new Error('ValueSet must be provided to InValueSet function');
     }
 
-    const codes = await this.codes.exec(ctx);
+    const codes = await this.codes.execute(ctx);
     return codes != null && codes.some((code: any) => valueset.hasMatch(code));
   }
 }

--- a/src/elm/list.ts
+++ b/src/elm/list.ts
@@ -233,7 +233,7 @@ export class First extends Expression {
   }
 
   async exec(ctx: Context) {
-    const src = await this.source.exec(ctx);
+    const src = await this.source.execute(ctx);
     if (src != null && typeIsArray(src) && src.length > 0) {
       return src[0];
     } else {
@@ -251,7 +251,7 @@ export class Last extends Expression {
   }
 
   async exec(ctx: Context) {
-    const src = await this.source.exec(ctx);
+    const src = await this.source.execute(ctx);
     if (src != null && typeIsArray(src) && src.length > 0) {
       return src[src.length - 1];
     } else {
@@ -273,10 +273,10 @@ export class Slice extends Expression {
   }
 
   async exec(ctx: Context) {
-    const src = await this.source.exec(ctx);
+    const src = await this.source.execute(ctx);
     if (src != null && typeIsArray(src)) {
-      const startIndex = await this.startIndex.exec(ctx);
-      const endIndex = await this.endIndex.exec(ctx);
+      const startIndex = await this.startIndex.execute(ctx);
+      const endIndex = await this.endIndex.execute(ctx);
       const start = startIndex != null ? startIndex : 0;
       const end = endIndex != null ? endIndex : src.length;
       if (src.length === 0 || start < 0 || end < 0 || end < start) {

--- a/src/elm/query.ts
+++ b/src/elm/query.ts
@@ -187,7 +187,7 @@ class AggregateClause extends Expression {
   }
 
   async aggregate(returnedValues: any, ctx: Context) {
-    let aggregateValue = this.starting != null ? await this.starting.exec(ctx) : null;
+    let aggregateValue = this.starting != null ? await this.starting.execute(ctx) : null;
     for (const contextValues of returnedValues) {
       const childContext = ctx.childContext(contextValues);
       childContext.set(this.identifier, aggregateValue);

--- a/src/elm/query.ts
+++ b/src/elm/query.ts
@@ -191,7 +191,7 @@ class AggregateClause extends Expression {
     for (const contextValues of returnedValues) {
       const childContext = ctx.childContext(contextValues);
       childContext.set(this.identifier, aggregateValue);
-      aggregateValue = await this.expression.exec(childContext);
+      aggregateValue = await this.expression.execute(childContext);
     }
     return aggregateValue;
   }

--- a/test/elm/clinical/clinical-test.ts
+++ b/test/elm/clinical/clinical-test.ts
@@ -53,17 +53,17 @@ describe('AnyInValueSet', () => {
 
   it('should call execute on codes which is a list of concepts', async function () {
     (await this.anyInListOfConcepts.exec(this.ctx)).should.be.true();
-    should(this.ctx.localId_context[12]).not.be.undefined();
+    should(this.ctx.localId_context[this.anyInListOfConcepts.codes.localId]).not.be.undefined();
   });
 
   it('should call execute on codes which is a list of codes', async function () {
     (await this.anyInListOfCodes.exec(this.ctx)).should.be.true();
-    should(this.ctx.localId_context[18]).not.be.undefined();
+    should(this.ctx.localId_context[this.anyInListOfCodes.codes.localId]).not.be.undefined();
   });
 
   it('should call execute on codes which is a list of strings', async function () {
     (await this.anyInListOfStrings.exec(this.ctx)).should.be.true();
-    should(this.ctx.localId_context[24]).not.be.undefined();
+    should(this.ctx.localId_context[this.anyInListOfStrings.codes.localId]).not.be.undefined();
   });
 });
 

--- a/test/elm/clinical/clinical-test.ts
+++ b/test/elm/clinical/clinical-test.ts
@@ -46,6 +46,27 @@ describe('ValueSetRef', () => {
   });
 });
 
+describe('AnyInValueSet', () => {
+  beforeEach(function () {
+    setup(this, data, [], vsets);
+  });
+
+  it('should call execute on codes which is a list of concepts', async function () {
+    (await this.anyInListOfConcepts.exec(this.ctx)).should.be.true();
+    should(this.ctx.localId_context[12]).not.be.undefined();
+  });
+
+  it('should call execute on codes which is a list of codes', async function () {
+    (await this.anyInListOfCodes.exec(this.ctx)).should.be.true();
+    should(this.ctx.localId_context[18]).not.be.undefined();
+  });
+
+  it('should call execute on codes which is a list of strings', async function () {
+    (await this.anyInListOfStrings.exec(this.ctx)).should.be.true();
+    should(this.ctx.localId_context[24]).not.be.undefined();
+  });
+});
+
 describe('InValueSet', () => {
   beforeEach(function () {
     setup(this, data, [], vsets);

--- a/test/elm/clinical/data.cql
+++ b/test/elm/clinical/data.cql
@@ -8,6 +8,16 @@ define Foo: 'Bar'
 valueset "Acute Pharyngitis": '2.16.840.1.113883.3.464.1003.101.12.1001'
 define Foo: "Acute Pharyngitis"
 
+// @Test: AnyInValueSet
+valueset "Major Depressive Disorder Active": '2.16.840.1.113883.3.526.3.1491'
+codesystem "SNOMED": 'http://snomed.info/sct'
+code "ChronicRecurrentDepression": '2618002' from "SNOMED" display 'Chronic recurrent major depressive disorder (disorder)'
+code "ModerateMajorDepression": '832007' from "SNOMED" display 'Moderate major depression (disorder)'
+concept "Depression Concept": { "ChronicRecurrentDepression", "ModerateMajorDepression" } display 'Depression Concept'
+define AnyInListOfConcepts: { "Depression Concept" } in "Major Depressive Disorder Active"
+define AnyInListOfCodes: { "ChronicRecurrentDepression", "ModerateMajorDepression" } in "Major Depressive Disorder Active"
+define AnyInListOfStrings: { '2618002', '12345' } in "Major Depressive Disorder Active"
+
 // @Test: InValueSet
 valueset "Female": '2.16.840.1.113883.3.560.100.2'
 valueset "Versioned Female": '2.16.840.1.113883.3.560.100.2' version '20121025'
@@ -34,7 +44,6 @@ define InListOfCodesExpressionRef: ListOfCodes in "Female"
 define InWrongListOfCodes: WrongListOfCodes in "Female"
 define ListOfCodesWithNull: { Code { code: 'M' }, (null as Code), Code { code: 'F', system: '2.16.840.1.113883.18.2' } } in "Female"
 define ListOfCodesNull: (null as List<Code>) in "Female"
-
 
 // @Test: Patient Property In ValueSet
 valueset "Female": '2.16.840.1.113883.3.560.100.2'

--- a/test/elm/clinical/data.js
+++ b/test/elm/clinical/data.js
@@ -279,6 +279,403 @@ module.exports['ValueSetRef'] = {
    }
 }
 
+/* AnyInValueSet
+library TestSnippet version '1'
+using Simple version '1.0.0'
+valueset "Major Depressive Disorder Active": '2.16.840.1.113883.3.526.3.1491'
+codesystem "SNOMED": 'http://snomed.info/sct'
+code "ChronicRecurrentDepression": '2618002' from "SNOMED" display 'Chronic recurrent major depressive disorder (disorder)'
+code "ModerateMajorDepression": '832007' from "SNOMED" display 'Moderate major depression (disorder)'
+concept "Depression Concept": { "ChronicRecurrentDepression", "ModerateMajorDepression" } display 'Depression Concept'
+context Patient
+define AnyInListOfConcepts: { "Depression Concept" } in "Major Depressive Disorder Active"
+define AnyInListOfCodes: { "ChronicRecurrentDepression", "ModerateMajorDepression" } in "Major Depressive Disorder Active"
+define AnyInListOfStrings: { '2618002', '12345' } in "Major Depressive Disorder Active"
+*/
+
+module.exports['AnyInValueSet'] = {
+   "library" : {
+      "annotation" : [ {
+         "translatorVersion" : "2.3.0",
+         "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
+         "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "27",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
+      } ],
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "1",
+            "localIdentifier" : "Simple",
+            "uri" : "https://github.com/cqframework/cql-execution/simple",
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "1",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version ","'1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "codeSystems" : {
+         "def" : [ {
+            "localId" : "3",
+            "name" : "SNOMED",
+            "id" : "http://snomed.info/sct",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "3",
+                  "s" : [ {
+                     "value" : [ "","codesystem ","\"SNOMED\"",": ","'http://snomed.info/sct'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "valueSets" : {
+         "def" : [ {
+            "localId" : "2",
+            "name" : "Major Depressive Disorder Active",
+            "id" : "2.16.840.1.113883.3.526.3.1491",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "2",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"Major Depressive Disorder Active\"",": ","'2.16.840.1.113883.3.526.3.1491'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "codes" : {
+         "def" : [ {
+            "localId" : "5",
+            "name" : "ChronicRecurrentDepression",
+            "id" : "2618002",
+            "display" : "Chronic recurrent major depressive disorder (disorder)",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "5",
+                  "s" : [ {
+                     "value" : [ "","code ","\"ChronicRecurrentDepression\"",": ","'2618002'"," from " ]
+                  }, {
+                     "r" : "4",
+                     "s" : [ {
+                        "value" : [ "\"SNOMED\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " display ","'Chronic recurrent major depressive disorder (disorder)'" ]
+                  } ]
+               }
+            } ],
+            "codeSystem" : {
+               "localId" : "4",
+               "name" : "SNOMED"
+            }
+         }, {
+            "localId" : "7",
+            "name" : "ModerateMajorDepression",
+            "id" : "832007",
+            "display" : "Moderate major depression (disorder)",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "7",
+                  "s" : [ {
+                     "value" : [ "","code ","\"ModerateMajorDepression\"",": ","'832007'"," from " ]
+                  }, {
+                     "r" : "6",
+                     "s" : [ {
+                        "value" : [ "\"SNOMED\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " display ","'Moderate major depression (disorder)'" ]
+                  } ]
+               }
+            } ],
+            "codeSystem" : {
+               "localId" : "6",
+               "name" : "SNOMED"
+            }
+         } ]
+      },
+      "concepts" : {
+         "def" : [ {
+            "localId" : "10",
+            "name" : "Depression Concept",
+            "display" : "Depression Concept",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "10",
+                  "s" : [ {
+                     "value" : [ "","concept ","\"Depression Concept\"",": { " ]
+                  }, {
+                     "r" : "8",
+                     "s" : [ {
+                        "value" : [ "\"ChronicRecurrentDepression\"" ]
+                     } ]
+                  }, {
+                     "value" : [ ", " ]
+                  }, {
+                     "r" : "9",
+                     "s" : [ {
+                        "value" : [ "\"ModerateMajorDepression\"" ]
+                     } ]
+                  }, {
+                     "value" : [ " } display ","'Depression Concept'" ]
+                  } ]
+               }
+            } ],
+            "code" : [ {
+               "localId" : "8",
+               "name" : "ChronicRecurrentDepression"
+            }, {
+               "localId" : "9",
+               "name" : "ModerateMajorDepression"
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "name" : "Patient"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "localId" : "15",
+            "name" : "AnyInListOfConcepts",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "15",
+                  "s" : [ {
+                     "value" : [ "","define ","AnyInListOfConcepts",": " ]
+                  }, {
+                     "r" : "14",
+                     "s" : [ {
+                        "r" : "12",
+                        "s" : [ {
+                           "value" : [ "{ " ]
+                        }, {
+                           "r" : "11",
+                           "s" : [ {
+                              "value" : [ "\"Depression Concept\"" ]
+                           } ]
+                        }, {
+                           "value" : [ " }" ]
+                        } ]
+                     }, {
+                        "value" : [ " in " ]
+                     }, {
+                        "r" : "13",
+                        "s" : [ {
+                           "value" : [ "\"Major Depressive Disorder Active\"" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "14",
+               "type" : "AnyInValueSet",
+               "codes" : {
+                  "localId" : "12",
+                  "type" : "List",
+                  "element" : [ {
+                     "localId" : "11",
+                     "name" : "Depression Concept",
+                     "type" : "ConceptRef"
+                  } ]
+               },
+               "valueset" : {
+                  "localId" : "13",
+                  "name" : "Major Depressive Disorder Active",
+                  "preserve" : true
+               }
+            }
+         }, {
+            "localId" : "21",
+            "name" : "AnyInListOfCodes",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "21",
+                  "s" : [ {
+                     "value" : [ "","define ","AnyInListOfCodes",": " ]
+                  }, {
+                     "r" : "20",
+                     "s" : [ {
+                        "r" : "18",
+                        "s" : [ {
+                           "value" : [ "{ " ]
+                        }, {
+                           "r" : "16",
+                           "s" : [ {
+                              "value" : [ "\"ChronicRecurrentDepression\"" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "17",
+                           "s" : [ {
+                              "value" : [ "\"ModerateMajorDepression\"" ]
+                           } ]
+                        }, {
+                           "value" : [ " }" ]
+                        } ]
+                     }, {
+                        "value" : [ " in " ]
+                     }, {
+                        "r" : "19",
+                        "s" : [ {
+                           "value" : [ "\"Major Depressive Disorder Active\"" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "20",
+               "type" : "AnyInValueSet",
+               "codes" : {
+                  "localId" : "18",
+                  "type" : "List",
+                  "element" : [ {
+                     "localId" : "16",
+                     "name" : "ChronicRecurrentDepression",
+                     "type" : "CodeRef"
+                  }, {
+                     "localId" : "17",
+                     "name" : "ModerateMajorDepression",
+                     "type" : "CodeRef"
+                  } ]
+               },
+               "valueset" : {
+                  "localId" : "19",
+                  "name" : "Major Depressive Disorder Active",
+                  "preserve" : true
+               }
+            }
+         }, {
+            "localId" : "27",
+            "name" : "AnyInListOfStrings",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "27",
+                  "s" : [ {
+                     "value" : [ "","define ","AnyInListOfStrings",": " ]
+                  }, {
+                     "r" : "26",
+                     "s" : [ {
+                        "r" : "24",
+                        "s" : [ {
+                           "value" : [ "{ " ]
+                        }, {
+                           "r" : "22",
+                           "s" : [ {
+                              "value" : [ "'2618002'" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "23",
+                           "s" : [ {
+                              "value" : [ "'12345'" ]
+                           } ]
+                        }, {
+                           "value" : [ " }" ]
+                        } ]
+                     }, {
+                        "value" : [ " in " ]
+                     }, {
+                        "r" : "25",
+                        "s" : [ {
+                           "value" : [ "\"Major Depressive Disorder Active\"" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "26",
+               "type" : "AnyInValueSet",
+               "codes" : {
+                  "localId" : "24",
+                  "type" : "List",
+                  "element" : [ {
+                     "localId" : "22",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "2618002",
+                     "type" : "Literal"
+                  }, {
+                     "localId" : "23",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "12345",
+                     "type" : "Literal"
+                  } ]
+               },
+               "valueset" : {
+                  "localId" : "25",
+                  "name" : "Major Depressive Disorder Active",
+                  "preserve" : true
+               }
+            }
+         } ]
+      }
+   }
+}
+
 /* InValueSet
 library TestSnippet version '1'
 using Simple version '1.0.0'

--- a/test/elm/clinical/valuesets.js
+++ b/test/elm/clinical/valuesets.js
@@ -22,5 +22,378 @@ module.exports = {
       { code: 'notCodeValue', system: '2.16.840.1.113883.18.2', version: 'bar' },
       { code: 'codeValue', system: '2.16.840.1.113883.18.1', version: 'bar' }
     ]
+  },
+  '2.16.840.1.113883.3.526.3.1491': {
+    20210220: [
+      {
+        code: '10811121000119102',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Major depressive disorder in mother complicating childbirth (disorder)'
+      },
+      {
+        code: '10811161000119107',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Major depressive disorder in mother complicating pregnancy (disorder)'
+      },
+      {
+        code: '14183003',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Chronic major depressive disorder, single episode (disorder)'
+      },
+      {
+        code: '15193003',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display:
+          'Severe recurrent major depression with psychotic features, mood-incongruent (disorder)'
+      },
+      {
+        code: '15639000',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Moderate major depression, single episode (disorder)'
+      },
+      {
+        code: '16264621000119109',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Recurrent mild major depressive disorder co-occurrent with anxiety (disorder)'
+      },
+      {
+        code: '16264821000119108',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Recurrent severe major depressive disorder co-occurrent with anxiety (disorder)'
+      },
+      {
+        code: '16264901000119109',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Recurrent moderate major depressive disorder co-occurrent with anxiety (disorder)'
+      },
+      {
+        code: '16265301000119106',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display:
+          'Recurrent major depressive disorder in partial remission co-occurrent with anxiety (disorder)'
+      },
+      {
+        code: '16265951000119109',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display:
+          'Mild major depressive disorder co-occurrent with anxiety single episode (disorder)'
+      },
+      {
+        code: '16266831000119100',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display:
+          'Moderate major depressive disorder co-occurrent with anxiety single episode (disorder)'
+      },
+      {
+        code: '16266991000119108',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display:
+          'Severe major depressive disorder co-occurrent with anxiety single episode (disorder)'
+      },
+      {
+        code: '18818009',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Moderate recurrent major depression (disorder)'
+      },
+      {
+        code: '191604000',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Single major depressive episode, severe, with psychosis (disorder)'
+      },
+      {
+        code: '191610000',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Recurrent major depressive episodes, mild (disorder)'
+      },
+      {
+        code: '191611001',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Recurrent major depressive episodes, moderate (disorder)'
+      },
+      {
+        code: '191613003',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Recurrent major depressive episodes, severe, with psychosis (disorder)'
+      },
+      {
+        code: '20250007',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display:
+          'Severe major depression, single episode, with psychotic features, mood-incongruent (disorder)'
+      },
+      {
+        code: '251000119105',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Severe major depression, single episode (disorder)'
+      },
+      {
+        code: '25922000',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Major depressive disorder, single episode with postpartum onset (disorder)'
+      },
+      {
+        code: '2618002',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Chronic recurrent major depressive disorder (disorder)'
+      },
+      {
+        code: '268621008',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Recurrent major depressive episodes (disorder)'
+      },
+      {
+        code: '281000119103',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Severe recurrent major depression (disorder)'
+      },
+      {
+        code: '28475009',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Severe recurrent major depression with psychotic features (disorder)'
+      },
+      {
+        code: '30605009',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Major depression in partial remission (disorder)'
+      },
+      {
+        code: '319768000',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Recurrent major depressive disorder with melancholic features (disorder)'
+      },
+      {
+        code: '320751009',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Major depression, melancholic type (disorder)'
+      },
+      {
+        code: '33078009',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display:
+          'Severe recurrent major depression with psychotic features, mood-congruent (disorder)'
+      },
+      {
+        code: '33135002',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Recurrent major depression in partial remission (disorder)'
+      },
+      {
+        code: '33736005',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Severe major depression with psychotic features, mood-congruent (disorder)'
+      },
+      {
+        code: '36474008',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Severe recurrent major depression without psychotic features (disorder)'
+      },
+      {
+        code: '36923009',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Major depression, single episode (disorder)'
+      },
+      {
+        code: '370143000',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Major depressive disorder (disorder)'
+      },
+      {
+        code: '38694004',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Recurrent major depressive disorder with atypical features (disorder)'
+      },
+      {
+        code: '39809009',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Recurrent major depressive disorder with catatonic features (disorder)'
+      },
+      {
+        code: '40379007',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Mild recurrent major depression (disorder)'
+      },
+      {
+        code: '42925002',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Major depressive disorder, single episode with atypical features (disorder)'
+      },
+      {
+        code: '430852001',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Severe major depression, single episode, with psychotic features (disorder)'
+      },
+      {
+        code: '450714000',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Severe major depression (disorder)'
+      },
+      {
+        code: '60099002',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Severe major depression with psychotic features, mood-incongruent (disorder)'
+      },
+      {
+        code: '63778009',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Major depressive disorder, single episode with melancholic features (disorder)'
+      },
+      {
+        code: '66344007',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Recurrent major depression (disorder)'
+      },
+      {
+        code: '67002003',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display:
+          'Severe bipolar II disorder, most recent episode major depressive, in partial remission (disorder)'
+      },
+      {
+        code: '69392006',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Major depressive disorder, single episode with catatonic features (disorder)'
+      },
+      {
+        code: '70747007',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Major depression single episode, in partial remission (disorder)'
+      },
+      {
+        code: '71336009',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Recurrent major depressive disorder with postpartum onset (disorder)'
+      },
+      {
+        code: '719592004',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Moderately severe major depression (disorder)'
+      },
+      {
+        code: '720451004',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Minimal recurrent major depression (disorder)'
+      },
+      {
+        code: '720452006',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Moderately severe recurrent major depression (disorder)'
+      },
+      {
+        code: '720453001',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Moderately severe major depression single episode (disorder)'
+      },
+      {
+        code: '720454007',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Minimal major depression single episode (disorder)'
+      },
+      {
+        code: '720455008',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Minimal major depression (disorder)'
+      },
+      {
+        code: '726772006',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Major depression with psychotic features (disorder)'
+      },
+      {
+        code: '73867007',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Severe major depression with psychotic features (disorder)'
+      },
+      {
+        code: '75084000',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Severe major depression without psychotic features (disorder)'
+      },
+      {
+        code: '76441001',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Severe major depression, single episode, without psychotic features (disorder)'
+      },
+      {
+        code: '77911002',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display:
+          'Severe major depression, single episode, with psychotic features, mood-congruent (disorder)'
+      },
+      {
+        code: '79298009',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Mild major depression, single episode (disorder)'
+      },
+      {
+        code: '832007',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Moderate major depression (disorder)'
+      },
+      {
+        code: '87512008',
+        system: 'http://snomed.info/sct',
+        version: 'http://snomed.info/sct/731000124108/version/20230301',
+        display: 'Mild major depression (disorder)'
+      }
+    ]
   }
 };

--- a/test/elm/list/list-test.ts
+++ b/test/elm/list/list-test.ts
@@ -669,32 +669,39 @@ describe('First', () => {
     setup(this, data);
   });
 
-  it('should get first of a list of numbers', async function () {
+  it('should get first of a list of numbers and the localId should exist on the root context', async function () {
     (await this.numbers.exec(this.ctx)).should.equal(1);
+    should(this.ctx.localId_context[6]).not.be.undefined();
   });
 
-  it('should get first of a list of letters', async function () {
+  it('should get first of a list of letters and the localId should exist on the root context', async function () {
     (await this.letters.exec(this.ctx)).should.equal('a');
+    should(this.ctx.localId_context[12]).not.be.undefined();
   });
 
-  it('should get first of a list of lists', async function () {
+  it('should get first of a list of lists and the localId should exist on the root context', async function () {
     (await this.lists.exec(this.ctx)).should.eql(['a', 'b', 'c']);
+    should(this.ctx.localId_context[23]).not.be.undefined();
   });
 
-  it('should get first of a list of tuples', async function () {
+  it('should get first of a list of tuples and the localId should exist on the root context', async function () {
     (await this.tuples.exec(this.ctx)).should.eql({ a: 1, b: 2, c: 3 });
+    should(this.ctx.localId_context[34]).not.be.undefined();
   });
 
-  it('should get first of a list of unordered numbers', async function () {
+  it('should get first of a list of unordered numbers and the localId should exist on the root context', async function () {
     (await this.unordered.exec(this.ctx)).should.equal(3);
+    should(this.ctx.localId_context[41]).not.be.undefined();
   });
 
-  it('should return null for an empty list', async function () {
+  it('should return null for an empty list and the localId should exist on the root context', async function () {
     should(await this.empty.exec(this.ctx)).be.null();
+    should(this.ctx.localId_context[45]).not.be.undefined();
   });
 
-  it('should return null for a null list', async function () {
+  it('should return null for a null list and the localId should exist on the root context', async function () {
     should(await this.nullValue.exec(this.ctx)).be.null();
+    should(this.ctx.localId_context[51]).not.be.undefined();
   });
 });
 
@@ -703,32 +710,39 @@ describe('Last', () => {
     setup(this, data);
   });
 
-  it('should get last of a list of numbers', async function () {
+  it('should get last of a list of numbers and the localId should exist on the root context', async function () {
     (await this.numbers.exec(this.ctx)).should.equal(4);
+    should(this.ctx.localId_context[6]).not.be.undefined();
   });
 
-  it('should get last of a list of letters', async function () {
+  it('should get last of a list of letters and the localId should exist on the root context', async function () {
     (await this.letters.exec(this.ctx)).should.equal('c');
+    should(this.ctx.localId_context[12]).not.be.undefined();
   });
 
-  it('should get last of a list of lists', async function () {
+  it('should get last of a list of lists and the localId should exist on the root context', async function () {
     (await this.lists.exec(this.ctx)).should.eql(['d', 'e', 'f']);
+    should(this.ctx.localId_context[23]).not.be.undefined();
   });
 
-  it('should get last of a list of tuples', async function () {
+  it('should get last of a list of tuples and the localId should exist on the root context', async function () {
     (await this.tuples.exec(this.ctx)).should.eql({ a: 24, b: 25, c: 26 });
+    should(this.ctx.localId_context[34]).not.be.undefined();
   });
 
-  it('should get last of a list of unordered numbers', async function () {
+  it('should get last of a list of unordered numbers and the localId should exist on the root context', async function () {
     (await this.unordered.exec(this.ctx)).should.equal(2);
+    should(this.ctx.localId_context[41]).not.be.undefined();
   });
 
-  it('should return null for an empty list', async function () {
+  it('should return null for an empty list and the localId should exist on the root context', async function () {
     should(await this.empty.exec(this.ctx)).be.null();
+    should(this.ctx.localId_context[45]).not.be.undefined();
   });
 
-  it('should return null for a null list', async function () {
+  it('should return null for a null list and the localId should exist on the root context', async function () {
     should(await this.nullValue.exec(this.ctx)).be.null();
+    should(this.ctx.localId_context[51]).not.be.undefined();
   });
 });
 
@@ -781,16 +795,21 @@ describe('Skip', () => {
     setup(this, data);
   });
 
-  it('should skip two elements', async function () {
+  it('should skip two elements and the localId of the source and the startIndex should exist on the root context', async function () {
     (await this.skip2.exec(this.ctx)).should.eql([3, 4, 5]);
+    should(this.ctx.localId_context[7]).not.be.undefined();
+    should(this.ctx.localId_context[8]).not.be.undefined();
   });
 
-  it('should not skip when using null', async function () {
+  it('should not skip when using null and the localId of the source should exist on the root context', async function () {
     (await this.skipNull.exec(this.ctx)).should.eql([1, 3, 5]);
+    should(this.ctx.localId_context[14]).not.be.undefined();
   });
 
-  it('should return empty list when using negative number', async function () {
+  it('should return empty list when using negative number and the localId of the source and the startIndex should exist on the root context', async function () {
     (await this.skipEmpty.exec(this.ctx)).should.eql([]);
+    should(this.ctx.localId_context[21]).not.be.undefined();
+    should(this.ctx.localId_context[23]).not.be.undefined();
   });
 
   it('should return null when given null', async function () {
@@ -803,12 +822,14 @@ describe('Tail', () => {
     setup(this, data);
   });
 
-  it('should get tail of list', async function () {
+  it('should get tail of list and the localId of the source should exist on the root context', async function () {
     (await this.tail234.exec(this.ctx)).should.eql([2, 3, 4]);
+    should(this.ctx.localId_context[6]).not.be.undefined();
   });
 
-  it('should return empty list when given empty list', async function () {
+  it('should return empty list when given empty list and the localId of the source should exist on the root context', async function () {
     (await this.tailEmpty.exec(this.ctx)).should.eql([]);
+    should(this.ctx.localId_context[9]).not.be.undefined();
   });
 
   it('should return null when given null', async function () {
@@ -821,16 +842,19 @@ describe('Take', () => {
     setup(this, data);
   });
 
-  it('should take two elements', async function () {
+  it('should take two elements and the localId of the source should exist on the root context', async function () {
     (await this.take2.exec(this.ctx)).should.eql([1, 2]);
+    should(this.ctx.localId_context[6]).not.be.undefined();
   });
 
-  it('should return full list when asked for too many elements', async function () {
+  it('should return full list when asked for too many elements and the localId of the source should exist on the root context', async function () {
     (await this.takeTooMany.exec(this.ctx)).should.eql([1, 2]);
+    should(this.ctx.localId_context[12]).not.be.undefined();
   });
 
-  it('should return empty list when using null', async function () {
+  it('should return empty list when using null and the localId of the source should exist on the root context', async function () {
     (await this.takeEmpty.exec(this.ctx)).should.eql([]);
+    should(this.ctx.localId_context[20]).not.be.undefined();
   });
 
   it('should return null when given null', async function () {

--- a/test/elm/query/query-test.ts
+++ b/test/elm/query/query-test.ts
@@ -433,22 +433,27 @@ describe('AggregateQuery', () => {
       new Interval(new DateTime(1982, 3, 16, 15, 0), new DateTime(2013, 5, 23, 10, 0))
     ];
     (await this.expressionStartingAggregation.exec(this.ctx)).should.eql(ret);
+    should(this.ctx.localId_context[30]).not.be.undefined();
   });
 
   it('should be able to aggregate over distinct values', async function () {
     (await this.distinctAggregation.exec(this.ctx)).should.eql(15);
+    should(this.ctx.localId_context[124]).not.be.undefined();
   });
 
   it('should be able to aggregate over non-distinct values', async function () {
     (await this.allAggregation.exec(this.ctx)).should.eql(30);
+    should(this.ctx.localId_context[105]).not.be.undefined();
   });
 
   it('should be able to aggregate with a String as the starting value', async function () {
     (await this.literalStartingAggregation.exec(this.ctx)).should.eql('Start12345');
+    should(this.ctx.localId_context[71]).not.be.undefined();
   });
 
   it('should be able to aggregate with a Quantity as the starting value', async function () {
     (await this.quantityStartingAggregation.exec(this.ctx)).should.eql(new Quantity(15, 'ml'));
+    should(this.ctx.localId_context[86]).not.be.undefined();
   });
 });
 


### PR DESCRIPTION
Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository.
It is strongly recommended to include a person from each of those projects as a reviewer.

## Summary
@hossenlopp and I worked on this pull request together and found that the `AnyInValueSet` class that extends from `Expression` contained code in its `exec` function that called `exec()` on `this.codes`. Since `this.exec` was being called instead of `this.execute`, the localId of `this.codes` and its result were not being set on the root context, thus causing situations in which this localId and result were missing. By making this change, `this.execute` now gets properly called. I wasn't sure about unit testing for this case, so I created a new one that checks the three inputs to codes in `AnyInValueSet` (list of strings, codes, or concepts) (defined [here](https://cql.hl7.org/04-logicalspecification.html#anyinvalueset)). Additionally, there are now checks that ensure the localId of the codes expression is present on the localId_context. 

After finding this, we wanted to check the rest of the code for other instances where `.exec` was being used when it should be `.execute()`. There were only a few places where this occurred: `First`, `Last`, and `Slice` in `list.ts` and `AggregateClause` in `query.ts`. I did not add any additional unit tests for these changes, but I did add checks for the existence of the localId of the expression on the root context.

**Submitter:**
- [✔] This pull request describes why these changes were made
- [✔] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [✔] Tests are included and test edge cases
- [✔] Tests have been run locally and pass
- [✔] Code coverage has not gone down and all code touched or added is covered.
- [✔] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [✔] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [✔] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
