### PR TITLE
Add missing await to Executor.exec_expression

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -8361,7 +8361,7 @@ class Executor {
             let currentPatient = await patientSource.currentPatient();
             while (currentPatient) {
                 const patient_ctx = new context_1.PatientContext(this.library, currentPatient, this.codeService, this.parameters, executionDateTime, this.messageListener);
-                r.recordPatientResults(patient_ctx, { [expression]: expr.execute(patient_ctx) });
+                r.recordPatientResults(patient_ctx, { [expression]: await expr.execute(patient_ctx) });
                 currentPatient = await patientSource.nextPatient();
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1996,10 +1996,11 @@
       "license": "ISC"
     },
     "node_modules/elliptic": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
-      "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -6603,9 +6604,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
-      "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dev": true,
       "requires": {
         "bn.js": "^4.11.9",

--- a/src/runtime/executor.ts
+++ b/src/runtime/executor.ts
@@ -49,7 +49,7 @@ export class Executor {
           executionDateTime,
           this.messageListener
         );
-        r.recordPatientResults(patient_ctx, { [expression]: expr.execute(patient_ctx) });
+        r.recordPatientResults(patient_ctx, { [expression]: await expr.execute(patient_ctx) });
         currentPatient = await patientSource.nextPatient();
       }
     }

--- a/test/elm/executor/executor-test.ts
+++ b/test/elm/executor/executor-test.ts
@@ -1,35 +1,126 @@
 import should from 'should';
 import setup from '../../setup';
+import { DataProvider, PatientObject } from '../../../src/types';
+import { DateTime } from '../../../src/datatypes/datetime';
 const data = require('./data');
 
 const { p1, p2 } = require('./patients');
-import { Patient } from '../../../src/cql-patient';
+import { Patient, PatientSource } from '../../../src/cql-patient';
+import { Results } from '../../../src/cql';
+import { nextTick } from 'process';
+
+/**
+ * Wrapper for PatientSource/DataProvider to allow for holding resolving of
+ * calls to the wrapped PatientSource.
+ */
+class AsyncPatientSourceWrap implements DataProvider {
+  private heldResolves: { value: any; resolve: (value: any | PromiseLike<any>) => void }[];
+  constructor(private patientSource: PatientSource) {
+    this.heldResolves = [];
+  }
+
+  currentPatient(): PatientObject | undefined | Promise<PatientObject | undefined> {
+    return new Promise(resolve => {
+      this.heldResolves.push({
+        value: this.patientSource.currentPatient(),
+        resolve: resolve
+      });
+    });
+  }
+
+  nextPatient(): PatientObject | undefined | Promise<PatientObject | undefined> {
+    return new Promise(resolve => {
+      this.heldResolves.push({
+        value: this.patientSource.nextPatient(),
+        resolve: resolve
+      });
+    });
+  }
+
+  get heldResolvesCount(): number {
+    return this.heldResolves.length;
+  }
+
+  /**
+   * Release each resolve that was held. Using nextTick to allow for any cascading
+   * resolved calls to come forward with new calls.
+   */
+  async releaseResolves() {
+    while (this.heldResolves.length > 0) {
+      const heldResolve = this.heldResolves.shift();
+      heldResolve.resolve(heldResolve.value);
+      await new Promise(resolve => {
+        nextTick(resolve);
+      });
+    }
+  }
+}
 
 describe('Age', () => {
   beforeEach(async function () {
     setup(this, data, [p1, p2]);
+  });
+
+  it('should have correct patient results with sync patient source', async function () {
+    const results = await this.executor.withLibrary(this.lib).exec(this.patientSource);
+    should(results.patientResults['1'].Age).equal(32);
+    should(results.patientResults['2'].Age).equal(5);
+  });
+
+  it('should have correct patient results with async patient source', async function () {
+    const asyncPatientSource = new AsyncPatientSourceWrap(this.patientSource);
+    const resultPromise: Promise<Results> = this.executor
+      .withLibrary(this.lib)
+      .exec(asyncPatientSource);
+
+    await asyncPatientSource.releaseResolves();
+    should(asyncPatientSource.heldResolvesCount).equal(0);
+
+    const results = await resultPromise;
+    should(results.patientResults['1'].Age).equal(32);
+    should(results.patientResults['2'].Age).equal(5);
+  });
+
+  it('should have correct patientEvaluatedRecords for each patient', async function () {
     this.results = await this.executor.withLibrary(this.lib).exec(this.patientSource);
-  });
-
-  it('should have correct patient results', function () {
-    should(this.results.patientResults['1'].Age).equal(32);
-    should(this.results.patientResults['2'].Age).equal(5);
-  });
-
-  it('should have correct patientEvaluatedRecords for each patient', function () {
     should(this.results.patientEvaluatedRecords['1']).eql([new Patient(p1)]);
     should(this.results.patientEvaluatedRecords['2']).eql([new Patient(p2)]);
   });
 
-  it('should support older evaluatedRecords array field', function () {
+  it('should support older evaluatedRecords array field', async function () {
+    this.results = await this.executor.withLibrary(this.lib).exec(this.patientSource);
     should(this.results.evaluatedRecords).eql([new Patient(p1), new Patient(p2)]);
   });
 
-  it('should have the correct unfiltered results', function () {
+  it('should have the correct unfiltered results', async function () {
+    this.results = await this.executor.withLibrary(this.lib).exec(this.patientSource);
     should(this.results.unfilteredResults.AgeSum).equal(37);
   });
 
-  it('should be able to reference other unfiltered context expressions', function () {
+  it('should be able to reference other unfiltered context expressions', async function () {
+    this.results = await this.executor.withLibrary(this.lib).exec(this.patientSource);
     this.results.unfilteredResults.AgeSumRef.should.equal(37);
+  });
+
+  it('should have correct patient results when executing a single expression with sync patient source', async function () {
+    const results = await this.executor
+      .withLibrary(this.lib)
+      .exec_expression('Age', this.patientSource, new DateTime(2024, 12, 31));
+    should(results.patientResults['1'].Age).equal(32);
+    should(results.patientResults['2'].Age).equal(5);
+  });
+
+  it('should have correct patient results when executing a single expression with async patient source', async function () {
+    const asyncPatientSource = new AsyncPatientSourceWrap(this.patientSource);
+    const resultPromise: Promise<Results> = this.executor
+      .withLibrary(this.lib)
+      .exec_expression('Age', asyncPatientSource, new DateTime(2024, 12, 31));
+
+    await asyncPatientSource.releaseResolves();
+    should(asyncPatientSource.heldResolvesCount).equal(0);
+
+    const results = await resultPromise;
+    should(results.patientResults['1'].Age).equal(32);
+    should(results.patientResults['2'].Age).equal(5);
   });
 });


### PR DESCRIPTION
Add missing await in Executor exec_expression function. This was not awaiting the result of the expression and recording the Promise instead of the result. Addresses #333.

Additional testing was added to provide some rudimentary testing of an async PatientSource being used by the Executor.

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

**Submitter:**

- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [ ] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name:

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
