### PR TITLE
ExpressionRef Library context_values performance issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "build:spec-test-data": "node \"test/spec-tests/generate-cql.js\" && cd \"./test/generator\" && \"./gradlew\" generateSpecTestData && cd ..",
     "build:all": "npm run build && npm run build:browserify && npm run build:test-data && npm run build:spec-test-data",
     "watch:test-data": "cd \"./test/generator\" && \"./gradlew\" watchTestData && cd ..",
-    "test": "cross-env TS_NODE_PROJECT=\"./test/tsconfig.json\" TS_NODE_FILES=true mocha --reporter spec --recursive",
+    "test": "cross-env TS_NODE_PROJECT=\"./test/tsconfig.json\" TS_NODE_FILES=true mocha --reporter spec --recursive --grep CommonLib3",
     "test:nyc": "cross-env TS_NODE_PROJECT=\"./test/tsconfig.json\" TS_NODE_FILES=true nyc --reporter=html npx mocha --reporter spec --recursive",
     "test:watch": "cross-env TS_NODE_PROJECT=\"./test/tsconfig.json\" TS_NODE_FILES=true mocha --reporter spec --recursive --watch",
     "lint": "eslint .",

--- a/test/elm/library/Common3.cql
+++ b/test/elm/library/Common3.cql
@@ -1,0 +1,18 @@
+// NOTE: This library must be DUPLICATED in the data.cql file as well!
+library Common3
+using Simple version '1.0.0'
+context Patient
+
+define function ExpensiveFunction():
+  First(expand Interval[1, 100000])
+
+define ExpensiveStatement:
+  ExpensiveFunction()
+
+define ExpensiveStatementRef:
+  ExpensiveStatement union 
+  ExpensiveStatement union 
+  ExpensiveStatement union 
+  ExpensiveStatement union 
+  ExpensiveStatement
+  

--- a/test/elm/library/Common3.js
+++ b/test/elm/library/Common3.js
@@ -1,0 +1,10 @@
+/*
+   WARNING: This is a GENERATED file.  Do not manually edit!
+
+   To generate this file:
+       - Edit Common3.cql to add a CQL Snippet
+       - From java dir: ./gradlew :cql-to-elm:generateTestData
+*/
+
+/* eslint-disable */
+

--- a/test/elm/library/data.cql
+++ b/test/elm/library/data.cql
@@ -110,3 +110,28 @@ context Patient
 
 define testCommonLib: common.SupportLibDef
 define testCommon2Lib: common2.SortUsingFunction
+
+// @Test: CommonLib3
+library Common3
+using Simple version '1.0.0'
+context Patient
+
+define function ExpensiveFunction():
+  First(expand Interval[1, 100000])
+
+define ExpensiveStatement:
+  ExpensiveFunction()
+
+define ExpensiveStatementRef:
+  ExpensiveStatement union 
+  ExpensiveStatement union 
+  ExpensiveStatement union 
+  ExpensiveStatement union 
+  ExpensiveStatement
+
+// @Test: Using CommonLib3
+using Simple version '1.0.0'
+include Common3 called common3
+context Patient
+
+define ExpensiveStatementRef: common3.ExpensiveStatementRef

--- a/test/elm/library/data.js
+++ b/test/elm/library/data.js
@@ -2772,3 +2772,470 @@ module.exports['Using CommonLib and CommonLib2'] = {
    }
 }
 
