### PR TITLE
Pass Message Listener to Included Libraries

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,4 @@ test/elm/external/Retrieve.js
 test/elm/library/Common.js
 test/elm/library/Common2.js
 test/elm/library/data-with-namespace.js
+test/elm/message/Included.js

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -8275,13 +8275,13 @@ class PatientContext extends Context {
     }
     getLibraryContext(library) {
         if (this.library_context[library] == null) {
-            this.library_context[library] = new PatientContext(this.get(library), this.patient, this.codeService, this.parameters, this.executionDateTime);
+            this.library_context[library] = new PatientContext(this.get(library), this.patient, this.codeService, this.parameters, this.executionDateTime, this.messageListener);
         }
         return this.library_context[library];
     }
     getLocalIdContext(localId) {
         if (this.localId_context[localId] == null) {
-            this.localId_context[localId] = new PatientContext(this.get(localId), this.patient, this.codeService, this.parameters, this.executionDateTime);
+            this.localId_context[localId] = new PatientContext(this.get(localId), this.patient, this.codeService, this.parameters, this.executionDateTime, this.messageListener);
         }
         return this.localId_context[localId];
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1104,7 +1104,9 @@
       }
     },
     "node_modules/ansi-colors": {
-      "version": "4.1.1",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1782,7 +1784,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1832,11 +1836,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/debug": {
-      "version": "4.3.3",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -1919,7 +1925,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.0.0",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -3366,31 +3374,32 @@
       "license": "MIT"
     },
     "node_modules/mocha": {
-      "version": "10.1.0",
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
-        "debug": "4.3.4",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.2.0",
-        "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "5.0.1",
-        "ms": "2.1.3",
-        "nanoid": "3.3.3",
-        "serialize-javascript": "6.0.0",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "workerpool": "6.2.1",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
       },
       "bin": {
         "_mocha": "bin/_mocha",
@@ -3398,10 +3407,6 @@
       },
       "engines": {
         "node": ">= 14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mochajs"
       }
     },
     "node_modules/mocha/node_modules/argparse": {
@@ -3411,32 +3416,34 @@
     },
     "node_modules/mocha/node_modules/brace-expansion": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/mocha/node_modules/debug": {
-      "version": "4.3.4",
+    "node_modules/mocha/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
-      "license": "MIT",
+      "license": "ISC",
       "dependencies": {
-        "ms": "2.1.2"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=12"
       },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/mocha/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/mocha/node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3450,7 +3457,9 @@
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.0.1",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3459,11 +3468,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/mocha/node_modules/ms": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/mocha/node_modules/supports-color": {
       "version": "8.1.1",
@@ -3508,20 +3512,11 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.3",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -4385,7 +4380,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.0",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5107,7 +5104,9 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "6.2.1",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -5204,7 +5203,9 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.4",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -5964,7 +5965,9 @@
       }
     },
     "ansi-colors": {
-      "version": "4.1.1",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true
     },
     "ansi-regex": {
@@ -6452,7 +6455,9 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.3",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -6491,10 +6496,12 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.3",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
       "requires": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       }
     },
     "decamelize": {
@@ -6544,7 +6551,9 @@
       }
     },
     "diff": {
-      "version": "5.0.0",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true
     },
     "diffie-hellman": {
@@ -7486,30 +7495,31 @@
       "dev": true
     },
     "mocha": {
-      "version": "10.1.0",
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
       "dev": true,
       "requires": {
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
-        "debug": "4.3.4",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.2.0",
-        "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "5.0.1",
-        "ms": "2.1.3",
-        "nanoid": "3.3.3",
-        "serialize-javascript": "6.0.0",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "workerpool": "6.2.1",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
       },
       "dependencies": {
         "argparse": {
@@ -7518,22 +7528,24 @@
         },
         "brace-expansion": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
           }
         },
