### PR TITLE
Fix toString for Date/DateTime

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -1327,9 +1327,6 @@ class DateTime extends AbstractDate {
     toJSON() {
         return this.toString();
     }
-    _pad(num) {
-        return String('0' + num).slice(-2);
-    }
     toString() {
         if (this.isTime()) {
             return this.toStringTime();
@@ -1341,13 +1338,13 @@ class DateTime extends AbstractDate {
     toStringTime() {
         let str = '';
         if (this.hour != null) {
-            str += this._pad(this.hour);
+            str += String(this.hour).padStart(2, '0');
             if (this.minute != null) {
-                str += ':' + this._pad(this.minute);
+                str += ':' + String(this.minute).padStart(2, '0');
                 if (this.second != null) {
-                    str += ':' + this._pad(this.second);
+                    str += ':' + String(this.second).padStart(2, '0');
                     if (this.millisecond != null) {
-                        str += '.' + String('00' + this.millisecond).slice(-3);
+                        str += '.' + String(this.millisecond).padStart(3, '0');
                     }
                 }
             }
@@ -1357,19 +1354,19 @@ class DateTime extends AbstractDate {
     toStringDateTime() {
         let str = '';
         if (this.year != null) {
-            str += this.year;
+            str += String(this.year).padStart(4, '0');
             if (this.month != null) {
-                str += '-' + this._pad(this.month);
+                str += '-' + String(this.month).padStart(2, '0');
                 if (this.day != null) {
-                    str += '-' + this._pad(this.day);
+                    str += '-' + String(this.day).padStart(2, '0');
                     if (this.hour != null) {
-                        str += 'T' + this._pad(this.hour);
+                        str += 'T' + String(this.hour).padStart(2, '0');
                         if (this.minute != null) {
-                            str += ':' + this._pad(this.minute);
+                            str += ':' + String(this.minute).padStart(2, '0');
                             if (this.second != null) {
-                                str += ':' + this._pad(this.second);
+                                str += ':' + String(this.second).padStart(2, '0');
                                 if (this.millisecond != null) {
-                                    str += '.' + String('00' + this.millisecond).slice(-3);
+                                    str += '.' + String(this.millisecond).padStart(3, '0');
                                 }
                             }
                         }
@@ -1380,9 +1377,9 @@ class DateTime extends AbstractDate {
         if (str.indexOf('T') !== -1 && this.timezoneOffset != null) {
             str += this.timezoneOffset < 0 ? '-' : '+';
             const offsetHours = Math.floor(Math.abs(this.timezoneOffset));
-            str += this._pad(offsetHours);
+            str += String(offsetHours).padStart(2, '0');
             const offsetMin = (Math.abs(this.timezoneOffset) - offsetHours) * 60;
-            str += ':' + this._pad(offsetMin);
+            str += ':' + String(offsetMin).padStart(2, '0');
         }
         return str;
     }
@@ -1589,7 +1586,7 @@ class Date extends AbstractDate {
     toString() {
         let str = '';
         if (this.year != null) {
-            str += this.year.toString();
+            str += this.year.toString().padStart(4, '0');
             if (this.month != null) {
                 str += '-' + this.month.toString().padStart(2, '0');
                 if (this.day != null) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -394,9 +394,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1227,9 +1227,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2701,16 +2701,16 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -4286,9 +4286,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4460,9 +4460,9 @@
       }
     },
     "node_modules/nyc/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4985,9 +4985,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5352,9 +5352,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5518,9 +5518,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -6152,9 +6152,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/datatypes/datetime.ts
+++ b/src/datatypes/datetime.ts
@@ -934,10 +934,6 @@ export class DateTime extends AbstractDate {
     return this.toString();
   }
 
-  _pad(num: number) {
-    return String('0' + num).slice(-2);
-  }
-
   toString() {
     if (this.isTime()) {
       return this.toStringTime();
@@ -949,13 +945,13 @@ export class DateTime extends AbstractDate {
   toStringTime() {
     let str = '';
     if (this.hour != null) {
-      str += this._pad(this.hour);
+      str += String(this.hour).padStart(2, '0');
       if (this.minute != null) {
-        str += ':' + this._pad(this.minute);
+        str += ':' + String(this.minute).padStart(2, '0');
         if (this.second != null) {
-          str += ':' + this._pad(this.second);
+          str += ':' + String(this.second).padStart(2, '0');
           if (this.millisecond != null) {
-            str += '.' + String('00' + this.millisecond).slice(-3);
+            str += '.' + String(this.millisecond).padStart(3, '0');
           }
         }
       }
@@ -967,19 +963,19 @@ export class DateTime extends AbstractDate {
   toStringDateTime() {
     let str = '';
     if (this.year != null) {
-      str += this.year;
+      str += String(this.year).padStart(4, '0');
       if (this.month != null) {
-        str += '-' + this._pad(this.month);
+        str += '-' + String(this.month).padStart(2, '0');
         if (this.day != null) {
-          str += '-' + this._pad(this.day);
+          str += '-' + String(this.day).padStart(2, '0');
           if (this.hour != null) {
-            str += 'T' + this._pad(this.hour);
+            str += 'T' + String(this.hour).padStart(2, '0');
             if (this.minute != null) {
-              str += ':' + this._pad(this.minute);
+              str += ':' + String(this.minute).padStart(2, '0');
               if (this.second != null) {
-                str += ':' + this._pad(this.second);
+                str += ':' + String(this.second).padStart(2, '0');
                 if (this.millisecond != null) {
-                  str += '.' + String('00' + this.millisecond).slice(-3);
+                  str += '.' + String(this.millisecond).padStart(3, '0');
                 }
               }
             }
@@ -991,9 +987,9 @@ export class DateTime extends AbstractDate {
     if (str.indexOf('T') !== -1 && this.timezoneOffset != null) {
       str += this.timezoneOffset < 0 ? '-' : '+';
       const offsetHours = Math.floor(Math.abs(this.timezoneOffset));
-      str += this._pad(offsetHours);
+      str += String(offsetHours).padStart(2, '0');
       const offsetMin = (Math.abs(this.timezoneOffset) - offsetHours) * 60;
-      str += ':' + this._pad(offsetMin);
+      str += ':' + String(offsetMin).padStart(2, '0');
     }
 
     return str;
@@ -1218,7 +1214,7 @@ export class Date extends AbstractDate {
   toString() {
     let str = '';
     if (this.year != null) {
-      str += this.year.toString();
+      str += this.year.toString().padStart(4, '0');
       if (this.month != null) {
         str += '-' + this.month.toString().padStart(2, '0');
         if (this.day != null) {

--- a/test/datatypes/date-test.ts
+++ b/test/datatypes/date-test.ts
@@ -1,6 +1,6 @@
 import * as luxon from 'luxon';
 import should from 'should';
-import { Date, DateTime } from '../../src/datatypes/datetime';
+import { Date, DateTime, MAX_DATE_VALUE, MIN_DATE_VALUE } from '../../src/datatypes/datetime';
 import { Uncertainty } from '../../src/datatypes/uncertainty';
 import { jsDate } from '../../src/util/util';
 
@@ -47,6 +47,11 @@ describe('Date', () => {
   it('should toString yyyy-mm-dd', () => {
     const d = new Date(2012, 10, 25);
     d.toString().should.eql('2012-10-25');
+  });
+
+  it('should toString min and max values', () => {
+    MIN_DATE_VALUE.toString().should.eql('0001-01-01');
+    MAX_DATE_VALUE.toString().should.eql('9999-12-31');
   });
 
   it('should return null when parsing non-string', () => should(Date.parse(20121025)).be.null());

--- a/test/datatypes/datetime-test.ts
+++ b/test/datatypes/datetime-test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import * as luxon from 'luxon';
 import should from 'should';
-import { DateTime } from '../../src/datatypes/datetime';
+import { DateTime, MAX_DATETIME_VALUE, MIN_DATETIME_VALUE } from '../../src/datatypes/datetime';
 import { Uncertainty } from '../../src/datatypes/uncertainty';
 
 const tzDate = function (
@@ -185,6 +185,11 @@ describe('DateTime', () => {
 
     d = new DateTime(2012, 10, 25, 12, 55, 14, 953, -5);
     d.toString().should.eql('2012-10-25T12:55:14.953-05:00');
+  });
+
+  it('should toString min and max values', () => {
+    MIN_DATETIME_VALUE.toString().should.match(/^0001-01-01T00:00:00\.000([+-]\d\d:\d\d|Z)$/);
+    MAX_DATETIME_VALUE.toString().should.match(/^9999-12-31T23:59:59\.999([+-]\d\d:\d\d|Z)$/);
   });
 
   it('should be null when parsing non-string', () => should(DateTime.parse(20121025)).be.null());


### PR DESCRIPTION
The minimum Date was incorrectly `toString`ing to `1-01-01` instead of `0001-01-01`. This fixes the string formatting for this use case and applies more consistent padding to date-based `toString` operations across the board.

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

**Submitter:**

- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name: Elsa Perelli

- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
