### PR TITLE
Added CodeSystemRef and updated CodeSystem type

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -464,10 +464,10 @@ function codesMatch(code1, code2) {
     return code1.code === code2.code && code1.system === code2.system;
 }
 class CodeSystem {
-    constructor(name, id, version) {
-        this.name = name;
+    constructor(id, version, name) {
         this.id = id;
         this.version = version;
+        this.name = name;
     }
 }
 exports.CodeSystem = CodeSystem;
@@ -3878,7 +3878,7 @@ class CodeSystemDef extends expression_1.Expression {
         this.version = json.version;
     }
     async exec(_ctx) {
-        return new dt.CodeSystem(this.name, this.id, this.version);
+        return new dt.CodeSystem(this.id, this.version, this.name);
     }
 }
 exports.CodeSystemDef = CodeSystemDef;

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -464,7 +464,8 @@ function codesMatch(code1, code2) {
     return code1.code === code2.code && code1.system === code2.system;
 }
 class CodeSystem {
-    constructor(id, version) {
+    constructor(name, id, version) {
+        this.name = name;
         this.id = id;
         this.version = version;
     }
@@ -3771,7 +3772,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.CalculateAgeAt = exports.CalculateAge = exports.Concept = exports.ConceptRef = exports.ConceptDef = exports.Code = exports.CodeRef = exports.CodeDef = exports.CodeSystemDef = exports.ExpandValueSet = exports.InValueSet = exports.AnyInValueSet = exports.ValueSetRef = exports.ValueSetDef = void 0;
+exports.CalculateAgeAt = exports.CalculateAge = exports.Concept = exports.ConceptRef = exports.ConceptDef = exports.Code = exports.CodeRef = exports.CodeDef = exports.CodeSystemRef = exports.CodeSystemDef = exports.ExpandValueSet = exports.InValueSet = exports.AnyInValueSet = exports.ValueSetRef = exports.ValueSetDef = void 0;
 const expression_1 = require("./expression");
 const dt = __importStar(require("../datatypes/datatypes"));
 const builder_1 = require("./builder");
@@ -3877,10 +3878,21 @@ class CodeSystemDef extends expression_1.Expression {
         this.version = json.version;
     }
     async exec(_ctx) {
-        return new dt.CodeSystem(this.id, this.version);
+        return new dt.CodeSystem(this.name, this.id, this.version);
     }
 }
 exports.CodeSystemDef = CodeSystemDef;
+class CodeSystemRef extends expression_1.Expression {
+    constructor(json) {
+        super(json);
+        this.name = json.name;
+    }
+    async exec(ctx) {
+        const codeSystemDef = ctx.getCodeSystem(this.name);
+        return codeSystemDef ? codeSystemDef.execute(ctx) : undefined;
+    }
+}
+exports.CodeSystemRef = CodeSystemRef;
 class CodeDef extends expression_1.Expression {
     constructor(json) {
         super(json);

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -5512,12 +5512,12 @@ class Library {
         return (this.expressions[identifier] || this.includes[identifier] || this.getFunction(identifier));
     }
     getValueSet(identifier, libraryName) {
-        if (this.valuesets[identifier] != null) {
+        if (libraryName && this.includes[libraryName]) {
+            return this.includes[libraryName].valuesets[identifier];
+        }
+        else if (libraryName == null || libraryName === this.name) {
             return this.valuesets[identifier];
         }
-        return this.includes[libraryName] != null
-            ? this.includes[libraryName].valuesets[identifier]
-            : undefined;
     }
     getCodeSystem(identifier, libraryName) {
         if (libraryName && this.includes[libraryName]) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1127,6 +1127,21 @@
         "inherits": "2.0.1"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
@@ -1167,9 +1182,10 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1444,6 +1460,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -1782,6 +1845,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/defined": {
       "version": "1.0.0",
       "dev": true,
@@ -1882,6 +1962,20 @@
         "npm": ">=1.2"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexer2": {
       "version": "0.1.4",
       "dev": true,
@@ -1935,6 +2029,36 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es6-error": {
@@ -2365,6 +2489,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "2.0.0",
       "dev": true,
@@ -2414,9 +2553,13 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
-      "license": "MIT"
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -2446,12 +2589,49 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stdin": {
@@ -2525,6 +2705,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.6",
       "devOptional": true,
@@ -2547,6 +2739,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hash-base": {
@@ -2605,6 +2836,18 @@
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/he": {
@@ -2763,6 +3006,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.8.1",
       "dev": true,
@@ -2845,6 +3100,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-typedarray": {
@@ -3196,6 +3466,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/md5.js": {
       "version": "1.3.5",
       "dev": true,
@@ -3317,11 +3596,10 @@
       "license": "Python-2.0"
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -3870,18 +4148,51 @@
       }
     },
     "node_modules/pbkdf2": {
-      "version": "3.1.2",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
+      "integrity": "sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "~1.1.3",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "=2.0.1",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.11",
+        "to-buffer": "^1.2.0"
       },
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/pbkdf2/node_modules/create-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+      "integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
+      "dev": true,
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/pbkdf2/node_modules/hash-base": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+      "integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/pbkdf2/node_modules/ripemd160": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+      "integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
+      "dev": true,
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "node_modules/picocolors": {
@@ -3959,6 +4270,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/prelude-ls": {
@@ -4295,6 +4615,23 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
@@ -4689,6 +5026,26 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/to-buffer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
+      "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/to-buffer/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4821,6 +5178,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/typedarray": {
@@ -4985,6 +5356,27 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
@@ -5880,6 +6272,15 @@
         }
       }
     },
+    "available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "requires": {
+        "possible-typed-array-names": "^1.0.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "dev": true
@@ -5899,7 +6300,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -6116,6 +6519,38 @@
         "make-dir": "^3.0.0",
         "package-hash": "^4.0.0",
         "write-file-atomic": "^3.0.0"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      }
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      }
+    },
+    "call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       }
     },
     "callsites": {
@@ -6344,6 +6779,17 @@
         "strip-bom": "^4.0.0"
       }
     },
+    "define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "requires": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      }
+    },
     "defined": {
       "version": "1.0.0",
       "dev": true
@@ -6414,6 +6860,17 @@
       "version": "1.2.0",
       "dev": true
     },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
     "duplexer2": {
       "version": "0.1.4",
       "dev": true,
@@ -6460,6 +6917,27 @@
       "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1"
+      }
+    },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true
+    },
+    "es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0"
       }
     },
     "es6-error": {
@@ -6739,6 +7217,15 @@
       "version": "3.2.5",
       "dev": true
     },
+    "for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.2.7"
+      }
+    },
     "foreground-child": {
       "version": "2.0.0",
       "dev": true,
@@ -6761,7 +7248,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true
     },
     "functional-red-black-tree": {
@@ -6782,9 +7271,37 @@
       "version": "2.0.5",
       "dev": true
     },
+    "get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      }
+    },
     "get-package-type": {
       "version": "0.1.0",
       "dev": true
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      }
     },
     "get-stdin": {
       "version": "6.0.0",
@@ -6828,6 +7345,12 @@
         "slash": "^3.0.0"
       }
     },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true
+    },
     "graceful-fs": {
       "version": "4.2.6",
       "devOptional": true
@@ -6842,6 +7365,30 @@
     "has-flag": {
       "version": "4.0.0",
       "dev": true
+    },
+    "has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "requires": {
+        "es-define-property": "^1.0.0"
+      }
+    },
+    "has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true
+    },
+    "has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.3"
+      }
     },
     "hash-base": {
       "version": "3.1.0",
@@ -6883,6 +7430,15 @@
           "version": "0.8.1",
           "dev": true
         }
+      }
+    },
+    "hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.2"
       }
     },
     "he": {
@@ -6984,6 +7540,12 @@
       "version": "1.1.6",
       "dev": true
     },
+    "is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true
+    },
     "is-core-module": {
       "version": "2.8.1",
       "dev": true,
@@ -7028,6 +7590,15 @@
     "is-stream": {
       "version": "2.0.1",
       "dev": true
+    },
+    "is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "requires": {
+        "which-typed-array": "^1.1.16"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -7259,6 +7830,12 @@
       "version": "1.3.6",
       "dev": true
     },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true
+    },
     "md5.js": {
       "version": "1.3.5",
       "dev": true,
@@ -7352,9 +7929,9 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+          "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
@@ -7743,14 +8320,50 @@
       "dev": true
     },
     "pbkdf2": {
-      "version": "3.1.2",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
+      "integrity": "sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==",
       "dev": true,
       "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "~1.1.3",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "=2.0.1",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.11",
+        "to-buffer": "^1.2.0"
+      },
+      "dependencies": {
+        "create-hash": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+          "integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
+          "dev": true,
+          "requires": {
+            "cipher-base": "^1.0.1",
+            "inherits": "^2.0.1",
+            "ripemd160": "^2.0.0",
+            "sha.js": "^2.4.0"
+          }
+        },
+        "hash-base": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+          "integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.1"
+          }
+        },
+        "ripemd160": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+          "integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
+          "dev": true,
+          "requires": {
+            "hash-base": "^2.0.0",
+            "inherits": "^2.0.1"
+          }
+        }
       }
     },
     "picocolors": {
@@ -7800,6 +8413,12 @@
           }
         }
       }
+    },
+    "possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -8002,6 +8621,20 @@
     "set-blocking": {
       "version": "2.0.0",
       "dev": true
+    },
+    "set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "requires": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      }
     },
     "sha.js": {
       "version": "2.4.11",
@@ -8285,6 +8918,25 @@
         "process": "~0.11.0"
       }
     },