-        "debug": {
-          "version": "4.3.4",
+        "glob": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "dev": true
-            }
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
           }
         },
         "js-yaml": {
@@ -7544,15 +7556,13 @@
           }
         },
         "minimatch": {
-          "version": "5.0.1",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "dev": true
         },
         "supports-color": {
           "version": "8.1.1",
@@ -7585,11 +7595,9 @@
       }
     },
     "ms": {
-      "version": "2.1.2",
-      "dev": true
-    },
-    "nanoid": {
-      "version": "3.3.3",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "natural-compare": {
@@ -8158,7 +8166,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "6.0.0",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
@@ -8640,7 +8650,9 @@
       "dev": true
     },
     "workerpool": {
-      "version": "6.2.1",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
       "dev": true
     },
     "wrap-ansi": {
@@ -8710,7 +8722,9 @@
       }
     },
     "yargs-parser": {
-      "version": "20.2.4",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
     },
     "yargs-unparser": {

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -442,7 +442,8 @@ export class PatientContext extends Context {
         this.patient,
         this.codeService,
         this.parameters,
-        this.executionDateTime
+        this.executionDateTime,
+        this.messageListener
       );
     }
     return this.library_context[library];
@@ -455,7 +456,8 @@ export class PatientContext extends Context {
         this.patient,
         this.codeService,
         this.parameters,
-        this.executionDateTime
+        this.executionDateTime,
+        this.messageListener
       );
     }
     return this.localId_context[localId];

--- a/test/elm/message/Included.cql
+++ b/test/elm/message/Included.cql
@@ -1,0 +1,5 @@
+library Included
+using Simple version '1.0.0'
+
+define function DoDivide(num Integer, den Integer):
+  Message(num / den, den = 0, 'DivideByZero', 'Error', 'Cannot divide by zero in included')

--- a/test/elm/message/Included.js
+++ b/test/elm/message/Included.js
@@ -1,0 +1,10 @@
+/*
+   WARNING: This is a GENERATED file.  Do not manually edit!
+
+   To generate this file:
+       - Edit Included.cql to add a CQL Snippet
+       - From java dir: ./gradlew :cql-to-elm:generateTestData
+*/
+
+/* eslint-disable */
+

--- a/test/elm/message/Included.js
+++ b/test/elm/message/Included.js
@@ -7,4 +7,3 @@
 */
 
 /* eslint-disable */
-

--- a/test/elm/message/Included.js
+++ b/test/elm/message/Included.js
@@ -7,3 +7,4 @@
 */
 
 /* eslint-disable */
+

--- a/test/elm/message/data.cql
+++ b/test/elm/message/data.cql
@@ -3,3 +3,17 @@ define function DoDivide(num Integer, den Integer):
   Message(num / den, den = 0, 'DivideByZero', 'Error', 'Cannot divide by zero')
 define oneOverTwo: DoDivide(1, 2)
 define oneOverZero: DoDivide(1, 0)
+
+// @Test: Included
+library Included
+using Simple version '1.0.0'
+
+define function DoDivide(num Integer, den Integer):
+  Message(num / den, den = 0, 'DivideByZero', 'Error', 'Cannot divide by zero in included')
+
+// @Test: Retrieve
+library Retrieve
+include Included called included
+
+define oneOverTwo: included.DoDivide(1, 2)
+define oneOverZero: included.DoDivide(1, 0)

--- a/test/elm/message/data.js
+++ b/test/elm/message/data.js
@@ -327,3 +327,455 @@ module.exports['Message'] = {
    }
 }
 
