### PR TITLE
Handle valuesets passed into functions

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -3792,13 +3792,15 @@ class AnyInValueSet extends expression_1.Expression {
     constructor(json) {
         super(json);
         this.codes = (0, builder_1.build)(json.codes);
-        this.valueset = new ValueSetRef(json.valueset);
+        this.valueset = json.valueset
+            ? new ValueSetRef(json.valueset)
+            : (0, builder_1.build)(json.valuesetExpression);
     }
     async exec(ctx) {
         const valueset = await this.valueset.execute(ctx);
         // If the value set reference cannot be resolved, a run-time error is thrown.
         if (valueset == null || !valueset.isValueSet) {
-            throw new Error('ValueSet must be provided to InValueSet function');
+            throw new Error('ValueSet must be provided to AnyInValueSet expression');
         }
         const codes = await this.codes.execute(ctx);
         return codes != null && codes.some((code) => valueset.hasMatch(code));
@@ -3809,7 +3811,9 @@ class InValueSet extends expression_1.Expression {
     constructor(json) {
         super(json);
         this.code = (0, builder_1.build)(json.code);
-        this.valueset = new ValueSetRef(json.valueset);
+        this.valueset = json.valueset
+            ? new ValueSetRef(json.valueset)
+            : (0, builder_1.build)(json.valuesetExpression);
     }
     async exec(ctx) {
         // If the code argument is null, the result is false
@@ -3817,7 +3821,7 @@ class InValueSet extends expression_1.Expression {
             return false;
         }
         if (this.valueset == null) {
-            throw new Error('ValueSet must be provided to InValueSet function');
+            throw new Error('ValueSet must be provided to InValueSet expression');
         }
         const code = await this.code.execute(ctx);
         // spec indicates to return false if code is null, throw error if value set cannot be resolved
@@ -3826,7 +3830,7 @@ class InValueSet extends expression_1.Expression {
         }
         const valueset = await this.valueset.execute(ctx);
         if (valueset == null || !valueset.isValueSet) {
-            throw new Error('ValueSet must be provided to InValueSet function');
+            throw new Error('ValueSet must be provided to InValueSet expression');
         }
         // If there is a code and valueset return whether or not the valueset has the code
         return valueset.hasMatch(code);
@@ -3836,7 +3840,7 @@ exports.InValueSet = InValueSet;
 class ExpandValueSet extends expression_1.Expression {
     constructor(json) {
         super(json);
-        this.valueset = new ValueSetRef(json.operand);
+        this.valueset = (0, builder_1.build)(json.operand);
     }
     async exec(ctx) {
         const valueset = await this.valueset.execute(ctx);

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -3797,13 +3797,16 @@ class AnyInValueSet extends expression_1.Expression {
             : (0, builder_1.build)(json.valuesetExpression);
     }
     async exec(ctx) {
+        const codes = await this.codes.execute(ctx);
+        // spec indicates to return false if code is null, throw error if value set cannot be resolved
+        if (codes == null) {
+            return false;
+        }
         const valueset = await this.valueset.execute(ctx);
-        // If the value set reference cannot be resolved, a run-time error is thrown.
         if (valueset == null || !valueset.isValueSet) {
             throw new Error('ValueSet must be provided to AnyInValueSet expression');
         }
-        const codes = await this.codes.execute(ctx);
-        return codes != null && codes.some((code) => valueset.hasMatch(code));
+        return codes.some((code) => valueset.hasMatch(code));
     }
 }
 exports.AnyInValueSet = AnyInValueSet;
@@ -3816,13 +3819,6 @@ class InValueSet extends expression_1.Expression {
             : (0, builder_1.build)(json.valuesetExpression);
     }
     async exec(ctx) {
-        // If the code argument is null, the result is false
-        if (this.code == null) {
-            return false;
-        }
-        if (this.valueset == null) {
-            throw new Error('ValueSet must be provided to InValueSet expression');
-        }
         const code = await this.code.execute(ctx);
         // spec indicates to return false if code is null, throw error if value set cannot be resolved
         if (code == null) {

--- a/src/elm/clinical.ts
+++ b/src/elm/clinical.ts
@@ -59,14 +59,16 @@ export class AnyInValueSet extends Expression {
   }
 
   async exec(ctx: Context) {
+    const codes = await this.codes.execute(ctx);
+    // spec indicates to return false if code is null, throw error if value set cannot be resolved
+    if (codes == null) {
+      return false;
+    }
     const valueset = await this.valueset.execute(ctx);
-    // If the value set reference cannot be resolved, a run-time error is thrown.
     if (valueset == null || !valueset.isValueSet) {
       throw new Error('ValueSet must be provided to AnyInValueSet expression');
     }
-
-    const codes = await this.codes.execute(ctx);
-    return codes != null && codes.some((code: any) => valueset.hasMatch(code));
+    return codes.some((code: any) => valueset.hasMatch(code));
   }
 }
 
@@ -83,13 +85,6 @@ export class InValueSet extends Expression {
   }
 
   async exec(ctx: Context) {
-    // If the code argument is null, the result is false
-    if (this.code == null) {
-      return false;
-    }
-    if (this.valueset == null) {
-      throw new Error('ValueSet must be provided to InValueSet expression');
-    }
     const code = await this.code.execute(ctx);
     // spec indicates to return false if code is null, throw error if value set cannot be resolved
     if (code == null) {

--- a/src/elm/clinical.ts
+++ b/src/elm/clinical.ts
@@ -47,20 +47,22 @@ export class ValueSetRef extends Expression {
 }
 
 export class AnyInValueSet extends Expression {
-  codes: any;
-  valueset: ValueSetRef;
+  codes: Expression;
+  valueset: Expression;
 
   constructor(json: any) {
     super(json);
-    this.codes = build(json.codes);
-    this.valueset = new ValueSetRef(json.valueset);
+    this.codes = build(json.codes) as Expression;
+    this.valueset = json.valueset
+      ? new ValueSetRef(json.valueset)
+      : (build(json.valuesetExpression) as Expression);
   }
 
   async exec(ctx: Context) {
     const valueset = await this.valueset.execute(ctx);
     // If the value set reference cannot be resolved, a run-time error is thrown.
     if (valueset == null || !valueset.isValueSet) {
-      throw new Error('ValueSet must be provided to InValueSet function');
+      throw new Error('ValueSet must be provided to AnyInValueSet expression');
     }
 
     const codes = await this.codes.execute(ctx);
@@ -69,13 +71,15 @@ export class AnyInValueSet extends Expression {
 }
 
 export class InValueSet extends Expression {
-  code: any;
-  valueset: ValueSetRef;
+  code: Expression;
+  valueset: Expression;
 
   constructor(json: any) {
     super(json);
-    this.code = build(json.code);
-    this.valueset = new ValueSetRef(json.valueset);
+    this.code = build(json.code) as Expression;
+    this.valueset = json.valueset
+      ? new ValueSetRef(json.valueset)
+      : (build(json.valuesetExpression) as Expression);
   }
 
   async exec(ctx: Context) {
@@ -84,7 +88,7 @@ export class InValueSet extends Expression {
       return false;
     }
     if (this.valueset == null) {
-      throw new Error('ValueSet must be provided to InValueSet function');
+      throw new Error('ValueSet must be provided to InValueSet expression');
     }
     const code = await this.code.execute(ctx);
     // spec indicates to return false if code is null, throw error if value set cannot be resolved
@@ -93,7 +97,7 @@ export class InValueSet extends Expression {
     }
     const valueset = await this.valueset.execute(ctx);
     if (valueset == null || !valueset.isValueSet) {
-      throw new Error('ValueSet must be provided to InValueSet function');
+      throw new Error('ValueSet must be provided to InValueSet expression');
     }
     // If there is a code and valueset return whether or not the valueset has the code
     return valueset.hasMatch(code);
@@ -101,11 +105,11 @@ export class InValueSet extends Expression {
 }
 
 export class ExpandValueSet extends Expression {
-  valueset: ValueSetRef;
+  valueset: Expression;
 
   constructor(json: any) {
     super(json);
-    this.valueset = new ValueSetRef(json.operand);
+    this.valueset = build(json.operand) as Expression;
   }
 
   async exec(ctx: Context) {

--- a/test/elm/clinical/clinical-test.ts
+++ b/test/elm/clinical/clinical-test.ts
@@ -175,6 +175,14 @@ describe('InValueSet', () => {
     (await this.nullCode.exec(this.ctx)).should.be.false();
   });
 
+  it('should return false if the passed in code is null', async function () {
+    (await this.nullCastAsCode.exec(this.ctx)).should.be.false();
+  });
+
+  it('should return false if the passed in code is null and the valueset is null', async function () {
+    (await this.nullCastAsCodeWithNullVS.exec(this.ctx)).should.be.false();
+  });
+
   it('should return true for correct valueset passed to function', async function () {
     (await this.fInPassedVS.exec(this.ctx)).should.be.true();
   });

--- a/test/elm/clinical/clinical-test.ts
+++ b/test/elm/clinical/clinical-test.ts
@@ -79,9 +79,9 @@ describe('AnyInValueSet', () => {
   });
 
   it('should return error for null cast valueset passed to list comparison function', async function () {
-    this.listInNullVS
+    return this.listInNullVS
       .exec(this.ctx)
-      .should.be.rejectedWith('ValueSet must be provided to AnyInValueSet expression');
+      .should.be.rejectedWith(/ValueSet must be provided to AnyInValueSet expression/);
   });
 });
 
@@ -183,7 +183,7 @@ describe('InValueSet', () => {
   });
 
   it('should return error for null cast valueset passed to function', async function () {
-    this.fInNullVS
+    return this.fInNullVS
       .exec(this.ctx)
       .should.be.rejectedWith('ValueSet must be provided to InValueSet expression');
   });

--- a/test/elm/clinical/clinical-test.ts
+++ b/test/elm/clinical/clinical-test.ts
@@ -69,6 +69,20 @@ describe('AnyInValueSet', () => {
     (await this.anyInListOfStrings.exec(this.ctx)).should.be.true();
     should(this.ctx.localId_context[this.anyInListOfStrings.codes.localId]).not.be.undefined();
   });
+
+  it('should return true for correct valueset passed to list comparison function', async function () {
+    (await this.listInPassedVS.exec(this.ctx)).should.be.true();
+  });
+
+  it('should return false for incorrect valueset passed to list comparison function', async function () {
+    (await this.listInWrongVS.exec(this.ctx)).should.be.false();
+  });
+
+  it('should return error for null cast valueset passed to list comparison function', async function () {
+    this.listInNullVS
+      .exec(this.ctx)
+      .should.be.rejectedWith('ValueSet must be provided to AnyInValueSet expression');
+  });
 });
 
 describe('InValueSet', () => {
@@ -159,6 +173,20 @@ describe('InValueSet', () => {
   it('should return false for null list of codes', async function () {
     (await this.listOfCodesNull.exec(this.ctx)).should.be.false();
   });
+
+  it('should return true for correct valueset passed to function', async function () {
+    (await this.fInPassedVS.exec(this.ctx)).should.be.true();
+  });
+
+  it('should return false for incorrect valueset passed to function', async function () {
+    (await this.fInWrongVS.exec(this.ctx)).should.be.false();
+  });
+
+  it('should return error for null cast valueset passed to function', async function () {
+    this.fInNullVS
+      .exec(this.ctx)
+      .should.be.rejectedWith('ValueSet must be provided to InValueSet expression');
+  });
 });
 
 describe('ExpandValueset', () => {
@@ -178,6 +206,29 @@ describe('ExpandValueset', () => {
 
   it('invoke expandValueSet with union', async function () {
     const received: any = await this.invokeExpandWithUnion.exec(this.ctx);
+    const expected: Code[] = [
+      new Code('F', '2.16.840.1.113883.18.2', 'HL7V2.5', undefined),
+      new Code('185349003', '2.16.840.1.113883.6.96', '2013-09', undefined),
+      new Code('270427003', '2.16.840.1.113883.6.96', '2013-09', undefined),
+      new Code('406547006', '2.16.840.1.113883.6.96', '2013-09', undefined)
+    ];
+    received.should.eql(expected);
+  });
+
+  it('expand valueset through function call', async function () {
+    const received: any = await this.expandPassedVS.exec(this.ctx);
+    const expected: Code[] = [new Code('F', '2.16.840.1.113883.18.2', 'HL7V2.5', undefined)];
+    received.should.eql(expected);
+  });
+
+  it('should return error for null cast valueset passed to function', async function () {
+    this.expandNullVS
+      .exec(this.ctx)
+      .should.be.rejectedWith('ExpandValueSet function invoked on object that is not a ValueSet');
+  });
+
+  it('invoke expandValueSet with union via function', async function () {
+    const received: any = await this.expandPassedWithUnion.exec(this.ctx);
     const expected: Code[] = [
       new Code('F', '2.16.840.1.113883.18.2', 'HL7V2.5', undefined),
       new Code('185349003', '2.16.840.1.113883.6.96', '2013-09', undefined),

--- a/test/elm/clinical/clinical-test.ts
+++ b/test/elm/clinical/clinical-test.ts
@@ -70,6 +70,27 @@ describe('AnyInValueSet', () => {
     should(this.ctx.localId_context[this.anyInListOfStrings.codes.localId]).not.be.undefined();
   });
 
+  it('should return false for null code list in valueset', async function () {
+    (await this.anyInNullList.exec(this.ctx)).should.be.false();
+  });
+
+  it('should return false for null code list in null valueset', async function () {
+    // code null returning false is prioritized over valueset resolution
+    (await this.anyInNullListNullVs.exec(this.ctx)).should.be.false();
+  });
+
+  it('should ignore null codes in list', async function () {
+    (await this.anyInListOfCodesWithNull.exec(this.ctx)).should.be.true();
+  });
+
+  it('should return true if code in list is equivalent using ExpressionRef', async function () {
+    (await this.anyInListOfCodesExpressionRef.exec(this.ctx)).should.be.true();
+  });
+
+  it('should return false if no code in list is equivalent', async function () {
+    (await this.anyInWrongListOfCodes.exec(this.ctx)).should.be.false();
+  });
+
   it('should return true for correct valueset passed to list comparison function', async function () {
     (await this.listInPassedVS.exec(this.ctx)).should.be.true();
   });
@@ -154,26 +175,6 @@ describe('InValueSet', () => {
     (await this.nullCode.exec(this.ctx)).should.be.false();
   });
 
-  it('should return true if code in list is equivalent', async function () {
-    (await this.inListOfCodes.exec(this.ctx)).should.be.true();
-  });
-
-  it('should return true if code in list is equivalent using ExpressionRef', async function () {
-    (await this.inListOfCodesExpressionRef.exec(this.ctx)).should.be.true();
-  });
-
-  it('should return false if no code in list is equivalent', async function () {
-    (await this.inWrongListOfCodes.exec(this.ctx)).should.be.false();
-  });
-
-  it('should ignore null codes in list', async function () {
-    (await this.listOfCodesWithNull.exec(this.ctx)).should.be.true();
-  });
-
-  it('should return false for null list of codes', async function () {
-    (await this.listOfCodesNull.exec(this.ctx)).should.be.false();
-  });
-
   it('should return true for correct valueset passed to function', async function () {
     (await this.fInPassedVS.exec(this.ctx)).should.be.true();
   });
@@ -185,7 +186,7 @@ describe('InValueSet', () => {
   it('should return error for null cast valueset passed to function', async function () {
     return this.fInNullVS
       .exec(this.ctx)
-      .should.be.rejectedWith('ValueSet must be provided to InValueSet expression');
+      .should.be.rejectedWith(/ValueSet must be provided to InValueSet expression/);
   });
 });
 
@@ -221,10 +222,8 @@ describe('ExpandValueset', () => {
     received.should.eql(expected);
   });
 
-  it('should return error for null cast valueset passed to function', async function () {
-    this.expandNullVS
-      .exec(this.ctx)
-      .should.be.rejectedWith('ExpandValueSet function invoked on object that is not a ValueSet');
+  it('should return null for null cast valueset passed to function', async function () {
+    should(await this.expandNullVS.exec(this.ctx)).be.null();
   });
 
   it('invoke expandValueSet with union via function', async function () {

--- a/test/elm/clinical/data.cql
+++ b/test/elm/clinical/data.cql
@@ -20,6 +20,13 @@ define AnyInListOfCodes: { "ChronicRecurrentDepression", "ModerateMajorDepressio
 define AnyInListOfStrings: { '2618002', '12345' } in "Major Depressive Disorder Active"
 define AnyInNullList: null as List<Code> in "Major Depressive Disorder Active"
 define AnyInNullListNullVs: null as List<Code> in null as ValueSet
+define AnyInListOfCodesWithNull: { Code { code: 'M' }, (null as Code), "ChronicRecurrentDepression" } in "Major Depressive Disorder Active"
+// expression data
+define ListOfCodes: { Code { code: 'M' } , "ChronicRecurrentDepression" }
+define WrongListOfCodes: { Code { code: 'M' }, Code { code: 'F', system: '3.16.840.1.113883.18.2' } }
+define AnyInListOfCodesExpressionRef: ListOfCodes in "Major Depressive Disorder Active"
+define AnyInWrongListOfCodes: WrongListOfCodes in "Major Depressive Disorder Active"
+// function data
 define function ListInVS(vs ValueSet): { '2618002', '12345' } in vs
 define ListInPassedVS: ListInVS("Major Depressive Disorder Active")
 define ListInWrongVS: ListInVS("Male")
@@ -45,13 +52,6 @@ define WrongShortCode: Code { code: 'M' } in "Female"
 define WrongMediumCode: Code { code: 'F', system: '3.16.840.1.113883.18.2' } in "Female"
 define LongCodeDifferentVersion: Code { code: 'F', system: '2.16.840.1.113883.18.2', version: 'HL7V2.6' } in "Female"
 define NullCode: Code { code: null, system: '2.16.840.1.113883.18.2', version: 'HL7V2.6' } in "Female"
-define InListOfCodes: { Code { code: 'M' } , Code { code: 'F', system: '2.16.840.1.113883.18.2', version: 'HL7V2.5' } } in "Female"
-define ListOfCodes: { Code { code: 'M' } , Code { code: 'F', system: '2.16.840.1.113883.18.2', version: 'HL7V2.5' } }
-define WrongListOfCodes: { Code { code: 'M' }, Code { code: 'F', system: '3.16.840.1.113883.18.2' } }
-define InListOfCodesExpressionRef: ListOfCodes in "Female"
-define InWrongListOfCodes: WrongListOfCodes in "Female"
-define ListOfCodesWithNull: { Code { code: 'M' }, (null as Code), Code { code: 'F', system: '2.16.840.1.113883.18.2' } } in "Female"
-define ListOfCodesNull: (null as List<Code>) in "Female"
 define function FInVS(vs ValueSet): 'F' in vs
 define FInPassedVS: FInVS("Female")
 define FInWrongVS: FInVS("Male")

--- a/test/elm/clinical/data.cql
+++ b/test/elm/clinical/data.cql
@@ -10,6 +10,7 @@ define Foo: "Acute Pharyngitis"
 
 // @Test: AnyInValueSet
 valueset "Major Depressive Disorder Active": '2.16.840.1.113883.3.526.3.1491'
+valueset "Male": '2.16.840.1.113883.3.560.100.1'
 codesystem "SNOMED": 'http://snomed.info/sct'
 code "ChronicRecurrentDepression": '2618002' from "SNOMED" display 'Chronic recurrent major depressive disorder (disorder)'
 code "ModerateMajorDepression": '832007' from "SNOMED" display 'Moderate major depression (disorder)'
@@ -17,9 +18,14 @@ concept "Depression Concept": { "ChronicRecurrentDepression", "ModerateMajorDepr
 define AnyInListOfConcepts: { "Depression Concept" } in "Major Depressive Disorder Active"
 define AnyInListOfCodes: { "ChronicRecurrentDepression", "ModerateMajorDepression" } in "Major Depressive Disorder Active"
 define AnyInListOfStrings: { '2618002', '12345' } in "Major Depressive Disorder Active"
+define function ListInVS(vs ValueSet): { '2618002', '12345' } in vs
+define ListInPassedVS: ListInVS("Major Depressive Disorder Active")
+define ListInWrongVS: ListInVS("Male")
+define ListInNullVS: ListInVS(null as ValueSet)
 
 // @Test: InValueSet
 valueset "Female": '2.16.840.1.113883.3.560.100.2'
+valueset "Male": '2.16.840.1.113883.3.560.100.1'
 valueset "Versioned Female": '2.16.840.1.113883.3.560.100.2' version '20121025'
 valueset "SharedCodes": '2.16.840.1.113883.3.000.000.0'
 valueset "ImproperSharedCodes": '2.16.840.1.113883.3.000.000.1'
@@ -44,6 +50,10 @@ define InListOfCodesExpressionRef: ListOfCodes in "Female"
 define InWrongListOfCodes: WrongListOfCodes in "Female"
 define ListOfCodesWithNull: { Code { code: 'M' }, (null as Code), Code { code: 'F', system: '2.16.840.1.113883.18.2' } } in "Female"
 define ListOfCodesNull: (null as List<Code>) in "Female"
+define function FInVS(vs ValueSet): 'F' in vs
+define FInPassedVS: FInVS("Female")
+define FInWrongVS: FInVS("Male")
+define FInNullVS: FInVS(null as ValueSet)
 
 
 // @Test: ExpandValueset
@@ -54,6 +64,11 @@ define ExpandFemale: ExpandValueSet("Female")
 define ExpandKnown: ExpandValueSet("Known")
 define ExpandNull: ExpandValueSet(null)
 define InvokeExpandWithUnion: "Female" union  "Known"
+define function ExpandVSHelper(vs ValueSet): ExpandValueSet(vs)
+define ExpandPassedVS: ExpandVSHelper("Female")
+define ExpandNullVS: ExpandVSHelper(null as ValueSet)
+define function UnionVSs(vs1 ValueSet, vs2 ValueSet): vs1 union vs2
+define ExpandPassedWithUnion: UnionVSs("Female", "Known")
 
 
 // @Test: Patient Property In ValueSet

--- a/test/elm/clinical/data.cql
+++ b/test/elm/clinical/data.cql
@@ -18,6 +18,8 @@ concept "Depression Concept": { "ChronicRecurrentDepression", "ModerateMajorDepr
 define AnyInListOfConcepts: { "Depression Concept" } in "Major Depressive Disorder Active"
 define AnyInListOfCodes: { "ChronicRecurrentDepression", "ModerateMajorDepression" } in "Major Depressive Disorder Active"
 define AnyInListOfStrings: { '2618002', '12345' } in "Major Depressive Disorder Active"
+define AnyInNullList: null as List<Code> in "Major Depressive Disorder Active"
+define AnyInNullListNullVs: null as List<Code> in null as ValueSet
 define function ListInVS(vs ValueSet): { '2618002', '12345' } in vs
 define ListInPassedVS: ListInVS("Major Depressive Disorder Active")
 define ListInWrongVS: ListInVS("Male")

--- a/test/elm/clinical/data.cql
+++ b/test/elm/clinical/data.cql
@@ -52,6 +52,8 @@ define WrongShortCode: Code { code: 'M' } in "Female"
 define WrongMediumCode: Code { code: 'F', system: '3.16.840.1.113883.18.2' } in "Female"
 define LongCodeDifferentVersion: Code { code: 'F', system: '2.16.840.1.113883.18.2', version: 'HL7V2.6' } in "Female"
 define NullCode: Code { code: null, system: '2.16.840.1.113883.18.2', version: 'HL7V2.6' } in "Female"
+define NullCastAsCode: null as Code in "Female"
+define NullCastAsCodeWithNullVS: null as Code in null as ValueSet
 define function FInVS(vs ValueSet): 'F' in vs
 define FInPassedVS: FInVS("Female")
 define FInWrongVS: FInVS("Male")

--- a/test/elm/clinical/data.js
+++ b/test/elm/clinical/data.js
@@ -328,6 +328,15 @@ context Patient
 define AnyInListOfConcepts: { "Depression Concept" } in "Major Depressive Disorder Active"
 define AnyInListOfCodes: { "ChronicRecurrentDepression", "ModerateMajorDepression" } in "Major Depressive Disorder Active"
 define AnyInListOfStrings: { '2618002', '12345' } in "Major Depressive Disorder Active"
+define AnyInNullList: null as List<Code> in "Major Depressive Disorder Active"
+define AnyInNullListNullVs: null as List<Code> in null as ValueSet
+define AnyInListOfCodesWithNull: { Code { code: 'M' }, (null as Code), "ChronicRecurrentDepression" } in "Major Depressive Disorder Active"
+// expression data
+define ListOfCodes: { Code { code: 'M' } , "ChronicRecurrentDepression" }
+define WrongListOfCodes: { Code { code: 'M' }, Code { code: 'F', system: '3.16.840.1.113883.18.2' } }
+define AnyInListOfCodesExpressionRef: ListOfCodes in "Major Depressive Disorder Active"
+define AnyInWrongListOfCodes: WrongListOfCodes in "Major Depressive Disorder Active"
+// function data
 define function ListInVS(vs ValueSet): { '2618002', '12345' } in vs
 define ListInPassedVS: ListInVS("Major Depressive Disorder Active")
 define ListInWrongVS: ListInVS("Male")
@@ -345,7 +354,7 @@ module.exports['AnyInValueSet'] = {
       }, {
          "type" : "Annotation",
          "s" : {
-            "r" : "242",
+            "r" : "367",
             "s" : [ {
                "value" : [ "","library TestSnippet version '1'" ]
             } ]
@@ -388,7 +397,7 @@ module.exports['AnyInValueSet'] = {
       },
       "codeSystems" : {
          "def" : [ {
-            "localId" : "208",
+            "localId" : "209",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
             "name" : "SNOMED",
             "id" : "http://snomed.info/sct",
@@ -423,6 +432,7 @@ module.exports['AnyInValueSet'] = {
             "codeSystem" : [ ]
          }, {
             "localId" : "208",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
             "name" : "Male",
             "id" : "2.16.840.1.113883.3.560.100.1",
             "accessLevel" : "Public",
@@ -440,7 +450,7 @@ module.exports['AnyInValueSet'] = {
       },
       "codes" : {
          "def" : [ {
-            "localId" : "209",
+            "localId" : "210",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
             "name" : "ChronicRecurrentDepression",
             "id" : "2618002",
@@ -463,12 +473,12 @@ module.exports['AnyInValueSet'] = {
                }
             } ],
             "codeSystem" : {
-               "localId" : "210",
+               "localId" : "211",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
                "name" : "SNOMED"
             }
          }, {
-            "localId" : "211",
+            "localId" : "212",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
             "name" : "ModerateMajorDepression",
             "id" : "832007",
@@ -491,7 +501,7 @@ module.exports['AnyInValueSet'] = {
                }
             } ],
             "codeSystem" : {
-               "localId" : "212",
+               "localId" : "213",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
                "name" : "SNOMED"
             }
@@ -499,7 +509,7 @@ module.exports['AnyInValueSet'] = {
       },
       "concepts" : {
          "def" : [ {
-            "localId" : "213",
+            "localId" : "214",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Concept",
             "name" : "Depression Concept",
             "display" : "Depression Concept",
@@ -528,11 +538,11 @@ module.exports['AnyInValueSet'] = {
                }
             } ],
             "code" : [ {
-               "localId" : "214",
+               "localId" : "215",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                "name" : "ChronicRecurrentDepression"
             }, {
-               "localId" : "215",
+               "localId" : "216",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                "name" : "ModerateMajorDepression"
             } ]
@@ -564,7 +574,7 @@ module.exports['AnyInValueSet'] = {
                }
             }
          }, {
-            "localId" : "221",
+            "localId" : "222",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "AnyInListOfConcepts",
             "context" : "Patient",
@@ -576,7 +586,7 @@ module.exports['AnyInValueSet'] = {
                   "s" : [ {
                      "value" : [ "","define ","AnyInListOfConcepts",": " ]
                   }, {
-                     "r" : "227",
+                     "r" : "228",
                      "s" : [ {
                         "r" : "223",
                         "s" : [ {
@@ -592,7 +602,7 @@ module.exports['AnyInValueSet'] = {
                      }, {
                         "value" : [ " in " ]
                      }, {
-                        "r" : "226",
+                        "r" : "227",
                         "s" : [ {
                            "value" : [ "\"Major Depressive Disorder Active\"" ]
                         } ]
@@ -601,14 +611,14 @@ module.exports['AnyInValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "227",
+               "localId" : "228",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "AnyInValueSet",
                "signature" : [ {
-                  "localId" : "228",
+                  "localId" : "229",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "229",
+                     "localId" : "230",
                      "name" : "{urn:hl7-org:elm-types:r1}Concept",
                      "type" : "NamedTypeSpecifier"
                   }
@@ -617,30 +627,30 @@ module.exports['AnyInValueSet'] = {
                   "localId" : "223",
                   "type" : "List",
                   "resultTypeSpecifier" : {
-                     "localId" : "224",
+                     "localId" : "225",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "225",
+                        "localId" : "226",
                         "name" : "{urn:hl7-org:elm-types:r1}Concept",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "element" : [ {
-                     "localId" : "223",
+                     "localId" : "224",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Concept",
                      "name" : "Depression Concept",
                      "type" : "ConceptRef"
                   } ]
                },
                "valueset" : {
-                  "localId" : "226",
+                  "localId" : "227",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Major Depressive Disorder Active",
                   "preserve" : true
                }
             }
          }, {
-            "localId" : "231",
+            "localId" : "232",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "AnyInListOfCodes",
             "context" : "Patient",
@@ -648,24 +658,24 @@ module.exports['AnyInValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "231",
+                  "r" : "232",
                   "s" : [ {
                      "value" : [ "","define ","AnyInListOfCodes",": " ]
                   }, {
-                     "r" : "238",
+                     "r" : "239",
                      "s" : [ {
-                        "r" : "232",
+                        "r" : "233",
                         "s" : [ {
                            "value" : [ "{ " ]
                         }, {
-                           "r" : "233",
+                           "r" : "234",
                            "s" : [ {
                               "value" : [ "\"ChronicRecurrentDepression\"" ]
                            } ]
                         }, {
                            "value" : [ ", " ]
                         }, {
-                           "r" : "234",
+                           "r" : "235",
                            "s" : [ {
                               "value" : [ "\"ModerateMajorDepression\"" ]
                            } ]
@@ -675,7 +685,7 @@ module.exports['AnyInValueSet'] = {
                      }, {
                         "value" : [ " in " ]
                      }, {
-                        "r" : "237",
+                        "r" : "238",
                         "s" : [ {
                            "value" : [ "\"Major Depressive Disorder Active\"" ]
                         } ]
@@ -684,51 +694,51 @@ module.exports['AnyInValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "238",
+               "localId" : "239",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "AnyInValueSet",
                "signature" : [ {
-                  "localId" : "239",
+                  "localId" : "240",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "240",
+                     "localId" : "241",
                      "name" : "{urn:hl7-org:elm-types:r1}Code",
                      "type" : "NamedTypeSpecifier"
                   }
                } ],
                "codes" : {
-                  "localId" : "232",
+                  "localId" : "233",
                   "type" : "List",
                   "resultTypeSpecifier" : {
-                     "localId" : "235",
+                     "localId" : "236",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "236",
+                        "localId" : "237",
                         "name" : "{urn:hl7-org:elm-types:r1}Code",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "element" : [ {
-                     "localId" : "233",
+                     "localId" : "234",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                      "name" : "ChronicRecurrentDepression",
                      "type" : "CodeRef"
                   }, {
-                     "localId" : "234",
+                     "localId" : "235",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                      "name" : "ModerateMajorDepression",
                      "type" : "CodeRef"
                   } ]
                },
                "valueset" : {
-                  "localId" : "237",
+                  "localId" : "238",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Major Depressive Disorder Active",
                   "preserve" : true
                }
             }
          }, {
-            "localId" : "242",
+            "localId" : "243",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "AnyInListOfStrings",
             "context" : "Patient",
@@ -736,24 +746,24 @@ module.exports['AnyInValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "242",
+                  "r" : "243",
                   "s" : [ {
                      "value" : [ "","define ","AnyInListOfStrings",": " ]
                   }, {
-                     "r" : "249",
+                     "r" : "250",
                      "s" : [ {
-                        "r" : "243",
+                        "r" : "244",
                         "s" : [ {
                            "value" : [ "{ " ]
                         }, {
-                           "r" : "244",
+                           "r" : "245",
                            "s" : [ {
                               "value" : [ "'2618002'" ]
                            } ]
                         }, {
                            "value" : [ ", " ]
                         }, {
-                           "r" : "245",
+                           "r" : "246",
                            "s" : [ {
                               "value" : [ "'12345'" ]
                            } ]
@@ -763,7 +773,7 @@ module.exports['AnyInValueSet'] = {
                      }, {
                         "value" : [ " in " ]
                      }, {
-                        "r" : "248",
+                        "r" : "249",
                         "s" : [ {
                            "value" : [ "\"Major Depressive Disorder Active\"" ]
                         } ]
@@ -772,38 +782,38 @@ module.exports['AnyInValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "249",
+               "localId" : "250",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "AnyInValueSet",
                "signature" : [ {
-                  "localId" : "250",
+                  "localId" : "251",
                   "type" : "ListTypeSpecifier",
                   "elementType" : {
-                     "localId" : "251",
+                     "localId" : "252",
                      "name" : "{urn:hl7-org:elm-types:r1}String",
                      "type" : "NamedTypeSpecifier"
                   }
                } ],
                "codes" : {
-                  "localId" : "243",
+                  "localId" : "244",
                   "type" : "List",
                   "resultTypeSpecifier" : {
-                     "localId" : "246",
+                     "localId" : "247",
                      "type" : "ListTypeSpecifier",
                      "elementType" : {
-                        "localId" : "247",
+                        "localId" : "248",
                         "name" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "NamedTypeSpecifier"
                      }
                   },
                   "element" : [ {
-                     "localId" : "244",
+                     "localId" : "245",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                      "valueType" : "{urn:hl7-org:elm-types:r1}String",
                      "value" : "2618002",
                      "type" : "Literal"
                   }, {
-                     "localId" : "245",
+                     "localId" : "246",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                      "valueType" : "{urn:hl7-org:elm-types:r1}String",
                      "value" : "12345",
@@ -811,14 +821,730 @@ module.exports['AnyInValueSet'] = {
                   } ]
                },
                "valueset" : {
-                  "localId" : "248",
+                  "localId" : "249",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Major Depressive Disorder Active",
                   "preserve" : true
                }
             }
          }, {
-            "localId" : "241",
+            "localId" : "254",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+            "name" : "AnyInNullList",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "254",
+                  "s" : [ {
+                     "value" : [ "","define ","AnyInNullList",": " ]
+                  }, {
+                     "r" : "264",
+                     "s" : [ {
+                        "r" : "255",
+                        "s" : [ {
+                           "r" : "256",
+                           "value" : [ "null"," as " ]
+                        }, {
+                           "r" : "257",
+                           "s" : [ {
+                              "value" : [ "List<" ]
+                           }, {
+                              "r" : "258",
+                              "s" : [ {
+                                 "value" : [ "Code" ]
+                              } ]
+                           }, {
+                              "value" : [ ">" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ " in " ]
+                     }, {
+                        "r" : "263",
+                        "s" : [ {
+                           "value" : [ "\"Major Depressive Disorder Active\"" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "264",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+               "type" : "AnyInValueSet",
+               "signature" : [ {
+                  "localId" : "265",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "266",
+                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ],
+               "codes" : {
+                  "localId" : "255",
+                  "strict" : false,
+                  "type" : "As",
+                  "resultTypeSpecifier" : {
+                     "localId" : "261",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "262",
+                        "name" : "{urn:hl7-org:elm-types:r1}Code",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "signature" : [ ],
+                  "operand" : {
+                     "localId" : "256",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "localId" : "257",
+                     "type" : "ListTypeSpecifier",
+                     "resultTypeSpecifier" : {
+                        "localId" : "259",
+                        "type" : "ListTypeSpecifier",
+                        "elementType" : {
+                           "localId" : "260",
+                           "name" : "{urn:hl7-org:elm-types:r1}Code",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     },
+                     "elementType" : {
+                        "localId" : "258",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                        "name" : "{urn:hl7-org:elm-types:r1}Code",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }
+               },
+               "valueset" : {
+                  "localId" : "263",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "name" : "Major Depressive Disorder Active",
+                  "preserve" : true
+               }
+            }
+         }, {
+            "localId" : "268",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+            "name" : "AnyInNullListNullVs",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "268",
+                  "s" : [ {
+                     "value" : [ "","define ","AnyInNullListNullVs",": " ]
+                  }, {
+                     "r" : "280",
+                     "s" : [ {
+                        "r" : "269",
+                        "s" : [ {
+                           "r" : "270",
+                           "value" : [ "null"," as " ]
+                        }, {
+                           "r" : "271",
+                           "s" : [ {
+                              "value" : [ "List<" ]
+                           }, {
+                              "r" : "272",
+                              "s" : [ {
+                                 "value" : [ "Code" ]
+                              } ]
+                           }, {
+                              "value" : [ ">" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ " in " ]
+                     }, {
+                        "r" : "277",
+                        "s" : [ {
+                           "r" : "278",
+                           "value" : [ "null"," as " ]
+                        }, {
+                           "r" : "279",
+                           "s" : [ {
+                              "value" : [ "ValueSet" ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "280",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+               "type" : "AnyInValueSet",
+               "signature" : [ {
+                  "localId" : "281",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "282",
+                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }, {
+                  "localId" : "283",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               } ],
+               "codes" : {
+                  "localId" : "269",
+                  "strict" : false,
+                  "type" : "As",
+                  "resultTypeSpecifier" : {
+                     "localId" : "275",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "276",
+                        "name" : "{urn:hl7-org:elm-types:r1}Code",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "signature" : [ ],
+                  "operand" : {
+                     "localId" : "270",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "localId" : "271",
+                     "type" : "ListTypeSpecifier",
+                     "resultTypeSpecifier" : {
+                        "localId" : "273",
+                        "type" : "ListTypeSpecifier",
+                        "elementType" : {
+                           "localId" : "274",
+                           "name" : "{urn:hl7-org:elm-types:r1}Code",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     },
+                     "elementType" : {
+                        "localId" : "272",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                        "name" : "{urn:hl7-org:elm-types:r1}Code",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }
+               },
+               "valuesetExpression" : {
+                  "localId" : "277",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "strict" : false,
+                  "type" : "As",
+                  "signature" : [ ],
+                  "operand" : {
+                     "localId" : "278",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "localId" : "279",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }
+            }
+         }, {
+            "localId" : "285",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+            "name" : "AnyInListOfCodesWithNull",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "285",
+                  "s" : [ {
+                     "value" : [ "","define ","AnyInListOfCodesWithNull",": " ]
+                  }, {
+                     "r" : "297",
+                     "s" : [ {
+                        "r" : "286",
+                        "s" : [ {
+                           "value" : [ "{ " ]
+                        }, {
+                           "r" : "287",
+                           "s" : [ {
+                              "value" : [ "Code"," { " ]
+                           }, {
+                              "s" : [ {
+                                 "value" : [ "code",": " ]
+                              }, {
+                                 "r" : "289",
+                                 "s" : [ {
+                                    "value" : [ "'M'" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ " }" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "290",
+                           "s" : [ {
+                              "value" : [ "(" ]
+                           }, {
+                              "r" : "290",
+                              "s" : [ {
+                                 "r" : "291",
+                                 "value" : [ "null"," as " ]
+                              }, {
+                                 "r" : "292",
+                                 "s" : [ {
+                                    "value" : [ "Code" ]
+                                 } ]
+                              } ]
+                           }, {
+                              "value" : [ ")" ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "r" : "293",
+                           "s" : [ {
+                              "value" : [ "\"ChronicRecurrentDepression\"" ]
+                           } ]
+                        }, {
+                           "value" : [ " }" ]
+                        } ]
+                     }, {
+                        "value" : [ " in " ]
+                     }, {
+                        "r" : "296",
+                        "s" : [ {
+                           "value" : [ "\"Major Depressive Disorder Active\"" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "297",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+               "type" : "AnyInValueSet",
+               "signature" : [ {
+                  "localId" : "298",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "299",
+                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ],
+               "codes" : {
+                  "localId" : "286",
+                  "type" : "List",
+                  "resultTypeSpecifier" : {
+                     "localId" : "294",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "295",
+                        "name" : "{urn:hl7-org:elm-types:r1}Code",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
+                  "element" : [ {
+                     "localId" : "287",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                     "classType" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "Instance",
+                     "element" : [ {
+                        "name" : "code",
+                        "value" : {
+                           "localId" : "289",
+                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "M",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }, {
+                     "localId" : "290",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                     "strict" : false,
+                     "type" : "As",
+                     "signature" : [ ],
+                     "operand" : {
+                        "localId" : "291",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                        "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "localId" : "292",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                        "name" : "{urn:hl7-org:elm-types:r1}Code",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }, {
+                     "localId" : "293",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                     "name" : "ChronicRecurrentDepression",
+                     "type" : "CodeRef"
+                  } ]
+               },
+               "valueset" : {
+                  "localId" : "296",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "name" : "Major Depressive Disorder Active",
+                  "preserve" : true
+               }
+            }
+         }, {
+            "localId" : "301",
+            "name" : "ListOfCodes",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "301",
+                  "s" : [ {
+                     "value" : [ "// expression data\n","define ","ListOfCodes",": " ]
+                  }, {
+                     "r" : "302",
+                     "s" : [ {
+                        "value" : [ "{ " ]
+                     }, {
+                        "r" : "303",
+                        "s" : [ {
+                           "value" : [ "Code"," { " ]
+                        }, {
+                           "s" : [ {
+                              "value" : [ "code",": " ]
+                           }, {
+                              "r" : "305",
+                              "s" : [ {
+                                 "value" : [ "'M'" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ " }" ]
+                        } ]
+                     }, {
+                        "value" : [ " , " ]
+                     }, {
+                        "r" : "306",
+                        "s" : [ {
+                           "value" : [ "\"ChronicRecurrentDepression\"" ]
+                        } ]
+                     }, {
+                        "value" : [ " }" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "resultTypeSpecifier" : {
+               "localId" : "309",
+               "type" : "ListTypeSpecifier",
+               "elementType" : {
+                  "localId" : "310",
+                  "name" : "{urn:hl7-org:elm-types:r1}Code",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
+            "expression" : {
+               "localId" : "302",
+               "type" : "List",
+               "resultTypeSpecifier" : {
+                  "localId" : "307",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "308",
+                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "element" : [ {
+                  "localId" : "303",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                  "classType" : "{urn:hl7-org:elm-types:r1}Code",
+                  "type" : "Instance",
+                  "element" : [ {
+                     "name" : "code",
+                     "value" : {
+                        "localId" : "305",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "M",
+                        "type" : "Literal"
+                     }
+                  } ]
+               }, {
+                  "localId" : "306",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                  "name" : "ChronicRecurrentDepression",
+                  "type" : "CodeRef"
+               } ]
+            }
+         }, {
+            "localId" : "312",
+            "name" : "WrongListOfCodes",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "312",
+                  "s" : [ {
+                     "value" : [ "","define ","WrongListOfCodes",": " ]
+                  }, {
+                     "r" : "313",
+                     "s" : [ {
+                        "value" : [ "{ " ]
+                     }, {
+                        "r" : "314",
+                        "s" : [ {
+                           "value" : [ "Code"," { " ]
+                        }, {
+                           "s" : [ {
+                              "value" : [ "code",": " ]
+                           }, {
+                              "r" : "316",
+                              "s" : [ {
+                                 "value" : [ "'M'" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ " }" ]
+                        } ]
+                     }, {
+                        "value" : [ ", " ]
+                     }, {
+                        "r" : "317",
+                        "s" : [ {
+                           "value" : [ "Code"," { " ]
+                        }, {
+                           "s" : [ {
+                              "value" : [ "code",": " ]
+                           }, {
+                              "r" : "319",
+                              "s" : [ {
+                                 "value" : [ "'F'" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ ", " ]
+                        }, {
+                           "s" : [ {
+                              "value" : [ "system",": " ]
+                           }, {
+                              "r" : "320",
+                              "s" : [ {
+                                 "value" : [ "'3.16.840.1.113883.18.2'" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ " }" ]
+                        } ]
+                     }, {
+                        "value" : [ " }" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "resultTypeSpecifier" : {
+               "localId" : "323",
+               "type" : "ListTypeSpecifier",
+               "elementType" : {
+                  "localId" : "324",
+                  "name" : "{urn:hl7-org:elm-types:r1}Code",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
+            "expression" : {
+               "localId" : "313",
+               "type" : "List",
+               "resultTypeSpecifier" : {
+                  "localId" : "321",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "322",
+                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "element" : [ {
+                  "localId" : "314",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                  "classType" : "{urn:hl7-org:elm-types:r1}Code",
+                  "type" : "Instance",
+                  "element" : [ {
+                     "name" : "code",
+                     "value" : {
+                        "localId" : "316",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "M",
+                        "type" : "Literal"
+                     }
+                  } ]
+               }, {
+                  "localId" : "317",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                  "classType" : "{urn:hl7-org:elm-types:r1}Code",
+                  "type" : "Instance",
+                  "element" : [ {
+                     "name" : "code",
+                     "value" : {
+                        "localId" : "319",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "F",
+                        "type" : "Literal"
+                     }
+                  }, {
+                     "name" : "system",
+                     "value" : {
+                        "localId" : "320",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "3.16.840.1.113883.18.2",
+                        "type" : "Literal"
+                     }
+                  } ]
+               } ]
+            }
+         }, {
+            "localId" : "326",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+            "name" : "AnyInListOfCodesExpressionRef",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "326",
+                  "s" : [ {
+                     "value" : [ "","define ","AnyInListOfCodesExpressionRef",": " ]
+                  }, {
+                     "r" : "331",
+                     "s" : [ {
+                        "r" : "327",
+                        "s" : [ {
+                           "value" : [ "ListOfCodes" ]
+                        } ]
+                     }, {
+                        "value" : [ " in " ]
+                     }, {
+                        "r" : "330",
+                        "s" : [ {
+                           "value" : [ "\"Major Depressive Disorder Active\"" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "331",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+               "type" : "AnyInValueSet",
+               "signature" : [ {
+                  "localId" : "332",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "333",
+                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ],
+               "codes" : {
+                  "localId" : "327",
+                  "name" : "ListOfCodes",
+                  "type" : "ExpressionRef",
+                  "resultTypeSpecifier" : {
+                     "localId" : "328",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "329",
+                        "name" : "{urn:hl7-org:elm-types:r1}Code",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }
+               },
+               "valueset" : {
+                  "localId" : "330",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "name" : "Major Depressive Disorder Active",
+                  "preserve" : true
+               }
+            }
+         }, {
+            "localId" : "335",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+            "name" : "AnyInWrongListOfCodes",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "335",
+                  "s" : [ {
+                     "value" : [ "","define ","AnyInWrongListOfCodes",": " ]
+                  }, {
+                     "r" : "340",
+                     "s" : [ {
+                        "r" : "336",
+                        "s" : [ {
+                           "value" : [ "WrongListOfCodes" ]
+                        } ]
+                     }, {
+                        "value" : [ " in " ]
+                     }, {
+                        "r" : "339",
+                        "s" : [ {
+                           "value" : [ "\"Major Depressive Disorder Active\"" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "340",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+               "type" : "AnyInValueSet",
+               "signature" : [ {
+                  "localId" : "341",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "342",
+                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ],
+               "codes" : {
+                  "localId" : "336",
+                  "name" : "WrongListOfCodes",
+                  "type" : "ExpressionRef",
+                  "resultTypeSpecifier" : {
+                     "localId" : "337",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "338",
+                        "name" : "{urn:hl7-org:elm-types:r1}Code",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }
+               },
+               "valueset" : {
+                  "localId" : "339",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "name" : "Major Depressive Disorder Active",
+                  "preserve" : true
+               }
+            }
+         }, {
+            "localId" : "343",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "ListInVS",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -826,26 +1552,26 @@ module.exports['AnyInValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "241",
+                  "r" : "343",
                   "s" : [ {
-                     "value" : [ "","define function ListInVS(vs ValueSet): " ]
+                     "value" : [ "// function data\n","define function ListInVS(vs ValueSet): " ]
                   }, {
-                     "r" : "248",
+                     "r" : "352",
                      "s" : [ {
-                        "r" : "248",
+                        "r" : "352",
                         "s" : [ {
-                           "r" : "244",
+                           "r" : "346",
                            "s" : [ {
                               "value" : [ "{ " ]
                            }, {
-                              "r" : "245",
+                              "r" : "347",
                               "s" : [ {
                                  "value" : [ "'2618002'" ]
                               } ]
                            }, {
                               "value" : [ ", " ]
                            }, {
-                              "r" : "246",
+                              "r" : "348",
                               "s" : [ {
                                  "value" : [ "'12345'" ]
                               } ]
@@ -855,7 +1581,7 @@ module.exports['AnyInValueSet'] = {
                         }, {
                            "value" : [ " in " ]
                         }, {
-                           "r" : "247",
+                           "r" : "351",
                            "s" : [ {
                               "value" : [ "vs" ]
                            } ]
@@ -865,56 +1591,83 @@ module.exports['AnyInValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "248",
+               "localId" : "352",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "AnyInValueSet",
-               "signature" : [ ],
+               "signature" : [ {
+                  "localId" : "353",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "354",
+                     "name" : "{urn:hl7-org:elm-types:r1}String",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }, {
+                  "localId" : "355",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               } ],
                "codes" : {
-                  "localId" : "244",
+                  "localId" : "346",
                   "type" : "List",
+                  "resultTypeSpecifier" : {
+                     "localId" : "349",
+                     "type" : "ListTypeSpecifier",
+                     "elementType" : {
+                        "localId" : "350",
+                        "name" : "{urn:hl7-org:elm-types:r1}String",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  },
                   "element" : [ {
-                     "localId" : "245",
+                     "localId" : "347",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                      "valueType" : "{urn:hl7-org:elm-types:r1}String",
                      "value" : "2618002",
                      "type" : "Literal"
                   }, {
-                     "localId" : "246",
+                     "localId" : "348",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                      "valueType" : "{urn:hl7-org:elm-types:r1}String",
                      "value" : "12345",
                      "type" : "Literal"
                   } ]
                },
                "valuesetExpression" : {
-                  "localId" : "247",
+                  "localId" : "351",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "vs",
                   "type" : "OperandRef"
                }
             },
             "operand" : [ {
-               "localId" : "243",
+               "localId" : "345",
                "name" : "vs",
                "operandTypeSpecifier" : {
-                  "localId" : "242",
+                  "localId" : "344",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "type" : "NamedTypeSpecifier"
                }
             } ]
          }, {
-            "localId" : "250",
+            "localId" : "357",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "ListInPassedVS",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "250",
+                  "r" : "357",
                   "s" : [ {
                      "value" : [ "","define ","ListInPassedVS",": " ]
                   }, {
-                     "r" : "252",
+                     "r" : "359",
                      "s" : [ {
                         "value" : [ "ListInVS","(" ]
                      }, {
-                        "r" : "251",
+                        "r" : "358",
                         "s" : [ {
                            "value" : [ "\"Major Depressive Disorder Active\"" ]
                         } ]
@@ -925,34 +1678,41 @@ module.exports['AnyInValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "252",
+               "localId" : "359",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "name" : "ListInVS",
                "type" : "FunctionRef",
-               "signature" : [ ],
+               "signature" : [ {
+                  "localId" : "360",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               } ],
                "operand" : [ {
-                  "localId" : "251",
+                  "localId" : "358",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Major Depressive Disorder Active",
                   "preserve" : true,
                   "type" : "ValueSetRef"
                } ]
             }
          }, {
-            "localId" : "254",
+            "localId" : "362",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "ListInWrongVS",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "254",
+                  "r" : "362",
                   "s" : [ {
                      "value" : [ "","define ","ListInWrongVS",": " ]
                   }, {
-                     "r" : "256",
+                     "r" : "364",
                      "s" : [ {
                         "value" : [ "ListInVS","(" ]
                      }, {
-                        "r" : "255",
+                        "r" : "363",
                         "s" : [ {
                            "value" : [ "\"Male\"" ]
                         } ]
@@ -963,39 +1723,46 @@ module.exports['AnyInValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "256",
+               "localId" : "364",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "name" : "ListInVS",
                "type" : "FunctionRef",
-               "signature" : [ ],
+               "signature" : [ {
+                  "localId" : "365",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               } ],
                "operand" : [ {
-                  "localId" : "255",
+                  "localId" : "363",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Male",
                   "preserve" : true,
                   "type" : "ValueSetRef"
                } ]
             }
          }, {
-            "localId" : "258",
+            "localId" : "367",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "ListInNullVS",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "258",
+                  "r" : "367",
                   "s" : [ {
                      "value" : [ "","define ","ListInNullVS",": " ]
                   }, {
-                     "r" : "262",
+                     "r" : "371",
                      "s" : [ {
                         "value" : [ "ListInVS","(" ]
                      }, {
-                        "r" : "259",
+                        "r" : "368",
                         "s" : [ {
-                           "r" : "260",
+                           "r" : "369",
                            "value" : [ "null"," as " ]
                         }, {
-                           "r" : "261",
+                           "r" : "370",
                            "s" : [ {
                               "value" : [ "ValueSet" ]
                            } ]
@@ -1007,21 +1774,29 @@ module.exports['AnyInValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "262",
+               "localId" : "371",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "name" : "ListInVS",
                "type" : "FunctionRef",
-               "signature" : [ ],
+               "signature" : [ {
+                  "localId" : "372",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               } ],
                "operand" : [ {
-                  "localId" : "259",
+                  "localId" : "368",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "strict" : false,
                   "type" : "As",
                   "signature" : [ ],
                   "operand" : {
-                     "localId" : "260",
+                     "localId" : "369",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
                      "type" : "Null"
                   },
                   "asTypeSpecifier" : {
-                     "localId" : "261",
+                     "localId" : "370",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                      "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
                      "type" : "NamedTypeSpecifier"
                   }
@@ -1055,13 +1830,6 @@ define WrongShortCode: Code { code: 'M' } in "Female"
 define WrongMediumCode: Code { code: 'F', system: '3.16.840.1.113883.18.2' } in "Female"
 define LongCodeDifferentVersion: Code { code: 'F', system: '2.16.840.1.113883.18.2', version: 'HL7V2.6' } in "Female"
 define NullCode: Code { code: null, system: '2.16.840.1.113883.18.2', version: 'HL7V2.6' } in "Female"
-define InListOfCodes: { Code { code: 'M' } , Code { code: 'F', system: '2.16.840.1.113883.18.2', version: 'HL7V2.5' } } in "Female"
-define ListOfCodes: { Code { code: 'M' } , Code { code: 'F', system: '2.16.840.1.113883.18.2', version: 'HL7V2.5' } }
-define WrongListOfCodes: { Code { code: 'M' }, Code { code: 'F', system: '3.16.840.1.113883.18.2' } }
-define InListOfCodesExpressionRef: ListOfCodes in "Female"
-define InWrongListOfCodes: WrongListOfCodes in "Female"
-define ListOfCodesWithNull: { Code { code: 'M' }, (null as Code), Code { code: 'F', system: '2.16.840.1.113883.18.2' } } in "Female"
-define ListOfCodesNull: (null as List<Code>) in "Female"
 define function FInVS(vs ValueSet): 'F' in vs
 define FInPassedVS: FInVS("Female")
 define FInWrongVS: FInVS("Male")
@@ -1079,7 +1847,7 @@ module.exports['InValueSet'] = {
       }, {
          "type" : "Annotation",
          "s" : {
-            "r" : "406",
+            "r" : "342",
             "s" : [ {
                "value" : [ "","library TestSnippet version '1'" ]
             } ]
@@ -1140,6 +1908,22 @@ module.exports['InValueSet'] = {
          }, {
             "localId" : "208",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "Male",
+            "id" : "2.16.840.1.113883.3.560.100.1",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "208",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"Male\"",": ","'2.16.840.1.113883.3.560.100.1'" ]
+                  } ]
+               }
+            } ],
+            "codeSystem" : [ ]
+         }, {
+            "localId" : "209",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
             "name" : "Versioned Female",
             "id" : "2.16.840.1.113883.3.560.100.2",
             "version" : "20121025",
@@ -1155,7 +1939,7 @@ module.exports['InValueSet'] = {
             } ],
             "codeSystem" : [ ]
          }, {
-            "localId" : "209",
+            "localId" : "210",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
             "name" : "SharedCodes",
             "id" : "2.16.840.1.113883.3.000.000.0",
@@ -1171,7 +1955,7 @@ module.exports['InValueSet'] = {
             } ],
             "codeSystem" : [ ]
          }, {
-            "localId" : "210",
+            "localId" : "211",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
             "name" : "ImproperSharedCodes",
             "id" : "2.16.840.1.113883.3.000.000.1",
@@ -1214,7 +1998,7 @@ module.exports['InValueSet'] = {
                }
             }
          }, {
-            "localId" : "216",
+            "localId" : "217",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "String",
             "context" : "Patient",
@@ -1244,30 +2028,30 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "219",
+               "localId" : "220",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "InValueSet",
                "signature" : [ {
-                  "localId" : "220",
+                  "localId" : "221",
                   "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
                } ],
                "code" : {
-                  "localId" : "217",
+                  "localId" : "218",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "F",
                   "type" : "Literal"
                },
                "valueset" : {
-                  "localId" : "218",
+                  "localId" : "219",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Female",
                   "preserve" : true
                }
             }
          }, {
-            "localId" : "222",
+            "localId" : "223",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "SharedCodesFoo",
             "context" : "Patient",
@@ -1275,20 +2059,20 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "222",
+                  "r" : "223",
                   "s" : [ {
                      "value" : [ "","define ","SharedCodesFoo",": " ]
                   }, {
-                     "r" : "225",
+                     "r" : "226",
                      "s" : [ {
-                        "r" : "223",
+                        "r" : "224",
                         "s" : [ {
                            "value" : [ "'foo'" ]
                         } ]
                      }, {
                         "value" : [ " in " ]
                      }, {
-                        "r" : "224",
+                        "r" : "225",
                         "s" : [ {
                            "value" : [ "\"SharedCodes\"" ]
                         } ]
@@ -1297,30 +2081,30 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "225",
+               "localId" : "226",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "InValueSet",
                "signature" : [ {
-                  "localId" : "226",
+                  "localId" : "227",
                   "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
                } ],
                "code" : {
-                  "localId" : "223",
+                  "localId" : "224",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "foo",
                   "type" : "Literal"
                },
                "valueset" : {
-                  "localId" : "224",
+                  "localId" : "225",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "SharedCodes",
                   "preserve" : true
                }
             }
          }, {
-            "localId" : "228",
+            "localId" : "229",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "SharedCodesNoMatch",
             "context" : "Patient",
@@ -1328,20 +2112,20 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "228",
+                  "r" : "229",
                   "s" : [ {
                      "value" : [ "","define ","SharedCodesNoMatch",": " ]
                   }, {
-                     "r" : "231",
+                     "r" : "232",
                      "s" : [ {
-                        "r" : "229",
+                        "r" : "230",
                         "s" : [ {
                            "value" : [ "'baz'" ]
                         } ]
                      }, {
                         "value" : [ " in " ]
                      }, {
-                        "r" : "230",
+                        "r" : "231",
                         "s" : [ {
                            "value" : [ "\"SharedCodes\"" ]
                         } ]
@@ -1350,30 +2134,30 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "231",
+               "localId" : "232",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "InValueSet",
                "signature" : [ {
-                  "localId" : "232",
+                  "localId" : "233",
                   "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
                } ],
                "code" : {
-                  "localId" : "229",
+                  "localId" : "230",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "baz",
                   "type" : "Literal"
                },
                "valueset" : {
-                  "localId" : "230",
+                  "localId" : "231",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "SharedCodes",
                   "preserve" : true
                }
             }
          }, {
-            "localId" : "234",
+            "localId" : "235",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "ImproperSharedCodesCodeValue",
             "context" : "Patient",
@@ -1381,20 +2165,20 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "234",
+                  "r" : "235",
                   "s" : [ {
                      "value" : [ "","define ","ImproperSharedCodesCodeValue",": " ]
                   }, {
-                     "r" : "237",
+                     "r" : "238",
                      "s" : [ {
-                        "r" : "235",
+                        "r" : "236",
                         "s" : [ {
                            "value" : [ "'codeValue'" ]
                         } ]
                      }, {
                         "value" : [ " in " ]
                      }, {
-                        "r" : "236",
+                        "r" : "237",
                         "s" : [ {
                            "value" : [ "\"ImproperSharedCodes\"" ]
                         } ]
@@ -1403,30 +2187,30 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "237",
+               "localId" : "238",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "InValueSet",
                "signature" : [ {
-                  "localId" : "238",
+                  "localId" : "239",
                   "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
                } ],
                "code" : {
-                  "localId" : "235",
+                  "localId" : "236",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "codeValue",
                   "type" : "Literal"
                },
                "valueset" : {
-                  "localId" : "236",
+                  "localId" : "237",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "ImproperSharedCodes",
                   "preserve" : true
                }
             }
          }, {
-            "localId" : "240",
+            "localId" : "241",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "StringInVersionedValueSet",
             "context" : "Patient",
@@ -1434,20 +2218,20 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "240",
+                  "r" : "241",
                   "s" : [ {
                      "value" : [ "","define ","StringInVersionedValueSet",": " ]
                   }, {
-                     "r" : "243",
+                     "r" : "244",
                      "s" : [ {
-                        "r" : "241",
+                        "r" : "242",
                         "s" : [ {
                            "value" : [ "'F'" ]
                         } ]
                      }, {
                         "value" : [ " in " ]
                      }, {
-                        "r" : "242",
+                        "r" : "243",
                         "s" : [ {
                            "value" : [ "\"Versioned Female\"" ]
                         } ]
@@ -1456,30 +2240,30 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "243",
+               "localId" : "244",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "InValueSet",
                "signature" : [ {
-                  "localId" : "244",
+                  "localId" : "245",
                   "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
                } ],
                "code" : {
-                  "localId" : "241",
+                  "localId" : "242",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "F",
                   "type" : "Literal"
                },
                "valueset" : {
-                  "localId" : "242",
+                  "localId" : "243",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Versioned Female",
                   "preserve" : true
                }
             }
          }, {
-            "localId" : "246",
+            "localId" : "247",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "ShortCode",
             "context" : "Patient",
@@ -1487,20 +2271,20 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "246",
+                  "r" : "247",
                   "s" : [ {
                      "value" : [ "","define ","ShortCode",": " ]
                   }, {
-                     "r" : "251",
+                     "r" : "252",
                      "s" : [ {
-                        "r" : "247",
+                        "r" : "248",
                         "s" : [ {
                            "value" : [ "Code"," { " ]
                         }, {
                            "s" : [ {
                               "value" : [ "code",": " ]
                            }, {
-                              "r" : "249",
+                              "r" : "250",
                               "s" : [ {
                                  "value" : [ "'F'" ]
                               } ]
@@ -1511,7 +2295,7 @@ module.exports['InValueSet'] = {
                      }, {
                         "value" : [ " in " ]
                      }, {
-                        "r" : "250",
+                        "r" : "251",
                         "s" : [ {
                            "value" : [ "\"Female\"" ]
                         } ]
@@ -1520,23 +2304,23 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "251",
+               "localId" : "252",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "InValueSet",
                "signature" : [ {
-                  "localId" : "252",
+                  "localId" : "253",
                   "name" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "NamedTypeSpecifier"
                } ],
                "code" : {
-                  "localId" : "247",
+                  "localId" : "248",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                   "classType" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "Instance",
                   "element" : [ {
                      "name" : "code",
                      "value" : {
-                        "localId" : "249",
+                        "localId" : "250",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "valueType" : "{urn:hl7-org:elm-types:r1}String",
                         "value" : "F",
@@ -1545,14 +2329,14 @@ module.exports['InValueSet'] = {
                   } ]
                },
                "valueset" : {
-                  "localId" : "250",
+                  "localId" : "251",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Female",
                   "preserve" : true
                }
             }
          }, {
-            "localId" : "254",
+            "localId" : "255",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "MediumCode",
             "context" : "Patient",
@@ -1560,20 +2344,20 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "254",
+                  "r" : "255",
                   "s" : [ {
                      "value" : [ "","define ","MediumCode",": " ]
                   }, {
-                     "r" : "260",
+                     "r" : "261",
                      "s" : [ {
-                        "r" : "255",
+                        "r" : "256",
                         "s" : [ {
                            "value" : [ "Code"," { " ]
                         }, {
                            "s" : [ {
                               "value" : [ "code",": " ]
                            }, {
-                              "r" : "257",
+                              "r" : "258",
                               "s" : [ {
                                  "value" : [ "'F'" ]
                               } ]
@@ -1584,7 +2368,7 @@ module.exports['InValueSet'] = {
                            "s" : [ {
                               "value" : [ "system",": " ]
                            }, {
-                              "r" : "258",
+                              "r" : "259",
                               "s" : [ {
                                  "value" : [ "'2.16.840.1.113883.18.2'" ]
                               } ]
@@ -1595,7 +2379,7 @@ module.exports['InValueSet'] = {
                      }, {
                         "value" : [ " in " ]
                      }, {
-                        "r" : "259",
+                        "r" : "260",
                         "s" : [ {
                            "value" : [ "\"Female\"" ]
                         } ]
@@ -1604,23 +2388,23 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "260",
+               "localId" : "261",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "InValueSet",
                "signature" : [ {
-                  "localId" : "261",
+                  "localId" : "262",
                   "name" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "NamedTypeSpecifier"
                } ],
                "code" : {
-                  "localId" : "255",
+                  "localId" : "256",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                   "classType" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "Instance",
                   "element" : [ {
                      "name" : "code",
                      "value" : {
-                        "localId" : "257",
+                        "localId" : "258",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "valueType" : "{urn:hl7-org:elm-types:r1}String",
                         "value" : "F",
@@ -1629,7 +2413,7 @@ module.exports['InValueSet'] = {
                   }, {
                      "name" : "system",
                      "value" : {
-                        "localId" : "258",
+                        "localId" : "259",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "valueType" : "{urn:hl7-org:elm-types:r1}String",
                         "value" : "2.16.840.1.113883.18.2",
@@ -1638,14 +2422,14 @@ module.exports['InValueSet'] = {
                   } ]
                },
                "valueset" : {
-                  "localId" : "259",
+                  "localId" : "260",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Female",
                   "preserve" : true
                }
             }
          }, {
-            "localId" : "263",
+            "localId" : "264",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "LongCode",
             "context" : "Patient",
@@ -1653,20 +2437,20 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "263",
+                  "r" : "264",
                   "s" : [ {
                      "value" : [ "","define ","LongCode",": " ]
                   }, {
-                     "r" : "270",
+                     "r" : "271",
                      "s" : [ {
-                        "r" : "264",
+                        "r" : "265",
                         "s" : [ {
                            "value" : [ "Code"," { " ]
                         }, {
                            "s" : [ {
                               "value" : [ "code",": " ]
                            }, {
-                              "r" : "266",
+                              "r" : "267",
                               "s" : [ {
                                  "value" : [ "'F'" ]
                               } ]
@@ -1677,7 +2461,7 @@ module.exports['InValueSet'] = {
                            "s" : [ {
                               "value" : [ "system",": " ]
                            }, {
-                              "r" : "267",
+                              "r" : "268",
                               "s" : [ {
                                  "value" : [ "'2.16.840.1.113883.18.2'" ]
                               } ]
@@ -1688,7 +2472,7 @@ module.exports['InValueSet'] = {
                            "s" : [ {
                               "value" : [ "version",": " ]
                            }, {
-                              "r" : "268",
+                              "r" : "269",
                               "s" : [ {
                                  "value" : [ "'HL7V2.5'" ]
                               } ]
@@ -1699,7 +2483,7 @@ module.exports['InValueSet'] = {
                      }, {
                         "value" : [ " in " ]
                      }, {
-                        "r" : "269",
+                        "r" : "270",
                         "s" : [ {
                            "value" : [ "\"Female\"" ]
                         } ]
@@ -1708,23 +2492,23 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "270",
+               "localId" : "271",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "InValueSet",
                "signature" : [ {
-                  "localId" : "271",
+                  "localId" : "272",
                   "name" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "NamedTypeSpecifier"
                } ],
                "code" : {
-                  "localId" : "264",
+                  "localId" : "265",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                   "classType" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "Instance",
                   "element" : [ {
                      "name" : "code",
                      "value" : {
-                        "localId" : "266",
+                        "localId" : "267",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "valueType" : "{urn:hl7-org:elm-types:r1}String",
                         "value" : "F",
@@ -1733,7 +2517,7 @@ module.exports['InValueSet'] = {
                   }, {
                      "name" : "system",
                      "value" : {
-                        "localId" : "267",
+                        "localId" : "268",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "valueType" : "{urn:hl7-org:elm-types:r1}String",
                         "value" : "2.16.840.1.113883.18.2",
@@ -1742,7 +2526,7 @@ module.exports['InValueSet'] = {
                   }, {
                      "name" : "version",
                      "value" : {
-                        "localId" : "268",
+                        "localId" : "269",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "valueType" : "{urn:hl7-org:elm-types:r1}String",
                         "value" : "HL7V2.5",
@@ -1751,14 +2535,14 @@ module.exports['InValueSet'] = {
                   } ]
                },
                "valueset" : {
-                  "localId" : "269",
+                  "localId" : "270",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Female",
                   "preserve" : true
                }
             }
          }, {
-            "localId" : "273",
+            "localId" : "274",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "WrongString",
             "context" : "Patient",
@@ -1766,20 +2550,20 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "273",
+                  "r" : "274",
                   "s" : [ {
                      "value" : [ "","define ","WrongString",": " ]
                   }, {
-                     "r" : "276",
+                     "r" : "277",
                      "s" : [ {
-                        "r" : "274",
+                        "r" : "275",
                         "s" : [ {
                            "value" : [ "'M'" ]
                         } ]
                      }, {
                         "value" : [ " in " ]
                      }, {
-                        "r" : "275",
+                        "r" : "276",
                         "s" : [ {
                            "value" : [ "\"Female\"" ]
                         } ]
@@ -1788,30 +2572,30 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "276",
+               "localId" : "277",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "InValueSet",
                "signature" : [ {
-                  "localId" : "277",
+                  "localId" : "278",
                   "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
                } ],
                "code" : {
-                  "localId" : "274",
+                  "localId" : "275",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "M",
                   "type" : "Literal"
                },
                "valueset" : {
-                  "localId" : "275",
+                  "localId" : "276",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Female",
                   "preserve" : true
                }
             }
          }, {
-            "localId" : "279",
+            "localId" : "280",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "WrongStringInVersionedValueSet",
             "context" : "Patient",
@@ -1819,20 +2603,20 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "279",
+                  "r" : "280",
                   "s" : [ {
                      "value" : [ "","define ","WrongStringInVersionedValueSet",": " ]
                   }, {
-                     "r" : "282",
+                     "r" : "283",
                      "s" : [ {
-                        "r" : "280",
+                        "r" : "281",
                         "s" : [ {
                            "value" : [ "'M'" ]
                         } ]
                      }, {
                         "value" : [ " in " ]
                      }, {
-                        "r" : "281",
+                        "r" : "282",
                         "s" : [ {
                            "value" : [ "\"Versioned Female\"" ]
                         } ]
@@ -1841,30 +2625,30 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "282",
+               "localId" : "283",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "InValueSet",
                "signature" : [ {
-                  "localId" : "283",
+                  "localId" : "284",
                   "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
                } ],
                "code" : {
-                  "localId" : "280",
+                  "localId" : "281",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "M",
                   "type" : "Literal"
                },
                "valueset" : {
-                  "localId" : "281",
+                  "localId" : "282",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Versioned Female",
                   "preserve" : true
                }
             }
          }, {
-            "localId" : "285",
+            "localId" : "286",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "WrongShortCode",
             "context" : "Patient",
@@ -1872,20 +2656,20 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "285",
+                  "r" : "286",
                   "s" : [ {
                      "value" : [ "","define ","WrongShortCode",": " ]
                   }, {
-                     "r" : "290",
+                     "r" : "291",
                      "s" : [ {
-                        "r" : "286",
+                        "r" : "287",
                         "s" : [ {
                            "value" : [ "Code"," { " ]
                         }, {
                            "s" : [ {
                               "value" : [ "code",": " ]
                            }, {
-                              "r" : "288",
+                              "r" : "289",
                               "s" : [ {
                                  "value" : [ "'M'" ]
                               } ]
@@ -1896,7 +2680,7 @@ module.exports['InValueSet'] = {
                      }, {
                         "value" : [ " in " ]
                      }, {
-                        "r" : "289",
+                        "r" : "290",
                         "s" : [ {
                            "value" : [ "\"Female\"" ]
                         } ]
@@ -1905,23 +2689,23 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "290",
+               "localId" : "291",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "InValueSet",
                "signature" : [ {
-                  "localId" : "291",
+                  "localId" : "292",
                   "name" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "NamedTypeSpecifier"
                } ],
                "code" : {
-                  "localId" : "286",
+                  "localId" : "287",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                   "classType" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "Instance",
                   "element" : [ {
                      "name" : "code",
                      "value" : {
-                        "localId" : "288",
+                        "localId" : "289",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "valueType" : "{urn:hl7-org:elm-types:r1}String",
                         "value" : "M",
@@ -1930,14 +2714,14 @@ module.exports['InValueSet'] = {
                   } ]
                },
                "valueset" : {
-                  "localId" : "289",
+                  "localId" : "290",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Female",
                   "preserve" : true
                }
             }
          }, {
-            "localId" : "293",
+            "localId" : "294",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "WrongMediumCode",
             "context" : "Patient",
@@ -1945,20 +2729,20 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "293",
+                  "r" : "294",
                   "s" : [ {
                      "value" : [ "","define ","WrongMediumCode",": " ]
                   }, {
-                     "r" : "299",
+                     "r" : "300",
                      "s" : [ {
-                        "r" : "294",
+                        "r" : "295",
                         "s" : [ {
                            "value" : [ "Code"," { " ]
                         }, {
                            "s" : [ {
                               "value" : [ "code",": " ]
                            }, {
-                              "r" : "296",
+                              "r" : "297",
                               "s" : [ {
                                  "value" : [ "'F'" ]
                               } ]
@@ -1969,7 +2753,7 @@ module.exports['InValueSet'] = {
                            "s" : [ {
                               "value" : [ "system",": " ]
                            }, {
-                              "r" : "297",
+                              "r" : "298",
                               "s" : [ {
                                  "value" : [ "'3.16.840.1.113883.18.2'" ]
                               } ]
@@ -1980,7 +2764,7 @@ module.exports['InValueSet'] = {
                      }, {
                         "value" : [ " in " ]
                      }, {
-                        "r" : "298",
+                        "r" : "299",
                         "s" : [ {
                            "value" : [ "\"Female\"" ]
                         } ]
@@ -1989,23 +2773,23 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "299",
+               "localId" : "300",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "InValueSet",
                "signature" : [ {
-                  "localId" : "300",
+                  "localId" : "301",
                   "name" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "NamedTypeSpecifier"
                } ],
                "code" : {
-                  "localId" : "294",
+                  "localId" : "295",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                   "classType" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "Instance",
                   "element" : [ {
                      "name" : "code",
                      "value" : {
-                        "localId" : "296",
+                        "localId" : "297",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "valueType" : "{urn:hl7-org:elm-types:r1}String",
                         "value" : "F",
@@ -2014,7 +2798,7 @@ module.exports['InValueSet'] = {
                   }, {
                      "name" : "system",
                      "value" : {
-                        "localId" : "297",
+                        "localId" : "298",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "valueType" : "{urn:hl7-org:elm-types:r1}String",
                         "value" : "3.16.840.1.113883.18.2",
@@ -2023,14 +2807,14 @@ module.exports['InValueSet'] = {
                   } ]
                },
                "valueset" : {
-                  "localId" : "298",
+                  "localId" : "299",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Female",
                   "preserve" : true
                }
             }
          }, {
-            "localId" : "302",
+            "localId" : "303",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "LongCodeDifferentVersion",
             "context" : "Patient",
@@ -2038,20 +2822,20 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "302",
+                  "r" : "303",
                   "s" : [ {
                      "value" : [ "","define ","LongCodeDifferentVersion",": " ]
                   }, {
-                     "r" : "309",
+                     "r" : "310",
                      "s" : [ {
-                        "r" : "303",
+                        "r" : "304",
                         "s" : [ {
                            "value" : [ "Code"," { " ]
                         }, {
                            "s" : [ {
                               "value" : [ "code",": " ]
                            }, {
-                              "r" : "305",
+                              "r" : "306",
                               "s" : [ {
                                  "value" : [ "'F'" ]
                               } ]
@@ -2062,7 +2846,7 @@ module.exports['InValueSet'] = {
                            "s" : [ {
                               "value" : [ "system",": " ]
                            }, {
-                              "r" : "306",
+                              "r" : "307",
                               "s" : [ {
                                  "value" : [ "'2.16.840.1.113883.18.2'" ]
                               } ]
@@ -2073,7 +2857,7 @@ module.exports['InValueSet'] = {
                            "s" : [ {
                               "value" : [ "version",": " ]
                            }, {
-                              "r" : "307",
+                              "r" : "308",
                               "s" : [ {
                                  "value" : [ "'HL7V2.6'" ]
                               } ]
@@ -2084,7 +2868,7 @@ module.exports['InValueSet'] = {
                      }, {
                         "value" : [ " in " ]
                      }, {
-                        "r" : "308",
+                        "r" : "309",
                         "s" : [ {
                            "value" : [ "\"Female\"" ]
                         } ]
@@ -2093,23 +2877,23 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "309",
+               "localId" : "310",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "InValueSet",
                "signature" : [ {
-                  "localId" : "310",
+                  "localId" : "311",
                   "name" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "NamedTypeSpecifier"
                } ],
                "code" : {
-                  "localId" : "303",
+                  "localId" : "304",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                   "classType" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "Instance",
                   "element" : [ {
                      "name" : "code",
                      "value" : {
-                        "localId" : "305",
+                        "localId" : "306",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "valueType" : "{urn:hl7-org:elm-types:r1}String",
                         "value" : "F",
@@ -2118,7 +2902,7 @@ module.exports['InValueSet'] = {
                   }, {
                      "name" : "system",
                      "value" : {
-                        "localId" : "306",
+                        "localId" : "307",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "valueType" : "{urn:hl7-org:elm-types:r1}String",
                         "value" : "2.16.840.1.113883.18.2",
@@ -2127,7 +2911,7 @@ module.exports['InValueSet'] = {
                   }, {
                      "name" : "version",
                      "value" : {
-                        "localId" : "307",
+                        "localId" : "308",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "valueType" : "{urn:hl7-org:elm-types:r1}String",
                         "value" : "HL7V2.6",
@@ -2136,14 +2920,14 @@ module.exports['InValueSet'] = {
                   } ]
                },
                "valueset" : {
-                  "localId" : "308",
+                  "localId" : "309",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Female",
                   "preserve" : true
                }
             }
          }, {
-            "localId" : "312",
+            "localId" : "313",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "NullCode",
             "context" : "Patient",
@@ -2151,18 +2935,18 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "312",
+                  "r" : "313",
                   "s" : [ {
                      "value" : [ "","define ","NullCode",": " ]
                   }, {
-                     "r" : "320",
+                     "r" : "321",
                      "s" : [ {
-                        "r" : "313",
+                        "r" : "314",
                         "s" : [ {
                            "value" : [ "Code"," { " ]
                         }, {
                            "s" : [ {
-                              "r" : "315",
+                              "r" : "316",
                               "value" : [ "code",": ","null" ]
                            } ]
                         }, {
@@ -2171,7 +2955,7 @@ module.exports['InValueSet'] = {
                            "s" : [ {
                               "value" : [ "system",": " ]
                            }, {
-                              "r" : "317",
+                              "r" : "318",
                               "s" : [ {
                                  "value" : [ "'2.16.840.1.113883.18.2'" ]
                               } ]
@@ -2182,7 +2966,7 @@ module.exports['InValueSet'] = {
                            "s" : [ {
                               "value" : [ "version",": " ]
                            }, {
-                              "r" : "318",
+                              "r" : "319",
                               "s" : [ {
                                  "value" : [ "'HL7V2.6'" ]
                               } ]
@@ -2193,7 +2977,7 @@ module.exports['InValueSet'] = {
                      }, {
                         "value" : [ " in " ]
                      }, {
-                        "r" : "319",
+                        "r" : "320",
                         "s" : [ {
                            "value" : [ "\"Female\"" ]
                         } ]
@@ -2202,28 +2986,28 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "320",
+               "localId" : "321",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "InValueSet",
                "signature" : [ {
-                  "localId" : "321",
+                  "localId" : "322",
                   "name" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "NamedTypeSpecifier"
                } ],
                "code" : {
-                  "localId" : "313",
+                  "localId" : "314",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                   "classType" : "{urn:hl7-org:elm-types:r1}Code",
                   "type" : "Instance",
                   "element" : [ {
                      "name" : "code",
                      "value" : {
-                        "localId" : "316",
+                        "localId" : "317",
                         "asType" : "{urn:hl7-org:elm-types:r1}String",
                         "type" : "As",
                         "signature" : [ ],
                         "operand" : {
-                           "localId" : "315",
+                           "localId" : "316",
                            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
                            "type" : "Null"
                         }
@@ -2231,7 +3015,7 @@ module.exports['InValueSet'] = {
                   }, {
                      "name" : "system",
                      "value" : {
-                        "localId" : "317",
+                        "localId" : "318",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "valueType" : "{urn:hl7-org:elm-types:r1}String",
                         "value" : "2.16.840.1.113883.18.2",
@@ -2240,7 +3024,7 @@ module.exports['InValueSet'] = {
                   }, {
                      "name" : "version",
                      "value" : {
-                        "localId" : "318",
+                        "localId" : "319",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                         "valueType" : "{urn:hl7-org:elm-types:r1}String",
                         "value" : "HL7V2.6",
@@ -2249,7 +3033,7 @@ module.exports['InValueSet'] = {
                   } ]
                },
                "valueset" : {
-                  "localId" : "319",
+                  "localId" : "320",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Female",
                   "preserve" : true
@@ -2258,875 +3042,6 @@ module.exports['InValueSet'] = {
          }, {
             "localId" : "323",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
-            "name" : "InListOfCodes",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "323",
-                  "s" : [ {
-                     "value" : [ "","define ","InListOfCodes",": " ]
-                  }, {
-                     "r" : "336",
-                     "s" : [ {
-                        "r" : "324",
-                        "s" : [ {
-                           "value" : [ "{ " ]
-                        }, {
-                           "r" : "325",
-                           "s" : [ {
-                              "value" : [ "Code"," { " ]
-                           }, {
-                              "s" : [ {
-                                 "value" : [ "code",": " ]
-                              }, {
-                                 "r" : "327",
-                                 "s" : [ {
-                                    "value" : [ "'M'" ]
-                                 } ]
-                              } ]
-                           }, {
-                              "value" : [ " }" ]
-                           } ]
-                        }, {
-                           "value" : [ " , " ]
-                        }, {
-                           "r" : "328",
-                           "s" : [ {
-                              "value" : [ "Code"," { " ]
-                           }, {
-                              "s" : [ {
-                                 "value" : [ "code",": " ]
-                              }, {
-                                 "r" : "330",
-                                 "s" : [ {
-                                    "value" : [ "'F'" ]
-                                 } ]
-                              } ]
-                           }, {
-                              "value" : [ ", " ]
-                           }, {
-                              "s" : [ {
-                                 "value" : [ "system",": " ]
-                              }, {
-                                 "r" : "331",
-                                 "s" : [ {
-                                    "value" : [ "'2.16.840.1.113883.18.2'" ]
-                                 } ]
-                              } ]
-                           }, {
-                              "value" : [ ", " ]
-                           }, {
-                              "s" : [ {
-                                 "value" : [ "version",": " ]
-                              }, {
-                                 "r" : "332",
-                                 "s" : [ {
-                                    "value" : [ "'HL7V2.5'" ]
-                                 } ]
-                              } ]
-                           }, {
-                              "value" : [ " }" ]
-                           } ]
-                        }, {
-                           "value" : [ " }" ]
-                        } ]
-                     }, {
-                        "value" : [ " in " ]
-                     }, {
-                        "r" : "335",
-                        "s" : [ {
-                           "value" : [ "\"Female\"" ]
-                        } ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "expression" : {
-               "localId" : "336",
-               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
-               "type" : "AnyInValueSet",
-               "signature" : [ {
-                  "localId" : "337",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "338",
-                     "name" : "{urn:hl7-org:elm-types:r1}Code",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               } ],
-               "codes" : {
-                  "localId" : "324",
-                  "type" : "List",
-                  "resultTypeSpecifier" : {
-                     "localId" : "333",
-                     "type" : "ListTypeSpecifier",
-                     "elementType" : {
-                        "localId" : "334",
-                        "name" : "{urn:hl7-org:elm-types:r1}Code",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  },
-                  "element" : [ {
-                     "localId" : "325",
-                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-                     "classType" : "{urn:hl7-org:elm-types:r1}Code",
-                     "type" : "Instance",
-                     "element" : [ {
-                        "name" : "code",
-                        "value" : {
-                           "localId" : "327",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "M",
-                           "type" : "Literal"
-                        }
-                     } ]
-                  }, {
-                     "localId" : "328",
-                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-                     "classType" : "{urn:hl7-org:elm-types:r1}Code",
-                     "type" : "Instance",
-                     "element" : [ {
-                        "name" : "code",
-                        "value" : {
-                           "localId" : "330",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "F",
-                           "type" : "Literal"
-                        }
-                     }, {
-                        "name" : "system",
-                        "value" : {
-                           "localId" : "331",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "2.16.840.1.113883.18.2",
-                           "type" : "Literal"
-                        }
-                     }, {
-                        "name" : "version",
-                        "value" : {
-                           "localId" : "332",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "HL7V2.5",
-                           "type" : "Literal"
-                        }
-                     } ]
-                  } ]
-               },
-               "valueset" : {
-                  "localId" : "335",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "name" : "Female",
-                  "preserve" : true
-               }
-            }
-         }, {
-            "localId" : "340",
-            "name" : "ListOfCodes",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "340",
-                  "s" : [ {
-                     "value" : [ "","define ","ListOfCodes",": " ]
-                  }, {
-                     "r" : "341",
-                     "s" : [ {
-                        "value" : [ "{ " ]
-                     }, {
-                        "r" : "342",
-                        "s" : [ {
-                           "value" : [ "Code"," { " ]
-                        }, {
-                           "s" : [ {
-                              "value" : [ "code",": " ]
-                           }, {
-                              "r" : "344",
-                              "s" : [ {
-                                 "value" : [ "'M'" ]
-                              } ]
-                           } ]
-                        }, {
-                           "value" : [ " }" ]
-                        } ]
-                     }, {
-                        "value" : [ " , " ]
-                     }, {
-                        "r" : "345",
-                        "s" : [ {
-                           "value" : [ "Code"," { " ]
-                        }, {
-                           "s" : [ {
-                              "value" : [ "code",": " ]
-                           }, {
-                              "r" : "347",
-                              "s" : [ {
-                                 "value" : [ "'F'" ]
-                              } ]
-                           } ]
-                        }, {
-                           "value" : [ ", " ]
-                        }, {
-                           "s" : [ {
-                              "value" : [ "system",": " ]
-                           }, {
-                              "r" : "348",
-                              "s" : [ {
-                                 "value" : [ "'2.16.840.1.113883.18.2'" ]
-                              } ]
-                           } ]
-                        }, {
-                           "value" : [ ", " ]
-                        }, {
-                           "s" : [ {
-                              "value" : [ "version",": " ]
-                           }, {
-                              "r" : "349",
-                              "s" : [ {
-                                 "value" : [ "'HL7V2.5'" ]
-                              } ]
-                           } ]
-                        }, {
-                           "value" : [ " }" ]
-                        } ]
-                     }, {
-                        "value" : [ " }" ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "resultTypeSpecifier" : {
-               "localId" : "352",
-               "type" : "ListTypeSpecifier",
-               "elementType" : {
-                  "localId" : "353",
-                  "name" : "{urn:hl7-org:elm-types:r1}Code",
-                  "type" : "NamedTypeSpecifier"
-               }
-            },
-            "expression" : {
-               "localId" : "341",
-               "type" : "List",
-               "resultTypeSpecifier" : {
-                  "localId" : "350",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "351",
-                     "name" : "{urn:hl7-org:elm-types:r1}Code",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               },
-               "element" : [ {
-                  "localId" : "342",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-                  "classType" : "{urn:hl7-org:elm-types:r1}Code",
-                  "type" : "Instance",
-                  "element" : [ {
-                     "name" : "code",
-                     "value" : {
-                        "localId" : "344",
-                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                        "value" : "M",
-                        "type" : "Literal"
-                     }
-                  } ]
-               }, {
-                  "localId" : "345",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-                  "classType" : "{urn:hl7-org:elm-types:r1}Code",
-                  "type" : "Instance",
-                  "element" : [ {
-                     "name" : "code",
-                     "value" : {
-                        "localId" : "347",
-                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                        "value" : "F",
-                        "type" : "Literal"
-                     }
-                  }, {
-                     "name" : "system",
-                     "value" : {
-                        "localId" : "348",
-                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                        "value" : "2.16.840.1.113883.18.2",
-                        "type" : "Literal"
-                     }
-                  }, {
-                     "name" : "version",
-                     "value" : {
-                        "localId" : "349",
-                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                        "value" : "HL7V2.5",
-                        "type" : "Literal"
-                     }
-                  } ]
-               } ]
-            }
-         }, {
-            "localId" : "355",
-            "name" : "WrongListOfCodes",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "355",
-                  "s" : [ {
-                     "value" : [ "","define ","WrongListOfCodes",": " ]
-                  }, {
-                     "r" : "356",
-                     "s" : [ {
-                        "value" : [ "{ " ]
-                     }, {
-                        "r" : "357",
-                        "s" : [ {
-                           "value" : [ "Code"," { " ]
-                        }, {
-                           "s" : [ {
-                              "value" : [ "code",": " ]
-                           }, {
-                              "r" : "359",
-                              "s" : [ {
-                                 "value" : [ "'M'" ]
-                              } ]
-                           } ]
-                        }, {
-                           "value" : [ " }" ]
-                        } ]
-                     }, {
-                        "value" : [ ", " ]
-                     }, {
-                        "r" : "360",
-                        "s" : [ {
-                           "value" : [ "Code"," { " ]
-                        }, {
-                           "s" : [ {
-                              "value" : [ "code",": " ]
-                           }, {
-                              "r" : "362",
-                              "s" : [ {
-                                 "value" : [ "'F'" ]
-                              } ]
-                           } ]
-                        }, {
-                           "value" : [ ", " ]
-                        }, {
-                           "s" : [ {
-                              "value" : [ "system",": " ]
-                           }, {
-                              "r" : "363",
-                              "s" : [ {
-                                 "value" : [ "'3.16.840.1.113883.18.2'" ]
-                              } ]
-                           } ]
-                        }, {
-                           "value" : [ " }" ]
-                        } ]
-                     }, {
-                        "value" : [ " }" ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "resultTypeSpecifier" : {
-               "localId" : "366",
-               "type" : "ListTypeSpecifier",
-               "elementType" : {
-                  "localId" : "367",
-                  "name" : "{urn:hl7-org:elm-types:r1}Code",
-                  "type" : "NamedTypeSpecifier"
-               }
-            },
-            "expression" : {
-               "localId" : "356",
-               "type" : "List",
-               "resultTypeSpecifier" : {
-                  "localId" : "364",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "365",
-                     "name" : "{urn:hl7-org:elm-types:r1}Code",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               },
-               "element" : [ {
-                  "localId" : "357",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-                  "classType" : "{urn:hl7-org:elm-types:r1}Code",
-                  "type" : "Instance",
-                  "element" : [ {
-                     "name" : "code",
-                     "value" : {
-                        "localId" : "359",
-                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                        "value" : "M",
-                        "type" : "Literal"
-                     }
-                  } ]
-               }, {
-                  "localId" : "360",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-                  "classType" : "{urn:hl7-org:elm-types:r1}Code",
-                  "type" : "Instance",
-                  "element" : [ {
-                     "name" : "code",
-                     "value" : {
-                        "localId" : "362",
-                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                        "value" : "F",
-                        "type" : "Literal"
-                     }
-                  }, {
-                     "name" : "system",
-                     "value" : {
-                        "localId" : "363",
-                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                        "value" : "3.16.840.1.113883.18.2",
-                        "type" : "Literal"
-                     }
-                  } ]
-               } ]
-            }
-         }, {
-            "localId" : "369",
-            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
-            "name" : "InListOfCodesExpressionRef",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "369",
-                  "s" : [ {
-                     "value" : [ "","define ","InListOfCodesExpressionRef",": " ]
-                  }, {
-                     "r" : "374",
-                     "s" : [ {
-                        "r" : "370",
-                        "s" : [ {
-                           "value" : [ "ListOfCodes" ]
-                        } ]
-                     }, {
-                        "value" : [ " in " ]
-                     }, {
-                        "r" : "373",
-                        "s" : [ {
-                           "value" : [ "\"Female\"" ]
-                        } ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "expression" : {
-               "localId" : "374",
-               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
-               "type" : "AnyInValueSet",
-               "signature" : [ {
-                  "localId" : "375",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "376",
-                     "name" : "{urn:hl7-org:elm-types:r1}Code",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               } ],
-               "codes" : {
-                  "localId" : "370",
-                  "name" : "ListOfCodes",
-                  "type" : "ExpressionRef",
-                  "resultTypeSpecifier" : {
-                     "localId" : "371",
-                     "type" : "ListTypeSpecifier",
-                     "elementType" : {
-                        "localId" : "372",
-                        "name" : "{urn:hl7-org:elm-types:r1}Code",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  }
-               },
-               "valueset" : {
-                  "localId" : "373",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "name" : "Female",
-                  "preserve" : true
-               }
-            }
-         }, {
-            "localId" : "378",
-            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
-            "name" : "InWrongListOfCodes",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "378",
-                  "s" : [ {
-                     "value" : [ "","define ","InWrongListOfCodes",": " ]
-                  }, {
-                     "r" : "383",
-                     "s" : [ {
-                        "r" : "379",
-                        "s" : [ {
-                           "value" : [ "WrongListOfCodes" ]
-                        } ]
-                     }, {
-                        "value" : [ " in " ]
-                     }, {
-                        "r" : "382",
-                        "s" : [ {
-                           "value" : [ "\"Female\"" ]
-                        } ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "expression" : {
-               "localId" : "383",
-               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
-               "type" : "AnyInValueSet",
-               "signature" : [ {
-                  "localId" : "384",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "385",
-                     "name" : "{urn:hl7-org:elm-types:r1}Code",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               } ],
-               "codes" : {
-                  "localId" : "379",
-                  "name" : "WrongListOfCodes",
-                  "type" : "ExpressionRef",
-                  "resultTypeSpecifier" : {
-                     "localId" : "380",
-                     "type" : "ListTypeSpecifier",
-                     "elementType" : {
-                        "localId" : "381",
-                        "name" : "{urn:hl7-org:elm-types:r1}Code",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  }
-               },
-               "valueset" : {
-                  "localId" : "382",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "name" : "Female",
-                  "preserve" : true
-               }
-            }
-         }, {
-            "localId" : "387",
-            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
-            "name" : "ListOfCodesWithNull",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "387",
-                  "s" : [ {
-                     "value" : [ "","define ","ListOfCodesWithNull",": " ]
-                  }, {
-                     "r" : "402",
-                     "s" : [ {
-                        "r" : "388",
-                        "s" : [ {
-                           "value" : [ "{ " ]
-                        }, {
-                           "r" : "389",
-                           "s" : [ {
-                              "value" : [ "Code"," { " ]
-                           }, {
-                              "s" : [ {
-                                 "value" : [ "code",": " ]
-                              }, {
-                                 "r" : "391",
-                                 "s" : [ {
-                                    "value" : [ "'M'" ]
-                                 } ]
-                              } ]
-                           }, {
-                              "value" : [ " }" ]
-                           } ]
-                        }, {
-                           "value" : [ ", " ]
-                        }, {
-                           "r" : "392",
-                           "s" : [ {
-                              "value" : [ "(" ]
-                           }, {
-                              "r" : "392",
-                              "s" : [ {
-                                 "r" : "393",
-                                 "value" : [ "null"," as " ]
-                              }, {
-                                 "r" : "394",
-                                 "s" : [ {
-                                    "value" : [ "Code" ]
-                                 } ]
-                              } ]
-                           }, {
-                              "value" : [ ")" ]
-                           } ]
-                        }, {
-                           "value" : [ ", " ]
-                        }, {
-                           "r" : "395",
-                           "s" : [ {
-                              "value" : [ "Code"," { " ]
-                           }, {
-                              "s" : [ {
-                                 "value" : [ "code",": " ]
-                              }, {
-                                 "r" : "397",
-                                 "s" : [ {
-                                    "value" : [ "'F'" ]
-                                 } ]
-                              } ]
-                           }, {
-                              "value" : [ ", " ]
-                           }, {
-                              "s" : [ {
-                                 "value" : [ "system",": " ]
-                              }, {
-                                 "r" : "398",
-                                 "s" : [ {
-                                    "value" : [ "'2.16.840.1.113883.18.2'" ]
-                                 } ]
-                              } ]
-                           }, {
-                              "value" : [ " }" ]
-                           } ]
-                        }, {
-                           "value" : [ " }" ]
-                        } ]
-                     }, {
-                        "value" : [ " in " ]
-                     }, {
-                        "r" : "401",
-                        "s" : [ {
-                           "value" : [ "\"Female\"" ]
-                        } ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "expression" : {
-               "localId" : "402",
-               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
-               "type" : "AnyInValueSet",
-               "signature" : [ {
-                  "localId" : "403",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "404",
-                     "name" : "{urn:hl7-org:elm-types:r1}Code",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               } ],
-               "codes" : {
-                  "localId" : "388",
-                  "type" : "List",
-                  "resultTypeSpecifier" : {
-                     "localId" : "399",
-                     "type" : "ListTypeSpecifier",
-                     "elementType" : {
-                        "localId" : "400",
-                        "name" : "{urn:hl7-org:elm-types:r1}Code",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  },
-                  "element" : [ {
-                     "localId" : "389",
-                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-                     "classType" : "{urn:hl7-org:elm-types:r1}Code",
-                     "type" : "Instance",
-                     "element" : [ {
-                        "name" : "code",
-                        "value" : {
-                           "localId" : "391",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "M",
-                           "type" : "Literal"
-                        }
-                     } ]
-                  }, {
-                     "localId" : "392",
-                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-                     "strict" : false,
-                     "type" : "As",
-                     "signature" : [ ],
-                     "operand" : {
-                        "localId" : "393",
-                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
-                        "type" : "Null"
-                     },
-                     "asTypeSpecifier" : {
-                        "localId" : "394",
-                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-                        "name" : "{urn:hl7-org:elm-types:r1}Code",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  }, {
-                     "localId" : "395",
-                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-                     "classType" : "{urn:hl7-org:elm-types:r1}Code",
-                     "type" : "Instance",
-                     "element" : [ {
-                        "name" : "code",
-                        "value" : {
-                           "localId" : "397",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "F",
-                           "type" : "Literal"
-                        }
-                     }, {
-                        "name" : "system",
-                        "value" : {
-                           "localId" : "398",
-                           "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "2.16.840.1.113883.18.2",
-                           "type" : "Literal"
-                        }
-                     } ]
-                  } ]
-               },
-               "valueset" : {
-                  "localId" : "401",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "name" : "Female",
-                  "preserve" : true
-               }
-            }
-         }, {
-            "localId" : "406",
-            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
-            "name" : "ListOfCodesNull",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "406",
-                  "s" : [ {
-                     "value" : [ "","define ","ListOfCodesNull",": " ]
-                  }, {
-                     "r" : "418",
-                     "s" : [ {
-                        "r" : "407",
-                        "s" : [ {
-                           "value" : [ "(" ]
-                        }, {
-                           "r" : "407",
-                           "s" : [ {
-                              "r" : "408",
-                              "value" : [ "null"," as " ]
-                           }, {
-                              "r" : "409",
-                              "s" : [ {
-                                 "value" : [ "List<" ]
-                              }, {
-                                 "r" : "410",
-                                 "s" : [ {
-                                    "value" : [ "Code" ]
-                                 } ]
-                              }, {
-                                 "value" : [ ">" ]
-                              } ]
-                           } ]
-                        }, {
-                           "value" : [ ")" ]
-                        } ]
-                     }, {
-                        "value" : [ " in " ]
-                     }, {
-                        "r" : "417",
-                        "s" : [ {
-                           "value" : [ "\"Female\"" ]
-                        } ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "expression" : {
-               "localId" : "418",
-               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
-               "type" : "AnyInValueSet",
-               "signature" : [ {
-                  "localId" : "419",
-                  "type" : "ListTypeSpecifier",
-                  "elementType" : {
-                     "localId" : "420",
-                     "name" : "{urn:hl7-org:elm-types:r1}Code",
-                     "type" : "NamedTypeSpecifier"
-                  }
-               } ],
-               "codes" : {
-                  "localId" : "407",
-                  "strict" : false,
-                  "type" : "As",
-                  "resultTypeSpecifier" : {
-                     "localId" : "415",
-                     "type" : "ListTypeSpecifier",
-                     "elementType" : {
-                        "localId" : "416",
-                        "name" : "{urn:hl7-org:elm-types:r1}Code",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  },
-                  "signature" : [ ],
-                  "operand" : {
-                     "localId" : "408",
-                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
-                     "type" : "Null"
-                  },
-                  "asTypeSpecifier" : {
-                     "localId" : "409",
-                     "type" : "ListTypeSpecifier",
-                     "resultTypeSpecifier" : {
-                        "localId" : "411",
-                        "type" : "ListTypeSpecifier",
-                        "elementType" : {
-                           "localId" : "412",
-                           "name" : "{urn:hl7-org:elm-types:r1}Code",
-                           "type" : "NamedTypeSpecifier"
-                        }
-                     },
-                     "elementType" : {
-                        "localId" : "410",
-                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-                        "name" : "{urn:hl7-org:elm-types:r1}Code",
-                        "type" : "NamedTypeSpecifier"
-                     }
-                  }
-               },
-               "valueset" : {
-                  "localId" : "417",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-                  "name" : "Female",
-                  "preserve" : true
-               }
-            }
-         }, {
-            "localId" : "376",
             "name" : "FInVS",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -3134,22 +3049,22 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "376",
+                  "r" : "323",
                   "s" : [ {
                      "value" : [ "","define function FInVS(vs ValueSet): " ]
                   }, {
-                     "r" : "381",
+                     "r" : "328",
                      "s" : [ {
-                        "r" : "381",
+                        "r" : "328",
                         "s" : [ {
-                           "r" : "379",
+                           "r" : "326",
                            "s" : [ {
                               "value" : [ "'F'" ]
                            } ]
                         }, {
                            "value" : [ " in " ]
                         }, {
-                           "r" : "380",
+                           "r" : "327",
                            "s" : [ {
                               "value" : [ "vs" ]
                            } ]
@@ -3159,47 +3074,60 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "381",
+               "localId" : "328",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "InValueSet",
-               "signature" : [ ],
+               "signature" : [ {
+                  "localId" : "329",
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }, {
+                  "localId" : "330",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               } ],
                "code" : {
-                  "localId" : "379",
+                  "localId" : "326",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "F",
                   "type" : "Literal"
                },
                "valuesetExpression" : {
-                  "localId" : "380",
+                  "localId" : "327",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "vs",
                   "type" : "OperandRef"
                }
             },
             "operand" : [ {
-               "localId" : "378",
+               "localId" : "325",
                "name" : "vs",
                "operandTypeSpecifier" : {
-                  "localId" : "377",
+                  "localId" : "324",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "type" : "NamedTypeSpecifier"
                }
             } ]
          }, {
-            "localId" : "383",
+            "localId" : "332",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "FInPassedVS",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "383",
+                  "r" : "332",
                   "s" : [ {
                      "value" : [ "","define ","FInPassedVS",": " ]
                   }, {
-                     "r" : "385",
+                     "r" : "334",
                      "s" : [ {
                         "value" : [ "FInVS","(" ]
                      }, {
-                        "r" : "384",
+                        "r" : "333",
                         "s" : [ {
                            "value" : [ "\"Female\"" ]
                         } ]
@@ -3210,34 +3138,41 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "385",
+               "localId" : "334",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "name" : "FInVS",
                "type" : "FunctionRef",
-               "signature" : [ ],
+               "signature" : [ {
+                  "localId" : "335",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               } ],
                "operand" : [ {
-                  "localId" : "384",
+                  "localId" : "333",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Female",
                   "preserve" : true,
                   "type" : "ValueSetRef"
                } ]
             }
          }, {
-            "localId" : "387",
+            "localId" : "337",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "FInWrongVS",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "387",
+                  "r" : "337",
                   "s" : [ {
                      "value" : [ "","define ","FInWrongVS",": " ]
                   }, {
-                     "r" : "389",
+                     "r" : "339",
                      "s" : [ {
                         "value" : [ "FInVS","(" ]
                      }, {
-                        "r" : "388",
+                        "r" : "338",
                         "s" : [ {
                            "value" : [ "\"Male\"" ]
                         } ]
@@ -3248,39 +3183,46 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "389",
+               "localId" : "339",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "name" : "FInVS",
                "type" : "FunctionRef",
-               "signature" : [ ],
+               "signature" : [ {
+                  "localId" : "340",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               } ],
                "operand" : [ {
-                  "localId" : "388",
+                  "localId" : "338",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Male",
                   "preserve" : true,
                   "type" : "ValueSetRef"
                } ]
             }
          }, {
-            "localId" : "391",
+            "localId" : "342",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "FInNullVS",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "391",
+                  "r" : "342",
                   "s" : [ {
                      "value" : [ "","define ","FInNullVS",": " ]
                   }, {
-                     "r" : "395",
+                     "r" : "346",
                      "s" : [ {
                         "value" : [ "FInVS","(" ]
                      }, {
-                        "r" : "392",
+                        "r" : "343",
                         "s" : [ {
-                           "r" : "393",
+                           "r" : "344",
                            "value" : [ "null"," as " ]
                         }, {
-                           "r" : "394",
+                           "r" : "345",
                            "s" : [ {
                               "value" : [ "ValueSet" ]
                            } ]
@@ -3292,21 +3234,29 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "395",
+               "localId" : "346",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "name" : "FInVS",
                "type" : "FunctionRef",
-               "signature" : [ ],
+               "signature" : [ {
+                  "localId" : "347",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               } ],
                "operand" : [ {
-                  "localId" : "392",
+                  "localId" : "343",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "strict" : false,
                   "type" : "As",
                   "signature" : [ ],
                   "operand" : {
-                     "localId" : "393",
+                     "localId" : "344",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
                      "type" : "Null"
                   },
                   "asTypeSpecifier" : {
-                     "localId" : "394",
+                     "localId" : "345",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                      "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
                      "type" : "NamedTypeSpecifier"
                   }
@@ -3346,7 +3296,7 @@ module.exports['ExpandValueset'] = {
       }, {
          "type" : "Annotation",
          "s" : {
-            "r" : "252",
+            "r" : "330",
             "s" : [ {
                "value" : [ "","library TestSnippet version '1'" ]
             } ]
@@ -3725,7 +3675,7 @@ module.exports['ExpandValueset'] = {
                } ]
             }
          }, {
-            "localId" : "242",
+            "localId" : "270",
             "name" : "ExpandVSHelper",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -3733,17 +3683,17 @@ module.exports['ExpandValueset'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "242",
+                  "r" : "270",
                   "s" : [ {
                      "value" : [ "","define function ExpandVSHelper(vs ValueSet): " ]
                   }, {
-                     "r" : "248",
+                     "r" : "277",
                      "s" : [ {
-                        "r" : "248",
+                        "r" : "277",
                         "s" : [ {
                            "value" : [ "ExpandValueSet","(" ]
                         }, {
-                           "r" : "245",
+                           "r" : "273",
                            "s" : [ {
                               "value" : [ "vs" ]
                            } ]
@@ -3754,42 +3704,66 @@ module.exports['ExpandValueset'] = {
                   } ]
                }
             } ],
+            "resultTypeSpecifier" : {
+               "localId" : "283",
+               "type" : "ListTypeSpecifier",
+               "elementType" : {
+                  "localId" : "284",
+                  "name" : "{urn:hl7-org:elm-types:r1}Code",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
             "expression" : {
-               "localId" : "248",
+               "localId" : "277",
                "type" : "ExpandValueSet",
-               "signature" : [ ],
+               "resultTypeSpecifier" : {
+                  "localId" : "281",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "282",
+                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "signature" : [ {
+                  "localId" : "278",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               } ],
                "operand" : {
-                  "localId" : "245",
+                  "localId" : "273",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "vs",
                   "type" : "OperandRef"
                }
             },
             "operand" : [ {
-               "localId" : "244",
+               "localId" : "272",
                "name" : "vs",
                "operandTypeSpecifier" : {
-                  "localId" : "243",
+                  "localId" : "271",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "type" : "NamedTypeSpecifier"
                }
             } ]
          }, {
-            "localId" : "250",
+            "localId" : "286",
             "name" : "ExpandPassedVS",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "250",
+                  "r" : "286",
                   "s" : [ {
                      "value" : [ "","define ","ExpandPassedVS",": " ]
                   }, {
-                     "r" : "252",
+                     "r" : "288",
                      "s" : [ {
                         "value" : [ "ExpandVSHelper","(" ]
                      }, {
-                        "r" : "251",
+                        "r" : "287",
                         "s" : [ {
                            "value" : [ "\"Female\"" ]
                         } ]
@@ -3799,40 +3773,63 @@ module.exports['ExpandValueset'] = {
                   } ]
                }
             } ],
+            "resultTypeSpecifier" : {
+               "localId" : "292",
+               "type" : "ListTypeSpecifier",
+               "elementType" : {
+                  "localId" : "293",
+                  "name" : "{urn:hl7-org:elm-types:r1}Code",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
             "expression" : {
-               "localId" : "252",
+               "localId" : "288",
                "name" : "ExpandVSHelper",
                "type" : "FunctionRef",
-               "signature" : [ ],
+               "resultTypeSpecifier" : {
+                  "localId" : "290",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "291",
+                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "signature" : [ {
+                  "localId" : "289",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               } ],
                "operand" : [ {
-                  "localId" : "251",
+                  "localId" : "287",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Female",
                   "preserve" : true,
                   "type" : "ValueSetRef"
                } ]
             }
          }, {
-            "localId" : "254",
+            "localId" : "295",
             "name" : "ExpandNullVS",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "254",
+                  "r" : "295",
                   "s" : [ {
                      "value" : [ "","define ","ExpandNullVS",": " ]
                   }, {
-                     "r" : "258",
+                     "r" : "299",
                      "s" : [ {
                         "value" : [ "ExpandVSHelper","(" ]
                      }, {
-                        "r" : "255",
+                        "r" : "296",
                         "s" : [ {
-                           "r" : "256",
+                           "r" : "297",
                            "value" : [ "null"," as " ]
                         }, {
-                           "r" : "257",
+                           "r" : "298",
                            "s" : [ {
                               "value" : [ "ValueSet" ]
                            } ]
@@ -3843,29 +3840,54 @@ module.exports['ExpandValueset'] = {
                   } ]
                }
             } ],
+            "resultTypeSpecifier" : {
+               "localId" : "303",
+               "type" : "ListTypeSpecifier",
+               "elementType" : {
+                  "localId" : "304",
+                  "name" : "{urn:hl7-org:elm-types:r1}Code",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
             "expression" : {
-               "localId" : "258",
+               "localId" : "299",
                "name" : "ExpandVSHelper",
                "type" : "FunctionRef",
-               "signature" : [ ],
+               "resultTypeSpecifier" : {
+                  "localId" : "301",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "302",
+                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "signature" : [ {
+                  "localId" : "300",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               } ],
                "operand" : [ {
-                  "localId" : "255",
+                  "localId" : "296",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "strict" : false,
                   "type" : "As",
                   "signature" : [ ],
                   "operand" : {
-                     "localId" : "256",
+                     "localId" : "297",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
                      "type" : "Null"
                   },
                   "asTypeSpecifier" : {
-                     "localId" : "257",
+                     "localId" : "298",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                      "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
                      "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
          }, {
-            "localId" : "259",
+            "localId" : "305",
             "name" : "UnionVSs",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -3873,22 +3895,22 @@ module.exports['ExpandValueset'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "259",
+                  "r" : "305",
                   "s" : [ {
                      "value" : [ "","define function UnionVSs(vs1 ValueSet, vs2 ValueSet): " ]
                   }, {
-                     "r" : "266",
+                     "r" : "312",
                      "s" : [ {
-                        "r" : "266",
+                        "r" : "312",
                         "s" : [ {
-                           "r" : "264",
+                           "r" : "310",
                            "s" : [ {
                               "value" : [ "vs1" ]
                            } ]
                         }, {
                            "value" : [ " union " ]
                         }, {
-                           "r" : "265",
+                           "r" : "311",
                            "s" : [ {
                               "value" : [ "vs2" ]
                            } ]
@@ -3897,71 +3919,117 @@ module.exports['ExpandValueset'] = {
                   } ]
                }
             } ],
+            "resultTypeSpecifier" : {
+               "localId" : "327",
+               "type" : "ListTypeSpecifier",
+               "elementType" : {
+                  "localId" : "328",
+                  "name" : "{urn:hl7-org:elm-types:r1}Code",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
             "expression" : {
-               "localId" : "266",
+               "localId" : "312",
                "type" : "Union",
-               "signature" : [ ],
+               "resultTypeSpecifier" : {
+                  "localId" : "325",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "326",
+                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "signature" : [ {
+                  "localId" : "319",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "320",
+                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }, {
+                  "localId" : "321",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "322",
+                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ],
                "operand" : [ {
-                  "localId" : "268",
+                  "localId" : "314",
                   "type" : "ExpandValueSet",
-                  "signature" : [ ],
+                  "signature" : [ {
+                     "localId" : "315",
+                     "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "type" : "NamedTypeSpecifier"
+                  } ],
                   "operand" : {
-                     "localId" : "264",
+                     "localId" : "310",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                      "name" : "vs1",
                      "type" : "OperandRef"
                   }
                }, {
-                  "localId" : "270",
+                  "localId" : "317",
                   "type" : "ExpandValueSet",
-                  "signature" : [ ],
+                  "signature" : [ {
+                     "localId" : "318",
+                     "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "type" : "NamedTypeSpecifier"
+                  } ],
                   "operand" : {
-                     "localId" : "265",
+                     "localId" : "311",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                      "name" : "vs2",
                      "type" : "OperandRef"
                   }
                } ]
             },
             "operand" : [ {
-               "localId" : "261",
+               "localId" : "307",
                "name" : "vs1",
                "operandTypeSpecifier" : {
-                  "localId" : "260",
+                  "localId" : "306",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "type" : "NamedTypeSpecifier"
                }
             }, {
-               "localId" : "263",
+               "localId" : "309",
                "name" : "vs2",
                "operandTypeSpecifier" : {
-                  "localId" : "262",
+                  "localId" : "308",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "type" : "NamedTypeSpecifier"
                }
             } ]
          }, {
-            "localId" : "272",
+            "localId" : "330",
             "name" : "ExpandPassedWithUnion",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "272",
+                  "r" : "330",
                   "s" : [ {
                      "value" : [ "","define ","ExpandPassedWithUnion",": " ]
                   }, {
-                     "r" : "275",
+                     "r" : "333",
                      "s" : [ {
                         "value" : [ "UnionVSs","(" ]
                      }, {
-                        "r" : "273",
+                        "r" : "331",
                         "s" : [ {
                            "value" : [ "\"Female\"" ]
                         } ]
                      }, {
                         "value" : [ ", " ]
                      }, {
-                        "r" : "274",
+                        "r" : "332",
                         "s" : [ {
                            "value" : [ "\"Known\"" ]
                         } ]
@@ -3971,18 +4039,46 @@ module.exports['ExpandValueset'] = {
                   } ]
                }
             } ],
+            "resultTypeSpecifier" : {
+               "localId" : "338",
+               "type" : "ListTypeSpecifier",
+               "elementType" : {
+                  "localId" : "339",
+                  "name" : "{urn:hl7-org:elm-types:r1}Code",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
             "expression" : {
-               "localId" : "275",
+               "localId" : "333",
                "name" : "UnionVSs",
                "type" : "FunctionRef",
-               "signature" : [ ],
+               "resultTypeSpecifier" : {
+                  "localId" : "336",
+                  "type" : "ListTypeSpecifier",
+                  "elementType" : {
+                     "localId" : "337",
+                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "signature" : [ {
+                  "localId" : "334",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               }, {
+                  "localId" : "335",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               } ],
                "operand" : [ {
-                  "localId" : "273",
+                  "localId" : "331",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Female",
                   "preserve" : true,
                   "type" : "ValueSetRef"
                }, {
-                  "localId" : "274",
+                  "localId" : "332",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Known",
                   "preserve" : true,
                   "type" : "ValueSetRef"

--- a/test/elm/clinical/data.js
+++ b/test/elm/clinical/data.js
@@ -319,6 +319,7 @@ module.exports['ValueSetRef'] = {
 library TestSnippet version '1'
 using Simple version '1.0.0'
 valueset "Major Depressive Disorder Active": '2.16.840.1.113883.3.526.3.1491'
+valueset "Male": '2.16.840.1.113883.3.560.100.1'
 codesystem "SNOMED": 'http://snomed.info/sct'
 code "ChronicRecurrentDepression": '2618002' from "SNOMED" display 'Chronic recurrent major depressive disorder (disorder)'
 code "ModerateMajorDepression": '832007' from "SNOMED" display 'Moderate major depression (disorder)'
@@ -327,6 +328,10 @@ context Patient
 define AnyInListOfConcepts: { "Depression Concept" } in "Major Depressive Disorder Active"
 define AnyInListOfCodes: { "ChronicRecurrentDepression", "ModerateMajorDepression" } in "Major Depressive Disorder Active"
 define AnyInListOfStrings: { '2618002', '12345' } in "Major Depressive Disorder Active"
+define function ListInVS(vs ValueSet): { '2618002', '12345' } in vs
+define ListInPassedVS: ListInVS("Major Depressive Disorder Active")
+define ListInWrongVS: ListInVS("Male")
+define ListInNullVS: ListInVS(null as ValueSet)
 */
 
 module.exports['AnyInValueSet'] = {
@@ -391,7 +396,7 @@ module.exports['AnyInValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "208",
+                  "r" : "209",
                   "s" : [ {
                      "value" : [ "","codesystem ","\"SNOMED\"",": ","'http://snomed.info/sct'" ]
                   } ]
@@ -416,6 +421,21 @@ module.exports['AnyInValueSet'] = {
                }
             } ],
             "codeSystem" : [ ]
+         }, {
+            "localId" : "208",
+            "name" : "Male",
+            "id" : "2.16.840.1.113883.3.560.100.1",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "208",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"Male\"",": ","'2.16.840.1.113883.3.560.100.1'" ]
+                  } ]
+               }
+            } ],
+            "codeSystem" : [ ]
          } ]
       },
       "codes" : {
@@ -429,11 +449,11 @@ module.exports['AnyInValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "209",
+                  "r" : "210",
                   "s" : [ {
                      "value" : [ "","code ","\"ChronicRecurrentDepression\"",": ","'2618002'"," from " ]
                   }, {
-                     "r" : "210",
+                     "r" : "211",
                      "s" : [ {
                         "value" : [ "\"SNOMED\"" ]
                      } ]
@@ -457,11 +477,11 @@ module.exports['AnyInValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "211",
+                  "r" : "212",
                   "s" : [ {
                      "value" : [ "","code ","\"ModerateMajorDepression\"",": ","'832007'"," from " ]
                   }, {
-                     "r" : "212",
+                     "r" : "213",
                      "s" : [ {
                         "value" : [ "\"SNOMED\"" ]
                      } ]
@@ -487,18 +507,18 @@ module.exports['AnyInValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "213",
+                  "r" : "214",
                   "s" : [ {
                      "value" : [ "","concept ","\"Depression Concept\"",": { " ]
                   }, {
-                     "r" : "214",
+                     "r" : "215",
                      "s" : [ {
                         "value" : [ "\"ChronicRecurrentDepression\"" ]
                      } ]
                   }, {
                      "value" : [ ", " ]
                   }, {
-                     "r" : "215",
+                     "r" : "216",
                      "s" : [ {
                         "value" : [ "\"ModerateMajorDepression\"" ]
                      } ]
@@ -520,21 +540,21 @@ module.exports['AnyInValueSet'] = {
       },
       "contexts" : {
          "def" : [ {
-            "localId" : "219",
+            "localId" : "220",
             "name" : "Patient"
          } ]
       },
       "statements" : {
          "def" : [ {
-            "localId" : "217",
+            "localId" : "218",
             "name" : "Patient",
             "context" : "Patient",
             "expression" : {
-               "localId" : "218",
+               "localId" : "219",
                "type" : "SingletonFrom",
                "signature" : [ ],
                "operand" : {
-                  "localId" : "216",
+                  "localId" : "217",
                   "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
                   "type" : "Retrieve",
                   "include" : [ ],
@@ -552,17 +572,17 @@ module.exports['AnyInValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "221",
+                  "r" : "222",
                   "s" : [ {
                      "value" : [ "","define ","AnyInListOfConcepts",": " ]
                   }, {
                      "r" : "227",
                      "s" : [ {
-                        "r" : "222",
+                        "r" : "223",
                         "s" : [ {
                            "value" : [ "{ " ]
                         }, {
-                           "r" : "223",
+                           "r" : "224",
                            "s" : [ {
                               "value" : [ "\"Depression Concept\"" ]
                            } ]
@@ -594,7 +614,7 @@ module.exports['AnyInValueSet'] = {
                   }
                } ],
                "codes" : {
-                  "localId" : "222",
+                  "localId" : "223",
                   "type" : "List",
                   "resultTypeSpecifier" : {
                      "localId" : "224",
@@ -797,6 +817,216 @@ module.exports['AnyInValueSet'] = {
                   "preserve" : true
                }
             }
+         }, {
+            "localId" : "241",
+            "name" : "ListInVS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "241",
+                  "s" : [ {
+                     "value" : [ "","define function ListInVS(vs ValueSet): " ]
+                  }, {
+                     "r" : "248",
+                     "s" : [ {
+                        "r" : "248",
+                        "s" : [ {
+                           "r" : "244",
+                           "s" : [ {
+                              "value" : [ "{ " ]
+                           }, {
+                              "r" : "245",
+                              "s" : [ {
+                                 "value" : [ "'2618002'" ]
+                              } ]
+                           }, {
+                              "value" : [ ", " ]
+                           }, {
+                              "r" : "246",
+                              "s" : [ {
+                                 "value" : [ "'12345'" ]
+                              } ]
+                           }, {
+                              "value" : [ " }" ]
+                           } ]
+                        }, {
+                           "value" : [ " in " ]
+                        }, {
+                           "r" : "247",
+                           "s" : [ {
+                              "value" : [ "vs" ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "248",
+               "type" : "AnyInValueSet",
+               "signature" : [ ],
+               "codes" : {
+                  "localId" : "244",
+                  "type" : "List",
+                  "element" : [ {
+                     "localId" : "245",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "2618002",
+                     "type" : "Literal"
+                  }, {
+                     "localId" : "246",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "12345",
+                     "type" : "Literal"
+                  } ]
+               },
+               "valuesetExpression" : {
+                  "localId" : "247",
+                  "name" : "vs",
+                  "type" : "OperandRef"
+               }
+            },
+            "operand" : [ {
+               "localId" : "243",
+               "name" : "vs",
+               "operandTypeSpecifier" : {
+                  "localId" : "242",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "localId" : "250",
+            "name" : "ListInPassedVS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "250",
+                  "s" : [ {
+                     "value" : [ "","define ","ListInPassedVS",": " ]
+                  }, {
+                     "r" : "252",
+                     "s" : [ {
+                        "value" : [ "ListInVS","(" ]
+                     }, {
+                        "r" : "251",
+                        "s" : [ {
+                           "value" : [ "\"Major Depressive Disorder Active\"" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "252",
+               "name" : "ListInVS",
+               "type" : "FunctionRef",
+               "signature" : [ ],
+               "operand" : [ {
+                  "localId" : "251",
+                  "name" : "Major Depressive Disorder Active",
+                  "preserve" : true,
+                  "type" : "ValueSetRef"
+               } ]
+            }
+         }, {
+            "localId" : "254",
+            "name" : "ListInWrongVS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "254",
+                  "s" : [ {
+                     "value" : [ "","define ","ListInWrongVS",": " ]
+                  }, {
+                     "r" : "256",
+                     "s" : [ {
+                        "value" : [ "ListInVS","(" ]
+                     }, {
+                        "r" : "255",
+                        "s" : [ {
+                           "value" : [ "\"Male\"" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "256",
+               "name" : "ListInVS",
+               "type" : "FunctionRef",
+               "signature" : [ ],
+               "operand" : [ {
+                  "localId" : "255",
+                  "name" : "Male",
+                  "preserve" : true,
+                  "type" : "ValueSetRef"
+               } ]
+            }
+         }, {
+            "localId" : "258",
+            "name" : "ListInNullVS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "258",
+                  "s" : [ {
+                     "value" : [ "","define ","ListInNullVS",": " ]
+                  }, {
+                     "r" : "262",
+                     "s" : [ {
+                        "value" : [ "ListInVS","(" ]
+                     }, {
+                        "r" : "259",
+                        "s" : [ {
+                           "r" : "260",
+                           "value" : [ "null"," as " ]
+                        }, {
+                           "r" : "261",
+                           "s" : [ {
+                              "value" : [ "ValueSet" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "262",
+               "name" : "ListInVS",
+               "type" : "FunctionRef",
+               "signature" : [ ],
+               "operand" : [ {
+                  "localId" : "259",
+                  "strict" : false,
+                  "type" : "As",
+                  "signature" : [ ],
+                  "operand" : {
+                     "localId" : "260",
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "localId" : "261",
+                     "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ]
+            }
          } ]
       }
    }
@@ -806,6 +1036,7 @@ module.exports['AnyInValueSet'] = {
 library TestSnippet version '1'
 using Simple version '1.0.0'
 valueset "Female": '2.16.840.1.113883.3.560.100.2'
+valueset "Male": '2.16.840.1.113883.3.560.100.1'
 valueset "Versioned Female": '2.16.840.1.113883.3.560.100.2' version '20121025'
 valueset "SharedCodes": '2.16.840.1.113883.3.000.000.0'
 valueset "ImproperSharedCodes": '2.16.840.1.113883.3.000.000.1'
@@ -831,6 +1062,10 @@ define InListOfCodesExpressionRef: ListOfCodes in "Female"
 define InWrongListOfCodes: WrongListOfCodes in "Female"
 define ListOfCodesWithNull: { Code { code: 'M' }, (null as Code), Code { code: 'F', system: '2.16.840.1.113883.18.2' } } in "Female"
 define ListOfCodesNull: (null as List<Code>) in "Female"
+define function FInVS(vs ValueSet): 'F' in vs
+define FInPassedVS: FInVS("Female")
+define FInWrongVS: FInVS("Male")
+define FInNullVS: FInVS(null as ValueSet)
 */
 
 module.exports['InValueSet'] = {
@@ -912,7 +1147,7 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "208",
+                  "r" : "209",
                   "s" : [ {
                      "value" : [ "","valueset ","\"Versioned Female\"",": ","'2.16.840.1.113883.3.560.100.2'"," version ","'20121025'" ]
                   } ]
@@ -928,7 +1163,7 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "209",
+                  "r" : "210",
                   "s" : [ {
                      "value" : [ "","valueset ","\"SharedCodes\"",": ","'2.16.840.1.113883.3.000.000.0'" ]
                   } ]
@@ -944,7 +1179,7 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "210",
+                  "r" : "211",
                   "s" : [ {
                      "value" : [ "","valueset ","\"ImproperSharedCodes\"",": ","'2.16.840.1.113883.3.000.000.1'" ]
                   } ]
@@ -955,21 +1190,21 @@ module.exports['InValueSet'] = {
       },
       "contexts" : {
          "def" : [ {
-            "localId" : "214",
+            "localId" : "215",
             "name" : "Patient"
          } ]
       },
       "statements" : {
          "def" : [ {
-            "localId" : "212",
+            "localId" : "213",
             "name" : "Patient",
             "context" : "Patient",
             "expression" : {
-               "localId" : "213",
+               "localId" : "214",
                "type" : "SingletonFrom",
                "signature" : [ ],
                "operand" : {
-                  "localId" : "211",
+                  "localId" : "212",
                   "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
                   "type" : "Retrieve",
                   "include" : [ ],
@@ -987,20 +1222,20 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "216",
+                  "r" : "217",
                   "s" : [ {
                      "value" : [ "","define ","String",": " ]
                   }, {
-                     "r" : "219",
+                     "r" : "220",
                      "s" : [ {
-                        "r" : "217",
+                        "r" : "218",
                         "s" : [ {
                            "value" : [ "'F'" ]
                         } ]
                      }, {
                         "value" : [ " in " ]
                      }, {
-                        "r" : "218",
+                        "r" : "219",
                         "s" : [ {
                            "value" : [ "\"Female\"" ]
                         } ]
@@ -2890,6 +3125,193 @@ module.exports['InValueSet'] = {
                   "preserve" : true
                }
             }
+         }, {
+            "localId" : "376",
+            "name" : "FInVS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "376",
+                  "s" : [ {
+                     "value" : [ "","define function FInVS(vs ValueSet): " ]
+                  }, {
+                     "r" : "381",
+                     "s" : [ {
+                        "r" : "381",
+                        "s" : [ {
+                           "r" : "379",
+                           "s" : [ {
+                              "value" : [ "'F'" ]
+                           } ]
+                        }, {
+                           "value" : [ " in " ]
+                        }, {
+                           "r" : "380",
+                           "s" : [ {
+                              "value" : [ "vs" ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "381",
+               "type" : "InValueSet",
+               "signature" : [ ],
+               "code" : {
+                  "localId" : "379",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "F",
+                  "type" : "Literal"
+               },
+               "valuesetExpression" : {
+                  "localId" : "380",
+                  "name" : "vs",
+                  "type" : "OperandRef"
+               }
+            },
+            "operand" : [ {
+               "localId" : "378",
+               "name" : "vs",
+               "operandTypeSpecifier" : {
+                  "localId" : "377",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "localId" : "383",
+            "name" : "FInPassedVS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "383",
+                  "s" : [ {
+                     "value" : [ "","define ","FInPassedVS",": " ]
+                  }, {
+                     "r" : "385",
+                     "s" : [ {
+                        "value" : [ "FInVS","(" ]
+                     }, {
+                        "r" : "384",
+                        "s" : [ {
+                           "value" : [ "\"Female\"" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "385",
+               "name" : "FInVS",
+               "type" : "FunctionRef",
+               "signature" : [ ],
+               "operand" : [ {
+                  "localId" : "384",
+                  "name" : "Female",
+                  "preserve" : true,
+                  "type" : "ValueSetRef"
+               } ]
+            }
+         }, {
+            "localId" : "387",
+            "name" : "FInWrongVS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "387",
+                  "s" : [ {
+                     "value" : [ "","define ","FInWrongVS",": " ]
+                  }, {
+                     "r" : "389",
+                     "s" : [ {
+                        "value" : [ "FInVS","(" ]
+                     }, {
+                        "r" : "388",
+                        "s" : [ {
+                           "value" : [ "\"Male\"" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "389",
+               "name" : "FInVS",
+               "type" : "FunctionRef",
+               "signature" : [ ],
+               "operand" : [ {
+                  "localId" : "388",
+                  "name" : "Male",
+                  "preserve" : true,
+                  "type" : "ValueSetRef"
+               } ]
+            }
+         }, {
+            "localId" : "391",
+            "name" : "FInNullVS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "391",
+                  "s" : [ {
+                     "value" : [ "","define ","FInNullVS",": " ]
+                  }, {
+                     "r" : "395",
+                     "s" : [ {
+                        "value" : [ "FInVS","(" ]
+                     }, {
+                        "r" : "392",
+                        "s" : [ {
+                           "r" : "393",
+                           "value" : [ "null"," as " ]
+                        }, {
+                           "r" : "394",
+                           "s" : [ {
+                              "value" : [ "ValueSet" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "395",
+               "name" : "FInVS",
+               "type" : "FunctionRef",
+               "signature" : [ ],
+               "operand" : [ {
+                  "localId" : "392",
+                  "strict" : false,
+                  "type" : "As",
+                  "signature" : [ ],
+                  "operand" : {
+                     "localId" : "393",
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "localId" : "394",
+                     "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ]
+            }
          } ]
       }
    }
@@ -2906,6 +3328,11 @@ define ExpandFemale: ExpandValueSet("Female")
 define ExpandKnown: ExpandValueSet("Known")
 define ExpandNull: ExpandValueSet(null)
 define InvokeExpandWithUnion: "Female" union  "Known"
+define function ExpandVSHelper(vs ValueSet): ExpandValueSet(vs)
+define ExpandPassedVS: ExpandVSHelper("Female")
+define ExpandNullVS: ExpandVSHelper(null as ValueSet)
+define function UnionVSs(vs1 ValueSet, vs2 ValueSet): vs1 union vs2
+define ExpandPassedWithUnion: UnionVSs("Female", "Known")
 */
 
 module.exports['ExpandValueset'] = {
@@ -3295,6 +3722,270 @@ module.exports['ExpandValueset'] = {
                      "preserve" : true,
                      "type" : "ValueSetRef"
                   }
+               } ]
+            }
+         }, {
+            "localId" : "242",
+            "name" : "ExpandVSHelper",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "242",
+                  "s" : [ {
+                     "value" : [ "","define function ExpandVSHelper(vs ValueSet): " ]
+                  }, {
+                     "r" : "248",
+                     "s" : [ {
+                        "r" : "248",
+                        "s" : [ {
+                           "value" : [ "ExpandValueSet","(" ]
+                        }, {
+                           "r" : "245",
+                           "s" : [ {
+                              "value" : [ "vs" ]
+                           } ]
+                        }, {
+                           "value" : [ ")" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "248",
+               "type" : "ExpandValueSet",
+               "signature" : [ ],
+               "operand" : {
+                  "localId" : "245",
+                  "name" : "vs",
+                  "type" : "OperandRef"
+               }
+            },
+            "operand" : [ {
+               "localId" : "244",
+               "name" : "vs",
+               "operandTypeSpecifier" : {
+                  "localId" : "243",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "localId" : "250",
+            "name" : "ExpandPassedVS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "250",
+                  "s" : [ {
+                     "value" : [ "","define ","ExpandPassedVS",": " ]
+                  }, {
+                     "r" : "252",
+                     "s" : [ {
+                        "value" : [ "ExpandVSHelper","(" ]
+                     }, {
+                        "r" : "251",
+                        "s" : [ {
+                           "value" : [ "\"Female\"" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "252",
+               "name" : "ExpandVSHelper",
+               "type" : "FunctionRef",
+               "signature" : [ ],
+               "operand" : [ {
+                  "localId" : "251",
+                  "name" : "Female",
+                  "preserve" : true,
+                  "type" : "ValueSetRef"
+               } ]
+            }
+         }, {
+            "localId" : "254",
+            "name" : "ExpandNullVS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "254",
+                  "s" : [ {
+                     "value" : [ "","define ","ExpandNullVS",": " ]
+                  }, {
+                     "r" : "258",
+                     "s" : [ {
+                        "value" : [ "ExpandVSHelper","(" ]
+                     }, {
+                        "r" : "255",
+                        "s" : [ {
+                           "r" : "256",
+                           "value" : [ "null"," as " ]
+                        }, {
+                           "r" : "257",
+                           "s" : [ {
+                              "value" : [ "ValueSet" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "258",
+               "name" : "ExpandVSHelper",
+               "type" : "FunctionRef",
+               "signature" : [ ],
+               "operand" : [ {
+                  "localId" : "255",
+                  "strict" : false,
+                  "type" : "As",
+                  "signature" : [ ],
+                  "operand" : {
+                     "localId" : "256",
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "localId" : "257",
+                     "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ]
+            }
+         }, {
+            "localId" : "259",
+            "name" : "UnionVSs",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "259",
+                  "s" : [ {
+                     "value" : [ "","define function UnionVSs(vs1 ValueSet, vs2 ValueSet): " ]
+                  }, {
+                     "r" : "266",
+                     "s" : [ {
+                        "r" : "266",
+                        "s" : [ {
+                           "r" : "264",
+                           "s" : [ {
+                              "value" : [ "vs1" ]
+                           } ]
+                        }, {
+                           "value" : [ " union " ]
+                        }, {
+                           "r" : "265",
+                           "s" : [ {
+                              "value" : [ "vs2" ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "266",
+               "type" : "Union",
+               "signature" : [ ],
+               "operand" : [ {
+                  "localId" : "268",
+                  "type" : "ExpandValueSet",
+                  "signature" : [ ],
+                  "operand" : {
+                     "localId" : "264",
+                     "name" : "vs1",
+                     "type" : "OperandRef"
+                  }
+               }, {
+                  "localId" : "270",
+                  "type" : "ExpandValueSet",
+                  "signature" : [ ],
+                  "operand" : {
+                     "localId" : "265",
+                     "name" : "vs2",
+                     "type" : "OperandRef"
+                  }
+               } ]
+            },
+            "operand" : [ {
+               "localId" : "261",
+               "name" : "vs1",
+               "operandTypeSpecifier" : {
+                  "localId" : "260",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "localId" : "263",
+               "name" : "vs2",
+               "operandTypeSpecifier" : {
+                  "localId" : "262",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "localId" : "272",
+            "name" : "ExpandPassedWithUnion",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "272",
+                  "s" : [ {
+                     "value" : [ "","define ","ExpandPassedWithUnion",": " ]
+                  }, {
+                     "r" : "275",
+                     "s" : [ {
+                        "value" : [ "UnionVSs","(" ]
+                     }, {
+                        "r" : "273",
+                        "s" : [ {
+                           "value" : [ "\"Female\"" ]
+                        } ]
+                     }, {
+                        "value" : [ ", " ]
+                     }, {
+                        "r" : "274",
+                        "s" : [ {
+                           "value" : [ "\"Known\"" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "275",
+               "name" : "UnionVSs",
+               "type" : "FunctionRef",
+               "signature" : [ ],
+               "operand" : [ {
+                  "localId" : "273",
+                  "name" : "Female",
+                  "preserve" : true,
+                  "type" : "ValueSetRef"
+               }, {
+                  "localId" : "274",
+                  "name" : "Known",
+                  "preserve" : true,
+                  "type" : "ValueSetRef"
                } ]
             }
          } ]

--- a/test/elm/clinical/data.js
+++ b/test/elm/clinical/data.js
@@ -1830,6 +1830,8 @@ define WrongShortCode: Code { code: 'M' } in "Female"
 define WrongMediumCode: Code { code: 'F', system: '3.16.840.1.113883.18.2' } in "Female"
 define LongCodeDifferentVersion: Code { code: 'F', system: '2.16.840.1.113883.18.2', version: 'HL7V2.6' } in "Female"
 define NullCode: Code { code: null, system: '2.16.840.1.113883.18.2', version: 'HL7V2.6' } in "Female"
+define NullCastAsCode: null as Code in "Female"
+define NullCastAsCodeWithNullVS: null as Code in null as ValueSet
 define function FInVS(vs ValueSet): 'F' in vs
 define FInPassedVS: FInVS("Female")
 define FInWrongVS: FInVS("Male")
@@ -1847,7 +1849,7 @@ module.exports['InValueSet'] = {
       }, {
          "type" : "Annotation",
          "s" : {
-            "r" : "342",
+            "r" : "361",
             "s" : [ {
                "value" : [ "","library TestSnippet version '1'" ]
             } ]
@@ -3040,7 +3042,169 @@ module.exports['InValueSet'] = {
                }
             }
          }, {
-            "localId" : "323",
+            "localId" : "324",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+            "name" : "NullCastAsCode",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "324",
+                  "s" : [ {
+                     "value" : [ "","define ","NullCastAsCode",": " ]
+                  }, {
+                     "r" : "329",
+                     "s" : [ {
+                        "r" : "325",
+                        "s" : [ {
+                           "r" : "326",
+                           "value" : [ "null"," as " ]
+                        }, {
+                           "r" : "327",
+                           "s" : [ {
+                              "value" : [ "Code" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ " in " ]
+                     }, {
+                        "r" : "328",
+                        "s" : [ {
+                           "value" : [ "\"Female\"" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "329",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+               "type" : "InValueSet",
+               "signature" : [ {
+                  "localId" : "330",
+                  "name" : "{urn:hl7-org:elm-types:r1}Code",
+                  "type" : "NamedTypeSpecifier"
+               } ],
+               "code" : {
+                  "localId" : "325",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                  "strict" : false,
+                  "type" : "As",
+                  "signature" : [ ],
+                  "operand" : {
+                     "localId" : "326",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "localId" : "327",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "valueset" : {
+                  "localId" : "328",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "name" : "Female",
+                  "preserve" : true
+               }
+            }
+         }, {
+            "localId" : "332",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+            "name" : "NullCastAsCodeWithNullVS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "332",
+                  "s" : [ {
+                     "value" : [ "","define ","NullCastAsCodeWithNullVS",": " ]
+                  }, {
+                     "r" : "339",
+                     "s" : [ {
+                        "r" : "333",
+                        "s" : [ {
+                           "r" : "334",
+                           "value" : [ "null"," as " ]
+                        }, {
+                           "r" : "335",
+                           "s" : [ {
+                              "value" : [ "Code" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ " in " ]
+                     }, {
+                        "r" : "336",
+                        "s" : [ {
+                           "r" : "337",
+                           "value" : [ "null"," as " ]
+                        }, {
+                           "r" : "338",
+                           "s" : [ {
+                              "value" : [ "ValueSet" ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "339",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+               "type" : "InValueSet",
+               "signature" : [ {
+                  "localId" : "340",
+                  "name" : "{urn:hl7-org:elm-types:r1}Code",
+                  "type" : "NamedTypeSpecifier"
+               }, {
+                  "localId" : "341",
+                  "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "NamedTypeSpecifier"
+               } ],
+               "code" : {
+                  "localId" : "333",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                  "strict" : false,
+                  "type" : "As",
+                  "signature" : [ ],
+                  "operand" : {
+                     "localId" : "334",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "localId" : "335",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                     "name" : "{urn:hl7-org:elm-types:r1}Code",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "valuesetExpression" : {
+                  "localId" : "336",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "strict" : false,
+                  "type" : "As",
+                  "signature" : [ ],
+                  "operand" : {
+                     "localId" : "337",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "localId" : "338",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }
+            }
+         }, {
+            "localId" : "342",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "FInVS",
             "context" : "Patient",
@@ -3049,22 +3213,22 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "323",
+                  "r" : "342",
                   "s" : [ {
                      "value" : [ "","define function FInVS(vs ValueSet): " ]
                   }, {
-                     "r" : "328",
+                     "r" : "347",
                      "s" : [ {
-                        "r" : "328",
+                        "r" : "347",
                         "s" : [ {
-                           "r" : "326",
+                           "r" : "345",
                            "s" : [ {
                               "value" : [ "'F'" ]
                            } ]
                         }, {
                            "value" : [ " in " ]
                         }, {
-                           "r" : "327",
+                           "r" : "346",
                            "s" : [ {
                               "value" : [ "vs" ]
                            } ]
@@ -3074,44 +3238,44 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "328",
+               "localId" : "347",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "InValueSet",
                "signature" : [ {
-                  "localId" : "329",
+                  "localId" : "348",
                   "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
                }, {
-                  "localId" : "330",
+                  "localId" : "349",
                   "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "type" : "NamedTypeSpecifier"
                } ],
                "code" : {
-                  "localId" : "326",
+                  "localId" : "345",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "F",
                   "type" : "Literal"
                },
                "valuesetExpression" : {
-                  "localId" : "327",
+                  "localId" : "346",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "vs",
                   "type" : "OperandRef"
                }
             },
             "operand" : [ {
-               "localId" : "325",
+               "localId" : "344",
                "name" : "vs",
                "operandTypeSpecifier" : {
-                  "localId" : "324",
+                  "localId" : "343",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "type" : "NamedTypeSpecifier"
                }
             } ]
          }, {
-            "localId" : "332",
+            "localId" : "351",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "FInPassedVS",
             "context" : "Patient",
@@ -3119,15 +3283,15 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "332",
+                  "r" : "351",
                   "s" : [ {
                      "value" : [ "","define ","FInPassedVS",": " ]
                   }, {
-                     "r" : "334",
+                     "r" : "353",
                      "s" : [ {
                         "value" : [ "FInVS","(" ]
                      }, {
-                        "r" : "333",
+                        "r" : "352",
                         "s" : [ {
                            "value" : [ "\"Female\"" ]
                         } ]
@@ -3138,17 +3302,17 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "334",
+               "localId" : "353",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "name" : "FInVS",
                "type" : "FunctionRef",
                "signature" : [ {
-                  "localId" : "335",
+                  "localId" : "354",
                   "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "333",
+                  "localId" : "352",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Female",
                   "preserve" : true,
@@ -3156,7 +3320,7 @@ module.exports['InValueSet'] = {
                } ]
             }
          }, {
-            "localId" : "337",
+            "localId" : "356",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "FInWrongVS",
             "context" : "Patient",
@@ -3164,15 +3328,15 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "337",
+                  "r" : "356",
                   "s" : [ {
                      "value" : [ "","define ","FInWrongVS",": " ]
                   }, {
-                     "r" : "339",
+                     "r" : "358",
                      "s" : [ {
                         "value" : [ "FInVS","(" ]
                      }, {
-                        "r" : "338",
+                        "r" : "357",
                         "s" : [ {
                            "value" : [ "\"Male\"" ]
                         } ]
@@ -3183,17 +3347,17 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "339",
+               "localId" : "358",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "name" : "FInVS",
                "type" : "FunctionRef",
                "signature" : [ {
-                  "localId" : "340",
+                  "localId" : "359",
                   "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "338",
+                  "localId" : "357",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "name" : "Male",
                   "preserve" : true,
@@ -3201,7 +3365,7 @@ module.exports['InValueSet'] = {
                } ]
             }
          }, {
-            "localId" : "342",
+            "localId" : "361",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "FInNullVS",
             "context" : "Patient",
@@ -3209,20 +3373,20 @@ module.exports['InValueSet'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "342",
+                  "r" : "361",
                   "s" : [ {
                      "value" : [ "","define ","FInNullVS",": " ]
                   }, {
-                     "r" : "346",
+                     "r" : "365",
                      "s" : [ {
                         "value" : [ "FInVS","(" ]
                      }, {
-                        "r" : "343",
+                        "r" : "362",
                         "s" : [ {
-                           "r" : "344",
+                           "r" : "363",
                            "value" : [ "null"," as " ]
                         }, {
-                           "r" : "345",
+                           "r" : "364",
                            "s" : [ {
                               "value" : [ "ValueSet" ]
                            } ]
@@ -3234,28 +3398,28 @@ module.exports['InValueSet'] = {
                }
             } ],
             "expression" : {
-               "localId" : "346",
+               "localId" : "365",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "name" : "FInVS",
                "type" : "FunctionRef",
                "signature" : [ {
-                  "localId" : "347",
+                  "localId" : "366",
                   "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "343",
+                  "localId" : "362",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                   "strict" : false,
                   "type" : "As",
                   "signature" : [ ],
                   "operand" : {
-                     "localId" : "344",
+                     "localId" : "363",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
                      "type" : "Null"
                   },
                   "asTypeSpecifier" : {
-                     "localId" : "345",
+                     "localId" : "364",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
                      "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
                      "type" : "NamedTypeSpecifier"


### PR DESCRIPTION
Partially addresses https://github.com/cqframework/cql-execution/issues/226 by further generalizing the building of the valueset fields for `AnyInValueSet`, `InValueSet`, and `ExpandValueSet`. All of these expression classes previously assumed that a valueset would come in as a reference (`ValueSetRef`), but when a valueset is passed into a function, the valueset must be built from a valueset expression.

This PR also updates some error messages and types to accurately reflect the state that's expected from the translator.


Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

**Submitter:**

- [✔ ] This pull request describes why these changes were made
- [✔ ] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [✔ ] Tests are included and test edge cases
- [✔ ] Tests have been run locally and pass
- [✔ ] Code coverage has not gone down and all code touched or added is covered.
- [✔ ] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [✔ ] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [✔ ] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name:

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