+    "to-buffer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
+      "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
+      "dev": true,
+      "requires": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+          "dev": true
+        }
+      }
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8355,6 +9007,17 @@
     "type-fest": {
       "version": "0.20.2",
       "dev": true
+    },
+    "typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "requires": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -8461,6 +9124,21 @@
     "which-module": {
       "version": "2.0.0",
       "dev": true
+    },
+    "which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      }
     },
     "word-wrap": {
       "version": "1.2.5",

--- a/src/datatypes/clinical.ts
+++ b/src/datatypes/clinical.ts
@@ -151,5 +151,5 @@ function codesMatch(code1: Code, code2: Code) {
 }
 
 export class CodeSystem {
-  constructor(public name: string, public id: string, public version?: string) {}
+  constructor(public id: string, public version?: string, public name?: string) {}
 }

--- a/src/datatypes/clinical.ts
+++ b/src/datatypes/clinical.ts
@@ -151,5 +151,5 @@ function codesMatch(code1: Code, code2: Code) {
 }
 
 export class CodeSystem {
-  constructor(public id: string, public version?: string) {}
+  constructor(public name: string, public id: string, public version?: string) {}
 }

--- a/src/elm/clinical.ts
+++ b/src/elm/clinical.ts
@@ -138,16 +138,13 @@ export class CodeSystemDef extends Expression {
 
 export class CodeSystemRef extends Expression {
   name: string;
-  library: string;
 
   constructor(json: any) {
     super(json);
     this.name = json.name;
-    this.library = json.libraryName;
   }
 
   async exec(ctx: Context) {
-    ctx = this.library ? ctx.getLibraryContext(this.library) : ctx;
     const codeSystemDef = ctx.getCodeSystem(this.name);
     return codeSystemDef ? codeSystemDef.execute(ctx) : undefined;
   }

--- a/src/elm/clinical.ts
+++ b/src/elm/clinical.ts
@@ -132,7 +132,24 @@ export class CodeSystemDef extends Expression {
   }
 
   async exec(_ctx: Context) {
-    return new dt.CodeSystem(this.id, this.version);
+    return new dt.CodeSystem(this.name, this.id, this.version);
+  }
+}
+
+export class CodeSystemRef extends Expression {
+  name: string;
+  library: string;
+
+  constructor(json: any) {
+    super(json);
+    this.name = json.name;
+    this.library = json.libraryName;
+  }
+
+  async exec(ctx: Context) {
+    ctx = this.library ? ctx.getLibraryContext(this.library) : ctx;
+    const codeSystemDef = ctx.getCodeSystem(this.name);
+    return codeSystemDef ? codeSystemDef.execute(ctx) : undefined;
   }
 }
 

--- a/src/elm/clinical.ts
+++ b/src/elm/clinical.ts
@@ -132,7 +132,7 @@ export class CodeSystemDef extends Expression {
   }
 
   async exec(_ctx: Context) {
-    return new dt.CodeSystem(this.name, this.id, this.version);
+    return new dt.CodeSystem(this.id, this.version, this.name);
   }
 }
 

--- a/src/elm/clinical.ts
+++ b/src/elm/clinical.ts
@@ -138,14 +138,16 @@ export class CodeSystemDef extends Expression {
 
 export class CodeSystemRef extends Expression {
   name: string;
+  libraryName: string;
 
   constructor(json: any) {
     super(json);
     this.name = json.name;
+    this.libraryName = json.libraryName;
   }
 
   async exec(ctx: Context) {
-    const codeSystemDef = ctx.getCodeSystem(this.name);
+    const codeSystemDef = ctx.getCodeSystem(this.name, this.libraryName);
     return codeSystemDef ? codeSystemDef.execute(ctx) : undefined;
   }
 }

--- a/src/elm/library.ts
+++ b/src/elm/library.ts
@@ -100,12 +100,11 @@ export class Library {
   }
 
   getValueSet(identifier: string, libraryName: string) {
-    if (this.valuesets[identifier] != null) {
+    if (libraryName && this.includes[libraryName]) {
+      return this.includes[libraryName].valuesets[identifier];
+    } else if (libraryName == null || libraryName === this.name) {
       return this.valuesets[identifier];
     }
-    return this.includes[libraryName] != null
-      ? this.includes[libraryName].valuesets[identifier]
-      : undefined;
   }
 
   getCodeSystem(identifier: string, libraryName?: string) {

--- a/src/elm/library.ts
+++ b/src/elm/library.ts
@@ -11,6 +11,8 @@ import {
 
 export class Library {
   source: any;
+  name?: string;
+  version?: string;
   usings: any;
   parameters: Parameter;
   codesystems: any;
@@ -23,6 +25,9 @@ export class Library {
 
   constructor(json: any, libraryManager?: any) {
     this.source = json;
+    // identifier
+    this.name = json.library.identifier?.id;
+    this.version = json.library.identifier?.version;
     // usings
     const usingDefs = (json.library.usings && json.library.usings.def) || [];
     this.usings = usingDefs
@@ -82,15 +87,6 @@ export class Library {
         this.includes[incl.localIdentifier] = libraryManager.resolve(incl.path, incl.version);
       }
     }
-
-    // Include codesystems from includes
-    for (const iProperty in this.includes) {
-      if (this.includes[iProperty] && this.includes[iProperty].codesystems) {
-        for (const csProperty in this.includes[iProperty].codesystems) {
-          this.codesystems[csProperty] = this.includes[iProperty].codesystems[csProperty];
-        }
-      }
-    }
   }
 
   getFunction(identifier: string) {
@@ -112,8 +108,12 @@ export class Library {
       : undefined;
   }
 
-  getCodeSystem(identifier: string) {
-    return this.codesystems[identifier];
+  getCodeSystem(identifier: string, libraryName?: string) {
+    if (libraryName && this.includes[libraryName]) {
+      return this.includes[libraryName].codesystems[identifier];
+    } else if (libraryName == null || libraryName === this.name) {
+      return this.codesystems[identifier];
+    }
   }
 
   getCode(identifier: string) {

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -143,8 +143,8 @@ export class Context {
     return this.parent && this.parent.getValueSet(name, library);
   }
 
-  getCodeSystem(name: string) {
-    return this.parent && this.parent.getCodeSystem(name);
+  getCodeSystem(name: string, libraryName?: string) {
+    return this.parent && this.parent.getCodeSystem(name, libraryName);
   }
 
   getCode(name: string) {

--- a/test/datatypes/clinical-test.ts
+++ b/test/datatypes/clinical-test.ts
@@ -1,4 +1,5 @@
 import { Code, CodeSystem, Concept, ValueSet } from '../../src/datatypes/clinical';
+import should from 'should';
 
 describe('Code', () => {
   let code: Code, code_no_version: Code, code_no_codesystem: Code;
@@ -232,7 +233,7 @@ describe('CodeSystem', () => {
 
   beforeEach(() => {
     codeSystemWithVersion = new CodeSystem('ExampleName', '5.4.3.2.1', '1');
-    codeSystemNoVersion = new CodeSystem('ExampleName', '5.4.3.2.1', '1');
+    codeSystemNoVersion = new CodeSystem('ExampleName', '5.4.3.2.1');
   });
 
   it('should properly represent the name, id, and version', () => {
@@ -244,5 +245,6 @@ describe('CodeSystem', () => {
   it('should properly represent the name and id when no version is present', () => {
     codeSystemNoVersion.name.should.equal('ExampleName');
     codeSystemNoVersion.id.should.equal('5.4.3.2.1');
+    should.not.exist(codeSystemNoVersion.version);
   });
 });

--- a/test/datatypes/clinical-test.ts
+++ b/test/datatypes/clinical-test.ts
@@ -1,4 +1,4 @@
-import { Code, Concept, ValueSet } from '../../src/datatypes/clinical';
+import { Code, CodeSystem, Concept, ValueSet } from '../../src/datatypes/clinical';
 
 describe('Code', () => {
   let code: Code, code_no_version: Code, code_no_codesystem: Code;
@@ -224,5 +224,25 @@ describe('ValueSet', () => {
     for (let i = 0; i < received.length; i++) {
       expected[i].hasMatch(received[i]).should.be.true();
     }
+  });
+});
+
+describe('CodeSystem', () => {
+  let codeSystemWithVersion: CodeSystem, codeSystemNoVersion: CodeSystem;
+
+  beforeEach(() => {
+    codeSystemWithVersion = new CodeSystem('ExampleName', '5.4.3.2.1', '1');
+    codeSystemNoVersion = new CodeSystem('ExampleName', '5.4.3.2.1', '1');
+  });
+
+  it('should properly represent the name, id, and version', () => {
+    codeSystemWithVersion.name.should.equal('ExampleName');
+    codeSystemWithVersion.id.should.equal('5.4.3.2.1');
+    codeSystemWithVersion.version.should.equal('1');
+  });
+
+  it('should properly represent the name and id when no version is present', () => {
+    codeSystemNoVersion.name.should.equal('ExampleName');
+    codeSystemNoVersion.id.should.equal('5.4.3.2.1');
   });
 });

--- a/test/datatypes/clinical-test.ts
+++ b/test/datatypes/clinical-test.ts
@@ -232,8 +232,8 @@ describe('CodeSystem', () => {
   let codeSystemWithVersion: CodeSystem, codeSystemNoVersion: CodeSystem;
 
   beforeEach(() => {
-    codeSystemWithVersion = new CodeSystem('ExampleName', '5.4.3.2.1', '1');
-    codeSystemNoVersion = new CodeSystem('ExampleName', '5.4.3.2.1');
+    codeSystemWithVersion = new CodeSystem('5.4.3.2.1', '1', 'ExampleName');
+    codeSystemNoVersion = new CodeSystem('5.4.3.2.1', null, 'ExampleName');
   });
 
   it('should properly represent the name, id, and version', () => {

--- a/test/datatypes/clinical-test.ts
+++ b/test/datatypes/clinical-test.ts
@@ -233,7 +233,7 @@ describe('CodeSystem', () => {
 
   beforeEach(() => {
     codeSystemWithVersion = new CodeSystem('5.4.3.2.1', '1', 'ExampleName');
-    codeSystemNoVersion = new CodeSystem('5.4.3.2.1', null, 'ExampleName');
+    codeSystemNoVersion = new CodeSystem('5.4.3.2.1', undefined, 'ExampleName');
   });
 
   it('should properly represent the name, id, and version', () => {

--- a/test/elm/clinical/clinical-test.ts
+++ b/test/elm/clinical/clinical-test.ts
@@ -352,6 +352,10 @@ describe('CodeSystemRef', () => {
   it('should execute to true', async function () {
     (await this.isMyCS.exec(this.ctx)).should.equal(true);
   });
+
+  it('should execute to string of CodeSystem id and version', async function () {
+    (await this.codeInfo.exec(this.ctx)).should.equal('http://loinc.org1');
+  });
 });
 
 describe('CalculateAge: Fully Specified Birth Date', () => {

--- a/test/elm/clinical/clinical-test.ts
+++ b/test/elm/clinical/clinical-test.ts
@@ -349,12 +349,14 @@ describe('CodeSystemRef', () => {
     setup(this, data);
   });
 
-  it('should execute to true', async function () {
-    (await this.isMyCS.exec(this.ctx)).should.equal(true);
+  it('should have a name', function () {
+    this.resolveMyCS.name.should.equal('MyCS');
   });
 
-  it('should execute to string of CodeSystem id and version', async function () {
-    (await this.codeInfo.exec(this.ctx)).should.equal('http://loinc.org1');
+  it('should execute to the defined code system', async function () {
+    const myCS = await this.resolveMyCS.exec(this.ctx);
+    myCS.id.should.equal('http://loinc.org');
+    myCS.version.should.equal('1');
   });
 });
 

--- a/test/elm/clinical/clinical-test.ts
+++ b/test/elm/clinical/clinical-test.ts
@@ -344,6 +344,16 @@ describe('ConceptRef', () => {
   });
 });
 
+describe('CodeSystemRef', () => {
+  beforeEach(function () {
+    setup(this, data);
+  });
+
+  it('should execute to true', async function () {
+    (await this.isMyCS.exec(this.ctx)).should.equal(true);
+  });
+});
+
 describe('CalculateAge: Fully Specified Birth Date', () => {
   // Patient birth date: 1980-06-17 at 9:00am GMT
   beforeEach(function () {

--- a/test/elm/clinical/data.cql
+++ b/test/elm/clinical/data.cql
@@ -102,9 +102,11 @@ concept "Tobacco smoking status": { "Tobacco smoking status code" } display 'Tob
 define Foo: "Tobacco smoking status"
 
 // @Test: CodeSystemRef
-codesystem MyCS: 'http://loinc.org'
+codesystem MyCS: 'http://loinc.org' version '1'
 define function IsCS(cs CodeSystem): cs is CodeSystem
+define function GetCodeSystemInfo(cs CodeSystem): cs.id + cs.version
 define IsMyCS: IsCS(MyCS)
+define CodeInfo: GetCodeSystemInfo(MyCS)
 
 // @Test: CalculateAge: Fully Specified Birth Date
 define Years: AgeInYears()

--- a/test/elm/clinical/data.cql
+++ b/test/elm/clinical/data.cql
@@ -101,6 +101,11 @@ code "Tobacco smoking status code": '72166-2' from "LOINC" display 'Tobacco smok
 concept "Tobacco smoking status": { "Tobacco smoking status code" } display 'Tobacco smoking status'
 define Foo: "Tobacco smoking status"
 
+// @Test: CodeSystemRef
+codesystem MyCS: 'http://loinc.org'
+define function IsCS(cs CodeSystem): cs is CodeSystem
+define IsMyCS: IsCS(MyCS)
+
 // @Test: CalculateAge: Fully Specified Birth Date
 define Years: AgeInYears()
 define Months: AgeInMonths()

--- a/test/elm/clinical/data.cql
+++ b/test/elm/clinical/data.cql
@@ -103,10 +103,7 @@ define Foo: "Tobacco smoking status"
 
 // @Test: CodeSystemRef
 codesystem MyCS: 'http://loinc.org' version '1'
-define function IsCS(cs CodeSystem): cs is CodeSystem
-define function GetCodeSystemInfo(cs CodeSystem): cs.id + cs.version
-define IsMyCS: IsCS(MyCS)
-define CodeInfo: GetCodeSystemInfo(MyCS)
+define ResolveMyCS: MyCS
 
 // @Test: CalculateAge: Fully Specified Birth Date
 define Years: AgeInYears()

--- a/test/elm/clinical/data.js
+++ b/test/elm/clinical/data.js
@@ -5161,10 +5161,12 @@ module.exports['ConceptRef'] = {
 /* CodeSystemRef
 library TestSnippet version '1'
 using Simple version '1.0.0'
-codesystem MyCS: 'http://loinc.org'
+codesystem MyCS: 'http://loinc.org' version '1'
 context Patient
 define function IsCS(cs CodeSystem): cs is CodeSystem
+define function GetCodeSystemInfo(cs CodeSystem): cs.id + cs.version
 define IsMyCS: IsCS(MyCS)
+define CodeInfo: GetCodeSystemInfo(MyCS)
 */
 
 module.exports['CodeSystemRef'] = {
@@ -5178,7 +5180,7 @@ module.exports['CodeSystemRef'] = {
       }, {
          "type" : "Annotation",
          "s" : {
-            "r" : "219",
+            "r" : "235",
             "s" : [ {
                "value" : [ "","library TestSnippet version '1'" ]
             } ]
@@ -5225,13 +5227,14 @@ module.exports['CodeSystemRef'] = {
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
             "name" : "MyCS",
             "id" : "http://loinc.org",
+            "version" : "1",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
                   "r" : "207",
                   "s" : [ {
-                     "value" : [ "","codesystem ","MyCS",": ","'http://loinc.org'" ]
+                     "value" : [ "","codesystem ","MyCS",": ","'http://loinc.org'"," version ","'1'" ]
                   } ]
                }
             } ]
@@ -5325,7 +5328,100 @@ module.exports['CodeSystemRef'] = {
                }
             } ]
          }, {
-            "localId" : "219",
+            "localId" : "218",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+            "name" : "GetCodeSystemInfo",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "218",
+                  "s" : [ {
+                     "value" : [ "","define function GetCodeSystemInfo(cs CodeSystem): " ]
+                  }, {
+                     "r" : "228",
+                     "s" : [ {
+                        "r" : "228",
+                        "s" : [ {
+                           "r" : "223",
+                           "s" : [ {
+                              "r" : "222",
+                              "s" : [ {
+                                 "value" : [ "cs" ]
+                              } ]
+                           }, {
+                              "value" : [ "." ]
+                           }, {
+                              "r" : "223",
+                              "s" : [ {
+                                 "value" : [ "id" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ " + " ]
+                        }, {
+                           "r" : "225",
+                           "s" : [ {
+                              "r" : "224",
+                              "s" : [ {
+                                 "value" : [ "cs" ]
+                              } ]
+                           }, {
+                              "value" : [ "." ]
+                           }, {
+                              "r" : "225",
+                              "s" : [ {
+                                 "value" : [ "version" ]
+                              } ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "228",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+               "type" : "Concatenate",
+               "signature" : [ ],
+               "operand" : [ {
+                  "localId" : "223",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                  "path" : "id",
+                  "type" : "Property",
+                  "source" : {
+                     "localId" : "222",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                     "name" : "cs",
+                     "type" : "OperandRef"
+                  }
+               }, {
+                  "localId" : "225",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                  "path" : "version",
+                  "type" : "Property",
+                  "source" : {
+                     "localId" : "224",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                     "name" : "cs",
+                     "type" : "OperandRef"
+                  }
+               } ]
+            },
+            "operand" : [ {
+               "localId" : "220",
+               "name" : "cs",
+               "operandTypeSpecifier" : {
+                  "localId" : "219",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                  "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "localId" : "230",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "IsMyCS",
             "context" : "Patient",
@@ -5333,15 +5429,15 @@ module.exports['CodeSystemRef'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "219",
+                  "r" : "230",
                   "s" : [ {
                      "value" : [ "","define ","IsMyCS",": " ]
                   }, {
-                     "r" : "221",
+                     "r" : "232",
                      "s" : [ {
                         "value" : [ "IsCS","(" ]
                      }, {
-                        "r" : "220",
+                        "r" : "231",
                         "s" : [ {
                            "value" : [ "MyCS" ]
                         } ]
@@ -5352,17 +5448,61 @@ module.exports['CodeSystemRef'] = {
                }
             } ],
             "expression" : {
-               "localId" : "221",
+               "localId" : "232",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "name" : "IsCS",
                "type" : "FunctionRef",
                "signature" : [ {
-                  "localId" : "222",
+                  "localId" : "233",
                   "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "220",
+                  "localId" : "231",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                  "name" : "MyCS",
+                  "type" : "CodeSystemRef"
+               } ]
+            }
+         }, {
+            "localId" : "235",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+            "name" : "CodeInfo",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "235",
+                  "s" : [ {
+                     "value" : [ "","define ","CodeInfo",": " ]
+                  }, {
+                     "r" : "237",
+                     "s" : [ {
+                        "value" : [ "GetCodeSystemInfo","(" ]
+                     }, {
+                        "r" : "236",
+                        "s" : [ {
+                           "value" : [ "MyCS" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "237",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+               "name" : "GetCodeSystemInfo",
+               "type" : "FunctionRef",
+               "signature" : [ {
+                  "localId" : "238",
+                  "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                  "type" : "NamedTypeSpecifier"
+               } ],
+               "operand" : [ {
+                  "localId" : "236",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
                   "name" : "MyCS",
                   "type" : "CodeSystemRef"

--- a/test/elm/clinical/data.js
+++ b/test/elm/clinical/data.js
@@ -5158,6 +5158,221 @@ module.exports['ConceptRef'] = {
    }
 }
 
+/* CodeSystemRef
+library TestSnippet version '1'
+using Simple version '1.0.0'
+codesystem MyCS: 'http://loinc.org'
+context Patient
+define function IsCS(cs CodeSystem): cs is CodeSystem
+define IsMyCS: IsCS(MyCS)
+*/
+
+module.exports['CodeSystemRef'] = {
+   "library" : {
+      "localId" : "0",
+      "annotation" : [ {
+         "translatorVersion" : "3.22.0",
+         "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations,EnableResultTypes",
+         "signatureLevel" : "All",
+         "type" : "CqlToElmInfo"
+      }, {
+         "type" : "Annotation",
+         "s" : {
+            "r" : "219",
+            "s" : [ {
+               "value" : [ "","library TestSnippet version '1'" ]
+            } ]
+         }
+      } ],
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localId" : "1",
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localId" : "206",
+            "localIdentifier" : "Simple",
+            "uri" : "https://github.com/cqframework/cql-execution/simple",
+            "version" : "1.0.0",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "206",
+                  "s" : [ {
+                     "value" : [ "","using " ]
+                  }, {
+                     "s" : [ {
+                        "value" : [ "Simple" ]
+                     } ]
+                  }, {
+                     "value" : [ " version '1.0.0'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "codeSystems" : {
+         "def" : [ {
+            "localId" : "207",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+            "name" : "MyCS",
+            "id" : "http://loinc.org",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "207",
+                  "s" : [ {
+                     "value" : [ "","codesystem ","MyCS",": ","'http://loinc.org'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "localId" : "211",
+            "name" : "Patient"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "localId" : "209",
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "localId" : "210",
+               "type" : "SingletonFrom",
+               "signature" : [ ],
+               "operand" : {
+                  "localId" : "208",
+                  "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+                  "type" : "Retrieve",
+                  "include" : [ ],
+                  "codeFilter" : [ ],
+                  "dateFilter" : [ ],
+                  "otherFilter" : [ ]
+               }
+            }
+         }, {
+            "localId" : "212",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+            "name" : "IsCS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "212",
+                  "s" : [ {
+                     "value" : [ "","define function IsCS(cs CodeSystem): " ]
+                  }, {
+                     "r" : "215",
+                     "s" : [ {
+                        "r" : "215",
+                        "s" : [ {
+                           "r" : "216",
+                           "s" : [ {
+                              "value" : [ "cs" ]
+                           } ]
+                        }, {
+                           "value" : [ " is " ]
+                        }, {
+                           "r" : "217",
+                           "s" : [ {
+                              "value" : [ "CodeSystem" ]
+                           } ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "215",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+               "type" : "Is",
+               "signature" : [ ],
+               "operand" : {
+                  "localId" : "216",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                  "name" : "cs",
+                  "type" : "OperandRef"
+               },
+               "isTypeSpecifier" : {
+                  "localId" : "217",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                  "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
+            "operand" : [ {
+               "localId" : "214",
+               "name" : "cs",
+               "operandTypeSpecifier" : {
+                  "localId" : "213",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                  "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "localId" : "219",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+            "name" : "IsMyCS",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "219",
+                  "s" : [ {
+                     "value" : [ "","define ","IsMyCS",": " ]
+                  }, {
+                     "r" : "221",
+                     "s" : [ {
+                        "value" : [ "IsCS","(" ]
+                     }, {
+                        "r" : "220",
+                        "s" : [ {
+                           "value" : [ "MyCS" ]
+                        } ]
+                     }, {
+                        "value" : [ ")" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "221",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+               "name" : "IsCS",
+               "type" : "FunctionRef",
+               "signature" : [ {
+                  "localId" : "222",
+                  "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                  "type" : "NamedTypeSpecifier"
+               } ],
+               "operand" : [ {
+                  "localId" : "220",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                  "name" : "MyCS",
+                  "type" : "CodeSystemRef"
+               } ]
+            }
+         } ]
+      }
+   }
+}
+
 /* CalculateAge: Fully Specified Birth Date
 library TestSnippet version '1'
 using Simple version '1.0.0'

--- a/test/elm/clinical/data.js
+++ b/test/elm/clinical/data.js
@@ -5163,10 +5163,7 @@ library TestSnippet version '1'
 using Simple version '1.0.0'
 codesystem MyCS: 'http://loinc.org' version '1'
 context Patient
-define function IsCS(cs CodeSystem): cs is CodeSystem
-define function GetCodeSystemInfo(cs CodeSystem): cs.id + cs.version
-define IsMyCS: IsCS(MyCS)
-define CodeInfo: GetCodeSystemInfo(MyCS)
+define ResolveMyCS: MyCS
 */
 
 module.exports['CodeSystemRef'] = {
@@ -5180,7 +5177,7 @@ module.exports['CodeSystemRef'] = {
       }, {
          "type" : "Annotation",
          "s" : {
-            "r" : "235",
+            "r" : "213",
             "s" : [ {
                "value" : [ "","library TestSnippet version '1'" ]
             } ]
@@ -5266,247 +5263,30 @@ module.exports['CodeSystemRef'] = {
                }
             }
          }, {
-            "localId" : "212",
-            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
-            "name" : "IsCS",
+            "localId" : "213",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+            "name" : "ResolveMyCS",
             "context" : "Patient",
             "accessLevel" : "Public",
-            "type" : "FunctionDef",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "212",
+                  "r" : "213",
                   "s" : [ {
-                     "value" : [ "","define function IsCS(cs CodeSystem): " ]
+                     "value" : [ "","define ","ResolveMyCS",": " ]
                   }, {
-                     "r" : "215",
+                     "r" : "214",
                      "s" : [ {
-                        "r" : "215",
-                        "s" : [ {
-                           "r" : "216",
-                           "s" : [ {
-                              "value" : [ "cs" ]
-                           } ]
-                        }, {
-                           "value" : [ " is " ]
-                        }, {
-                           "r" : "217",
-                           "s" : [ {
-                              "value" : [ "CodeSystem" ]
-                           } ]
-                        } ]
+                        "value" : [ "MyCS" ]
                      } ]
                   } ]
                }
             } ],
             "expression" : {
-               "localId" : "215",
-               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
-               "type" : "Is",
-               "signature" : [ ],
-               "operand" : {
-                  "localId" : "216",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-                  "name" : "cs",
-                  "type" : "OperandRef"
-               },
-               "isTypeSpecifier" : {
-                  "localId" : "217",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-                  "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-                  "type" : "NamedTypeSpecifier"
-               }
-            },
-            "operand" : [ {
                "localId" : "214",
-               "name" : "cs",
-               "operandTypeSpecifier" : {
-                  "localId" : "213",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-                  "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-                  "type" : "NamedTypeSpecifier"
-               }
-            } ]
-         }, {
-            "localId" : "218",
-            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-            "name" : "GetCodeSystemInfo",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "type" : "FunctionDef",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "218",
-                  "s" : [ {
-                     "value" : [ "","define function GetCodeSystemInfo(cs CodeSystem): " ]
-                  }, {
-                     "r" : "228",
-                     "s" : [ {
-                        "r" : "228",
-                        "s" : [ {
-                           "r" : "223",
-                           "s" : [ {
-                              "r" : "222",
-                              "s" : [ {
-                                 "value" : [ "cs" ]
-                              } ]
-                           }, {
-                              "value" : [ "." ]
-                           }, {
-                              "r" : "223",
-                              "s" : [ {
-                                 "value" : [ "id" ]
-                              } ]
-                           } ]
-                        }, {
-                           "value" : [ " + " ]
-                        }, {
-                           "r" : "225",
-                           "s" : [ {
-                              "r" : "224",
-                              "s" : [ {
-                                 "value" : [ "cs" ]
-                              } ]
-                           }, {
-                              "value" : [ "." ]
-                           }, {
-                              "r" : "225",
-                              "s" : [ {
-                                 "value" : [ "version" ]
-                              } ]
-                           } ]
-                        } ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "expression" : {
-               "localId" : "228",
-               "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-               "type" : "Concatenate",
-               "signature" : [ ],
-               "operand" : [ {
-                  "localId" : "223",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-                  "path" : "id",
-                  "type" : "Property",
-                  "source" : {
-                     "localId" : "222",
-                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-                     "name" : "cs",
-                     "type" : "OperandRef"
-                  }
-               }, {
-                  "localId" : "225",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-                  "path" : "version",
-                  "type" : "Property",
-                  "source" : {
-                     "localId" : "224",
-                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-                     "name" : "cs",
-                     "type" : "OperandRef"
-                  }
-               } ]
-            },
-            "operand" : [ {
-               "localId" : "220",
-               "name" : "cs",
-               "operandTypeSpecifier" : {
-                  "localId" : "219",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-                  "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-                  "type" : "NamedTypeSpecifier"
-               }
-            } ]
-         }, {
-            "localId" : "230",
-            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
-            "name" : "IsMyCS",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "230",
-                  "s" : [ {
-                     "value" : [ "","define ","IsMyCS",": " ]
-                  }, {
-                     "r" : "232",
-                     "s" : [ {
-                        "value" : [ "IsCS","(" ]
-                     }, {
-                        "r" : "231",
-                        "s" : [ {
-                           "value" : [ "MyCS" ]
-                        } ]
-                     }, {
-                        "value" : [ ")" ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "expression" : {
-               "localId" : "232",
-               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
-               "name" : "IsCS",
-               "type" : "FunctionRef",
-               "signature" : [ {
-                  "localId" : "233",
-                  "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-                  "type" : "NamedTypeSpecifier"
-               } ],
-               "operand" : [ {
-                  "localId" : "231",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-                  "name" : "MyCS",
-                  "type" : "CodeSystemRef"
-               } ]
-            }
-         }, {
-            "localId" : "235",
-            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-            "name" : "CodeInfo",
-            "context" : "Patient",
-            "accessLevel" : "Public",
-            "annotation" : [ {
-               "type" : "Annotation",
-               "s" : {
-                  "r" : "235",
-                  "s" : [ {
-                     "value" : [ "","define ","CodeInfo",": " ]
-                  }, {
-                     "r" : "237",
-                     "s" : [ {
-                        "value" : [ "GetCodeSystemInfo","(" ]
-                     }, {
-                        "r" : "236",
-                        "s" : [ {
-                           "value" : [ "MyCS" ]
-                        } ]
-                     }, {
-                        "value" : [ ")" ]
-                     } ]
-                  } ]
-               }
-            } ],
-            "expression" : {
-               "localId" : "237",
-               "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-               "name" : "GetCodeSystemInfo",
-               "type" : "FunctionRef",
-               "signature" : [ {
-                  "localId" : "238",
-                  "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-                  "type" : "NamedTypeSpecifier"
-               } ],
-               "operand" : [ {
-                  "localId" : "236",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-                  "name" : "MyCS",
-                  "type" : "CodeSystemRef"
-               } ]
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+               "name" : "MyCS",
+               "type" : "CodeSystemRef"
             }
          } ]
       }

--- a/test/elm/library/Common.cql
+++ b/test/elm/library/Common.cql
@@ -4,6 +4,8 @@ using Simple version '1.0.0'
 
 include Common2 called common2
 
+valueset "My Favorite VS": '9.7.5.3.1'
+valueset "Acute Pharyngitis": '2.16.840.1.113883.3.464.1003.101.12.1001'
 codesystem "My Favorite CS": '1.3.5.7.9'
 codesystem "SNOMEDCT": '2.16.840.1.113883.6.96'
 code "directReferenceCode": '428371000124100' from "SNOMEDCT" display 'directReferenceCode'

--- a/test/elm/library/Common.cql
+++ b/test/elm/library/Common.cql
@@ -4,6 +4,7 @@ using Simple version '1.0.0'
 
 include Common2 called common2
 
+codesystem "My Favorite CS": '1.3.5.7.9'
 codesystem "SNOMEDCT": '2.16.840.1.113883.6.96'
 code "directReferenceCode": '428371000124100' from "SNOMEDCT" display 'directReferenceCode'
 

--- a/test/elm/library/data.cql
+++ b/test/elm/library/data.cql
@@ -11,6 +11,8 @@ library Common
 using Simple version '1.0.0'
 include Common2 called common2
 
+valueset "My Favorite VS": '9.7.5.3.1'
+valueset "Acute Pharyngitis": '2.16.840.1.113883.3.464.1003.101.12.1001'
 codesystem "My Favorite CS": '1.3.5.7.9'
 codesystem "SNOMEDCT": '2.16.840.1.113883.6.96'
 code "directReferenceCode": '428371000124100' from "SNOMEDCT" display 'directReferenceCode'
@@ -33,6 +35,7 @@ using Simple version '1.0.0'
 
 include Common called common
 
+valueset "My Favorite VS": '10.8.6.4.2'
 codesystem "My Favorite CS": '2.4.6.8.10'
 
 parameter MeasurementPeriod default Interval[DateTime(2013, 1, 1), DateTime(2014, 1, 1))
@@ -49,6 +52,12 @@ define supportClashingCodeSystemNames:
   Tuple {
     MyFavorite: "My Favorite CS",
     MyLibsFavorite: common."My Favorite CS"
+  }
+define supportLibValueSet: common."Acute Pharyngitis"
+define supportClashingValueSetNames:
+  Tuple {
+    MyFavorite: "My Favorite VS",
+    MyLibsFavorite: common."My Favorite VS"
   }
 
 // @Test: CommonLib2

--- a/test/elm/library/data.cql
+++ b/test/elm/library/data.cql
@@ -11,6 +11,7 @@ library Common
 using Simple version '1.0.0'
 include Common2 called common2
 
+codesystem "My Favorite CS": '1.3.5.7.9'
 codesystem "SNOMEDCT": '2.16.840.1.113883.6.96'
 code "directReferenceCode": '428371000124100' from "SNOMEDCT" display 'directReferenceCode'
 
@@ -31,6 +32,9 @@ define SupportLibDef:
 using Simple version '1.0.0'
 
 include Common called common
+
+codesystem "My Favorite CS": '2.4.6.8.10'
+
 parameter MeasurementPeriod default Interval[DateTime(2013, 1, 1), DateTime(2014, 1, 1))
 
 context Patient
@@ -40,6 +44,12 @@ define ID: common.InDemographic
 define L : Length(Patient.name)
 define FuncTest : common.foo(2, 5)
 define supportLibCode: common."directReferenceCode"
+define supportLibCodeSystem: common."SNOMEDCT"
+define supportClashingCodeSystemNames:
+  Tuple {
+    MyFavorite: "My Favorite CS",
+    MyLibsFavorite: common."My Favorite CS"
+  }
 
 // @Test: CommonLib2
 library Common2
@@ -102,6 +112,7 @@ define ExprSortsOnFunc: common2.SortUsingFunction
 
 
 // @Test: Using CommonLib and CommonLib2
+library UsingTwoLibs version '0.0.1'
 using Simple version '1.0.0'
 include Common2 called common2
 include Common called common

--- a/test/elm/library/data.js
+++ b/test/elm/library/data.js
@@ -468,6 +468,7 @@ library Common
 using Simple version '1.0.0'
 include Common2 called common2
 
+codesystem "My Favorite CS": '1.3.5.7.9'
 codesystem "SNOMEDCT": '2.16.840.1.113883.6.96'
 code "directReferenceCode": '428371000124100' from "SNOMEDCT" display 'directReferenceCode'
 
@@ -496,7 +497,7 @@ module.exports['CommonLib'] = {
       }, {
          "type" : "Annotation",
          "s" : {
-            "r" : "295",
+            "r" : "296",
             "s" : [ {
                "value" : [ "","library Common" ]
             } ]
@@ -560,31 +561,31 @@ module.exports['CommonLib'] = {
       },
       "parameters" : {
          "def" : [ {
-            "localId" : "211",
+            "localId" : "212",
             "name" : "MeasurementPeriod",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "211",
+                  "r" : "212",
                   "s" : [ {
                      "value" : [ "","parameter ","MeasurementPeriod"," default " ]
                   }, {
-                     "r" : "236",
+                     "r" : "237",
                      "s" : [ {
                         "value" : [ "Interval[" ]
                      }, {
-                        "r" : "220",
+                        "r" : "221",
                         "s" : [ {
-                           "r" : "212",
+                           "r" : "213",
                            "value" : [ "DateTime","(","2013",", ","1",", ","1",")" ]
                         } ]
                      }, {
                         "value" : [ ", " ]
                      }, {
-                        "r" : "232",
+                        "r" : "233",
                         "s" : [ {
-                           "r" : "224",
+                           "r" : "225",
                            "value" : [ "DateTime","(","2014",", ","1",", ","1",")" ]
                         } ]
                      }, {
@@ -594,37 +595,33 @@ module.exports['CommonLib'] = {
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "239",
+               "localId" : "240",
                "type" : "IntervalTypeSpecifier",
                "pointType" : {
-                  "localId" : "240",
+                  "localId" : "241",
                   "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "default" : {
-               "localId" : "236",
+               "localId" : "237",
                "lowClosed" : true,
                "highClosed" : false,
                "type" : "Interval",
                "resultTypeSpecifier" : {
-                  "localId" : "237",
+                  "localId" : "238",
                   "type" : "IntervalTypeSpecifier",
                   "pointType" : {
-                     "localId" : "238",
+                     "localId" : "239",
                      "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                      "type" : "NamedTypeSpecifier"
                   }
                },
                "low" : {
-                  "localId" : "220",
+                  "localId" : "221",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "type" : "DateTime",
                   "signature" : [ {
-                     "localId" : "221",
-                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "type" : "NamedTypeSpecifier"
-                  }, {
                      "localId" : "222",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
@@ -632,23 +629,27 @@ module.exports['CommonLib'] = {
                      "localId" : "223",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
+                  }, {
+                     "localId" : "224",
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
                   } ],
                   "year" : {
-                     "localId" : "212",
+                     "localId" : "213",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2013",
                      "type" : "Literal"
                   },
                   "month" : {
-                     "localId" : "213",
+                     "localId" : "214",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
                      "type" : "Literal"
                   },
                   "day" : {
-                     "localId" : "214",
+                     "localId" : "215",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
@@ -656,14 +657,10 @@ module.exports['CommonLib'] = {
                   }
                },
                "high" : {
-                  "localId" : "232",
+                  "localId" : "233",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "type" : "DateTime",
                   "signature" : [ {
-                     "localId" : "233",
-                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "type" : "NamedTypeSpecifier"
-                  }, {
                      "localId" : "234",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
@@ -671,23 +668,27 @@ module.exports['CommonLib'] = {
                      "localId" : "235",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
+                  }, {
+                     "localId" : "236",
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
                   } ],
                   "year" : {
-                     "localId" : "224",
+                     "localId" : "225",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2014",
                      "type" : "Literal"
                   },
                   "month" : {
-                     "localId" : "225",
+                     "localId" : "226",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
                      "type" : "Literal"
                   },
                   "day" : {
-                     "localId" : "226",
+                     "localId" : "227",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
@@ -701,13 +702,28 @@ module.exports['CommonLib'] = {
          "def" : [ {
             "localId" : "208",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+            "name" : "My Favorite CS",
+            "id" : "1.3.5.7.9",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "208",
+                  "s" : [ {
+                     "value" : [ "","codesystem ","\"My Favorite CS\"",": ","'1.3.5.7.9'" ]
+                  } ]
+               }
+            } ]
+         }, {
+            "localId" : "209",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
             "name" : "SNOMEDCT",
             "id" : "2.16.840.1.113883.6.96",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "208",
+                  "r" : "209",
                   "s" : [ {
                      "value" : [ "","codesystem ","\"SNOMEDCT\"",": ","'2.16.840.1.113883.6.96'" ]
                   } ]
@@ -717,7 +733,7 @@ module.exports['CommonLib'] = {
       },
       "codes" : {
          "def" : [ {
-            "localId" : "209",
+            "localId" : "210",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
             "name" : "directReferenceCode",
             "id" : "428371000124100",
@@ -726,11 +742,11 @@ module.exports['CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "209",
+                  "r" : "210",
                   "s" : [ {
                      "value" : [ "","code ","\"directReferenceCode\"",": ","'428371000124100'"," from " ]
                   }, {
-                     "r" : "210",
+                     "r" : "211",
                      "s" : [ {
                         "value" : [ "\"SNOMEDCT\"" ]
                      } ]
@@ -740,7 +756,7 @@ module.exports['CommonLib'] = {
                }
             } ],
             "codeSystem" : {
-               "localId" : "210",
+               "localId" : "211",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
                "name" : "SNOMEDCT"
             }
@@ -748,21 +764,21 @@ module.exports['CommonLib'] = {
       },
       "contexts" : {
          "def" : [ {
-            "localId" : "244",
+            "localId" : "245",
             "name" : "Patient"
          } ]
       },
       "statements" : {
          "def" : [ {
-            "localId" : "242",
+            "localId" : "243",
             "name" : "Patient",
             "context" : "Patient",
             "expression" : {
-               "localId" : "243",
+               "localId" : "244",
                "type" : "SingletonFrom",
                "signature" : [ ],
                "operand" : {
-                  "localId" : "241",
+                  "localId" : "242",
                   "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
                   "type" : "Retrieve",
                   "include" : [ ],
@@ -772,7 +788,7 @@ module.exports['CommonLib'] = {
                }
             }
          }, {
-            "localId" : "246",
+            "localId" : "247",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "InDemographic",
             "context" : "Patient",
@@ -780,23 +796,23 @@ module.exports['CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "246",
+                  "r" : "247",
                   "s" : [ {
                      "value" : [ "","define ","InDemographic",":\n" ]
                   }, {
-                     "r" : "247",
+                     "r" : "248",
                      "s" : [ {
-                        "r" : "248",
+                        "r" : "249",
                         "s" : [ {
-                           "r" : "259",
+                           "r" : "260",
                            "s" : [ {
                               "value" : [ "AgeInYearsAt","(" ]
                            }, {
-                              "r" : "249",
+                              "r" : "250",
                               "s" : [ {
                                  "value" : [ "start of " ]
                               }, {
-                                 "r" : "250",
+                                 "r" : "251",
                                  "s" : [ {
                                     "value" : [ "MeasurementPeriod" ]
                                  } ]
@@ -805,23 +821,23 @@ module.exports['CommonLib'] = {
                               "value" : [ ")" ]
                            } ]
                         }, {
-                           "r" : "262",
+                           "r" : "263",
                            "value" : [ " ",">="," ","2" ]
                         } ]
                      }, {
                         "value" : [ " and " ]
                      }, {
-                        "r" : "265",
+                        "r" : "266",
                         "s" : [ {
-                           "r" : "276",
+                           "r" : "277",
                            "s" : [ {
                               "value" : [ "AgeInYearsAt","(" ]
                            }, {
-                              "r" : "266",
+                              "r" : "267",
                               "s" : [ {
                                  "value" : [ "start of " ]
                               }, {
-                                 "r" : "267",
+                                 "r" : "268",
                                  "s" : [ {
                                     "value" : [ "MeasurementPeriod" ]
                                  } ]
@@ -830,7 +846,7 @@ module.exports['CommonLib'] = {
                               "value" : [ ")" ]
                            } ]
                         }, {
-                           "r" : "279",
+                           "r" : "280",
                            "value" : [ " ","<"," ","18" ]
                         } ]
                      } ]
@@ -838,76 +854,76 @@ module.exports['CommonLib'] = {
                }
             } ],
             "expression" : {
-               "localId" : "247",
+               "localId" : "248",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "And",
                "signature" : [ {
-                  "localId" : "282",
+                  "localId" : "283",
                   "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "NamedTypeSpecifier"
                }, {
-                  "localId" : "283",
+                  "localId" : "284",
                   "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "248",
+                  "localId" : "249",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "GreaterOrEqual",
                   "signature" : [ {
-                     "localId" : "263",
+                     "localId" : "264",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
                   }, {
-                     "localId" : "264",
+                     "localId" : "265",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
                   } ],
                   "operand" : [ {
-                     "localId" : "259",
+                     "localId" : "260",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "precision" : "Year",
                      "type" : "CalculateAgeAt",
                      "signature" : [ {
-                        "localId" : "260",
+                        "localId" : "261",
                         "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "NamedTypeSpecifier"
                      }, {
-                        "localId" : "261",
+                        "localId" : "262",
                         "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "NamedTypeSpecifier"
                      } ],
                      "operand" : [ {
-                        "localId" : "258",
+                        "localId" : "259",
                         "path" : "birthDate",
                         "type" : "Property",
                         "source" : {
-                           "localId" : "257",
+                           "localId" : "258",
                            "name" : "Patient",
                            "type" : "ExpressionRef"
                         }
                      }, {
-                        "localId" : "249",
+                        "localId" : "250",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "Start",
                         "signature" : [ {
-                           "localId" : "253",
+                           "localId" : "254",
                            "type" : "IntervalTypeSpecifier",
                            "pointType" : {
-                              "localId" : "254",
+                              "localId" : "255",
                               "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         } ],
                         "operand" : {
-                           "localId" : "250",
+                           "localId" : "251",
                            "name" : "MeasurementPeriod",
                            "type" : "ParameterRef",
                            "resultTypeSpecifier" : {
-                              "localId" : "251",
+                              "localId" : "252",
                               "type" : "IntervalTypeSpecifier",
                               "pointType" : {
-                                 "localId" : "252",
+                                 "localId" : "253",
                                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -915,70 +931,70 @@ module.exports['CommonLib'] = {
                         }
                      } ]
                   }, {
-                     "localId" : "262",
+                     "localId" : "263",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2",
                      "type" : "Literal"
                   } ]
                }, {
-                  "localId" : "265",
+                  "localId" : "266",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "Less",
                   "signature" : [ {
-                     "localId" : "280",
+                     "localId" : "281",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
                   }, {
-                     "localId" : "281",
+                     "localId" : "282",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
                   } ],
                   "operand" : [ {
-                     "localId" : "276",
+                     "localId" : "277",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "precision" : "Year",
                      "type" : "CalculateAgeAt",
                      "signature" : [ {
-                        "localId" : "277",
+                        "localId" : "278",
                         "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "NamedTypeSpecifier"
                      }, {
-                        "localId" : "278",
+                        "localId" : "279",
                         "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "NamedTypeSpecifier"
                      } ],
                      "operand" : [ {
-                        "localId" : "275",
+                        "localId" : "276",
                         "path" : "birthDate",
                         "type" : "Property",
                         "source" : {
-                           "localId" : "274",
+                           "localId" : "275",
                            "name" : "Patient",
                            "type" : "ExpressionRef"
                         }
                      }, {
-                        "localId" : "266",
+                        "localId" : "267",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "Start",
                         "signature" : [ {
-                           "localId" : "270",
+                           "localId" : "271",
                            "type" : "IntervalTypeSpecifier",
                            "pointType" : {
-                              "localId" : "271",
+                              "localId" : "272",
                               "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         } ],
                         "operand" : {
-                           "localId" : "267",
+                           "localId" : "268",
                            "name" : "MeasurementPeriod",
                            "type" : "ParameterRef",
                            "resultTypeSpecifier" : {
-                              "localId" : "268",
+                              "localId" : "269",
                               "type" : "IntervalTypeSpecifier",
                               "pointType" : {
-                                 "localId" : "269",
+                                 "localId" : "270",
                                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -986,7 +1002,7 @@ module.exports['CommonLib'] = {
                         }
                      } ]
                   }, {
-                     "localId" : "279",
+                     "localId" : "280",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "18",
@@ -995,7 +1011,7 @@ module.exports['CommonLib'] = {
                } ]
             }
          }, {
-            "localId" : "284",
+            "localId" : "285",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
             "name" : "foo",
             "context" : "Patient",
@@ -1004,22 +1020,22 @@ module.exports['CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "284",
+                  "r" : "285",
                   "s" : [ {
                      "value" : [ "","define function foo (a Integer, b Integer) :\n  " ]
                   }, {
-                     "r" : "289",
+                     "r" : "290",
                      "s" : [ {
-                        "r" : "289",
+                        "r" : "290",
                         "s" : [ {
-                           "r" : "290",
+                           "r" : "291",
                            "s" : [ {
                               "value" : [ "a" ]
                            } ]
                         }, {
                            "value" : [ " + " ]
                         }, {
-                           "r" : "291",
+                           "r" : "292",
                            "s" : [ {
                               "value" : [ "b" ]
                            } ]
@@ -1029,51 +1045,51 @@ module.exports['CommonLib'] = {
                }
             } ],
             "expression" : {
-               "localId" : "289",
+               "localId" : "290",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                "type" : "Add",
                "signature" : [ {
-                  "localId" : "292",
+                  "localId" : "293",
                   "name" : "{urn:hl7-org:elm-types:r1}Integer",
                   "type" : "NamedTypeSpecifier"
                }, {
-                  "localId" : "293",
+                  "localId" : "294",
                   "name" : "{urn:hl7-org:elm-types:r1}Integer",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "290",
+                  "localId" : "291",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                   "name" : "a",
                   "type" : "OperandRef"
                }, {
-                  "localId" : "291",
+                  "localId" : "292",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                   "name" : "b",
                   "type" : "OperandRef"
                } ]
             },
             "operand" : [ {
-               "localId" : "286",
+               "localId" : "287",
                "name" : "a",
                "operandTypeSpecifier" : {
-                  "localId" : "285",
+                  "localId" : "286",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                   "name" : "{urn:hl7-org:elm-types:r1}Integer",
                   "type" : "NamedTypeSpecifier"
                }
             }, {
-               "localId" : "288",
+               "localId" : "289",
                "name" : "b",
                "operandTypeSpecifier" : {
-                  "localId" : "287",
+                  "localId" : "288",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                   "name" : "{urn:hl7-org:elm-types:r1}Integer",
                   "type" : "NamedTypeSpecifier"
                }
             } ]
          }, {
-            "localId" : "295",
+            "localId" : "296",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
             "name" : "SupportLibDef",
             "context" : "Patient",
@@ -1081,24 +1097,24 @@ module.exports['CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "295",
+                  "r" : "296",
                   "s" : [ {
                      "value" : [ "","define ","SupportLibDef",":\n  " ]
                   }, {
-                     "r" : "296",
+                     "r" : "297",
                      "s" : [ {
-                        "r" : "297",
+                        "r" : "298",
                         "s" : [ {
-                           "r" : "299",
+                           "r" : "300",
                            "s" : [ {
-                              "r" : "298",
+                              "r" : "299",
                               "s" : [ {
                                  "value" : [ "common2" ]
                               } ]
                            }, {
                               "value" : [ "." ]
                            }, {
-                              "r" : "299",
+                              "r" : "300",
                               "s" : [ {
                                  "value" : [ "TheParameter" ]
                               } ]
@@ -1106,16 +1122,16 @@ module.exports['CommonLib'] = {
                         }, {
                            "value" : [ " + " ]
                         }, {
-                           "r" : "301",
+                           "r" : "302",
                            "s" : [ {
-                              "r" : "300",
+                              "r" : "301",
                               "s" : [ {
                                  "value" : [ "common2" ]
                               } ]
                            }, {
                               "value" : [ "." ]
                            }, {
-                              "r" : "301",
+                              "r" : "302",
                               "s" : [ {
                                  "value" : [ "TwoPlusOne" ]
                               } ]
@@ -1124,16 +1140,16 @@ module.exports['CommonLib'] = {
                      }, {
                         "value" : [ " + " ]
                      }, {
-                        "r" : "305",
+                        "r" : "306",
                         "s" : [ {
-                           "r" : "304",
+                           "r" : "305",
                            "s" : [ {
                               "value" : [ "common2" ]
                            } ]
                         }, {
                            "value" : [ "." ]
                         }, {
-                           "r" : "305",
+                           "r" : "306",
                            "s" : [ {
                               "value" : [ "TwoTimesThree" ]
                            } ]
@@ -1143,46 +1159,46 @@ module.exports['CommonLib'] = {
                }
             } ],
             "expression" : {
-               "localId" : "296",
+               "localId" : "297",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                "type" : "Add",
                "signature" : [ {
-                  "localId" : "306",
+                  "localId" : "307",
                   "name" : "{urn:hl7-org:elm-types:r1}Integer",
                   "type" : "NamedTypeSpecifier"
                }, {
-                  "localId" : "307",
+                  "localId" : "308",
                   "name" : "{urn:hl7-org:elm-types:r1}Integer",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "297",
+                  "localId" : "298",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                   "type" : "Add",
                   "signature" : [ {
-                     "localId" : "302",
+                     "localId" : "303",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
                   }, {
-                     "localId" : "303",
+                     "localId" : "304",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
                   } ],
                   "operand" : [ {
-                     "localId" : "299",
+                     "localId" : "300",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "name" : "TheParameter",
                      "libraryName" : "common2",
                      "type" : "ExpressionRef"
                   }, {
-                     "localId" : "301",
+                     "localId" : "302",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "name" : "TwoPlusOne",
                      "libraryName" : "common2",
                      "type" : "ExpressionRef"
                   } ]
                }, {
-                  "localId" : "305",
+                  "localId" : "306",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                   "name" : "TwoTimesThree",
                   "libraryName" : "common2",
@@ -1199,6 +1215,9 @@ library TestSnippet version '1'
 using Simple version '1.0.0'
 
 include Common called common
+
+codesystem "My Favorite CS": '2.4.6.8.10'
+
 parameter MeasurementPeriod default Interval[DateTime(2013, 1, 1), DateTime(2014, 1, 1))
 
 context Patient
@@ -1208,6 +1227,12 @@ define ID: common.InDemographic
 define L : Length(Patient.name)
 define FuncTest : common.foo(2, 5)
 define supportLibCode: common."directReferenceCode"
+define supportLibCodeSystem: common."SNOMEDCT"
+define supportClashingCodeSystemNames:
+  Tuple {
+    MyFavorite: "My Favorite CS",
+    MyLibsFavorite: common."My Favorite CS"
+  }
 */
 
 module.exports['Using CommonLib'] = {
@@ -1221,7 +1246,7 @@ module.exports['Using CommonLib'] = {
       }, {
          "type" : "Annotation",
          "s" : {
-            "r" : "264",
+            "r" : "273",
             "s" : [ {
                "value" : [ "","library TestSnippet version '1'" ]
             } ]
@@ -1286,31 +1311,31 @@ module.exports['Using CommonLib'] = {
       },
       "parameters" : {
          "def" : [ {
-            "localId" : "208",
+            "localId" : "209",
             "name" : "MeasurementPeriod",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "208",
+                  "r" : "209",
                   "s" : [ {
                      "value" : [ "","parameter ","MeasurementPeriod"," default " ]
                   }, {
-                     "r" : "233",
+                     "r" : "234",
                      "s" : [ {
                         "value" : [ "Interval[" ]
                      }, {
-                        "r" : "217",
+                        "r" : "218",
                         "s" : [ {
-                           "r" : "209",
+                           "r" : "210",
                            "value" : [ "DateTime","(","2013",", ","1",", ","1",")" ]
                         } ]
                      }, {
                         "value" : [ ", " ]
                      }, {
-                        "r" : "229",
+                        "r" : "230",
                         "s" : [ {
-                           "r" : "221",
+                           "r" : "222",
                            "value" : [ "DateTime","(","2014",", ","1",", ","1",")" ]
                         } ]
                      }, {
@@ -1320,37 +1345,33 @@ module.exports['Using CommonLib'] = {
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "236",
+               "localId" : "237",
                "type" : "IntervalTypeSpecifier",
                "pointType" : {
-                  "localId" : "237",
+                  "localId" : "238",
                   "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "default" : {
-               "localId" : "233",
+               "localId" : "234",
                "lowClosed" : true,
                "highClosed" : false,
                "type" : "Interval",
                "resultTypeSpecifier" : {
-                  "localId" : "234",
+                  "localId" : "235",
                   "type" : "IntervalTypeSpecifier",
                   "pointType" : {
-                     "localId" : "235",
+                     "localId" : "236",
                      "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                      "type" : "NamedTypeSpecifier"
                   }
                },
                "low" : {
-                  "localId" : "217",
+                  "localId" : "218",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "type" : "DateTime",
                   "signature" : [ {
-                     "localId" : "218",
-                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "type" : "NamedTypeSpecifier"
-                  }, {
                      "localId" : "219",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
@@ -1358,23 +1379,27 @@ module.exports['Using CommonLib'] = {
                      "localId" : "220",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
+                  }, {
+                     "localId" : "221",
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
                   } ],
                   "year" : {
-                     "localId" : "209",
+                     "localId" : "210",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2013",
                      "type" : "Literal"
                   },
                   "month" : {
-                     "localId" : "210",
+                     "localId" : "211",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
                      "type" : "Literal"
                   },
                   "day" : {
-                     "localId" : "211",
+                     "localId" : "212",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
@@ -1382,14 +1407,10 @@ module.exports['Using CommonLib'] = {
                   }
                },
                "high" : {
-                  "localId" : "229",
+                  "localId" : "230",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "type" : "DateTime",
                   "signature" : [ {
-                     "localId" : "230",
-                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "type" : "NamedTypeSpecifier"
-                  }, {
                      "localId" : "231",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
@@ -1397,23 +1418,27 @@ module.exports['Using CommonLib'] = {
                      "localId" : "232",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
+                  }, {
+                     "localId" : "233",
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
                   } ],
                   "year" : {
-                     "localId" : "221",
+                     "localId" : "222",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2014",
                      "type" : "Literal"
                   },
                   "month" : {
-                     "localId" : "222",
+                     "localId" : "223",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
                      "type" : "Literal"
                   },
                   "day" : {
-                     "localId" : "223",
+                     "localId" : "224",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
@@ -1423,23 +1448,41 @@ module.exports['Using CommonLib'] = {
             }
          } ]
       },
+      "codeSystems" : {
+         "def" : [ {
+            "localId" : "208",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+            "name" : "My Favorite CS",
+            "id" : "2.4.6.8.10",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "208",
+                  "s" : [ {
+                     "value" : [ "","codesystem ","\"My Favorite CS\"",": ","'2.4.6.8.10'" ]
+                  } ]
+               }
+            } ]
+         } ]
+      },
       "contexts" : {
          "def" : [ {
-            "localId" : "241",
+            "localId" : "242",
             "name" : "Patient"
          } ]
       },
       "statements" : {
          "def" : [ {
-            "localId" : "239",
+            "localId" : "240",
             "name" : "Patient",
             "context" : "Patient",
             "expression" : {
-               "localId" : "240",
+               "localId" : "241",
                "type" : "SingletonFrom",
                "signature" : [ ],
                "operand" : {
-                  "localId" : "238",
+                  "localId" : "239",
                   "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
                   "type" : "Retrieve",
                   "include" : [ ],
@@ -1449,7 +1492,7 @@ module.exports['Using CommonLib'] = {
                }
             }
          }, {
-            "localId" : "243",
+            "localId" : "244",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "ID",
             "context" : "Patient",
@@ -1457,20 +1500,20 @@ module.exports['Using CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "243",
+                  "r" : "244",
                   "s" : [ {
                      "value" : [ "","define ","ID",": " ]
                   }, {
-                     "r" : "245",
+                     "r" : "246",
                      "s" : [ {
-                        "r" : "244",
+                        "r" : "245",
                         "s" : [ {
                            "value" : [ "common" ]
                         } ]
                      }, {
                         "value" : [ "." ]
                      }, {
-                        "r" : "245",
+                        "r" : "246",
                         "s" : [ {
                            "value" : [ "InDemographic" ]
                         } ]
@@ -1479,14 +1522,14 @@ module.exports['Using CommonLib'] = {
                }
             } ],
             "expression" : {
-               "localId" : "245",
+               "localId" : "246",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "name" : "InDemographic",
                "libraryName" : "common",
                "type" : "ExpressionRef"
             }
          }, {
-            "localId" : "247",
+            "localId" : "248",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
             "name" : "L",
             "context" : "Patient",
@@ -1494,24 +1537,24 @@ module.exports['Using CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "247",
+                  "r" : "248",
                   "s" : [ {
                      "value" : [ "","define ","L"," : " ]
                   }, {
-                     "r" : "253",
+                     "r" : "254",
                      "s" : [ {
                         "value" : [ "Length","(" ]
                      }, {
-                        "r" : "249",
+                        "r" : "250",
                         "s" : [ {
-                           "r" : "248",
+                           "r" : "249",
                            "s" : [ {
                               "value" : [ "Patient" ]
                            } ]
                         }, {
                            "value" : [ "." ]
                         }, {
-                           "r" : "249",
+                           "r" : "250",
                            "s" : [ {
                               "value" : [ "name" ]
                            } ]
@@ -1523,21 +1566,21 @@ module.exports['Using CommonLib'] = {
                }
             } ],
             "expression" : {
-               "localId" : "253",
+               "localId" : "254",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                "type" : "Length",
                "signature" : [ {
-                  "localId" : "254",
+                  "localId" : "255",
                   "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : {
-                  "localId" : "249",
+                  "localId" : "250",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "path" : "name",
                   "type" : "Property",
                   "source" : {
-                     "localId" : "248",
+                     "localId" : "249",
                      "resultTypeName" : "{https://github.com/cqframework/cql-execution/simple}Patient",
                      "name" : "Patient",
                      "type" : "ExpressionRef"
@@ -1545,7 +1588,7 @@ module.exports['Using CommonLib'] = {
                }
             }
          }, {
-            "localId" : "256",
+            "localId" : "257",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
             "name" : "FuncTest",
             "context" : "Patient",
@@ -1553,22 +1596,22 @@ module.exports['Using CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "256",
+                  "r" : "257",
                   "s" : [ {
                      "value" : [ "","define ","FuncTest"," : " ]
                   }, {
-                     "r" : "260",
+                     "r" : "261",
                      "s" : [ {
-                        "r" : "257",
+                        "r" : "258",
                         "s" : [ {
                            "value" : [ "common" ]
                         } ]
                      }, {
                         "value" : [ "." ]
                      }, {
-                        "r" : "260",
+                        "r" : "261",
                         "s" : [ {
-                           "r" : "258",
+                           "r" : "259",
                            "value" : [ "foo","(","2",", ","5",")" ]
                         } ]
                      } ]
@@ -1576,28 +1619,28 @@ module.exports['Using CommonLib'] = {
                }
             } ],
             "expression" : {
-               "localId" : "260",
+               "localId" : "261",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                "name" : "foo",
                "libraryName" : "common",
                "type" : "FunctionRef",
                "signature" : [ {
-                  "localId" : "261",
+                  "localId" : "262",
                   "name" : "{urn:hl7-org:elm-types:r1}Integer",
                   "type" : "NamedTypeSpecifier"
                }, {
-                  "localId" : "262",
+                  "localId" : "263",
                   "name" : "{urn:hl7-org:elm-types:r1}Integer",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "258",
+                  "localId" : "259",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "2",
                   "type" : "Literal"
                }, {
-                  "localId" : "259",
+                  "localId" : "260",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "5",
@@ -1605,7 +1648,7 @@ module.exports['Using CommonLib'] = {
                } ]
             }
          }, {
-            "localId" : "264",
+            "localId" : "265",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
             "name" : "supportLibCode",
             "context" : "Patient",
@@ -1613,20 +1656,20 @@ module.exports['Using CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "264",
+                  "r" : "265",
                   "s" : [ {
                      "value" : [ "","define ","supportLibCode",": " ]
                   }, {
-                     "r" : "266",
+                     "r" : "267",
                      "s" : [ {
-                        "r" : "265",
+                        "r" : "266",
                         "s" : [ {
                            "value" : [ "common" ]
                         } ]
                      }, {
                         "value" : [ "." ]
                      }, {
-                        "r" : "266",
+                        "r" : "267",
                         "s" : [ {
                            "value" : [ "\"directReferenceCode\"" ]
                         } ]
@@ -1635,11 +1678,163 @@ module.exports['Using CommonLib'] = {
                }
             } ],
             "expression" : {
-               "localId" : "266",
+               "localId" : "267",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                "name" : "directReferenceCode",
                "libraryName" : "common",
                "type" : "CodeRef"
+            }
+         }, {
+            "localId" : "269",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+            "name" : "supportLibCodeSystem",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "269",
+                  "s" : [ {
+                     "value" : [ "","define ","supportLibCodeSystem",": " ]
+                  }, {
+                     "r" : "271",
+                     "s" : [ {
+                        "r" : "270",
+                        "s" : [ {
+                           "value" : [ "common" ]
+                        } ]
+                     }, {
+                        "value" : [ "." ]
+                     }, {
+                        "r" : "271",
+                        "s" : [ {
+                           "value" : [ "\"SNOMEDCT\"" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "271",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+               "name" : "SNOMEDCT",
+               "libraryName" : "common",
+               "type" : "CodeSystemRef"
+            }
+         }, {
+            "localId" : "273",
+            "name" : "supportClashingCodeSystemNames",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "273",
+                  "s" : [ {
+                     "value" : [ "","define ","supportClashingCodeSystemNames",":\n  " ]
+                  }, {
+                     "r" : "274",
+                     "s" : [ {
+                        "value" : [ "Tuple {\n    " ]
+                     }, {
+                        "s" : [ {
+                           "value" : [ "MyFavorite",": " ]
+                        }, {
+                           "r" : "275",
+                           "s" : [ {
+                              "value" : [ "\"My Favorite CS\"" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ ",\n    " ]
+                     }, {
+                        "s" : [ {
+                           "value" : [ "MyLibsFavorite",": " ]
+                        }, {
+                           "r" : "277",
+                           "s" : [ {
+                              "r" : "276",
+                              "s" : [ {
+                                 "value" : [ "common" ]
+                              } ]
+                           }, {
+                              "value" : [ "." ]
+                           }, {
+                              "r" : "277",
+                              "s" : [ {
+                                 "value" : [ "\"My Favorite CS\"" ]
+                              } ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ "\n  }" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "resultTypeSpecifier" : {
+               "localId" : "283",
+               "type" : "TupleTypeSpecifier",
+               "element" : [ {
+                  "localId" : "284",
+                  "name" : "MyFavorite",
+                  "elementType" : {
+                     "localId" : "285",
+                     "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }, {
+                  "localId" : "286",
+                  "name" : "MyLibsFavorite",
+                  "elementType" : {
+                     "localId" : "287",
+                     "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ]
+            },
+            "expression" : {
+               "localId" : "274",
+               "type" : "Tuple",
+               "resultTypeSpecifier" : {
+                  "localId" : "278",
+                  "type" : "TupleTypeSpecifier",
+                  "element" : [ {
+                     "localId" : "279",
+                     "name" : "MyFavorite",
+                     "elementType" : {
+                        "localId" : "280",
+                        "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }, {
+                     "localId" : "281",
+                     "name" : "MyLibsFavorite",
+                     "elementType" : {
+                        "localId" : "282",
+                        "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ]
+               },
+               "element" : [ {
+                  "name" : "MyFavorite",
+                  "value" : {
+                     "localId" : "275",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                     "name" : "My Favorite CS",
+                     "type" : "CodeSystemRef"
+                  }
+               }, {
+                  "name" : "MyLibsFavorite",
+                  "value" : {
+                     "localId" : "277",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+                     "name" : "My Favorite CS",
+                     "libraryName" : "common",
+                     "type" : "CodeSystemRef"
+                  }
+               } ]
             }
          } ]
       }
@@ -3218,7 +3413,7 @@ module.exports['Using CommonLib2'] = {
 }
 
 /* Using CommonLib and CommonLib2
-library TestSnippet version '1'
+library UsingTwoLibs version '0.0.1'
 using Simple version '1.0.0'
 include Common2 called common2
 include Common called common
@@ -3242,13 +3437,13 @@ module.exports['Using CommonLib and CommonLib2'] = {
          "s" : {
             "r" : "218",
             "s" : [ {
-               "value" : [ "","library TestSnippet version '1'" ]
+               "value" : [ "","library UsingTwoLibs version '0.0.1'" ]
             } ]
          }
       } ],
       "identifier" : {
-         "id" : "TestSnippet",
-         "version" : "1"
+         "id" : "UsingTwoLibs",
+         "version" : "0.0.1"
       },
       "schemaIdentifier" : {
          "id" : "urn:hl7-org:elm",

--- a/test/elm/library/data.js
+++ b/test/elm/library/data.js
@@ -468,6 +468,8 @@ library Common
 using Simple version '1.0.0'
 include Common2 called common2
 
+valueset "My Favorite VS": '9.7.5.3.1'
+valueset "Acute Pharyngitis": '2.16.840.1.113883.3.464.1003.101.12.1001'
 codesystem "My Favorite CS": '1.3.5.7.9'
 codesystem "SNOMEDCT": '2.16.840.1.113883.6.96'
 code "directReferenceCode": '428371000124100' from "SNOMEDCT" display 'directReferenceCode'
@@ -497,7 +499,7 @@ module.exports['CommonLib'] = {
       }, {
          "type" : "Annotation",
          "s" : {
-            "r" : "296",
+            "r" : "298",
             "s" : [ {
                "value" : [ "","library Common" ]
             } ]
@@ -561,31 +563,31 @@ module.exports['CommonLib'] = {
       },
       "parameters" : {
          "def" : [ {
-            "localId" : "212",
+            "localId" : "214",
             "name" : "MeasurementPeriod",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "212",
+                  "r" : "214",
                   "s" : [ {
                      "value" : [ "","parameter ","MeasurementPeriod"," default " ]
                   }, {
-                     "r" : "237",
+                     "r" : "239",
                      "s" : [ {
                         "value" : [ "Interval[" ]
                      }, {
-                        "r" : "221",
+                        "r" : "223",
                         "s" : [ {
-                           "r" : "213",
+                           "r" : "215",
                            "value" : [ "DateTime","(","2013",", ","1",", ","1",")" ]
                         } ]
                      }, {
                         "value" : [ ", " ]
                      }, {
-                        "r" : "233",
+                        "r" : "235",
                         "s" : [ {
-                           "r" : "225",
+                           "r" : "227",
                            "value" : [ "DateTime","(","2014",", ","1",", ","1",")" ]
                         } ]
                      }, {
@@ -595,61 +597,61 @@ module.exports['CommonLib'] = {
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "240",
+               "localId" : "242",
                "type" : "IntervalTypeSpecifier",
                "pointType" : {
-                  "localId" : "241",
+                  "localId" : "243",
                   "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "default" : {
-               "localId" : "237",
+               "localId" : "239",
                "lowClosed" : true,
                "highClosed" : false,
                "type" : "Interval",
                "resultTypeSpecifier" : {
-                  "localId" : "238",
+                  "localId" : "240",
                   "type" : "IntervalTypeSpecifier",
                   "pointType" : {
-                     "localId" : "239",
+                     "localId" : "241",
                      "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                      "type" : "NamedTypeSpecifier"
                   }
                },
                "low" : {
-                  "localId" : "221",
+                  "localId" : "223",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "type" : "DateTime",
                   "signature" : [ {
-                     "localId" : "222",
-                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "type" : "NamedTypeSpecifier"
-                  }, {
-                     "localId" : "223",
-                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "type" : "NamedTypeSpecifier"
-                  }, {
                      "localId" : "224",
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
+                  }, {
+                     "localId" : "225",
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
+                  }, {
+                     "localId" : "226",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
                   } ],
                   "year" : {
-                     "localId" : "213",
+                     "localId" : "215",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2013",
                      "type" : "Literal"
                   },
                   "month" : {
-                     "localId" : "214",
+                     "localId" : "216",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
                      "type" : "Literal"
                   },
                   "day" : {
-                     "localId" : "215",
+                     "localId" : "217",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
@@ -657,38 +659,38 @@ module.exports['CommonLib'] = {
                   }
                },
                "high" : {
-                  "localId" : "233",
+                  "localId" : "235",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "type" : "DateTime",
                   "signature" : [ {
-                     "localId" : "234",
-                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "type" : "NamedTypeSpecifier"
-                  }, {
-                     "localId" : "235",
-                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "type" : "NamedTypeSpecifier"
-                  }, {
                      "localId" : "236",
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
+                  }, {
+                     "localId" : "237",
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
+                  }, {
+                     "localId" : "238",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
                   } ],
                   "year" : {
-                     "localId" : "225",
+                     "localId" : "227",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2014",
                      "type" : "Literal"
                   },
                   "month" : {
-                     "localId" : "226",
+                     "localId" : "228",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
                      "type" : "Literal"
                   },
                   "day" : {
-                     "localId" : "227",
+                     "localId" : "229",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
@@ -700,7 +702,7 @@ module.exports['CommonLib'] = {
       },
       "codeSystems" : {
          "def" : [ {
-            "localId" : "208",
+            "localId" : "210",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
             "name" : "My Favorite CS",
             "id" : "1.3.5.7.9",
@@ -708,14 +710,14 @@ module.exports['CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "208",
+                  "r" : "210",
                   "s" : [ {
                      "value" : [ "","codesystem ","\"My Favorite CS\"",": ","'1.3.5.7.9'" ]
                   } ]
                }
             } ]
          }, {
-            "localId" : "209",
+            "localId" : "211",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
             "name" : "SNOMEDCT",
             "id" : "2.16.840.1.113883.6.96",
@@ -723,7 +725,7 @@ module.exports['CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "209",
+                  "r" : "211",
                   "s" : [ {
                      "value" : [ "","codesystem ","\"SNOMEDCT\"",": ","'2.16.840.1.113883.6.96'" ]
                   } ]
@@ -731,9 +733,44 @@ module.exports['CommonLib'] = {
             } ]
          } ]
       },
+      "valueSets" : {
+         "def" : [ {
+            "localId" : "208",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "My Favorite VS",
+            "id" : "9.7.5.3.1",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "208",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"My Favorite VS\"",": ","'9.7.5.3.1'" ]
+                  } ]
+               }
+            } ],
+            "codeSystem" : [ ]
+         }, {
+            "localId" : "209",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "Acute Pharyngitis",
+            "id" : "2.16.840.1.113883.3.464.1003.101.12.1001",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "209",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"Acute Pharyngitis\"",": ","'2.16.840.1.113883.3.464.1003.101.12.1001'" ]
+                  } ]
+               }
+            } ],
+            "codeSystem" : [ ]
+         } ]
+      },
       "codes" : {
          "def" : [ {
-            "localId" : "210",
+            "localId" : "212",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
             "name" : "directReferenceCode",
             "id" : "428371000124100",
@@ -742,11 +779,11 @@ module.exports['CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "210",
+                  "r" : "212",
                   "s" : [ {
                      "value" : [ "","code ","\"directReferenceCode\"",": ","'428371000124100'"," from " ]
                   }, {
-                     "r" : "211",
+                     "r" : "213",
                      "s" : [ {
                         "value" : [ "\"SNOMEDCT\"" ]
                      } ]
@@ -756,7 +793,7 @@ module.exports['CommonLib'] = {
                }
             } ],
             "codeSystem" : {
-               "localId" : "211",
+               "localId" : "213",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
                "name" : "SNOMEDCT"
             }
@@ -764,21 +801,21 @@ module.exports['CommonLib'] = {
       },
       "contexts" : {
          "def" : [ {
-            "localId" : "245",
+            "localId" : "247",
             "name" : "Patient"
          } ]
       },
       "statements" : {
          "def" : [ {
-            "localId" : "243",
+            "localId" : "245",
             "name" : "Patient",
             "context" : "Patient",
             "expression" : {
-               "localId" : "244",
+               "localId" : "246",
                "type" : "SingletonFrom",
                "signature" : [ ],
                "operand" : {
-                  "localId" : "242",
+                  "localId" : "244",
                   "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
                   "type" : "Retrieve",
                   "include" : [ ],
@@ -788,7 +825,7 @@ module.exports['CommonLib'] = {
                }
             }
          }, {
-            "localId" : "247",
+            "localId" : "249",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "InDemographic",
             "context" : "Patient",
@@ -796,23 +833,23 @@ module.exports['CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "247",
+                  "r" : "249",
                   "s" : [ {
                      "value" : [ "","define ","InDemographic",":\n" ]
                   }, {
-                     "r" : "248",
+                     "r" : "250",
                      "s" : [ {
-                        "r" : "249",
+                        "r" : "251",
                         "s" : [ {
-                           "r" : "260",
+                           "r" : "262",
                            "s" : [ {
                               "value" : [ "AgeInYearsAt","(" ]
                            }, {
-                              "r" : "250",
+                              "r" : "252",
                               "s" : [ {
                                  "value" : [ "start of " ]
                               }, {
-                                 "r" : "251",
+                                 "r" : "253",
                                  "s" : [ {
                                     "value" : [ "MeasurementPeriod" ]
                                  } ]
@@ -821,23 +858,23 @@ module.exports['CommonLib'] = {
                               "value" : [ ")" ]
                            } ]
                         }, {
-                           "r" : "263",
+                           "r" : "265",
                            "value" : [ " ",">="," ","2" ]
                         } ]
                      }, {
                         "value" : [ " and " ]
                      }, {
-                        "r" : "266",
+                        "r" : "268",
                         "s" : [ {
-                           "r" : "277",
+                           "r" : "279",
                            "s" : [ {
                               "value" : [ "AgeInYearsAt","(" ]
                            }, {
-                              "r" : "267",
+                              "r" : "269",
                               "s" : [ {
                                  "value" : [ "start of " ]
                               }, {
-                                 "r" : "268",
+                                 "r" : "270",
                                  "s" : [ {
                                     "value" : [ "MeasurementPeriod" ]
                                  } ]
@@ -846,7 +883,7 @@ module.exports['CommonLib'] = {
                               "value" : [ ")" ]
                            } ]
                         }, {
-                           "r" : "280",
+                           "r" : "282",
                            "value" : [ " ","<"," ","18" ]
                         } ]
                      } ]
@@ -854,76 +891,76 @@ module.exports['CommonLib'] = {
                }
             } ],
             "expression" : {
-               "localId" : "248",
+               "localId" : "250",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "type" : "And",
                "signature" : [ {
-                  "localId" : "283",
+                  "localId" : "285",
                   "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "NamedTypeSpecifier"
                }, {
-                  "localId" : "284",
+                  "localId" : "286",
                   "name" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "249",
+                  "localId" : "251",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "GreaterOrEqual",
                   "signature" : [ {
-                     "localId" : "264",
+                     "localId" : "266",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
                   }, {
-                     "localId" : "265",
+                     "localId" : "267",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
                   } ],
                   "operand" : [ {
-                     "localId" : "260",
+                     "localId" : "262",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "precision" : "Year",
                      "type" : "CalculateAgeAt",
                      "signature" : [ {
-                        "localId" : "261",
+                        "localId" : "263",
                         "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "NamedTypeSpecifier"
                      }, {
-                        "localId" : "262",
+                        "localId" : "264",
                         "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "NamedTypeSpecifier"
                      } ],
                      "operand" : [ {
-                        "localId" : "259",
+                        "localId" : "261",
                         "path" : "birthDate",
                         "type" : "Property",
                         "source" : {
-                           "localId" : "258",
+                           "localId" : "260",
                            "name" : "Patient",
                            "type" : "ExpressionRef"
                         }
                      }, {
-                        "localId" : "250",
+                        "localId" : "252",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "Start",
                         "signature" : [ {
-                           "localId" : "254",
+                           "localId" : "256",
                            "type" : "IntervalTypeSpecifier",
                            "pointType" : {
-                              "localId" : "255",
+                              "localId" : "257",
                               "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         } ],
                         "operand" : {
-                           "localId" : "251",
+                           "localId" : "253",
                            "name" : "MeasurementPeriod",
                            "type" : "ParameterRef",
                            "resultTypeSpecifier" : {
-                              "localId" : "252",
+                              "localId" : "254",
                               "type" : "IntervalTypeSpecifier",
                               "pointType" : {
-                                 "localId" : "253",
+                                 "localId" : "255",
                                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -931,70 +968,70 @@ module.exports['CommonLib'] = {
                         }
                      } ]
                   }, {
-                     "localId" : "263",
+                     "localId" : "265",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2",
                      "type" : "Literal"
                   } ]
                }, {
-                  "localId" : "266",
+                  "localId" : "268",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "Less",
                   "signature" : [ {
-                     "localId" : "281",
+                     "localId" : "283",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
                   }, {
-                     "localId" : "282",
+                     "localId" : "284",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
                   } ],
                   "operand" : [ {
-                     "localId" : "277",
+                     "localId" : "279",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "precision" : "Year",
                      "type" : "CalculateAgeAt",
                      "signature" : [ {
-                        "localId" : "278",
+                        "localId" : "280",
                         "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "NamedTypeSpecifier"
                      }, {
-                        "localId" : "279",
+                        "localId" : "281",
                         "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "NamedTypeSpecifier"
                      } ],
                      "operand" : [ {
-                        "localId" : "276",
+                        "localId" : "278",
                         "path" : "birthDate",
                         "type" : "Property",
                         "source" : {
-                           "localId" : "275",
+                           "localId" : "277",
                            "name" : "Patient",
                            "type" : "ExpressionRef"
                         }
                      }, {
-                        "localId" : "267",
+                        "localId" : "269",
                         "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                         "type" : "Start",
                         "signature" : [ {
-                           "localId" : "271",
+                           "localId" : "273",
                            "type" : "IntervalTypeSpecifier",
                            "pointType" : {
-                              "localId" : "272",
+                              "localId" : "274",
                               "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                               "type" : "NamedTypeSpecifier"
                            }
                         } ],
                         "operand" : {
-                           "localId" : "268",
+                           "localId" : "270",
                            "name" : "MeasurementPeriod",
                            "type" : "ParameterRef",
                            "resultTypeSpecifier" : {
-                              "localId" : "269",
+                              "localId" : "271",
                               "type" : "IntervalTypeSpecifier",
                               "pointType" : {
-                                 "localId" : "270",
+                                 "localId" : "272",
                                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                                  "type" : "NamedTypeSpecifier"
                               }
@@ -1002,7 +1039,7 @@ module.exports['CommonLib'] = {
                         }
                      } ]
                   }, {
-                     "localId" : "280",
+                     "localId" : "282",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "18",
@@ -1011,7 +1048,7 @@ module.exports['CommonLib'] = {
                } ]
             }
          }, {
-            "localId" : "285",
+            "localId" : "287",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
             "name" : "foo",
             "context" : "Patient",
@@ -1020,22 +1057,22 @@ module.exports['CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "285",
+                  "r" : "287",
                   "s" : [ {
                      "value" : [ "","define function foo (a Integer, b Integer) :\n  " ]
                   }, {
-                     "r" : "290",
+                     "r" : "292",
                      "s" : [ {
-                        "r" : "290",
+                        "r" : "292",
                         "s" : [ {
-                           "r" : "291",
+                           "r" : "293",
                            "s" : [ {
                               "value" : [ "a" ]
                            } ]
                         }, {
                            "value" : [ " + " ]
                         }, {
-                           "r" : "292",
+                           "r" : "294",
                            "s" : [ {
                               "value" : [ "b" ]
                            } ]
@@ -1045,51 +1082,51 @@ module.exports['CommonLib'] = {
                }
             } ],
             "expression" : {
-               "localId" : "290",
+               "localId" : "292",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                "type" : "Add",
                "signature" : [ {
-                  "localId" : "293",
+                  "localId" : "295",
                   "name" : "{urn:hl7-org:elm-types:r1}Integer",
                   "type" : "NamedTypeSpecifier"
                }, {
-                  "localId" : "294",
+                  "localId" : "296",
                   "name" : "{urn:hl7-org:elm-types:r1}Integer",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "291",
+                  "localId" : "293",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                   "name" : "a",
                   "type" : "OperandRef"
                }, {
-                  "localId" : "292",
+                  "localId" : "294",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                   "name" : "b",
                   "type" : "OperandRef"
                } ]
             },
             "operand" : [ {
-               "localId" : "287",
-               "name" : "a",
-               "operandTypeSpecifier" : {
-                  "localId" : "286",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                  "type" : "NamedTypeSpecifier"
-               }
-            }, {
                "localId" : "289",
-               "name" : "b",
+               "name" : "a",
                "operandTypeSpecifier" : {
                   "localId" : "288",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                   "name" : "{urn:hl7-org:elm-types:r1}Integer",
                   "type" : "NamedTypeSpecifier"
                }
+            }, {
+               "localId" : "291",
+               "name" : "b",
+               "operandTypeSpecifier" : {
+                  "localId" : "290",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "type" : "NamedTypeSpecifier"
+               }
             } ]
          }, {
-            "localId" : "296",
+            "localId" : "298",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
             "name" : "SupportLibDef",
             "context" : "Patient",
@@ -1097,31 +1134,14 @@ module.exports['CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "296",
+                  "r" : "298",
                   "s" : [ {
                      "value" : [ "","define ","SupportLibDef",":\n  " ]
                   }, {
-                     "r" : "297",
+                     "r" : "299",
                      "s" : [ {
-                        "r" : "298",
+                        "r" : "300",
                         "s" : [ {
-                           "r" : "300",
-                           "s" : [ {
-                              "r" : "299",
-                              "s" : [ {
-                                 "value" : [ "common2" ]
-                              } ]
-                           }, {
-                              "value" : [ "." ]
-                           }, {
-                              "r" : "300",
-                              "s" : [ {
-                                 "value" : [ "TheParameter" ]
-                              } ]
-                           } ]
-                        }, {
-                           "value" : [ " + " ]
-                        }, {
                            "r" : "302",
                            "s" : [ {
                               "r" : "301",
@@ -1133,6 +1153,23 @@ module.exports['CommonLib'] = {
                            }, {
                               "r" : "302",
                               "s" : [ {
+                                 "value" : [ "TheParameter" ]
+                              } ]
+                           } ]
+                        }, {
+                           "value" : [ " + " ]
+                        }, {
+                           "r" : "304",
+                           "s" : [ {
+                              "r" : "303",
+                              "s" : [ {
+                                 "value" : [ "common2" ]
+                              } ]
+                           }, {
+                              "value" : [ "." ]
+                           }, {
+                              "r" : "304",
+                              "s" : [ {
                                  "value" : [ "TwoPlusOne" ]
                               } ]
                            } ]
@@ -1140,16 +1177,16 @@ module.exports['CommonLib'] = {
                      }, {
                         "value" : [ " + " ]
                      }, {
-                        "r" : "306",
+                        "r" : "308",
                         "s" : [ {
-                           "r" : "305",
+                           "r" : "307",
                            "s" : [ {
                               "value" : [ "common2" ]
                            } ]
                         }, {
                            "value" : [ "." ]
                         }, {
-                           "r" : "306",
+                           "r" : "308",
                            "s" : [ {
                               "value" : [ "TwoTimesThree" ]
                            } ]
@@ -1159,46 +1196,46 @@ module.exports['CommonLib'] = {
                }
             } ],
             "expression" : {
-               "localId" : "297",
+               "localId" : "299",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                "type" : "Add",
                "signature" : [ {
-                  "localId" : "307",
+                  "localId" : "309",
                   "name" : "{urn:hl7-org:elm-types:r1}Integer",
                   "type" : "NamedTypeSpecifier"
                }, {
-                  "localId" : "308",
+                  "localId" : "310",
                   "name" : "{urn:hl7-org:elm-types:r1}Integer",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "298",
+                  "localId" : "300",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                   "type" : "Add",
                   "signature" : [ {
-                     "localId" : "303",
+                     "localId" : "305",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
                   }, {
-                     "localId" : "304",
+                     "localId" : "306",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
                   } ],
                   "operand" : [ {
-                     "localId" : "300",
+                     "localId" : "302",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "name" : "TheParameter",
                      "libraryName" : "common2",
                      "type" : "ExpressionRef"
                   }, {
-                     "localId" : "302",
+                     "localId" : "304",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "name" : "TwoPlusOne",
                      "libraryName" : "common2",
                      "type" : "ExpressionRef"
                   } ]
                }, {
-                  "localId" : "306",
+                  "localId" : "308",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                   "name" : "TwoTimesThree",
                   "libraryName" : "common2",
@@ -1216,6 +1253,7 @@ using Simple version '1.0.0'
 
 include Common called common
 
+valueset "My Favorite VS": '10.8.6.4.2'
 codesystem "My Favorite CS": '2.4.6.8.10'
 
 parameter MeasurementPeriod default Interval[DateTime(2013, 1, 1), DateTime(2014, 1, 1))
@@ -1233,6 +1271,12 @@ define supportClashingCodeSystemNames:
     MyFavorite: "My Favorite CS",
     MyLibsFavorite: common."My Favorite CS"
   }
+define supportLibValueSet: common."Acute Pharyngitis"
+define supportClashingValueSetNames:
+  Tuple {
+    MyFavorite: "My Favorite VS",
+    MyLibsFavorite: common."My Favorite VS"
+  }
 */
 
 module.exports['Using CommonLib'] = {
@@ -1246,7 +1290,7 @@ module.exports['Using CommonLib'] = {
       }, {
          "type" : "Annotation",
          "s" : {
-            "r" : "273",
+            "r" : "294",
             "s" : [ {
                "value" : [ "","library TestSnippet version '1'" ]
             } ]
@@ -1311,31 +1355,31 @@ module.exports['Using CommonLib'] = {
       },
       "parameters" : {
          "def" : [ {
-            "localId" : "209",
+            "localId" : "210",
             "name" : "MeasurementPeriod",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "209",
+                  "r" : "210",
                   "s" : [ {
                      "value" : [ "","parameter ","MeasurementPeriod"," default " ]
                   }, {
-                     "r" : "234",
+                     "r" : "235",
                      "s" : [ {
                         "value" : [ "Interval[" ]
                      }, {
-                        "r" : "218",
+                        "r" : "219",
                         "s" : [ {
-                           "r" : "210",
+                           "r" : "211",
                            "value" : [ "DateTime","(","2013",", ","1",", ","1",")" ]
                         } ]
                      }, {
                         "value" : [ ", " ]
                      }, {
-                        "r" : "230",
+                        "r" : "231",
                         "s" : [ {
-                           "r" : "222",
+                           "r" : "223",
                            "value" : [ "DateTime","(","2014",", ","1",", ","1",")" ]
                         } ]
                      }, {
@@ -1345,37 +1389,33 @@ module.exports['Using CommonLib'] = {
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "237",
+               "localId" : "238",
                "type" : "IntervalTypeSpecifier",
                "pointType" : {
-                  "localId" : "238",
+                  "localId" : "239",
                   "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "type" : "NamedTypeSpecifier"
                }
             },
             "default" : {
-               "localId" : "234",
+               "localId" : "235",
                "lowClosed" : true,
                "highClosed" : false,
                "type" : "Interval",
                "resultTypeSpecifier" : {
-                  "localId" : "235",
+                  "localId" : "236",
                   "type" : "IntervalTypeSpecifier",
                   "pointType" : {
-                     "localId" : "236",
+                     "localId" : "237",
                      "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                      "type" : "NamedTypeSpecifier"
                   }
                },
                "low" : {
-                  "localId" : "218",
+                  "localId" : "219",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "type" : "DateTime",
                   "signature" : [ {
-                     "localId" : "219",
-                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "type" : "NamedTypeSpecifier"
-                  }, {
                      "localId" : "220",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
@@ -1383,23 +1423,27 @@ module.exports['Using CommonLib'] = {
                      "localId" : "221",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
+                  }, {
+                     "localId" : "222",
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
                   } ],
                   "year" : {
-                     "localId" : "210",
+                     "localId" : "211",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2013",
                      "type" : "Literal"
                   },
                   "month" : {
-                     "localId" : "211",
+                     "localId" : "212",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
                      "type" : "Literal"
                   },
                   "day" : {
-                     "localId" : "212",
+                     "localId" : "213",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
@@ -1407,14 +1451,10 @@ module.exports['Using CommonLib'] = {
                   }
                },
                "high" : {
-                  "localId" : "230",
+                  "localId" : "231",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "type" : "DateTime",
                   "signature" : [ {
-                     "localId" : "231",
-                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "type" : "NamedTypeSpecifier"
-                  }, {
                      "localId" : "232",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
@@ -1422,23 +1462,27 @@ module.exports['Using CommonLib'] = {
                      "localId" : "233",
                      "name" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "NamedTypeSpecifier"
+                  }, {
+                     "localId" : "234",
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
                   } ],
                   "year" : {
-                     "localId" : "222",
+                     "localId" : "223",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2014",
                      "type" : "Literal"
                   },
                   "month" : {
-                     "localId" : "223",
+                     "localId" : "224",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
                      "type" : "Literal"
                   },
                   "day" : {
-                     "localId" : "224",
+                     "localId" : "225",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
@@ -1450,7 +1494,7 @@ module.exports['Using CommonLib'] = {
       },
       "codeSystems" : {
          "def" : [ {
-            "localId" : "208",
+            "localId" : "209",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
             "name" : "My Favorite CS",
             "id" : "2.4.6.8.10",
@@ -1458,7 +1502,7 @@ module.exports['Using CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "208",
+                  "r" : "209",
                   "s" : [ {
                      "value" : [ "","codesystem ","\"My Favorite CS\"",": ","'2.4.6.8.10'" ]
                   } ]
@@ -1466,23 +1510,42 @@ module.exports['Using CommonLib'] = {
             } ]
          } ]
       },
+      "valueSets" : {
+         "def" : [ {
+            "localId" : "208",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "My Favorite VS",
+            "id" : "10.8.6.4.2",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "208",
+                  "s" : [ {
+                     "value" : [ "","valueset ","\"My Favorite VS\"",": ","'10.8.6.4.2'" ]
+                  } ]
+               }
+            } ],
+            "codeSystem" : [ ]
+         } ]
+      },
       "contexts" : {
          "def" : [ {
-            "localId" : "242",
+            "localId" : "243",
             "name" : "Patient"
          } ]
       },
       "statements" : {
          "def" : [ {
-            "localId" : "240",
+            "localId" : "241",
             "name" : "Patient",
             "context" : "Patient",
             "expression" : {
-               "localId" : "241",
+               "localId" : "242",
                "type" : "SingletonFrom",
                "signature" : [ ],
                "operand" : {
-                  "localId" : "239",
+                  "localId" : "240",
                   "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
                   "type" : "Retrieve",
                   "include" : [ ],
@@ -1492,7 +1555,7 @@ module.exports['Using CommonLib'] = {
                }
             }
          }, {
-            "localId" : "244",
+            "localId" : "245",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
             "name" : "ID",
             "context" : "Patient",
@@ -1500,20 +1563,20 @@ module.exports['Using CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "244",
+                  "r" : "245",
                   "s" : [ {
                      "value" : [ "","define ","ID",": " ]
                   }, {
-                     "r" : "246",
+                     "r" : "247",
                      "s" : [ {
-                        "r" : "245",
+                        "r" : "246",
                         "s" : [ {
                            "value" : [ "common" ]
                         } ]
                      }, {
                         "value" : [ "." ]
                      }, {
-                        "r" : "246",
+                        "r" : "247",
                         "s" : [ {
                            "value" : [ "InDemographic" ]
                         } ]
@@ -1522,14 +1585,14 @@ module.exports['Using CommonLib'] = {
                }
             } ],
             "expression" : {
-               "localId" : "246",
+               "localId" : "247",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
                "name" : "InDemographic",
                "libraryName" : "common",
                "type" : "ExpressionRef"
             }
          }, {
-            "localId" : "248",
+            "localId" : "249",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
             "name" : "L",
             "context" : "Patient",
@@ -1537,24 +1600,24 @@ module.exports['Using CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "248",
+                  "r" : "249",
                   "s" : [ {
                      "value" : [ "","define ","L"," : " ]
                   }, {
-                     "r" : "254",
+                     "r" : "255",
                      "s" : [ {
                         "value" : [ "Length","(" ]
                      }, {
-                        "r" : "250",
+                        "r" : "251",
                         "s" : [ {
-                           "r" : "249",
+                           "r" : "250",
                            "s" : [ {
                               "value" : [ "Patient" ]
                            } ]
                         }, {
                            "value" : [ "." ]
                         }, {
-                           "r" : "250",
+                           "r" : "251",
                            "s" : [ {
                               "value" : [ "name" ]
                            } ]
@@ -1566,21 +1629,21 @@ module.exports['Using CommonLib'] = {
                }
             } ],
             "expression" : {
-               "localId" : "254",
+               "localId" : "255",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                "type" : "Length",
                "signature" : [ {
-                  "localId" : "255",
+                  "localId" : "256",
                   "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : {
-                  "localId" : "250",
+                  "localId" : "251",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
                   "path" : "name",
                   "type" : "Property",
                   "source" : {
-                     "localId" : "249",
+                     "localId" : "250",
                      "resultTypeName" : "{https://github.com/cqframework/cql-execution/simple}Patient",
                      "name" : "Patient",
                      "type" : "ExpressionRef"
@@ -1588,7 +1651,7 @@ module.exports['Using CommonLib'] = {
                }
             }
          }, {
-            "localId" : "257",
+            "localId" : "258",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
             "name" : "FuncTest",
             "context" : "Patient",
@@ -1596,22 +1659,22 @@ module.exports['Using CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "257",
+                  "r" : "258",
                   "s" : [ {
                      "value" : [ "","define ","FuncTest"," : " ]
                   }, {
-                     "r" : "261",
+                     "r" : "262",
                      "s" : [ {
-                        "r" : "258",
+                        "r" : "259",
                         "s" : [ {
                            "value" : [ "common" ]
                         } ]
                      }, {
                         "value" : [ "." ]
                      }, {
-                        "r" : "261",
+                        "r" : "262",
                         "s" : [ {
-                           "r" : "259",
+                           "r" : "260",
                            "value" : [ "foo","(","2",", ","5",")" ]
                         } ]
                      } ]
@@ -1619,28 +1682,28 @@ module.exports['Using CommonLib'] = {
                }
             } ],
             "expression" : {
-               "localId" : "261",
+               "localId" : "262",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                "name" : "foo",
                "libraryName" : "common",
                "type" : "FunctionRef",
                "signature" : [ {
-                  "localId" : "262",
+                  "localId" : "263",
                   "name" : "{urn:hl7-org:elm-types:r1}Integer",
                   "type" : "NamedTypeSpecifier"
                }, {
-                  "localId" : "263",
+                  "localId" : "264",
                   "name" : "{urn:hl7-org:elm-types:r1}Integer",
                   "type" : "NamedTypeSpecifier"
                } ],
                "operand" : [ {
-                  "localId" : "259",
+                  "localId" : "260",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "2",
                   "type" : "Literal"
                }, {
-                  "localId" : "260",
+                  "localId" : "261",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "5",
@@ -1648,7 +1711,7 @@ module.exports['Using CommonLib'] = {
                } ]
             }
          }, {
-            "localId" : "265",
+            "localId" : "266",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
             "name" : "supportLibCode",
             "context" : "Patient",
@@ -1656,20 +1719,20 @@ module.exports['Using CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "265",
+                  "r" : "266",
                   "s" : [ {
                      "value" : [ "","define ","supportLibCode",": " ]
                   }, {
-                     "r" : "267",
+                     "r" : "268",
                      "s" : [ {
-                        "r" : "266",
+                        "r" : "267",
                         "s" : [ {
                            "value" : [ "common" ]
                         } ]
                      }, {
                         "value" : [ "." ]
                      }, {
-                        "r" : "267",
+                        "r" : "268",
                         "s" : [ {
                            "value" : [ "\"directReferenceCode\"" ]
                         } ]
@@ -1678,14 +1741,14 @@ module.exports['Using CommonLib'] = {
                }
             } ],
             "expression" : {
-               "localId" : "267",
+               "localId" : "268",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
                "name" : "directReferenceCode",
                "libraryName" : "common",
                "type" : "CodeRef"
             }
          }, {
-            "localId" : "269",
+            "localId" : "270",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
             "name" : "supportLibCodeSystem",
             "context" : "Patient",
@@ -1693,20 +1756,20 @@ module.exports['Using CommonLib'] = {
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "269",
+                  "r" : "270",
                   "s" : [ {
                      "value" : [ "","define ","supportLibCodeSystem",": " ]
                   }, {
-                     "r" : "271",
+                     "r" : "272",
                      "s" : [ {
-                        "r" : "270",
+                        "r" : "271",
                         "s" : [ {
                            "value" : [ "common" ]
                         } ]
                      }, {
                         "value" : [ "." ]
                      }, {
-                        "r" : "271",
+                        "r" : "272",
                         "s" : [ {
                            "value" : [ "\"SNOMEDCT\"" ]
                         } ]
@@ -1715,32 +1778,32 @@ module.exports['Using CommonLib'] = {
                }
             } ],
             "expression" : {
-               "localId" : "271",
+               "localId" : "272",
                "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
                "name" : "SNOMEDCT",
                "libraryName" : "common",
                "type" : "CodeSystemRef"
             }
          }, {
-            "localId" : "273",
+            "localId" : "274",
             "name" : "supportClashingCodeSystemNames",
             "context" : "Patient",
             "accessLevel" : "Public",
             "annotation" : [ {
                "type" : "Annotation",
                "s" : {
-                  "r" : "273",
+                  "r" : "274",
                   "s" : [ {
                      "value" : [ "","define ","supportClashingCodeSystemNames",":\n  " ]
                   }, {
-                     "r" : "274",
+                     "r" : "275",
                      "s" : [ {
                         "value" : [ "Tuple {\n    " ]
                      }, {
                         "s" : [ {
                            "value" : [ "MyFavorite",": " ]
                         }, {
-                           "r" : "275",
+                           "r" : "276",
                            "s" : [ {
                               "value" : [ "\"My Favorite CS\"" ]
                            } ]
@@ -1751,16 +1814,16 @@ module.exports['Using CommonLib'] = {
                         "s" : [ {
                            "value" : [ "MyLibsFavorite",": " ]
                         }, {
-                           "r" : "277",
+                           "r" : "278",
                            "s" : [ {
-                              "r" : "276",
+                              "r" : "277",
                               "s" : [ {
                                  "value" : [ "common" ]
                               } ]
                            }, {
                               "value" : [ "." ]
                            }, {
-                              "r" : "277",
+                              "r" : "278",
                               "s" : [ {
                                  "value" : [ "\"My Favorite CS\"" ]
                               } ]
@@ -1773,45 +1836,45 @@ module.exports['Using CommonLib'] = {
                }
             } ],
             "resultTypeSpecifier" : {
-               "localId" : "283",
+               "localId" : "284",
                "type" : "TupleTypeSpecifier",
                "element" : [ {
-                  "localId" : "284",
+                  "localId" : "285",
                   "name" : "MyFavorite",
                   "elementType" : {
-                     "localId" : "285",
+                     "localId" : "286",
                      "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
                      "type" : "NamedTypeSpecifier"
                   }
                }, {
-                  "localId" : "286",
+                  "localId" : "287",
                   "name" : "MyLibsFavorite",
                   "elementType" : {
-                     "localId" : "287",
+                     "localId" : "288",
                      "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
                      "type" : "NamedTypeSpecifier"
                   }
                } ]
             },
             "expression" : {
-               "localId" : "274",
+               "localId" : "275",
                "type" : "Tuple",
                "resultTypeSpecifier" : {
-                  "localId" : "278",
+                  "localId" : "279",
                   "type" : "TupleTypeSpecifier",
                   "element" : [ {
-                     "localId" : "279",
+                     "localId" : "280",
                      "name" : "MyFavorite",
                      "elementType" : {
-                        "localId" : "280",
+                        "localId" : "281",
                         "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
                         "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "localId" : "281",
+                     "localId" : "282",
                      "name" : "MyLibsFavorite",
                      "elementType" : {
-                        "localId" : "282",
+                        "localId" : "283",
                         "name" : "{urn:hl7-org:elm-types:r1}CodeSystem",
                         "type" : "NamedTypeSpecifier"
                      }
@@ -1820,7 +1883,7 @@ module.exports['Using CommonLib'] = {
                "element" : [ {
                   "name" : "MyFavorite",
                   "value" : {
-                     "localId" : "275",
+                     "localId" : "276",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
                      "name" : "My Favorite CS",
                      "type" : "CodeSystemRef"
@@ -1828,11 +1891,166 @@ module.exports['Using CommonLib'] = {
                }, {
                   "name" : "MyLibsFavorite",
                   "value" : {
-                     "localId" : "277",
+                     "localId" : "278",
                      "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
                      "name" : "My Favorite CS",
                      "libraryName" : "common",
                      "type" : "CodeSystemRef"
+                  }
+               } ]
+            }
+         }, {
+            "localId" : "290",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "supportLibValueSet",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "290",
+                  "s" : [ {
+                     "value" : [ "","define ","supportLibValueSet",": " ]
+                  }, {
+                     "r" : "292",
+                     "s" : [ {
+                        "r" : "291",
+                        "s" : [ {
+                           "value" : [ "common" ]
+                        } ]
+                     }, {
+                        "value" : [ "." ]
+                     }, {
+                        "r" : "292",
+                        "s" : [ {
+                           "value" : [ "\"Acute Pharyngitis\"" ]
+                        } ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "expression" : {
+               "localId" : "292",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+               "name" : "Acute Pharyngitis",
+               "libraryName" : "common",
+               "preserve" : true,
+               "type" : "ValueSetRef"
+            }
+         }, {
+            "localId" : "294",
+            "name" : "supportClashingValueSetNames",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "s" : {
+                  "r" : "294",
+                  "s" : [ {
+                     "value" : [ "","define ","supportClashingValueSetNames",":\n  " ]
+                  }, {
+                     "r" : "295",
+                     "s" : [ {
+                        "value" : [ "Tuple {\n    " ]
+                     }, {
+                        "s" : [ {
+                           "value" : [ "MyFavorite",": " ]
+                        }, {
+                           "r" : "296",
+                           "s" : [ {
+                              "value" : [ "\"My Favorite VS\"" ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ ",\n    " ]
+                     }, {
+                        "s" : [ {
+                           "value" : [ "MyLibsFavorite",": " ]
+                        }, {
+                           "r" : "298",
+                           "s" : [ {
+                              "r" : "297",
+                              "s" : [ {
+                                 "value" : [ "common" ]
+                              } ]
+                           }, {
+                              "value" : [ "." ]
+                           }, {
+                              "r" : "298",
+                              "s" : [ {
+                                 "value" : [ "\"My Favorite VS\"" ]
+                              } ]
+                           } ]
+                        } ]
+                     }, {
+                        "value" : [ "\n  }" ]
+                     } ]
+                  } ]
+               }
+            } ],
+            "resultTypeSpecifier" : {
+               "localId" : "304",
+               "type" : "TupleTypeSpecifier",
+               "element" : [ {
+                  "localId" : "305",
+                  "name" : "MyFavorite",
+                  "elementType" : {
+                     "localId" : "306",
+                     "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }, {
+                  "localId" : "307",
+                  "name" : "MyLibsFavorite",
+                  "elementType" : {
+                     "localId" : "308",
+                     "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ]
+            },
+            "expression" : {
+               "localId" : "295",
+               "type" : "Tuple",
+               "resultTypeSpecifier" : {
+                  "localId" : "299",
+                  "type" : "TupleTypeSpecifier",
+                  "element" : [ {
+                     "localId" : "300",
+                     "name" : "MyFavorite",
+                     "elementType" : {
+                        "localId" : "301",
+                        "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }, {
+                     "localId" : "302",
+                     "name" : "MyLibsFavorite",
+                     "elementType" : {
+                        "localId" : "303",
+                        "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ]
+               },
+               "element" : [ {
+                  "name" : "MyFavorite",
+                  "value" : {
+                     "localId" : "296",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "name" : "My Favorite VS",
+                     "preserve" : true,
+                     "type" : "ValueSetRef"
+                  }
+               }, {
+                  "name" : "MyLibsFavorite",
+                  "value" : {
+                     "localId" : "298",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "name" : "My Favorite VS",
+                     "libraryName" : "common",
+                     "preserve" : true,
+                     "type" : "ValueSetRef"
                   }
                } ]
             }

--- a/test/elm/library/library-test.ts
+++ b/test/elm/library/library-test.ts
@@ -30,11 +30,6 @@ describe('Using CommonLib', () => {
     setup(this, data, [p1, p2], {}, {}, new Repository(data));
   });
 
-  it('should include codesystems from CommonLib', function () {
-    const codesystems = this.lib.codesystems;
-    codesystems.should.not.be.empty();
-  });
-
   it('should have using models defined', function () {
     this.lib.usings.should.not.be.empty();
     this.lib.usings.length.should.equal(1);
@@ -61,6 +56,18 @@ describe('Using CommonLib', () => {
       await this.supportLibCode.exec(this.ctx),
       new Code('428371000124100', '2.16.840.1.113883.6.96', 'foo', 'directReferenceCode')
     ).should.be.true();
+  });
+
+  it('should find the code system defined in the included library', async function () {
+    const snomed = await this.supportLibCodeSystem.exec(this.ctx);
+    should.exist(snomed);
+    snomed.id.should.equal('2.16.840.1.113883.6.96');
+  });
+
+  it('should differentiate between code systems with the same name', async function () {
+    const favorites = await this.supportClashingCodeSystemNames.exec(this.ctx);
+    favorites.MyFavorite.id.should.equal('2.4.6.8.10');
+    favorites.MyLibsFavorite.id.should.equal('1.3.5.7.9');
   });
 });
 
@@ -146,6 +153,11 @@ describe('Using CommonLib and CommonLib2', () => {
       .exec_patient_context(this.patientSource);
     this.commonLocalIdObject = this.results.localIdPatientResultsMap['1'].Common;
     this.common2LocalIdObject = this.results.localIdPatientResultsMap['1'].Common2;
+  });
+
+  it('should have name and version defined since CQL used library identifier', function () {
+    this.lib.name.should.equal('UsingTwoLibs');
+    this.lib.version.should.equal('0.0.1');
   });
 
   it('should contain TheParameter localId in the localIdMap', function () {

--- a/test/elm/library/library-test.ts
+++ b/test/elm/library/library-test.ts
@@ -69,6 +69,18 @@ describe('Using CommonLib', () => {
     favorites.MyFavorite.id.should.equal('2.4.6.8.10');
     favorites.MyLibsFavorite.id.should.equal('1.3.5.7.9');
   });
+
+  it('should find the value set defined in the included library', async function () {
+    const pharyngitis = await this.supportLibValueSet.exec(this.ctx);
+    should.exist(pharyngitis);
+    pharyngitis.oid.should.equal('2.16.840.1.113883.3.464.1003.101.12.1001');
+  });
+
+  it('should differentiate between value sets with the same name', async function () {
+    const favorites = await this.supportClashingValueSetNames.exec(this.ctx);
+    favorites.MyFavorite.oid.should.equal('10.8.6.4.2');
+    favorites.MyLibsFavorite.oid.should.equal('9.7.5.3.1');
+  });
 });
 
 describe('Using CommonLib2', () => {


### PR DESCRIPTION
## Summary
This PR addresses #259 to add capability for `CodeSystemRef`. It also adds `name` to the `CodeSystem` type, something that was introduced in [CQL 1.5](https://cql.hl7.org/09-b-cqlreference.html#codesystem).

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

**Submitter:**

- [✔] This pull request describes why these changes were made
- [✔] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [✔] Tests are included and test edge cases
- [✔] Tests have been run locally and pass
- [✔] Code coverage has not gone down and all code touched or added is covered.
- [✔] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [✔] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [✔] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name:

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