+/* Included
+library Included
+using Simple version '1.0.0'
+context Patient
+
+define function DoDivide(num Integer, den Integer):
+  Message(num / den, den = 0, 'DivideByZero', 'Error', 'Cannot divide by zero in included')
+*/
+
+module.exports['Included'] = {
+   "library" : {
+      "localId" : "0",
+      "annotation" : [ {
+         "translatorVersion" : "3.12.0",
+         "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
+         "signatureLevel" : "None",
+         "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "211",
+            "s" : [ {
+               "value" : [ "","library Included" ]
+            } ]
+         }
+      } ],
+      "identifier" : {
+         "id" : "Included"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localId" : "1",
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "206",
+            "localIdentifier" : "Simple",
+            "uri" : "https://github.com/cqframework/cql-execution/simple",
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "206",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version '1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "localId" : "210",
+            "name" : "Patient"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "localId" : "208",
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "localId" : "209",
+               "type" : "SingletonFrom",
+               "signature" : [ ],
+               "operand" : {
+                  "localId" : "207",
+                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "type" : "Retrieve",
+                  "include" : [ ],
+                  "codeFilter" : [ ],
+                  "dateFilter" : [ ],
+                  "otherFilter" : [ ]
+               }
+            }
+         }, {
+            "localId" : "211",
+            "name" : "DoDivide",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "211",
+                  "s" : [ {
+                     "value" : [ "","define function DoDivide(num Integer, den Integer):\n  " ]
+                  }, {
+                     "r" : "231",
+                     "s" : [ {
+                        "r" : "231",
+                        "s" : [ {
+                           "value" : [ "Message","(" ]
+                        }, {
+                           "r" : "216",
+                           "s" : [ {
+                              "r" : "217",
+                              "s" : [ {
+                                 "value" : [ "num" ]
+                              } ]
+                           }, {
+                              "value" : [ " / " ]
+                           }, {
+                              "r" : "218",
+                              "s" : [ {
+                                 "value" : [ "den" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "223",
+                           "s" : [ {
+                              "r" : "224",
+                              "s" : [ {
+                                 "value" : [ "den" ]
+                              } ]
+                           }, {
+                              "r" : "225",
+                              "value" : [ " ","="," ","0" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "226",
+                           "s" : [ {
+                              "value" : [ "'DivideByZero'" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "227",
+                           "s" : [ {
+                              "value" : [ "'Error'" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "228",
+                           "s" : [ {
+                              "value" : [ "'Cannot divide by zero in included'" ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "231",
+               "type" : "Message",
+               "signature" : [ ],
+               "source" : {
+                  "localId" : "216",
+                  "type" : "Divide",
+                  "signature" : [ ],
+                  "operand" : [ {
+                     "localId" : "220",
+                     "type" : "ToDecimal",
+                     "signature" : [ ],
+                     "operand" : {
+                        "localId" : "217",
+                        "name" : "num",
+                        "type" : "OperandRef"
+                     }
+                  }, {
+                     "localId" : "222",
+                     "type" : "ToDecimal",
+                     "signature" : [ ],
+                     "operand" : {
+                        "localId" : "218",
+                        "name" : "den",
+                        "type" : "OperandRef"
+                     }
+                  } ]
+               },
+               "condition" : {
+                  "localId" : "223",
+                  "type" : "Equal",
+                  "signature" : [ ],
+                  "operand" : [ {
+                     "localId" : "224",
+                     "name" : "den",
+                     "type" : "OperandRef"
+                  }, {
+                     "localId" : "225",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "0",
+                     "type" : "Literal"
+                  } ]
+               },
+               "code" : {
+                  "localId" : "226",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "DivideByZero",
+                  "type" : "Literal"
+               },
+               "severity" : {
+                  "localId" : "227",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "Error",
+                  "type" : "Literal"
+               },
+               "message" : {
+                  "localId" : "228",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "Cannot divide by zero in included",
+                  "type" : "Literal"
+               }
+            },
+            "operand" : [ {
+               "localId" : "213",
+               "name" : "num",
+               "operandTypeSpecifier" : {
+                  "localId" : "212",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "localId" : "215",
+               "name" : "den",
+               "operandTypeSpecifier" : {
+                  "localId" : "214",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         } ]
+      }
+   }
+}
+
+/* Retrieve
+library Retrieve
+using Simple version '1.0.0'
+include Included called included
+context Patient
+
+define oneOverTwo: included.DoDivide(1, 2)
+define oneOverZero: included.DoDivide(1, 0)
+*/
+
+module.exports['Retrieve'] = {
+   "library" : {
+      "localId" : "0",
+      "annotation" : [ {
+         "translatorVersion" : "3.12.0",
+         "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations",
+         "signatureLevel" : "None",
+         "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "219",
+            "s" : [ {
+               "value" : [ "","library Retrieve" ]
+            } ]
+         }
+      } ],
+      "identifier" : {
+         "id" : "Retrieve"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localId" : "1",
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "206",
+            "localIdentifier" : "Simple",
+            "uri" : "https://github.com/cqframework/cql-execution/simple",
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "206",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version '1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "includes" : {
+         "def" : [ {
+            "localId" : "207",
+            "localIdentifier" : "included",
+            "path" : "Included",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "207",
+                  "s" : [ {
+                     "value" : [ "","include " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Included" ]
+                     } ]
+                  }, {
+                     "value" : [ " called ","included" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "localId" : "211",
+            "name" : "Patient"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "localId" : "209",
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "localId" : "210",
+               "type" : "SingletonFrom",
+               "signature" : [ ],
+               "operand" : {
+                  "localId" : "208",
+                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "type" : "Retrieve",
+                  "include" : [ ],
+                  "codeFilter" : [ ],
+                  "dateFilter" : [ ],
+                  "otherFilter" : [ ]
+               }
+            }
+         }, {
+            "localId" : "213",
+            "name" : "oneOverTwo",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "213",
+                  "s" : [ {
+                     "value" : [ "","define ","oneOverTwo",": " ]
+                  }, {
+                     "r" : "217",
+                     "s" : [ {
+                        "r" : "214",
+                        "s" : [ {
+                           "value" : [ "included" ]
+                        } ]
+                     }, {
+                        "value" : [ "." ]
+                     }, {
+                        "r" : "217",
+                        "s" : [ {
+                           "r" : "215",
+                           "value" : [ "DoDivide","(","1",", ","2",")" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "217",
+               "name" : "DoDivide",
+               "libraryName" : "included",
+               "type" : "FunctionRef",
+               "signature" : [ ],
+               "operand" : [ {
+                  "localId" : "215",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "1",
+                  "type" : "Literal"
+               }, {
+                  "localId" : "216",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "2",
+                  "type" : "Literal"
+               } ]
+            }
+         }, {
+            "localId" : "219",
+            "name" : "oneOverZero",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "219",
+                  "s" : [ {
+                     "value" : [ "","define ","oneOverZero",": " ]
+                  }, {
+                     "r" : "223",
+                     "s" : [ {
+                        "r" : "220",
+                        "s" : [ {
+                           "value" : [ "included" ]
+                        } ]
+                     }, {
+                        "value" : [ "." ]
+                     }, {
+                        "r" : "223",
+                        "s" : [ {
+                           "r" : "221",
+                           "value" : [ "DoDivide","(","1",", ","0",")" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "223",
+               "name" : "DoDivide",
+               "libraryName" : "included",
+               "type" : "FunctionRef",
+               "signature" : [ ],
+               "operand" : [ {
+                  "localId" : "221",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "1",
+                  "type" : "Literal"
+               }, {
+                  "localId" : "222",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "0",
+                  "type" : "Literal"
+               } ]
+            }
+         } ]
+      }
+   }
+}
+

--- a/test/elm/message/message-test.ts
+++ b/test/elm/message/message-test.ts
@@ -51,7 +51,9 @@ describe('Retrieve', () => {
   it('should log a message when the condition is true', async function () {
     await this.oneOverZero.exec(this.ctx);
     messageCollector.messages.length.should.equal(1);
-    messageCollector.messages[0].should.equal('Error: [DivideByZero] Cannot divide by zero in included (null)');
+    messageCollector.messages[0].should.equal(
+      'Error: [DivideByZero] Cannot divide by zero in included (null)'
+    );
   });
 });
 

--- a/test/elm/message/message-test.ts
+++ b/test/elm/message/message-test.ts
@@ -1,6 +1,7 @@
 import should from 'should';
 import setup from '../../setup';
 const data = require('./data');
+import { Repository } from '../../../src/cql';
 
 describe('Message', () => {
   let messageCollector: any;
@@ -25,6 +26,32 @@ describe('Message', () => {
     await this.oneOverZero.exec(this.ctx);
     messageCollector.messages.length.should.equal(1);
     messageCollector.messages[0].should.equal('Error: [DivideByZero] Cannot divide by zero (null)');
+  });
+});
+
+describe('Retrieve', () => {
+  let messageCollector: any;
+  beforeEach(function () {
+    setup(this, data, [], {}, {}, new Repository(data));
+    messageCollector = new TestMessageCollector();
+    this.executor.withMessageListener(messageCollector);
+    this.ctx.messageListener = messageCollector;
+  });
+
+  it('should always return the first argument as-is', async function () {
+    (await this.oneOverTwo.exec(this.ctx)).should.equal(0.5);
+    should(await this.oneOverZero.exec(this.ctx)).be.null();
+  });
+
+  it('should not log a message when the condition is false', async function () {
+    await this.oneOverTwo.exec(this.ctx);
+    messageCollector.messages.length.should.equal(0);
+  });
+
+  it('should log a message when the condition is true', async function () {
+    await this.oneOverZero.exec(this.ctx);
+    messageCollector.messages.length.should.equal(1);
+    messageCollector.messages[0].should.equal('Error: [DivideByZero] Cannot divide by zero in included (null)');
   });
 });
 


### PR DESCRIPTION
Fix for cqframework/cql-execution#324

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

**Submitter:**

- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change - N/A
- [x] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name:

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
