### PR TITLE
Duration uncertainty

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -1185,11 +1185,11 @@ class DateTime extends AbstractDate {
         /* eslint-disable @typescript-eslint/no-this-alias */
         let aDateTime = this;
         let bDateTime = other;
-        if (this.second !== null && this.millisecond == null) {
+        if (this.second !== null && this.millisecond == null && unitField !== 'millisecond') {
             aDateTime = this.copy();
             aDateTime.millisecond = 0;
         }
-        if (other.second != null && other.millisecond == null) {
+        if (other.second != null && other.millisecond == null && unitField !== 'millisecond') {
             bDateTime = other.copy();
             bDateTime.millisecond = 0;
         }

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -1185,11 +1185,15 @@ class DateTime extends AbstractDate {
         /* eslint-disable @typescript-eslint/no-this-alias */
         let aDateTime = this;
         let bDateTime = other;
-        if (this.second !== null && this.millisecond == null && unitField !== 'millisecond') {
+        if (this.second !== null &&
+            this.millisecond == null &&
+            unitField !== DateTime.Unit.MILLISECOND) {
             aDateTime = this.copy();
             aDateTime.millisecond = 0;
         }
-        if (other.second != null && other.millisecond == null && unitField !== 'millisecond') {
+        if (other.second != null &&
+            other.millisecond == null &&
+            unitField !== DateTime.Unit.MILLISECOND) {
             bDateTime = other.copy();
             bDateTime.millisecond = 0;
         }

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -1182,13 +1182,14 @@ class DateTime extends AbstractDate {
         // consider seconds and milliseconds as a single combined precision with decimal semantics
         // this means that if milliseconds are not specified, then we treat it as though their
         // millisecond value is "0" so that no Uncertainty will be produced
+        /* eslint-disable @typescript-eslint/no-this-alias */
         let aDateTime = this;
         let bDateTime = other;
-        if (this.millisecond == null) {
+        if (this.second !== null && this.millisecond == null) {
             aDateTime = this.copy();
             aDateTime.millisecond = 0;
         }
-        if (other.millisecond == null) {
+        if (other.second != null && other.millisecond == null) {
             bDateTime = other.copy();
             bDateTime.millisecond = 0;
         }

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -1178,8 +1178,22 @@ class DateTime extends AbstractDate {
         if (other == null || !other.isDateTime) {
             return null;
         }
-        const a = this.toLuxonUncertainty();
-        const b = other.toLuxonUncertainty();
+        // According to the CQL specification, just like date and time comparison calculations,
+        // consider seconds and milliseconds as a single combined precision with decimal semantics
+        // this means that if milliseconds are not specified, then we treat it as though their
+        // millisecond value is "0" so that no Uncertainty will be produced
+        let aDateTime = this;
+        let bDateTime = other;
+        if (this.millisecond == null) {
+            aDateTime = this.copy();
+            aDateTime.millisecond = 0;
+        }
+        if (other.millisecond == null) {
+            bDateTime = other.copy();
+            bDateTime.millisecond = 0;
+        }
+        const a = aDateTime.toLuxonUncertainty();
+        const b = bDateTime.toLuxonUncertainty();
         return new uncertainty_1.Uncertainty(wholeLuxonDuration(b.low.diff(a.high, unitField), unitField), wholeLuxonDuration(b.high.diff(a.low, unitField), unitField));
     }
     isUTC() {
@@ -1610,7 +1624,7 @@ function compareWithDefaultResult(a, b, defaultResult) {
             // For the purposes of comparison, seconds and milliseconds are combined
             // as a single precision using a decimal, with decimal equality semantics
             if (field === 'second') {
-                // NOTE: if millisecond is null it will calcualte like this anyway, but
+                // NOTE: if millisecond is null it will calculate like this anyway, but
                 // if millisecond is undefined, using it will result in NaN calculations
                 const aMillisecond = a['millisecond'] != null ? a['millisecond'] : 0;
                 const aSecondAndMillisecond = a[field] + aMillisecond / 1000;

--- a/src/datatypes/datetime.ts
+++ b/src/datatypes/datetime.ts
@@ -821,11 +821,19 @@ export class DateTime extends AbstractDate {
     /* eslint-disable @typescript-eslint/no-this-alias */
     let aDateTime: DateTime = this;
     let bDateTime: DateTime = other;
-    if (this.second !== null && this.millisecond == null && unitField !== 'millisecond') {
+    if (
+      this.second !== null &&
+      this.millisecond == null &&
+      unitField !== DateTime.Unit.MILLISECOND
+    ) {
       aDateTime = this.copy();
       aDateTime.millisecond = 0;
     }
-    if (other.second != null && other.millisecond == null && unitField !== 'millisecond') {
+    if (
+      other.second != null &&
+      other.millisecond == null &&
+      unitField !== DateTime.Unit.MILLISECOND
+    ) {
       bDateTime = other.copy();
       bDateTime.millisecond = 0;
     }

--- a/src/datatypes/datetime.ts
+++ b/src/datatypes/datetime.ts
@@ -821,11 +821,11 @@ export class DateTime extends AbstractDate {
     /* eslint-disable @typescript-eslint/no-this-alias */
     let aDateTime: DateTime = this;
     let bDateTime: DateTime = other;
-    if (this.second !== null && this.millisecond == null) {
+    if (this.second !== null && this.millisecond == null && unitField !== 'millisecond') {
       aDateTime = this.copy();
       aDateTime.millisecond = 0;
     }
-    if (other.second != null && other.millisecond == null) {
+    if (other.second != null && other.millisecond == null && unitField !== 'millisecond') {
       bDateTime = other.copy();
       bDateTime.millisecond = 0;
     }

--- a/src/datatypes/datetime.ts
+++ b/src/datatypes/datetime.ts
@@ -818,13 +818,14 @@ export class DateTime extends AbstractDate {
     // consider seconds and milliseconds as a single combined precision with decimal semantics
     // this means that if milliseconds are not specified, then we treat it as though their
     // millisecond value is "0" so that no Uncertainty will be produced
+    /* eslint-disable @typescript-eslint/no-this-alias */
     let aDateTime: DateTime = this;
     let bDateTime: DateTime = other;
-    if (this.millisecond == null) {
+    if (this.second !== null && this.millisecond == null) {
       aDateTime = this.copy();
       aDateTime.millisecond = 0;
     }
-    if (other.millisecond == null) {
+    if (other.second != null && other.millisecond == null) {
       bDateTime = other.copy();
       bDateTime.millisecond = 0;
     }

--- a/src/datatypes/datetime.ts
+++ b/src/datatypes/datetime.ts
@@ -814,8 +814,22 @@ export class DateTime extends AbstractDate {
     if (other == null || !other.isDateTime) {
       return null;
     }
-    const a = this.toLuxonUncertainty();
-    const b = other.toLuxonUncertainty();
+    // According to the CQL specification, just like date and time comparison calculations,
+    // consider seconds and milliseconds as a single combined precision with decimal semantics
+    // this means that if milliseconds are not specified, then we treat it as though their
+    // millisecond value is "0" so that no Uncertainty will be produced
+    let aDateTime: DateTime = this;
+    let bDateTime: DateTime = other;
+    if (this.millisecond == null) {
+      aDateTime = this.copy();
+      aDateTime.millisecond = 0;
+    }
+    if (other.millisecond == null) {
+      const bDateTime = other.copy();
+      bDateTime.millisecond = 0;
+    }
+    const a = aDateTime.toLuxonUncertainty();
+    const b = bDateTime.toLuxonUncertainty();
     return new Uncertainty(
       wholeLuxonDuration(b.low.diff(a.high, unitField), unitField),
       wholeLuxonDuration(b.high.diff(a.low, unitField), unitField)
@@ -1274,7 +1288,7 @@ function compareWithDefaultResult(a: any, b: any, defaultResult: any) {
       // For the purposes of comparison, seconds and milliseconds are combined
       // as a single precision using a decimal, with decimal equality semantics
       if (field === 'second') {
-        // NOTE: if millisecond is null it will calcualte like this anyway, but
+        // NOTE: if millisecond is null it will calculate like this anyway, but
         // if millisecond is undefined, using it will result in NaN calculations
         const aMillisecond = a['millisecond'] != null ? a['millisecond'] : 0;
         const aSecondAndMillisecond = a[field] + aMillisecond / 1000;

--- a/src/datatypes/datetime.ts
+++ b/src/datatypes/datetime.ts
@@ -825,7 +825,7 @@ export class DateTime extends AbstractDate {
       aDateTime.millisecond = 0;
     }
     if (other.millisecond == null) {
-      const bDateTime = other.copy();
+      bDateTime = other.copy();
       bDateTime.millisecond = 0;
     }
     const a = aDateTime.toLuxonUncertainty();

--- a/test/elm/datetime/data.cql
+++ b/test/elm/datetime/data.cql
@@ -340,8 +340,8 @@ define HoursBetween1and3CrossingSpringDST: hours between DateTime(2017, 3, 12, 1
 define HoursBetween1and3CrossingFallDST: hours between DateTime(2017, 11, 5, 1, 0, 0, 0, -4.0) and DateTime(2017, 11, 5, 3, 0, 0, 0, -5.0)
 define DurationInDaysWith0MS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 0), DateTime(2026, 11, 13, 13, 41, 38, 0)]
 define DurationInDaysNoMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38), DateTime(2026, 11, 13, 13, 41, 38)]
-define DurationInDaysSameMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 59), DateTime(2026, 11, 13, 13, 41, 59)]
-define DurationInDaysDiffMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 59), DateTime(2026, 11, 13, 13, 41, 58)]
+define DurationInDaysSameMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 59), DateTime(2026, 11, 13, 13, 41, 38, 59)]
+define DurationInDaysDiffMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 59), DateTime(2026, 11, 13, 13, 41, 38, 58)]
 
 // @Test: DateMath
 define June15th2013: DateTime(2013, 6, 15, 0, 0, 0, 0)

--- a/test/elm/datetime/data.cql
+++ b/test/elm/datetime/data.cql
@@ -342,6 +342,7 @@ define DurationInDaysWith0MS: duration in days of Interval[DateTime(2026, 11, 12
 define DurationInDaysNoMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38), DateTime(2026, 11, 13, 13, 41, 38)]
 define DurationInDaysSameMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 59), DateTime(2026, 11, 13, 13, 41, 38, 59)]
 define DurationInDaysDiffMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 59), DateTime(2026, 11, 13, 13, 41, 38, 58)]
+define DurationInMSNoMS: duration in milliseconds of Interval[DateTime(2026, 11, 12, 13, 41, 38), DateTime(2026, 11, 12, 13, 41, 38)]
 
 // @Test: DateMath
 define June15th2013: DateTime(2013, 6, 15, 0, 0, 0, 0)

--- a/test/elm/datetime/data.cql
+++ b/test/elm/datetime/data.cql
@@ -338,6 +338,10 @@ define MillisecondsBetweenUncertainty: milliseconds between JanOne2015 and Janua
 define MillisecondsBetweenReversedUncertainty: milliseconds between January2015 and JanOne2015
 define HoursBetween1and3CrossingSpringDST: hours between DateTime(2017, 3, 12, 1, 0, 0, 0, -5.0) and DateTime(2017, 3, 12, 3, 0, 0, 0, -4.0)
 define HoursBetween1and3CrossingFallDST: hours between DateTime(2017, 11, 5, 1, 0, 0, 0, -4.0) and DateTime(2017, 11, 5, 3, 0, 0, 0, -5.0)
+define DurationInDaysWith0MS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 0), DateTime(2026, 11, 13, 13, 41, 38, 0)]
+define DurationInDaysNoMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38), DateTime(2026, 11, 13, 13, 41, 38)]
+define DurationInDaysSameMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 59), DateTime(2026, 11, 13, 13, 41, 59)]
+define DurationInDaysDiffMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 59), DateTime(2026, 11, 13, 13, 41, 58)]
 
 // @Test: DateMath
 define June15th2013: DateTime(2013, 6, 15, 0, 0, 0, 0)

--- a/test/elm/datetime/data.js
+++ b/test/elm/datetime/data.js
@@ -52150,6 +52150,7 @@ define DurationInDaysWith0MS: duration in days of Interval[DateTime(2026, 11, 12
 define DurationInDaysNoMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38), DateTime(2026, 11, 13, 13, 41, 38)]
 define DurationInDaysSameMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 59), DateTime(2026, 11, 13, 13, 41, 38, 59)]
 define DurationInDaysDiffMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 59), DateTime(2026, 11, 13, 13, 41, 38, 58)]