+/* CommonLib3
+library Common3
+using Simple version '1.0.0'
+context Patient
+
+define function ExpensiveFunction():
+  First(expand Interval[1, 100000])
+
+define ExpensiveStatement:
+  ExpensiveFunction()
+
+define ExpensiveStatementRef:
+  ExpensiveStatement union 
+  ExpensiveStatement union 
+  ExpensiveStatement union 
+  ExpensiveStatement union 
+  ExpensiveStatement
+*/
+
+module.exports['CommonLib3'] = {
+   "library" : {
+      "localId" : "0",
+      "annotation" : [ {
+         "translatorVersion" : "3.12.0",
+         "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
+         "signatureLevel" : "None",
+         "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "224",
+            "s" : [ {
+               "value" : [ "","library Common3" ]
+            } ]
+         }
+      } ],
+      "identifier" : {
+         "id" : "Common3"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localId" : "1",
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "206",
+            "localIdentifier" : "Simple",
+            "uri" : "https://github.com/cqframework/cql-execution/simple",
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "206",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version '1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "localId" : "210",
+            "name" : "Patient"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "localId" : "208",
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "localId" : "209",
+               "type" : "SingletonFrom",
+               "signature" : [ ],
+               "operand" : {
+                  "localId" : "207",
+                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "type" : "Retrieve",
+                  "include" : [ ],
+                  "codeFilter" : [ ],
+                  "dateFilter" : [ ],
+                  "otherFilter" : [ ]
+               }
+            }
+         }, {
+            "localId" : "211",
+            "name" : "ExpensiveFunction",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "211",
+                  "s" : [ {
+                     "value" : [ "","define function ExpensiveFunction():\n  " ]
+                  }, {
+                     "r" : "219",
+                     "s" : [ {
+                        "r" : "219",
+                        "s" : [ {
+                           "value" : [ "First","(" ]
+                        }, {
+                           "r" : "216",
+                           "s" : [ {
+                              "value" : [ "expand " ]
+                           }, {
+                              "r" : "214",
+                              "s" : [ {
+                                 "r" : "212",
+                                 "value" : [ "Interval[","1",", ","100000","]" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "219",
+               "type" : "First",
+               "signature" : [ ],
+               "source" : {
+                  "localId" : "216",
+                  "type" : "Expand",
+                  "signature" : [ ],
+                  "operand" : [ {
+                     "localId" : "214",
+                     "lowClosed" : true,
+                     "highClosed" : true,
+                     "type" : "Interval",
+                     "low" : {
+                        "localId" : "212",
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "1",
+                        "type" : "Literal"
+                     },
+                     "high" : {
+                        "localId" : "213",
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "100000",
+                        "type" : "Literal"
+                     }
+                  }, {
+                     "localId" : "215",
+                     "type" : "Null"
+                  } ]
+               }
+            },
+            "operand" : [ ]
+         }, {
+            "localId" : "221",
+            "name" : "ExpensiveStatement",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "221",
+                  "s" : [ {
+                     "value" : [ "","define ","ExpensiveStatement",":\n  " ]
+                  }, {
+                     "r" : "222",
+                     "s" : [ {
+                        "value" : [ "ExpensiveFunction","()" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "222",
+               "name" : "ExpensiveFunction",
+               "type" : "FunctionRef",
+               "signature" : [ ],
+               "operand" : [ ]
+            }
+         }, {
+            "localId" : "224",
+            "name" : "ExpensiveStatementRef",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "224",
+                  "s" : [ {
+                     "value" : [ "","define ","ExpensiveStatementRef",":\n  " ]
+                  }, {
+                     "r" : "238",
+                     "s" : [ {
+                        "r" : "236",
+                        "s" : [ {
+                           "r" : "231",
+                           "s" : [ {
+                              "r" : "227",
+                              "s" : [ {
+                                 "r" : "225",
+                                 "s" : [ {
+                                    "value" : [ "ExpensiveStatement" ]
+                                 } ]
+                              }, {
+                                 "value" : [ " union \n  " ]
+                              }, {
+                                 "r" : "226",
+                                 "s" : [ {
+                                    "value" : [ "ExpensiveStatement" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " union \n  " ]
+                           }, {
+                              "r" : "230",
+                              "s" : [ {
+                                 "value" : [ "ExpensiveStatement" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ " union \n  " ]
+                        }, {
+                           "r" : "233",
+                           "s" : [ {
+                              "value" : [ "ExpensiveStatement" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ " union \n  " ]
+                     }, {
+                        "r" : "237",
+                        "s" : [ {
+                           "value" : [ "ExpensiveStatement" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "238",
+               "type" : "Union",
+               "signature" : [ ],
+               "operand" : [ {
+                  "localId" : "236",
+                  "type" : "Union",
+                  "signature" : [ ],
+                  "operand" : [ {
+                     "localId" : "227",
+                     "type" : "Union",
+                     "signature" : [ ],
+                     "operand" : [ {
+                        "localId" : "228",
+                        "type" : "ToList",
+                        "signature" : [ ],
+                        "operand" : {
+                           "localId" : "225",
+                           "name" : "ExpensiveStatement",
+                           "type" : "ExpressionRef"
+                        }
+                     }, {
+                        "localId" : "229",
+                        "type" : "ToList",
+                        "signature" : [ ],
+                        "operand" : {
+                           "localId" : "226",
+                           "name" : "ExpensiveStatement",
+                           "type" : "ExpressionRef"
+                        }
+                     } ]
+                  }, {
+                     "localId" : "234",
+                     "type" : "Union",
+                     "signature" : [ ],
+                     "operand" : [ {
+                        "localId" : "232",
+                        "type" : "ToList",
+                        "signature" : [ ],
+                        "operand" : {
+                           "localId" : "230",
+                           "name" : "ExpensiveStatement",
+                           "type" : "ExpressionRef"
+                        }
+                     }, {
+                        "localId" : "235",
+                        "type" : "ToList",
+                        "signature" : [ ],
+                        "operand" : {
+                           "localId" : "233",
+                           "name" : "ExpensiveStatement",
+                           "type" : "ExpressionRef"
+                        }
+                     } ]
+                  } ]
+               }, {
+                  "localId" : "239",
+                  "type" : "ToList",
+                  "signature" : [ ],
+                  "operand" : {
+                     "localId" : "237",
+                     "name" : "ExpensiveStatement",
+                     "type" : "ExpressionRef"
+                  }
+               } ]
+            }
+         } ]
+      }
+   }
+}
+
+/* Using CommonLib3
+library TestSnippet version '1'
+using Simple version '1.0.0'
+include Common3 called common3
+context Patient
+
+define ExpensiveStatementRef: common3.ExpensiveStatementRef
+*/
+
+module.exports['Using CommonLib3'] = {
+   "library" : {
+      "localId" : "0",
+      "annotation" : [ {
+         "translatorVersion" : "3.12.0",
+         "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
+         "signatureLevel" : "None",
+         "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "213",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
+      } ],
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localId" : "1",
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "206",
+            "localIdentifier" : "Simple",
+            "uri" : "https://github.com/cqframework/cql-execution/simple",
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "206",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version '1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "includes" : {
+         "def" : [ {
+            "localId" : "207",
+            "localIdentifier" : "common3",
+            "path" : "Common3",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "207",
+                  "s" : [ {
+                     "value" : [ "","include " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Common3" ]
+                     } ]
+                  }, {
+                     "value" : [ " called ","common3" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "localId" : "211",
+            "name" : "Patient"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "localId" : "209",
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "localId" : "210",
+               "type" : "SingletonFrom",
+               "signature" : [ ],
+               "operand" : {
+                  "localId" : "208",
+                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "type" : "Retrieve",
+                  "include" : [ ],
+                  "codeFilter" : [ ],
+                  "dateFilter" : [ ],
+                  "otherFilter" : [ ]
+               }
+            }
+         }, {
+            "localId" : "213",
+            "name" : "ExpensiveStatementRef",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "213",
+                  "s" : [ {
+                     "value" : [ "","define ","ExpensiveStatementRef",": " ]
+                  }, {
+                     "r" : "215",
+                     "s" : [ {
+                        "r" : "214",
+                        "s" : [ {
+                           "value" : [ "common3" ]
+                        } ]
+                     }, {
+                        "value" : [ "." ]
+                     }, {
+                        "r" : "215",
+                        "s" : [ {
+                           "value" : [ "ExpensiveStatementRef" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "215",
+               "name" : "ExpensiveStatementRef",
+               "libraryName" : "common3",
+               "type" : "ExpressionRef"
+            }
+         } ]
+      }
+   }
+}
+

--- a/test/elm/library/library-test.ts
+++ b/test/elm/library/library-test.ts
@@ -213,3 +213,41 @@ describe('Using CommonLib and CommonLib2 with namespace support', () => {
     should.exist(this.common2LocalIdObject[sortUsingFunctionLocalId]);
   });
 });
+
+describe('CommonLib3', () => {
+  beforeEach(function () {
+    setup(this, data, [p1, p2], {}, {}, new Repository(data));
+  });
+  it('should be able to execute an expensive expression', async function () {
+    const startTime = Date.now();    
+    this.results = await this.executor
+      .withLibrary(this.lib)
+      .exec_patient_context(this.patientSource);
+    const endTime = Date.now();
+    const executionTime = endTime - startTime;
+    executionTime.should.be.lessThan(250);
+    this.results.patientResults['1'].ExpensiveStatementRef.length.should.equal(1);
+  });  
+});
+
+describe('Using CommonLib3', () => {
+  beforeEach(function () {
+    setup(this, data, [p1, p2], {}, {}, new Repository(data));
+  });
+
+  it('should execute expression from included library at similar cost', async function () {
+    const startTime = Date.now();    
+    this.results = await this.executor
+      .withLibrary(this.lib)
+      .exec_patient_context(this.patientSource);
+    const endTime = Date.now();
+    const executionTime = endTime - startTime;
+    executionTime.should.be.lessThan(1000);
+    this.results.patientResults['1'].ExpensiveStatementRef.length.should.equal(1);
+  });
+
+  it('should execute expression directly from included library at similar cost', async function () {
+    (await this.expensiveStatementRef.exec(this.ctx)).length.should.equal(1);
+  });
+
+});


### PR DESCRIPTION
A performance slowdown has been identified when executing referenced CQL statements under certain conditions.

### Assumptions
- Execution results of `ExpressionDef` expressions are cached in their library context. 
- `ExpressionRef` expressions use those cached results.

### Issue
The CQL below performs in a degraded, non-cached way. We suspect the wrong context is used to store or lookup the cached context values when ExpressionRefs cross library contexts.

### Test

CommonLib3:
```cql
library Common3
using Simple version '1.0.0'
context Patient

define function ExpensiveFunction():
  First(expand Interval[1, 100000])

define ExpensiveStatement:
  ExpensiveFunction()

define ExpensiveStatementRef:
  ExpensiveStatement union 
  ExpensiveStatement union 
  ExpensiveStatement union 
  ExpensiveStatement union 
  ExpensiveStatement
```

Using CommonLib3:
```
using Simple version '1.0.0'
include Common3 called common3
context Patient

define ExpensiveStatementRef: common3.ExpensiveStatementRef
```

The result of the library-test shows the perf degradation as if `ExpensiveStatement` was _not_ being cached:
```bash
$ npm test

  CommonLib3
    ✔ should be able to execute an expensive expression (123ms)

  Using CommonLib3
    ✔ should execute expression from included library at similar cost (565ms)
    ✔ should execute expression directly from included library at similar cost (291ms)
```

### Solution
?

Please note there are no changes to src code, only tests were added to demonstrate the perf issue. Looking for feedback.

We hope that a fix can be identified and included with this PR.
  
  
  
Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

**Submitter:**

- [x] This pull request describes why these changes were made
- [ ] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [ ] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [ ] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name:

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
