### PR TITLE
Cache function ref

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -6811,21 +6811,21 @@ class FunctionRef extends expression_1.Expression {
         super(json);
         this.name = json.name;
         this.library = json.libraryName;
+        this.functionDefs = null;
     }
-    async exec(ctx) {
-        let functionDefs, child_ctx;
+    getFunctionDefs(ctx, args) {
+        if (this.functionDefs != null) {
+            // cache hit
+            return this.functionDefs;
+        }
+        let functionDefs;
         if (this.library) {
             const lib = ctx.get(this.library);
             functionDefs = lib ? lib.getFunction(this.name) : undefined;
-            const libCtx = ctx.getLibraryContext(this.library);
-            child_ctx = libCtx ? libCtx.childContext() : undefined;
         }
         else {
             functionDefs = ctx.get(this.name);
-            child_ctx = ctx.childContext();
         }
-        const args = await this.execArgs(ctx);
-        // Filter out functions w/ wrong number of arguments.
         functionDefs = functionDefs.filter((f) => f.parameters.length === args.length);
         // If there is still > 1 matching function, filter by argument types
         if (functionDefs.length > 1) {
@@ -6847,16 +6847,31 @@ class FunctionRef extends expression_1.Expression {
                 return match;
             });
         }
+        this.functionDefs = functionDefs;
+        return functionDefs;
+    }
+    async exec(ctx) {
+        const args = await this.execArgs(ctx);
+        // Filter out functions w/ wrong number of arguments.
+        const fDefs = this.getFunctionDefs(ctx, args);
         // If there is still > 1 matching function, calculate a score based on quality of matches
-        if (functionDefs.length > 1) {
+        if (fDefs.length > 1) {
             // TODO
         }
-        if (functionDefs.length === 0) {
+        if (fDefs.length === 0) {
             throw new Error('no function with matching signature could be found');
+        }
+        let child_ctx;
+        if (this.library) {
+            const libCtx = ctx.getLibraryContext(this.library);
+            child_ctx = libCtx ? libCtx.childContext() : undefined;
+        }
+        else {
+            child_ctx = ctx.childContext();
         }
         // By this point, we should have only one function, but until implementation is completed,
         // use the last one (no matter how many still remain)
-        const functionDef = functionDefs[functionDefs.length - 1];
+        const functionDef = fDefs[fDefs.length - 1];
         for (let i = 0; i < functionDef.parameters.length; i++) {
             child_ctx.set(functionDef.parameters[i].name, args[i]);
         }

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -6861,6 +6861,8 @@ class FunctionRef extends expression_1.Expression {
         if (fDefs.length === 0) {
             throw new Error('no function with matching signature could be found');
         }
+        // Moved context creation below the functionDef checks because it's not needed if 
+        // there are no matching function defs
         let child_ctx;
         if (this.library) {
             const libCtx = ctx.getLibraryContext(this.library);

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -6861,7 +6861,7 @@ class FunctionRef extends expression_1.Expression {
         if (fDefs.length === 0) {
             throw new Error('no function with matching signature could be found');
         }
-        // Moved context creation below the functionDef checks because it's not needed if 
+        // Moved context creation below the functionDef checks because it's not needed if
         // there are no matching function defs
         let child_ctx;
         if (this.library) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1988,11 +1988,10 @@
       "license": "ISC"
     },
     "node_modules/elliptic": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
-      "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -3306,12 +3305,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.4",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -3951,9 +3951,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "1.8.0",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "isarray": "0.0.1"
       }
@@ -6593,9 +6594,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
-      "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
       "dev": true,
       "requires": {
         "bn.js": "^4.11.9",
@@ -7438,11 +7439,13 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.4",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
       }
     },
     "miller-rabin": {
@@ -7888,7 +7891,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "1.8.0",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
       "dev": true,
       "requires": {
         "isarray": "0.0.1"

--- a/src/elm/reusable.ts
+++ b/src/elm/reusable.ts
@@ -73,7 +73,7 @@ export class FunctionRef extends Expression {
       // cache hit
       return this.functionDefs;
     }
-    let functionDefs, child_ctx;
+    let functionDefs;
     if (this.library) {
       const lib = ctx.get(this.library);
       functionDefs = lib ? lib.getFunction(this.name) : undefined;

--- a/src/elm/reusable.ts
+++ b/src/elm/reusable.ts
@@ -118,7 +118,7 @@ export class FunctionRef extends Expression {
     if (fDefs.length === 0) {
       throw new Error('no function with matching signature could be found');
     }
-    // Moved context creation below the functionDef checks because it's not needed if 
+    // Moved context creation below the functionDef checks because it's not needed if
     // there are no matching function defs
     let child_ctx;
     if (this.library) {

--- a/src/elm/reusable.ts
+++ b/src/elm/reusable.ts
@@ -68,6 +68,36 @@ export class FunctionRef extends Expression {
     this.functionDefs = null;
   }
 
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
+    // Filter out functions w/ wrong number of arguments.
+    const fDefs = this.getFunctionDefs(ctx, args);
+    // If there is still > 1 matching function, calculate a score based on quality of matches
+    if (fDefs.length > 1) {
+      // TODO
+    }
+
+    if (fDefs.length === 0) {
+      throw new Error('no function with matching signature could be found');
+    }
+    // Moved context creation below the functionDef checks because it's not needed if
+    // there are no matching function defs
+    let child_ctx;
+    if (this.library) {
+      const libCtx = ctx.getLibraryContext(this.library);
+      child_ctx = libCtx ? libCtx.childContext() : undefined;
+    } else {
+      child_ctx = ctx.childContext();
+    }
+    // By this point, we should have only one function, but until implementation is completed,
+    // use the last one (no matter how many still remain)
+    const functionDef = fDefs[fDefs.length - 1];
+    for (let i = 0; i < functionDef.parameters.length; i++) {
+      child_ctx.set(functionDef.parameters[i].name, args[i]);
+    }
+    return functionDef.expression.execute(child_ctx);
+  }
+
   getFunctionDefs(ctx: Context, args: any) {
     if (this.functionDefs != null) {
       // cache hit
@@ -104,36 +134,6 @@ export class FunctionRef extends Expression {
     }
     this.functionDefs = functionDefs;
     return functionDefs;
-  }
-
-  async exec(ctx: Context) {
-    const args = await this.execArgs(ctx);
-    // Filter out functions w/ wrong number of arguments.
-    const fDefs = this.getFunctionDefs(ctx, args);
-    // If there is still > 1 matching function, calculate a score based on quality of matches
-    if (fDefs.length > 1) {
-      // TODO
-    }
-
-    if (fDefs.length === 0) {
-      throw new Error('no function with matching signature could be found');
-    }
-    // Moved context creation below the functionDef checks because it's not needed if
-    // there are no matching function defs
-    let child_ctx;
-    if (this.library) {
-      const libCtx = ctx.getLibraryContext(this.library);
-      child_ctx = libCtx ? libCtx.childContext() : undefined;
-    } else {
-      child_ctx = ctx.childContext();
-    }
-    // By this point, we should have only one function, but until implementation is completed,
-    // use the last one (no matter how many still remain)
-    const functionDef = fDefs[fDefs.length - 1];
-    for (let i = 0; i < functionDef.parameters.length; i++) {
-      child_ctx.set(functionDef.parameters[i].name, args[i]);
-    }
-    return functionDef.expression.execute(child_ctx);
   }
 }
 

--- a/src/elm/reusable.ts
+++ b/src/elm/reusable.ts
@@ -118,7 +118,8 @@ export class FunctionRef extends Expression {
     if (fDefs.length === 0) {
       throw new Error('no function with matching signature could be found');
     }
-
+    // Moved context creation below the functionDef checks because it's not needed if 
+    // there are no matching function defs
     let child_ctx;
     if (this.library) {
       const libCtx = ctx.getLibraryContext(this.library);

--- a/src/elm/reusable.ts
+++ b/src/elm/reusable.ts
@@ -59,27 +59,28 @@ export class FunctionDef extends Expression {
 export class FunctionRef extends Expression {
   name: string;
   library: string;
+  functionDefs: FunctionDef[] | null;
 
   constructor(json: any) {
     super(json);
     this.name = json.name;
     this.library = json.libraryName;
+    this.functionDefs = null;
   }
 
-  async exec(ctx: Context) {
+  getFunctionDefs(ctx: Context, args: any) {
+    if (this.functionDefs != null) {
+      // cache hit
+      return this.functionDefs;
+    }
     let functionDefs, child_ctx;
     if (this.library) {
       const lib = ctx.get(this.library);
       functionDefs = lib ? lib.getFunction(this.name) : undefined;
-      const libCtx = ctx.getLibraryContext(this.library);
-      child_ctx = libCtx ? libCtx.childContext() : undefined;
     } else {
       functionDefs = ctx.get(this.name);
-      child_ctx = ctx.childContext();
     }
-    const args = await this.execArgs(ctx);
 
-    // Filter out functions w/ wrong number of arguments.
     functionDefs = functionDefs.filter((f: any) => f.parameters.length === args.length);
     // If there is still > 1 matching function, filter by argument types
     if (functionDefs.length > 1) {
@@ -101,17 +102,33 @@ export class FunctionRef extends Expression {
         return match;
       });
     }
+    this.functionDefs = functionDefs;
+    return functionDefs;
+  }
+
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
+    // Filter out functions w/ wrong number of arguments.
+    const fDefs = this.getFunctionDefs(ctx, args);
     // If there is still > 1 matching function, calculate a score based on quality of matches
-    if (functionDefs.length > 1) {
+    if (fDefs.length > 1) {
       // TODO
     }
 
-    if (functionDefs.length === 0) {
+    if (fDefs.length === 0) {
       throw new Error('no function with matching signature could be found');
+    }
+
+    let child_ctx;
+    if (this.library) {
+      const libCtx = ctx.getLibraryContext(this.library);
+      child_ctx = libCtx ? libCtx.childContext() : undefined;
+    } else {
+      child_ctx = ctx.childContext();
     }
     // By this point, we should have only one function, but until implementation is completed,
     // use the last one (no matter how many still remain)
-    const functionDef = functionDefs[functionDefs.length - 1];
+    const functionDef = fDefs[fDefs.length - 1];
     for (let i = 0; i < functionDef.parameters.length; i++) {
       child_ctx.set(functionDef.parameters[i].name, args[i]);
     }


### PR DESCRIPTION
This is primarily a performance enhancement.  When function use is defined within a Query, every iteration of elements in the where clause caused a re-evaluation of finding the correct FunctionDef to use.  When there are a large number of items to go through this becomes a very expensive process, mainly due to the type comparisons that are used to perform the FunctionDef lookups. 

This PR implements caching of the FunctionDef look ups with a FunctionRef the first time it is executed. 

Note that this PR also contains updates to 3 node modules that were not passing audit tests 
Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

This is primarily a performance enhancement.  When function use is defined within a Query, every iteration of elements in the where clause caused a re-evaluation of finding the correct FunctionDef to use.  When there are a large number of items to go through this becomes a very expensive process, mainly due to the type comparisons that are used to perform the FunctionDef lookups. 

This PR implements caching of the FunctionDef look ups with a FunctionRef the first time it is executed. 

Note that this PR also contains updates to 3 node modules that were not passing audit tests 
Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

**Submitter:**

- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name:

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