+define DurationInMSNoMS: duration in milliseconds of Interval[DateTime(2026, 11, 12, 13, 41, 38), DateTime(2026, 11, 12, 13, 41, 38)]
 */
 
 module.exports['DurationBetween'] = {
@@ -52163,7 +52164,7 @@ module.exports['DurationBetween'] = {
       }, {
          "type" : "Annotation",
          "s" : {
-            "r" : "707",
+            "r" : "769",
             "s" : [ {
                "value" : [ "","library TestSnippet version '1'" ]
             } ]
@@ -55796,6 +55797,405 @@ module.exports['DurationBetween'] = {
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "58",
+                           "type" : "Literal"
+                        }
+                     }
+                  }
+               } ]
+            }
+         }, {
+            "localId" : "769",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "name" : "DurationInMSNoMS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "769",
+                  "s" : [ {
+                     "value" : [ "","define ","DurationInMSNoMS",": " ]
+                  }, {
+                     "r" : "821",
+                     "s" : [ {
+                        "value" : [ "duration in milliseconds of " ]
+                     }, {
+                        "r" : "812",
+                        "s" : [ {
+                           "value" : [ "Interval[" ]
+                        }, {
+                           "r" : "784",
+                           "s" : [ {
+                              "r" : "770",
+                              "value" : [ "DateTime","(","2026",", ","11",", ","12",", ","13",", ","41",", ","38",")" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "805",
+                           "s" : [ {
+                              "r" : "791",
+                              "value" : [ "DateTime","(","2026",", ","11",", ","12",", ","13",", ","41",", ","38",")" ]
+                           } ]
+                        }, {
+                           "value" : [ "]" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "821",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+               "precision" : "Millisecond",
+               "type" : "DurationBetween",
+               "signature" : [ {
+                  "localId" : "822",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier"
+               }, {
+                  "localId" : "823",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier"
+               } ],
+               "operand" : [ {
+                  "localId" : "815",
+                  "type" : "Start",
+                  "signature" : [ {
+                     "localId" : "816",
+                     "type" : "IntervalTypeSpecifier",
+                     "pointType" : {
+                        "localId" : "817",
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ],
+                  "operand" : {
+                     "localId" : "812",
+                     "lowClosed" : true,
+                     "highClosed" : true,
+                     "type" : "Interval",
+                     "resultTypeSpecifier" : {
+                        "localId" : "813",
+                        "type" : "IntervalTypeSpecifier",
+                        "pointType" : {
+                           "localId" : "814",
+                           "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     },
+                     "low" : {
+                        "localId" : "784",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "785",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "786",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "787",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "788",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "789",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "790",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "770",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "771",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "772",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "12",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "773",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "774",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "775",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        }
+                     },
+                     "high" : {
+                        "localId" : "805",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "806",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "807",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "808",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "809",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "810",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "811",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "791",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "792",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "793",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "12",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "794",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "795",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "796",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        }
+                     }
+                  }
+               }, {
+                  "localId" : "818",
+                  "type" : "End",
+                  "signature" : [ {
+                     "localId" : "819",
+                     "type" : "IntervalTypeSpecifier",
+                     "pointType" : {
+                        "localId" : "820",
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ],
+                  "operand" : {
+                     "localId" : "812",
+                     "lowClosed" : true,
+                     "highClosed" : true,
+                     "type" : "Interval",
+                     "resultTypeSpecifier" : {
+                        "localId" : "813",
+                        "type" : "IntervalTypeSpecifier",
+                        "pointType" : {
+                           "localId" : "814",
+                           "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     },
+                     "low" : {
+                        "localId" : "784",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "785",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "786",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "787",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "788",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "789",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "790",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "770",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "771",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "772",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "12",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "773",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "774",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "775",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        }
+                     },
+                     "high" : {
+                        "localId" : "805",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "806",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "807",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "808",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "809",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "810",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "811",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "791",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "792",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "793",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "12",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "794",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "795",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "796",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
                            "type" : "Literal"
                         }
                      }

--- a/test/elm/datetime/data.js
+++ b/test/elm/datetime/data.js
@@ -52148,8 +52148,8 @@ define HoursBetween1and3CrossingSpringDST: hours between DateTime(2017, 3, 12, 1
 define HoursBetween1and3CrossingFallDST: hours between DateTime(2017, 11, 5, 1, 0, 0, 0, -4.0) and DateTime(2017, 11, 5, 3, 0, 0, 0, -5.0)
 define DurationInDaysWith0MS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 0), DateTime(2026, 11, 13, 13, 41, 38, 0)]
 define DurationInDaysNoMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38), DateTime(2026, 11, 13, 13, 41, 38)]
-define DurationInDaysSameMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 59), DateTime(2026, 11, 13, 13, 41, 59)]
-define DurationInDaysDiffMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 59), DateTime(2026, 11, 13, 13, 41, 58)]
+define DurationInDaysSameMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 59), DateTime(2026, 11, 13, 13, 41, 38, 59)]
+define DurationInDaysDiffMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 59), DateTime(2026, 11, 13, 13, 41, 38, 58)]
 */
 
 module.exports['DurationBetween'] = {
@@ -52163,7 +52163,7 @@ module.exports['DurationBetween'] = {
       }, {
          "type" : "Annotation",
          "s" : {
-            "r" : "704",
+            "r" : "707",
             "s" : [ {
                "value" : [ "","library TestSnippet version '1'" ]
             } ]
@@ -54929,11 +54929,11 @@ module.exports['DurationBetween'] = {
                   "s" : [ {
                      "value" : [ "","define ","DurationInDaysSameMS",": " ]
                   }, {
-                     "r" : "700",
+                     "r" : "703",
                      "s" : [ {
                         "value" : [ "duration in days of " ]
                      }, {
-                        "r" : "691",
+                        "r" : "694",
                         "s" : [ {
                            "value" : [ "Interval[" ]
                         }, {
@@ -54945,10 +54945,10 @@ module.exports['DurationBetween'] = {
                         }, {
                            "value" : [ ", " ]
                         }, {
-                           "r" : "684",
+                           "r" : "686",
                            "s" : [ {
                               "r" : "670",
-                              "value" : [ "DateTime","(","2026",", ","11",", ","13",", ","13",", ","41",", ","59",")" ]
+                              "value" : [ "DateTime","(","2026",", ","11",", ","13",", ","13",", ","41",", ","38",", ","59",")" ]
                            } ]
                         }, {
                            "value" : [ "]" ]
@@ -54958,204 +54958,22 @@ module.exports['DurationBetween'] = {
                }
             } ],
             "expression" : {
-               "localId" : "700",
+               "localId" : "703",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                "precision" : "Day",
                "type" : "DurationBetween",
                "signature" : [ {
-                  "localId" : "701",
+                  "localId" : "704",
                   "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "type" : "NamedTypeSpecifier"
                }, {
-                  "localId" : "702",
+                  "localId" : "705",
                   "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "694",
-                  "type" : "Start",
-                  "signature" : [ {
-                     "localId" : "695",
-                     "type" : "IntervalTypeSpecifier",
-                     "pointType" : {
-                        "localId" : "696",
-                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  } ],
-                  "operand" : {
-                     "localId" : "691",
-                     "lowClosed" : true,
-                     "highClosed" : true,
-                     "type" : "Interval",
-                     "resultTypeSpecifier" : {
-                        "localId" : "692",
-                        "type" : "IntervalTypeSpecifier",
-                        "pointType" : {
-                           "localId" : "693",
-                           "name" : "{urn:hl7-org:elm-types:r1}DateTime",
-                           "type" : "NamedTypeSpecifier"
-                        }
-                     },
-                     "low" : {
-                        "localId" : "662",
-                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
-                        "type" : "DateTime",
-                        "signature" : [ {
-                           "localId" : "663",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "664",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "665",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "666",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "667",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "668",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "669",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        } ],
-                        "year" : {
-                           "localId" : "646",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "value" : "2026",
-                           "type" : "Literal"
-                        },
-                        "month" : {
-                           "localId" : "647",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "value" : "11",
-                           "type" : "Literal"
-                        },
-                        "day" : {
-                           "localId" : "648",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "value" : "12",
-                           "type" : "Literal"
-                        },
-                        "hour" : {
-                           "localId" : "649",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "value" : "13",
-                           "type" : "Literal"
-                        },
-                        "minute" : {
-                           "localId" : "650",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "value" : "41",
-                           "type" : "Literal"
-                        },
-                        "second" : {
-                           "localId" : "651",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "value" : "38",
-                           "type" : "Literal"
-                        },
-                        "millisecond" : {
-                           "localId" : "652",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "value" : "59",
-                           "type" : "Literal"
-                        }
-                     },
-                     "high" : {
-                        "localId" : "684",
-                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
-                        "type" : "DateTime",
-                        "signature" : [ {
-                           "localId" : "685",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "686",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "687",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "688",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "689",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "690",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        } ],
-                        "year" : {
-                           "localId" : "670",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "value" : "2026",
-                           "type" : "Literal"
-                        },
-                        "month" : {
-                           "localId" : "671",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "value" : "11",
-                           "type" : "Literal"
-                        },
-                        "day" : {
-                           "localId" : "672",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "value" : "13",
-                           "type" : "Literal"
-                        },
-                        "hour" : {
-                           "localId" : "673",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "value" : "13",
-                           "type" : "Literal"
-                        },
-                        "minute" : {
-                           "localId" : "674",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "value" : "41",
-                           "type" : "Literal"
-                        },
-                        "second" : {
-                           "localId" : "675",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "value" : "59",
-                           "type" : "Literal"
-                        }
-                     }
-                  }
-               }, {
                   "localId" : "697",
-                  "type" : "End",
+                  "type" : "Start",
                   "signature" : [ {
                      "localId" : "698",
                      "type" : "IntervalTypeSpecifier",
@@ -55166,15 +54984,15 @@ module.exports['DurationBetween'] = {
                      }
                   } ],
                   "operand" : {
-                     "localId" : "691",
+                     "localId" : "694",
                      "lowClosed" : true,
                      "highClosed" : true,
                      "type" : "Interval",
                      "resultTypeSpecifier" : {
-                        "localId" : "692",
+                        "localId" : "695",
                         "type" : "IntervalTypeSpecifier",
                         "pointType" : {
-                           "localId" : "693",
+                           "localId" : "696",
                            "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                            "type" : "NamedTypeSpecifier"
                         }
@@ -55263,18 +55081,10 @@ module.exports['DurationBetween'] = {
                         }
                      },
                      "high" : {
-                        "localId" : "684",
+                        "localId" : "686",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "DateTime",
                         "signature" : [ {
-                           "localId" : "685",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "686",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
                            "localId" : "687",
                            "name" : "{urn:hl7-org:elm-types:r1}Integer",
                            "type" : "NamedTypeSpecifier"
@@ -55288,6 +55098,18 @@ module.exports['DurationBetween'] = {
                            "type" : "NamedTypeSpecifier"
                         }, {
                            "localId" : "690",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "691",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "692",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "693",
                            "name" : "{urn:hl7-org:elm-types:r1}Integer",
                            "type" : "NamedTypeSpecifier"
                         } ],
@@ -55330,6 +55152,206 @@ module.exports['DurationBetween'] = {
                            "localId" : "675",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        },
+                        "millisecond" : {
+                           "localId" : "676",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "59",
+                           "type" : "Literal"
+                        }
+                     }
+                  }
+               }, {
+                  "localId" : "700",
+                  "type" : "End",
+                  "signature" : [ {
+                     "localId" : "701",
+                     "type" : "IntervalTypeSpecifier",
+                     "pointType" : {
+                        "localId" : "702",
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ],
+                  "operand" : {
+                     "localId" : "694",
+                     "lowClosed" : true,
+                     "highClosed" : true,
+                     "type" : "Interval",
+                     "resultTypeSpecifier" : {
+                        "localId" : "695",
+                        "type" : "IntervalTypeSpecifier",
+                        "pointType" : {
+                           "localId" : "696",
+                           "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     },
+                     "low" : {
+                        "localId" : "662",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "663",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "664",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "665",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "666",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "667",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "668",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "669",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "646",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "647",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "648",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "12",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "649",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "650",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "651",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        },
+                        "millisecond" : {
+                           "localId" : "652",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "59",
+                           "type" : "Literal"
+                        }
+                     },
+                     "high" : {
+                        "localId" : "686",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "687",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "688",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "689",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "690",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "691",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "692",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "693",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "670",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "671",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "672",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "673",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "674",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "675",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        },
+                        "millisecond" : {
+                           "localId" : "676",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "59",
                            "type" : "Literal"
                         }
@@ -55338,7 +55360,7 @@ module.exports['DurationBetween'] = {
                } ]
             }
          }, {
-            "localId" : "704",
+            "localId" : "707",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
             "name" : "DurationInDaysDiffMS",
             "context" : "Patient",
@@ -55346,30 +55368,30 @@ module.exports['DurationBetween'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "704",
+                  "r" : "707",
                   "s" : [ {
                      "value" : [ "","define ","DurationInDaysDiffMS",": " ]
                   }, {
-                     "r" : "759",
+                     "r" : "765",
                      "s" : [ {
                         "value" : [ "duration in days of " ]
                      }, {
-                        "r" : "750",
+                        "r" : "756",
                         "s" : [ {
                            "value" : [ "Interval[" ]
                         }, {
-                           "r" : "721",
+                           "r" : "724",
                            "s" : [ {
-                              "r" : "705",
+                              "r" : "708",
                               "value" : [ "DateTime","(","2026",", ","11",", ","12",", ","13",", ","41",", ","38",", ","59",")" ]
                            } ]
                         }, {
                            "value" : [ ", " ]
                         }, {
-                           "r" : "743",
+                           "r" : "748",
                            "s" : [ {
-                              "r" : "729",
-                              "value" : [ "DateTime","(","2026",", ","11",", ","13",", ","13",", ","41",", ","58",")" ]
+                              "r" : "732",
+                              "value" : [ "DateTime","(","2026",", ","11",", ","13",", ","13",", ","41",", ","38",", ","58",")" ]
                            } ]
                         }, {
                            "value" : [ "]" ]
@@ -55379,62 +55401,50 @@ module.exports['DurationBetween'] = {
                }
             } ],
             "expression" : {
-               "localId" : "759",
+               "localId" : "765",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                "precision" : "Day",
                "type" : "DurationBetween",
                "signature" : [ {
-                  "localId" : "760",
+                  "localId" : "766",
                   "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "type" : "NamedTypeSpecifier"
                }, {
-                  "localId" : "761",
+                  "localId" : "767",
                   "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "753",
+                  "localId" : "759",
                   "type" : "Start",
                   "signature" : [ {
-                     "localId" : "754",
+                     "localId" : "760",
                      "type" : "IntervalTypeSpecifier",
                      "pointType" : {
-                        "localId" : "755",
+                        "localId" : "761",
                         "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "NamedTypeSpecifier"
                      }
                   } ],
                   "operand" : {
-                     "localId" : "750",
+                     "localId" : "756",
                      "lowClosed" : true,
                      "highClosed" : true,
                      "type" : "Interval",
                      "resultTypeSpecifier" : {
-                        "localId" : "751",
+                        "localId" : "757",
                         "type" : "IntervalTypeSpecifier",
                         "pointType" : {
-                           "localId" : "752",
+                           "localId" : "758",
                            "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                            "type" : "NamedTypeSpecifier"
                         }
                      },
                      "low" : {
-                        "localId" : "721",
+                        "localId" : "724",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "DateTime",
                         "signature" : [ {
-                           "localId" : "722",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "723",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "724",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
                            "localId" : "725",
                            "name" : "{urn:hl7-org:elm-types:r1}Integer",
                            "type" : "NamedTypeSpecifier"
@@ -55450,51 +55460,63 @@ module.exports['DurationBetween'] = {
                            "localId" : "728",
                            "name" : "{urn:hl7-org:elm-types:r1}Integer",
                            "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "729",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "730",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "731",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
                         } ],
                         "year" : {
-                           "localId" : "705",
+                           "localId" : "708",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "2026",
                            "type" : "Literal"
                         },
                         "month" : {
-                           "localId" : "706",
+                           "localId" : "709",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "11",
                            "type" : "Literal"
                         },
                         "day" : {
-                           "localId" : "707",
+                           "localId" : "710",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "12",
                            "type" : "Literal"
                         },
                         "hour" : {
-                           "localId" : "708",
+                           "localId" : "711",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "13",
                            "type" : "Literal"
                         },
                         "minute" : {
-                           "localId" : "709",
+                           "localId" : "712",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "41",
                            "type" : "Literal"
                         },
                         "second" : {
-                           "localId" : "710",
+                           "localId" : "713",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "38",
                            "type" : "Literal"
                         },
                         "millisecond" : {
-                           "localId" : "711",
+                           "localId" : "714",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "59",
@@ -55502,71 +55524,82 @@ module.exports['DurationBetween'] = {
                         }
                      },
                      "high" : {
-                        "localId" : "743",
+                        "localId" : "748",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "DateTime",
                         "signature" : [ {
-                           "localId" : "744",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "745",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "746",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "747",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "748",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
                            "localId" : "749",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "750",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "751",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "752",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "753",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "754",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "755",
                            "name" : "{urn:hl7-org:elm-types:r1}Integer",
                            "type" : "NamedTypeSpecifier"
                         } ],
                         "year" : {
-                           "localId" : "729",
+                           "localId" : "732",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "2026",
                            "type" : "Literal"
                         },
                         "month" : {
-                           "localId" : "730",
+                           "localId" : "733",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "11",
                            "type" : "Literal"
                         },
                         "day" : {
-                           "localId" : "731",
+                           "localId" : "734",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "13",
                            "type" : "Literal"
                         },
                         "hour" : {
-                           "localId" : "732",
+                           "localId" : "735",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "13",
                            "type" : "Literal"
                         },
                         "minute" : {
-                           "localId" : "733",
+                           "localId" : "736",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "41",
                            "type" : "Literal"
                         },
                         "second" : {
-                           "localId" : "734",
+                           "localId" : "737",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        },
+                        "millisecond" : {
+                           "localId" : "738",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "58",
@@ -55575,48 +55608,36 @@ module.exports['DurationBetween'] = {
                      }
                   }
                }, {
-                  "localId" : "756",
+                  "localId" : "762",
                   "type" : "End",
                   "signature" : [ {
-                     "localId" : "757",
+                     "localId" : "763",
                      "type" : "IntervalTypeSpecifier",
                      "pointType" : {
-                        "localId" : "758",
+                        "localId" : "764",
                         "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "NamedTypeSpecifier"
                      }
                   } ],
                   "operand" : {
-                     "localId" : "750",
+                     "localId" : "756",
                      "lowClosed" : true,
                      "highClosed" : true,
                      "type" : "Interval",
                      "resultTypeSpecifier" : {
-                        "localId" : "751",
+                        "localId" : "757",
                         "type" : "IntervalTypeSpecifier",
                         "pointType" : {
-                           "localId" : "752",
+                           "localId" : "758",
                            "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                            "type" : "NamedTypeSpecifier"
                         }
                      },
                      "low" : {
-                        "localId" : "721",
+                        "localId" : "724",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "DateTime",
                         "signature" : [ {
-                           "localId" : "722",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "723",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "724",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
                            "localId" : "725",
                            "name" : "{urn:hl7-org:elm-types:r1}Integer",
                            "type" : "NamedTypeSpecifier"
@@ -55632,51 +55653,63 @@ module.exports['DurationBetween'] = {
                            "localId" : "728",
                            "name" : "{urn:hl7-org:elm-types:r1}Integer",
                            "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "729",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "730",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "731",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
                         } ],
                         "year" : {
-                           "localId" : "705",
+                           "localId" : "708",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "2026",
                            "type" : "Literal"
                         },
                         "month" : {
-                           "localId" : "706",
+                           "localId" : "709",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "11",
                            "type" : "Literal"
                         },
                         "day" : {
-                           "localId" : "707",
+                           "localId" : "710",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "12",
                            "type" : "Literal"
                         },
                         "hour" : {
-                           "localId" : "708",
+                           "localId" : "711",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "13",
                            "type" : "Literal"
                         },
                         "minute" : {
-                           "localId" : "709",
+                           "localId" : "712",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "41",
                            "type" : "Literal"
                         },
                         "second" : {
-                           "localId" : "710",
+                           "localId" : "713",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "38",
                            "type" : "Literal"
                         },
                         "millisecond" : {
-                           "localId" : "711",
+                           "localId" : "714",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "59",
@@ -55684,71 +55717,82 @@ module.exports['DurationBetween'] = {
                         }
                      },
                      "high" : {
-                        "localId" : "743",
+                        "localId" : "748",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "DateTime",
                         "signature" : [ {
-                           "localId" : "744",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "745",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "746",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "747",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
-                           "localId" : "748",
-                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "type" : "NamedTypeSpecifier"
-                        }, {
                            "localId" : "749",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "750",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "751",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "752",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "753",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "754",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "755",
                            "name" : "{urn:hl7-org:elm-types:r1}Integer",
                            "type" : "NamedTypeSpecifier"
                         } ],
                         "year" : {
-                           "localId" : "729",
+                           "localId" : "732",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "2026",
                            "type" : "Literal"
                         },
                         "month" : {
-                           "localId" : "730",
+                           "localId" : "733",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "11",
                            "type" : "Literal"
                         },
                         "day" : {
-                           "localId" : "731",
+                           "localId" : "734",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "13",
                            "type" : "Literal"
                         },
                         "hour" : {
-                           "localId" : "732",
+                           "localId" : "735",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "13",
                            "type" : "Literal"
                         },
                         "minute" : {
-                           "localId" : "733",
+                           "localId" : "736",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "41",
                            "type" : "Literal"
                         },
                         "second" : {
-                           "localId" : "734",
+                           "localId" : "737",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        },
+                        "millisecond" : {
+                           "localId" : "738",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "58",

--- a/test/elm/datetime/data.js
+++ b/test/elm/datetime/data.js
@@ -52146,6 +52146,10 @@ define MillisecondsBetweenUncertainty: milliseconds between JanOne2015 and Janua
 define MillisecondsBetweenReversedUncertainty: milliseconds between January2015 and JanOne2015
 define HoursBetween1and3CrossingSpringDST: hours between DateTime(2017, 3, 12, 1, 0, 0, 0, -5.0) and DateTime(2017, 3, 12, 3, 0, 0, 0, -4.0)
 define HoursBetween1and3CrossingFallDST: hours between DateTime(2017, 11, 5, 1, 0, 0, 0, -4.0) and DateTime(2017, 11, 5, 3, 0, 0, 0, -5.0)
+define DurationInDaysWith0MS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 0), DateTime(2026, 11, 13, 13, 41, 38, 0)]
+define DurationInDaysNoMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38), DateTime(2026, 11, 13, 13, 41, 38)]
+define DurationInDaysSameMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 59), DateTime(2026, 11, 13, 13, 41, 59)]
+define DurationInDaysDiffMS: duration in days of Interval[DateTime(2026, 11, 12, 13, 41, 38, 59), DateTime(2026, 11, 13, 13, 41, 58)]
 */
 
 module.exports['DurationBetween'] = {
@@ -52159,7 +52163,7 @@ module.exports['DurationBetween'] = {
       }, {
          "type" : "Annotation",
          "s" : {
-            "r" : "464",
+            "r" : "704",
             "s" : [ {
                "value" : [ "","library TestSnippet version '1'" ]
             } ]
@@ -54066,6 +54070,1690 @@ module.exports['DurationBetween'] = {
                         "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
                         "value" : "5.0",
                         "type" : "Literal"
+                     }
+                  }
+               } ]
+            }
+         }, {
+            "localId" : "527",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "name" : "DurationInDaysWith0MS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "527",
+                  "s" : [ {
+                     "value" : [ "","define ","DurationInDaysWith0MS",": " ]
+                  }, {
+                     "r" : "585",
+                     "s" : [ {
+                        "value" : [ "duration in days of " ]
+                     }, {
+                        "r" : "576",
+                        "s" : [ {
+                           "value" : [ "Interval[" ]
+                        }, {
+                           "r" : "544",
+                           "s" : [ {
+                              "r" : "528",
+                              "value" : [ "DateTime","(","2026",", ","11",", ","12",", ","13",", ","41",", ","38",", ","0",")" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "568",
+                           "s" : [ {
+                              "r" : "552",
+                              "value" : [ "DateTime","(","2026",", ","11",", ","13",", ","13",", ","41",", ","38",", ","0",")" ]
+                           } ]
+                        }, {
+                           "value" : [ "]" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "585",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+               "precision" : "Day",
+               "type" : "DurationBetween",
+               "signature" : [ {
+                  "localId" : "586",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier"
+               }, {
+                  "localId" : "587",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier"
+               } ],
+               "operand" : [ {
+                  "localId" : "579",
+                  "type" : "Start",
+                  "signature" : [ {
+                     "localId" : "580",
+                     "type" : "IntervalTypeSpecifier",
+                     "pointType" : {
+                        "localId" : "581",
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ],
+                  "operand" : {
+                     "localId" : "576",
+                     "lowClosed" : true,
+                     "highClosed" : true,
+                     "type" : "Interval",
+                     "resultTypeSpecifier" : {
+                        "localId" : "577",
+                        "type" : "IntervalTypeSpecifier",
+                        "pointType" : {
+                           "localId" : "578",
+                           "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     },
+                     "low" : {
+                        "localId" : "544",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "545",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "546",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "547",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "548",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "549",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "550",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "551",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "528",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "529",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "530",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "12",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "531",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "532",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "533",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        },
+                        "millisecond" : {
+                           "localId" : "534",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "0",
+                           "type" : "Literal"
+                        }
+                     },
+                     "high" : {
+                        "localId" : "568",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "569",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "570",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "571",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "572",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "573",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "574",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "575",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "552",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "553",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "554",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "555",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "556",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "557",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        },
+                        "millisecond" : {
+                           "localId" : "558",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "0",
+                           "type" : "Literal"
+                        }
+                     }
+                  }
+               }, {
+                  "localId" : "582",
+                  "type" : "End",
+                  "signature" : [ {
+                     "localId" : "583",
+                     "type" : "IntervalTypeSpecifier",
+                     "pointType" : {
+                        "localId" : "584",
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ],
+                  "operand" : {
+                     "localId" : "576",
+                     "lowClosed" : true,
+                     "highClosed" : true,
+                     "type" : "Interval",
+                     "resultTypeSpecifier" : {
+                        "localId" : "577",
+                        "type" : "IntervalTypeSpecifier",
+                        "pointType" : {
+                           "localId" : "578",
+                           "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     },
+                     "low" : {
+                        "localId" : "544",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "545",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "546",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "547",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "548",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "549",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "550",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "551",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "528",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "529",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "530",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "12",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "531",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "532",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "533",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        },
+                        "millisecond" : {
+                           "localId" : "534",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "0",
+                           "type" : "Literal"
+                        }
+                     },
+                     "high" : {
+                        "localId" : "568",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "569",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "570",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "571",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "572",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "573",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "574",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "575",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "552",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "553",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "554",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "555",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "556",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "557",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        },
+                        "millisecond" : {
+                           "localId" : "558",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "0",
+                           "type" : "Literal"
+                        }
+                     }
+                  }
+               } ]
+            }
+         }, {
+            "localId" : "589",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "name" : "DurationInDaysNoMS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "589",
+                  "s" : [ {
+                     "value" : [ "","define ","DurationInDaysNoMS",": " ]
+                  }, {
+                     "r" : "641",
+                     "s" : [ {
+                        "value" : [ "duration in days of " ]
+                     }, {
+                        "r" : "632",
+                        "s" : [ {
+                           "value" : [ "Interval[" ]
+                        }, {
+                           "r" : "604",
+                           "s" : [ {
+                              "r" : "590",
+                              "value" : [ "DateTime","(","2026",", ","11",", ","12",", ","13",", ","41",", ","38",")" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "625",
+                           "s" : [ {
+                              "r" : "611",
+                              "value" : [ "DateTime","(","2026",", ","11",", ","13",", ","13",", ","41",", ","38",")" ]
+                           } ]
+                        }, {
+                           "value" : [ "]" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "641",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+               "precision" : "Day",
+               "type" : "DurationBetween",
+               "signature" : [ {
+                  "localId" : "642",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier"
+               }, {
+                  "localId" : "643",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier"
+               } ],
+               "operand" : [ {
+                  "localId" : "635",
+                  "type" : "Start",
+                  "signature" : [ {
+                     "localId" : "636",
+                     "type" : "IntervalTypeSpecifier",
+                     "pointType" : {
+                        "localId" : "637",
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ],
+                  "operand" : {
+                     "localId" : "632",
+                     "lowClosed" : true,
+                     "highClosed" : true,
+                     "type" : "Interval",
+                     "resultTypeSpecifier" : {
+                        "localId" : "633",
+                        "type" : "IntervalTypeSpecifier",
+                        "pointType" : {
+                           "localId" : "634",
+                           "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     },
+                     "low" : {
+                        "localId" : "604",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "605",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "606",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "607",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "608",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "609",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "610",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "590",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "591",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "592",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "12",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "593",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "594",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "595",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        }
+                     },
+                     "high" : {
+                        "localId" : "625",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "626",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "627",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "628",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "629",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "630",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "631",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "611",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "612",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "613",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "614",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "615",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "616",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        }
+                     }
+                  }
+               }, {
+                  "localId" : "638",
+                  "type" : "End",
+                  "signature" : [ {
+                     "localId" : "639",
+                     "type" : "IntervalTypeSpecifier",
+                     "pointType" : {
+                        "localId" : "640",
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ],
+                  "operand" : {
+                     "localId" : "632",
+                     "lowClosed" : true,
+                     "highClosed" : true,
+                     "type" : "Interval",
+                     "resultTypeSpecifier" : {
+                        "localId" : "633",
+                        "type" : "IntervalTypeSpecifier",
+                        "pointType" : {
+                           "localId" : "634",
+                           "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     },
+                     "low" : {
+                        "localId" : "604",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "605",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "606",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "607",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "608",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "609",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "610",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "590",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "591",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "592",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "12",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "593",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "594",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "595",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        }
+                     },
+                     "high" : {
+                        "localId" : "625",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "626",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "627",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "628",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "629",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "630",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "631",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "611",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "612",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "613",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "614",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "615",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "616",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        }
+                     }
+                  }
+               } ]
+            }
+         }, {
+            "localId" : "645",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "name" : "DurationInDaysSameMS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "645",
+                  "s" : [ {
+                     "value" : [ "","define ","DurationInDaysSameMS",": " ]
+                  }, {
+                     "r" : "700",
+                     "s" : [ {
+                        "value" : [ "duration in days of " ]
+                     }, {
+                        "r" : "691",
+                        "s" : [ {
+                           "value" : [ "Interval[" ]
+                        }, {
+                           "r" : "662",
+                           "s" : [ {
+                              "r" : "646",
+                              "value" : [ "DateTime","(","2026",", ","11",", ","12",", ","13",", ","41",", ","38",", ","59",")" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "684",
+                           "s" : [ {
+                              "r" : "670",
+                              "value" : [ "DateTime","(","2026",", ","11",", ","13",", ","13",", ","41",", ","59",")" ]
+                           } ]
+                        }, {
+                           "value" : [ "]" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "700",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+               "precision" : "Day",
+               "type" : "DurationBetween",
+               "signature" : [ {
+                  "localId" : "701",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier"
+               }, {
+                  "localId" : "702",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier"
+               } ],
+               "operand" : [ {
+                  "localId" : "694",
+                  "type" : "Start",
+                  "signature" : [ {
+                     "localId" : "695",
+                     "type" : "IntervalTypeSpecifier",
+                     "pointType" : {
+                        "localId" : "696",
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ],
+                  "operand" : {
+                     "localId" : "691",
+                     "lowClosed" : true,
+                     "highClosed" : true,
+                     "type" : "Interval",
+                     "resultTypeSpecifier" : {
+                        "localId" : "692",
+                        "type" : "IntervalTypeSpecifier",
+                        "pointType" : {
+                           "localId" : "693",
+                           "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     },
+                     "low" : {
+                        "localId" : "662",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "663",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "664",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "665",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "666",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "667",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "668",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "669",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "646",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "647",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "648",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "12",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "649",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "650",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "651",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        },
+                        "millisecond" : {
+                           "localId" : "652",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "59",
+                           "type" : "Literal"
+                        }
+                     },
+                     "high" : {
+                        "localId" : "684",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "685",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "686",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "687",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "688",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "689",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "690",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "670",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "671",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "672",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "673",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "674",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "675",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "59",
+                           "type" : "Literal"
+                        }
+                     }
+                  }
+               }, {
+                  "localId" : "697",
+                  "type" : "End",
+                  "signature" : [ {
+                     "localId" : "698",
+                     "type" : "IntervalTypeSpecifier",
+                     "pointType" : {
+                        "localId" : "699",
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ],
+                  "operand" : {
+                     "localId" : "691",
+                     "lowClosed" : true,
+                     "highClosed" : true,
+                     "type" : "Interval",
+                     "resultTypeSpecifier" : {
+                        "localId" : "692",
+                        "type" : "IntervalTypeSpecifier",
+                        "pointType" : {
+                           "localId" : "693",
+                           "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     },
+                     "low" : {
+                        "localId" : "662",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "663",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "664",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "665",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "666",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "667",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "668",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "669",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "646",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "647",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "648",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "12",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "649",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "650",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "651",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        },
+                        "millisecond" : {
+                           "localId" : "652",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "59",
+                           "type" : "Literal"
+                        }
+                     },
+                     "high" : {
+                        "localId" : "684",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "685",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "686",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "687",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "688",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "689",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "690",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "670",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "671",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "672",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "673",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "674",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "675",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "59",
+                           "type" : "Literal"
+                        }
+                     }
+                  }
+               } ]
+            }
+         }, {
+            "localId" : "704",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "name" : "DurationInDaysDiffMS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "704",
+                  "s" : [ {
+                     "value" : [ "","define ","DurationInDaysDiffMS",": " ]
+                  }, {
+                     "r" : "759",
+                     "s" : [ {
+                        "value" : [ "duration in days of " ]
+                     }, {
+                        "r" : "750",
+                        "s" : [ {
+                           "value" : [ "Interval[" ]
+                        }, {
+                           "r" : "721",
+                           "s" : [ {
+                              "r" : "705",
+                              "value" : [ "DateTime","(","2026",", ","11",", ","12",", ","13",", ","41",", ","38",", ","59",")" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "743",
+                           "s" : [ {
+                              "r" : "729",
+                              "value" : [ "DateTime","(","2026",", ","11",", ","13",", ","13",", ","41",", ","58",")" ]
+                           } ]
+                        }, {
+                           "value" : [ "]" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "759",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+               "precision" : "Day",
+               "type" : "DurationBetween",
+               "signature" : [ {
+                  "localId" : "760",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier"
+               }, {
+                  "localId" : "761",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier"
+               } ],
+               "operand" : [ {
+                  "localId" : "753",
+                  "type" : "Start",
+                  "signature" : [ {
+                     "localId" : "754",
+                     "type" : "IntervalTypeSpecifier",
+                     "pointType" : {
+                        "localId" : "755",
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ],
+                  "operand" : {
+                     "localId" : "750",
+                     "lowClosed" : true,
+                     "highClosed" : true,
+                     "type" : "Interval",
+                     "resultTypeSpecifier" : {
+                        "localId" : "751",
+                        "type" : "IntervalTypeSpecifier",
+                        "pointType" : {
+                           "localId" : "752",
+                           "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     },
+                     "low" : {
+                        "localId" : "721",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "722",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "723",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "724",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "725",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "726",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "727",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "728",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "705",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "706",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "707",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "12",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "708",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "709",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "710",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        },
+                        "millisecond" : {
+                           "localId" : "711",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "59",
+                           "type" : "Literal"
+                        }
+                     },
+                     "high" : {
+                        "localId" : "743",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "744",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "745",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "746",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "747",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "748",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "749",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "729",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "730",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "731",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "732",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "733",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "734",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "58",
+                           "type" : "Literal"
+                        }
+                     }
+                  }
+               }, {
+                  "localId" : "756",
+                  "type" : "End",
+                  "signature" : [ {
+                     "localId" : "757",
+                     "type" : "IntervalTypeSpecifier",
+                     "pointType" : {
+                        "localId" : "758",
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ],
+                  "operand" : {
+                     "localId" : "750",
+                     "lowClosed" : true,
+                     "highClosed" : true,
+                     "type" : "Interval",
+                     "resultTypeSpecifier" : {
+                        "localId" : "751",
+                        "type" : "IntervalTypeSpecifier",
+                        "pointType" : {
+                           "localId" : "752",
+                           "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     },
+                     "low" : {
+                        "localId" : "721",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "722",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "723",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "724",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "725",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "726",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "727",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "728",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "705",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "706",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "707",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "12",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "708",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "709",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "710",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "38",
+                           "type" : "Literal"
+                        },
+                        "millisecond" : {
+                           "localId" : "711",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "59",
+                           "type" : "Literal"
+                        }
+                     },
+                     "high" : {
+                        "localId" : "743",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "DateTime",
+                        "signature" : [ {
+                           "localId" : "744",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "745",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "746",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "747",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "748",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        }, {
+                           "localId" : "749",
+                           "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "type" : "NamedTypeSpecifier"
+                        } ],
+                        "year" : {
+                           "localId" : "729",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "2026",
+                           "type" : "Literal"
+                        },
+                        "month" : {
+                           "localId" : "730",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "11",
+                           "type" : "Literal"
+                        },
+                        "day" : {
+                           "localId" : "731",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "hour" : {
+                           "localId" : "732",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "13",
+                           "type" : "Literal"
+                        },
+                        "minute" : {
+                           "localId" : "733",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "41",
+                           "type" : "Literal"
+                        },
+                        "second" : {
+                           "localId" : "734",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "58",
+                           "type" : "Literal"
+                        }
                      }
                   }
                } ]

--- a/test/elm/datetime/datetime-test.ts
+++ b/test/elm/datetime/datetime-test.ts
@@ -1064,6 +1064,22 @@ describe('DurationBetween', () => {
   it('should properly execute hours between when springing ahead for DST', async function () {
     (await this.hoursBetween1and3CrossingFallDST.exec(this.ctx)).should.equal(3);
   });
+
+  it('should not return an uncertainty when the DateTimes have 0 ms', async function () {
+    (await this.durationInDaysWith0MS.exec(this.ctx)).should.equal(1);
+  });
+
+  it('should not return an uncertainty when the DateTimes do not specify ms', async function () {
+    (await this.durationInDaysNoMS.exec(this.ctx)).should.equal(1);
+  });
+
+  it('should not return an uncertainty when the DateTimes have the same nonzero ms', async function () {
+    (await this.durationInDaysSameMS.exec(this.ctx)).should.equal(1);
+  });
+
+  it('should not return an uncertainty when the DateTimes have different nonzero ms', async function () {
+    (await this.durationInDaysDiffMS.exec(this.ctx)).should.equal(1);
+  });
 });
 
 describe('DateMath', () => {

--- a/test/elm/datetime/datetime-test.ts
+++ b/test/elm/datetime/datetime-test.ts
@@ -1078,7 +1078,7 @@ describe('DurationBetween', () => {
   });
 
   it('should not return an uncertainty when the DateTimes have different nonzero ms', async function () {
-    (await this.durationInDaysDiffMS.exec(this.ctx)).should.equal(1);
+    (await this.durationInDaysDiffMS.exec(this.ctx)).should.equal(0);
   });
 });
 

--- a/test/elm/datetime/datetime-test.ts
+++ b/test/elm/datetime/datetime-test.ts
@@ -1080,6 +1080,10 @@ describe('DurationBetween', () => {
   it('should not return an uncertainty when the DateTimes have different nonzero ms', async function () {
     (await this.durationInDaysDiffMS.exec(this.ctx)).should.equal(0);
   });
+
+  it('should return an uncertainty when the DateTimes do not specify ms but the duration unitField is is ms', async function () {
+    (await this.durationInMSNoMS.exec(this.ctx)).should.eql(new Uncertainty(-999, 999));
+  });
 });
 
 describe('DateMath', () => {


### PR DESCRIPTION
## Summary
This PR updates the functionality of `durationBetween` calculations in order to match the latest descriptions in the CQL Logical Specification described [here](https://cql.hl7.org/05-languagesemantics.html#determining-difference-and-duration). This PR also fixes #325. 

According to the CQL Logical Specification, "Note that uncertainty calculations, just like date and time comparison calculations, consider seconds and milliseconds as a single combined precision with decimal semantics". This means that the duration between calculation should **NOT** produce an Uncertainty in both cases: when ms are defined and when ms are not defined.

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

**Submitter:**

- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name:

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

## Additional Testing Guidance
- Recommend testing the measure bundle and two test cases provided in #325 with fqm-execution with this branch of cql-execution linked 