### PR TITLE
Improve handling of boundless and unknown intervals

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,5 @@
 {
   "ignore": ["test/spec-tests/*.js"],
   "extension": ["ts"],
-  "require": "ts-node/register"
+  "require": ["ts-node/register", "./test/should-extensions.ts"]
 }

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -2289,25 +2289,31 @@ class Interval {
     }
     start() {
         if (this.low == null) {
-            if (this.lowClosed) {
-                return (0, math_1.minValueForInstance)(this.high);
+            const quantityInstance = this.high && this.pointType == elmTypes_1.ELM_QUANTITY_TYPE ? this.high : undefined;
+            const minValue = (0, math_1.minValueForType)(this.pointType, quantityInstance);
+            if (this.lowClosed || minValue == null) {
+                return minValue;
             }
             else {
-                return this.low;
+                const end = ((end) => (end.isUncertainty ? end.high : end))(this.high == null ? (0, math_1.maxValueForType)(this.pointType) : this.end());
+                return new uncertainty_1.Uncertainty(minValue, end);
             }
         }
-        return this.toClosed().low;
+        return this.lowClosed ? this.low : (0, math_1.successor)(this.low, this.pointType);
     }
     end() {
         if (this.high == null) {
-            if (this.highClosed) {
-                return (0, math_1.maxValueForInstance)(this.low);
+            const quantityInstance = this.low && this.pointType == elmTypes_1.ELM_QUANTITY_TYPE ? this.low : undefined;
+            const maxValue = (0, math_1.maxValueForType)(this.pointType, quantityInstance);
+            if (this.highClosed || maxValue == null) {
+                return maxValue;
             }
             else {
-                return this.high;
+                const start = ((start) => (start.isUncertainty ? start.low : start))(this.low == null ? (0, math_1.minValueForType)(this.pointType) : this.start());
+                return new uncertainty_1.Uncertainty(start, maxValue);
             }
         }
-        return this.toClosed().high;
+        return this.highClosed ? this.high : (0, math_1.predecessor)(this.high, this.pointType);
     }
     starts(other, precision) {
         if (this.isBoundlessInterval) {
@@ -2576,7 +2582,7 @@ exports.ThreeValuedLogic = ThreeValuedLogic;
 },{}],12:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Quantity = void 0;
+exports.MAX_QUANTITY_VALUE = exports.MIN_QUANTITY_VALUE = exports.Quantity = void 0;
 exports.parseQuantity = parseQuantity;
 exports.doAddition = doAddition;
 exports.doSubtraction = doSubtraction;
@@ -2716,6 +2722,10 @@ class Quantity {
     }
 }
 exports.Quantity = Quantity;
+// Require MIN/MAX here because math.js requires this file, and when we make this file require
+// math.js before it exports DateTime and Date, it errors due to the circular dependency...
+exports.MIN_QUANTITY_VALUE = new Quantity(math_1.MIN_FLOAT_VALUE, '1');
+exports.MAX_QUANTITY_VALUE = new Quantity(math_1.MAX_FLOAT_VALUE, '1');
 function parseQuantity(str) {
     const components = /([+|-]?\d+\.?\d*)\s*('(.+)')?/.exec(str);
     if (components != null && components[1] != null) {
@@ -9261,7 +9271,7 @@ exports.greaterThan = greaterThan;
 exports.greaterThanOrEquals = greaterThanOrEquals;
 exports.equivalent = equivalent;
 exports.equals = equals;
-const datatypes_1 = require("../datatypes/datatypes");
+const uncertainty_1 = require("../datatypes/uncertainty");
 function areNumbers(a, b) {
     return typeof a === 'number' && typeof b === 'number';
 }
@@ -9277,7 +9287,7 @@ function areDateTimesOrQuantities(a, b) {
         (a && a.isQuantity && b && b.isQuantity));
 }
 function isUncertainty(x) {
-    return x instanceof datatypes_1.Uncertainty;
+    return x instanceof uncertainty_1.Uncertainty;
 }
 function lessThan(a, b, precision) {
     if (areNumbers(a, b) || areBigInts(a, b) || areStrings(a, b)) {
@@ -9290,7 +9300,7 @@ function lessThan(a, b, precision) {
         return a.lessThan(b);
     }
     else if (isUncertainty(b)) {
-        return datatypes_1.Uncertainty.from(a).lessThan(b);
+        return uncertainty_1.Uncertainty.from(a).lessThan(b);
     }
     else {
         return null;
@@ -9307,7 +9317,7 @@ function lessThanOrEquals(a, b, precision) {
         return a.lessThanOrEquals(b);
     }
     else if (isUncertainty(b)) {
-        return datatypes_1.Uncertainty.from(a).lessThanOrEquals(b);
+        return uncertainty_1.Uncertainty.from(a).lessThanOrEquals(b);
     }
     else {
         return null;
@@ -9324,7 +9334,7 @@ function greaterThan(a, b, precision) {
         return a.greaterThan(b);
     }
     else if (isUncertainty(b)) {
-        return datatypes_1.Uncertainty.from(a).greaterThan(b);
+        return uncertainty_1.Uncertainty.from(a).greaterThan(b);
     }
     else {
         return null;
@@ -9341,7 +9351,7 @@ function greaterThanOrEquals(a, b, precision) {
         return a.greaterThanOrEquals(b);
     }
     else if (isUncertainty(b)) {
-        return datatypes_1.Uncertainty.from(a).greaterThanOrEquals(b);
+        return uncertainty_1.Uncertainty.from(a).greaterThanOrEquals(b);
     }
     else {
         return null;
@@ -9454,11 +9464,11 @@ function equals(a, b) {
         return a.equals(b);
     }
     // If one is an Uncertainty, convert the other to an Uncertainty
-    if (a instanceof datatypes_1.Uncertainty) {
-        b = datatypes_1.Uncertainty.from(b);
+    if (a instanceof uncertainty_1.Uncertainty) {
+        b = uncertainty_1.Uncertainty.from(b);
     }
-    else if (b instanceof datatypes_1.Uncertainty) {
-        a = datatypes_1.Uncertainty.from(a);
+    else if (b instanceof uncertainty_1.Uncertainty) {
+        a = uncertainty_1.Uncertainty.from(a);
     }
     // Use overloaded 'equals' function if it is available
     if (typeof a.equals === 'function') {
@@ -9500,7 +9510,7 @@ function equals(a, b) {
     return false;
 }
 
-},{"../datatypes/datatypes":7}],54:[function(require,module,exports){
+},{"../datatypes/uncertainty":14}],54:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.AnnotatedError = void 0;
@@ -9727,6 +9737,7 @@ exports.decimalAdjust = decimalAdjust;
 exports.decimalOrNull = decimalOrNull;
 exports.decimalLongOrNull = decimalLongOrNull;
 const exception_1 = require("../datatypes/exception");
+const quantity_1 = require("../datatypes/quantity");
 const datetime_1 = require("../datatypes/datetime");
 const uncertainty_1 = require("../datatypes/uncertainty");
 const elmTypes_1 = require("./elmTypes");
@@ -10025,9 +10036,14 @@ function maxValueForInstance(val) {
         return exports.MAX_DATE_VALUE?.copy();
     }
     else if (val && val.isQuantity) {
-        const val2 = val.clone();
-        val2.value = maxValueForInstance(val2.value);
-        return val2;
+        // Although the spec says max Quantity has unit '1', it doesn't make sense to change the unit,
+        // especially if this is being used in the context of an interval or uncertainty since the
+        // left and right sides need to be comparable in those cases.
+        const maxQuantity = quantity_1.MAX_QUANTITY_VALUE.clone();
+        if (val.unit) {
+            maxQuantity.unit = val.unit;
+        }
+        return maxQuantity;
     }
     else {
         return null;
@@ -10048,13 +10064,17 @@ function maxValueForType(type, quantityInstance) {
         case elmTypes_1.ELM_TIME_TYPE:
             return exports.MAX_TIME_VALUE?.copy();
         case elmTypes_1.ELM_QUANTITY_TYPE: {
+            // Although the spec says max Quantity has unit '1', it doesn't make sense to change the unit,
+            // especially if this is being used in the context of an interval or uncertainty since the
+            // left and right sides need to be comparable in those cases.
+            const maxQuantity = quantity_1.MAX_QUANTITY_VALUE.clone();
             if (quantityInstance == null) {
-                // can't infer a quantity unit type from nothing]
-                return null;
+                return maxQuantity;
             }
-            const maxQty = quantityInstance.clone();
-            maxQty.value = exports.MAX_FLOAT_VALUE;
-            return maxQty;
+            if (quantityInstance.unit) {
+                maxQuantity.unit = quantityInstance.unit;
+            }
+            return maxQuantity;
         }
     }
     return null;
@@ -10081,9 +10101,14 @@ function minValueForInstance(val) {
         return exports.MIN_DATE_VALUE?.copy();
     }
     else if (val && val.isQuantity) {
-        const val2 = val.clone();
-        val2.value = minValueForInstance(val2.value);
-        return val2;
+        // Although the spec says max Quantity has unit '1', it doesn't make sense to change the unit,
+        // especially if this is being used in the context of an interval or uncertainty since the
+        // left and right sides need to be comparable in those cases.
+        const minQuantity = quantity_1.MIN_QUANTITY_VALUE.clone();
+        if (val.unit) {
+            minQuantity.unit = val.unit;
+        }
+        return minQuantity;
     }
     else {
         return null;
@@ -10104,13 +10129,17 @@ function minValueForType(type, quantityInstance) {
         case elmTypes_1.ELM_TIME_TYPE:
             return exports.MIN_TIME_VALUE?.copy();
         case elmTypes_1.ELM_QUANTITY_TYPE: {
+            // Although the spec says max Quantity has unit '1', it doesn't make sense to change the unit,
+            // especially if this is being used in the context of an interval or uncertainty since the
+            // left and right sides need to be comparable in those cases.
+            const minQuantity = quantity_1.MIN_QUANTITY_VALUE.clone();
             if (quantityInstance == null) {
-                // can't infer a quantity unit type from nothing]
-                return null;
+                return minQuantity;
             }
-            const minQty = quantityInstance.clone();
-            minQty.value = exports.MIN_FLOAT_VALUE;
-            return minQty;
+            if (quantityInstance.unit) {
+                minQuantity.unit = quantityInstance.unit;
+            }
+            return minQuantity;
         }
     }
     return null;
@@ -10145,7 +10174,7 @@ function decimalLongOrNull(value) {
         : null;
 }
 
-},{"../datatypes/datetime":8,"../datatypes/exception":9,"../datatypes/uncertainty":14,"./elmTypes":55}],58:[function(require,module,exports){
+},{"../datatypes/datetime":8,"../datatypes/exception":9,"../datatypes/quantity":12,"../datatypes/uncertainty":14,"./elmTypes":55}],58:[function(require,module,exports){
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -134,7 +134,7 @@ class Record {
                 name: '{https://github.com/cqframework/cql-execution/simple}Record',
                 type: elmTypes_1.ELM_NAMED_TYPE_SPECIFIER
             },
-            { name: '{urn:hl7-org:elm-types:r1}Any', type: elmTypes_1.ELM_NAMED_TYPE_SPECIFIER }
+            { name: elmTypes_1.ELM_ANY_TYPE, type: elmTypes_1.ELM_NAMED_TYPE_SPECIFIER }
         ];
     }
     _recursiveGet(field) {
@@ -522,7 +522,7 @@ function codesMatch(code1, code2) {
     return code1.code === code2.code && code1.system === code2.system;
 }
 
-},{"../util/util":59}],7:[function(require,module,exports){
+},{"../util/util":60}],7:[function(require,module,exports){
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
@@ -556,6 +556,7 @@ exports.MAX_TIME_VALUE = exports.MIN_TIME_VALUE = exports.MAX_DATE_VALUE = expor
 const uncertainty_1 = require("./uncertainty");
 const util_1 = require("../util/util");
 const luxon_1 = require("luxon");
+const limits_1 = require("../util/limits");
 // It's easiest and most performant to organize formats by length of the supported strings.
 // This way we can test strings only against the formats that have a chance of working.
 // NOTE: Formats use Luxon formats, documented here: https://moment.github.io/luxon/docs/manual/parsing.html#table-of-tokens
@@ -1058,7 +1059,7 @@ class AbstractDate {
             case 'millisecond':
                 return 999;
             default:
-                throw new Error('Tried to clieling a field that has no cieling value: ' + field);
+                throw new Error('Tried to ceiling a field that has no cieling value: ' + field);
         }
     }
 }
@@ -1147,8 +1148,11 @@ class DateTime extends AbstractDate {
     copy() {
         return new DateTime(this.year, this.month, this.day, this.hour, this.minute, this.second, this.millisecond, this.timezoneOffset);
     }
-    successor() {
-        if (this.millisecond != null) {
+    successor(precision) {
+        if (precision) {
+            return this.add(1, precision);
+        }
+        else if (this.millisecond != null) {
             return this.add(1, DateTime.Unit.MILLISECOND);
         }
         else if (this.second != null) {
@@ -1170,8 +1174,11 @@ class DateTime extends AbstractDate {
             return this.add(1, DateTime.Unit.YEAR);
         }
     }
-    predecessor() {
-        if (this.millisecond != null) {
+    predecessor(precision) {
+        if (precision) {
+            return this.add(-1, precision);
+        }
+        else if (this.millisecond != null) {
             return this.add(-1, DateTime.Unit.MILLISECOND);
         }
         else if (this.second != null) {
@@ -1481,8 +1488,11 @@ class Date extends AbstractDate {
     copy() {
         return new Date(this.year, this.month, this.day);
     }
-    successor() {
-        if (this.day != null) {
+    successor(precision) {
+        if (precision) {
+            return this.add(1, precision);
+        }
+        else if (this.day != null) {
             return this.add(1, Date.Unit.DAY);
         }
         else if (this.month != null) {
@@ -1492,8 +1502,11 @@ class Date extends AbstractDate {
             return this.add(1, Date.Unit.YEAR);
         }
     }
-    predecessor() {
-        if (this.day != null) {
+    predecessor(precision) {
+        if (precision) {
+            return this.add(-1, precision);
+        }
+        else if (this.day != null) {
             return this.add(-1, Date.Unit.DAY);
         }
         else if (this.month != null) {
@@ -1638,15 +1651,12 @@ class Date extends AbstractDate {
 exports.Date = Date;
 Date.Unit = { YEAR: 'year', MONTH: 'month', WEEK: 'week', DAY: 'day' };
 Date.FIELDS = [Date.Unit.YEAR, Date.Unit.MONTH, Date.Unit.DAY];
-// Require MIN/MAX here because math.js requires this file, and when we make this file require
-// math.js before it exports DateTime and Date, it errors due to the circular dependency...
-// const { MAX_DATETIME_VALUE, MIN_DATETIME_VALUE } = require('../util/math');
-exports.MIN_DATETIME_VALUE = DateTime.parse('0001-01-01T00:00:00.000');
-exports.MAX_DATETIME_VALUE = DateTime.parse('9999-12-31T23:59:59.999');
-exports.MIN_DATE_VALUE = Date.parse('0001-01-01');
-exports.MAX_DATE_VALUE = Date.parse('9999-12-31');
-exports.MIN_TIME_VALUE = DateTime.parse('0000-01-01T00:00:00.000')?.getTime();
-exports.MAX_TIME_VALUE = DateTime.parse('0000-01-01T23:59:59.999')?.getTime();
+exports.MIN_DATETIME_VALUE = DateTime.parse(limits_1.MIN_DATETIME_VALUE_STRING);
+exports.MAX_DATETIME_VALUE = DateTime.parse(limits_1.MAX_DATETIME_VALUE_STRING);
+exports.MIN_DATE_VALUE = Date.parse(limits_1.MIN_DATE_VALUE_STRING);
+exports.MAX_DATE_VALUE = Date.parse(limits_1.MAX_DATE_VALUE_STRING);
+exports.MIN_TIME_VALUE = DateTime.parse(limits_1.MIN_TIME_VALUE_STRING)?.getTime();
+exports.MAX_TIME_VALUE = DateTime.parse(limits_1.MAX_TIME_VALUE_STRING)?.getTime();
 const DATETIME_PRECISION_VALUE_MAP = (() => {
     const dtpvMap = new Map();
     dtpvMap.set(DateTime.Unit.YEAR, 4);
@@ -1744,7 +1754,7 @@ function isPrecisionUnspecifiedOrGreaterThanDay(precision) {
     return precision == null || /^h|mi|s/.test(precision);
 }
 
-},{"../util/util":59,"./uncertainty":14,"luxon":77}],9:[function(require,module,exports){
+},{"../util/limits":57,"../util/util":60,"./uncertainty":14,"luxon":78}],9:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Exception = void 0;
@@ -1794,58 +1804,53 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Interval = void 0;
 const uncertainty_1 = require("./uncertainty");
-const quantity_1 = require("./quantity");
 const logic_1 = require("./logic");
 const math_1 = require("../util/math");
 const cmp = __importStar(require("../util/comparison"));
 const elmTypes_1 = require("../util/elmTypes");
+const limits_1 = require("../util/limits");
+const quantity_1 = require("./quantity");
 class Interval {
-    constructor(low, high, lowClosed, highClosed, defaultPointType // defaultPointType is used in the case that both endpoints are null
-    ) {
+    constructor(low, high, lowClosed, highClosed, pointType = elmTypes_1.ELM_ANY_TYPE) {
         this.low = low;
         this.high = high;
         this.lowClosed = lowClosed;
         this.highClosed = highClosed;
-        this.defaultPointType = defaultPointType;
+        this.pointType = pointType;
         this.lowClosed = lowClosed != null ? lowClosed : true;
         this.highClosed = highClosed != null ? highClosed : true;
+        if (this.pointType == null || this.pointType === elmTypes_1.ELM_ANY_TYPE) {
+            let point = low ?? high;
+            if (point?.isUncertainty) {
+                point = point.low ?? point.high;
+            }
+            if (point != null) {
+                if (typeof point === 'number') {
+                    this.pointType = Number.isInteger(point) ? elmTypes_1.ELM_INTEGER_TYPE : elmTypes_1.ELM_DECIMAL_TYPE;
+                }
+                else if (typeof point === 'bigint') {
+                    this.pointType = elmTypes_1.ELM_LONG_TYPE;
+                }
+                else if (point.isTime && point.isTime()) {
+                    this.pointType = elmTypes_1.ELM_TIME_TYPE;
+                }
+                else if (point.isDate) {
+                    this.pointType = elmTypes_1.ELM_DATE_TYPE;
+                }
+                else if (point.isDateTime) {
+                    this.pointType = elmTypes_1.ELM_DATETIME_TYPE;
+                }
+                else if (point.isQuantity) {
+                    this.pointType = elmTypes_1.ELM_QUANTITY_TYPE;
+                }
+            }
+            if (this.pointType == null) {
+                this.pointType = elmTypes_1.ELM_ANY_TYPE;
+            }
+        }
     }
     get isInterval() {
         return true;
-    }
-    get isBoundlessInterval() {
-        return this.low == null && this.lowClosed && this.high == null && this.highClosed;
-    }
-    get isUnknownInterval() {
-        return this.low == null && !this.lowClosed && this.high == null && !this.highClosed;
-    }
-    get pointType() {
-        let pointType = null;
-        const point = this.low != null ? this.low : this.high;
-        if (point != null) {
-            if (typeof point === 'number') {
-                pointType = Number.isInteger(point) ? elmTypes_1.ELM_INTEGER_TYPE : elmTypes_1.ELM_DECIMAL_TYPE;
-            }
-            else if (typeof point === 'bigint') {
-                pointType = elmTypes_1.ELM_LONG_TYPE;
-            }
-            else if (point.isTime && point.isTime()) {
-                pointType = elmTypes_1.ELM_TIME_TYPE;
-            }
-            else if (point.isDate) {
-                pointType = elmTypes_1.ELM_DATE_TYPE;
-            }
-            else if (point.isDateTime) {
-                pointType = elmTypes_1.ELM_DATETIME_TYPE;
-            }
-            else if (point.isQuantity) {
-                pointType = elmTypes_1.ELM_QUANTITY_TYPE;
-            }
-        }
-        if (pointType == null && this.defaultPointType != null) {
-            pointType = this.defaultPointType;
-        }
-        return pointType;
     }
     copy() {
         let newLow = this.low;
@@ -1856,43 +1861,18 @@ class Interval {
         if (this.high != null && typeof this.high.copy === 'function') {
             newHigh = this.high.copy();
         }
-        return new Interval(newLow, newHigh, this.lowClosed, this.highClosed, this.defaultPointType);
+        return new Interval(newLow, newHigh, this.lowClosed, this.highClosed, this.pointType);
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#contains
     contains(item, precision) {
         if (item != null && item.isInterval) {
             throw new Error('Argument to contains must be a point');
         }
-        if (this.isBoundlessInterval) {
-            return true;
-        }
-        // Ensure correct handling of edge case where an item equals the closed boundary
-        if (this.lowClosed && this.low != null && cmp.equals(this.low, item)) {
-            return true;
-        }
-        if (this.highClosed && this.high != null && cmp.equals(this.high, item)) {
-            return true;
-        }
-        let lowFn;
-        if (this.lowClosed && this.low == null) {
-            lowFn = () => true;
-        }
-        else if (this.lowClosed) {
-            lowFn = cmp.lessThanOrEquals;
-        }
-        else {
-            lowFn = cmp.lessThan;
-        }
-        let highFn;
-        if (this.highClosed && this.high == null) {
-            highFn = () => true;
-        }
-        else if (this.highClosed) {
-            highFn = cmp.greaterThanOrEquals;
-        }
-        else {
-            highFn = cmp.greaterThan;
-        }
-        return logic_1.ThreeValuedLogic.and(lowFn(this.low, item, precision), highFn(this.high, item, precision));
+        // "The contains operator for intervals returns true if the given point is equal to the starting
+        // or ending point of the interval, or greater than the starting point and less than the ending
+        // point... If precision is specified and the point type is a Date, DateTime, or Time type,
+        // comparisons used in the operation are performed at the specified precision."
+        return logic_1.ThreeValuedLogic.and(cmp.greaterThanOrEquals(item, this.start(), precision), cmp.lessThanOrEquals(item, this.end(), precision));
     }
     properContains(item, precision) {
         if (item == null) {
@@ -1903,391 +1883,364 @@ class Interval {
         }
         return logic_1.ThreeValuedLogic.and(cmp.lessThan(this.start(), item, precision), cmp.greaterThan(this.end(), item, precision));
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#properly-includes
     properlyIncludes(other, precision) {
+        // TODO: "For the interval-point overload, this operator returns true if the interval contains
+        // (i.e. includes) the point, and the interval is not a unit interval containing only the
+        // point."
         if (other == null || !other.isInterval) {
             throw new Error('Argument to properlyIncludes must be an interval');
         }
-        return logic_1.ThreeValuedLogic.and(this.includes(other, precision), logic_1.ThreeValuedLogic.not(other.includes(this, precision)));
+        // "... the starting point of the first interval is less than or equal to the starting point of
+        // the second interval, and the ending point of the first interval is greater than or equal to
+        // the ending point of the second interval, and they are not the same interval... If precision
+        // is specified and the point type is a Date, DateTime, or Time type, comparisons used in the
+        // operation are performed at the specified precision."
+        return logic_1.ThreeValuedLogic.and(cmp.lessThanOrEquals(this.start(), other.start(), precision), cmp.greaterThanOrEquals(this.end(), other.end(), precision), logic_1.ThreeValuedLogic.not(other.includes(this, precision)));
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#includes
     includes(other, precision) {
-        if (this.isBoundlessInterval) {
-            return true;
+        // "For the interval-interval overload, if either argument is null, the result is null."
+        if (other == null) {
+            return null;
         }
-        else if (other?.isBoundlessInterval) {
-            return this.isUnknownInterval ? null : false;
-        }
-        if (other == null || !other.isInterval) {
+        // "For the point-interval overload, this operator is a synonym for the contains operator."
+        else if (!other.isInterval) {
             return this.contains(other, precision);
         }
-        const a = this.toClosed();
-        const b = other.toClosed();
-        return logic_1.ThreeValuedLogic.and(cmp.lessThanOrEquals(a.low, b.low, precision), cmp.greaterThanOrEquals(a.high, b.high, precision));
+        // "... the starting point of the first interval is less than or equal to the starting point of
+        // the second interval, and the ending point of the first interval is greater than or equal to
+        // the ending point of the second interval... If precision is specified and the point type is a
+        // Date, DateTime, or Time type, comparisons used in the operation are performed at the
+        // specified precision."
+        return logic_1.ThreeValuedLogic.and(cmp.lessThanOrEquals(this.start(), other.start(), precision), cmp.greaterThanOrEquals(this.end(), other.end(), precision));
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#included-in
     includedIn(other, precision) {
-        // For the point overload, this operator is a synonym for the in operator
-        if (other == null || !other.isInterval) {
-            return this.contains(other, precision);
-        }
-        else {
-            return other.includes(this);
-        }
-    }
-    overlaps(item, precision) {
-        if (this.isUnknownInterval || item == null || item.isUnknownInterval) {
+        // "For the interval-interval overload, if either argument is null, the result is null."
+        if (other == null) {
             return null;
         }
-        else if (this.isBoundlessInterval || item?.isBoundlessInterval) {
-            return true;
+        else if (other == null || !other.isInterval) {
+            throw new Error('Argument to includedIn must be an interval');
         }
-        const closed = this.toClosed();
-        const [low, high] = (() => {
-            if (item != null && item.isInterval) {
-                const itemClosed = item.toClosed();
-                return [itemClosed.low, itemClosed.high];
-            }
-            else {
-                return [item, item];
-            }
-        })();
-        return logic_1.ThreeValuedLogic.and(cmp.lessThanOrEquals(closed.low, high, precision), cmp.greaterThanOrEquals(closed.high, low, precision));
+        // "... the starting point of the first interval is greater than or equal to the starting point
+        // of the second interval, and the ending point of the first interval is less than or equal to
+        // the ending point of the second interval... If precision is specified and the point type is a
+        // Date, DateTime, or Time type, comparisons used in the operation are performed at the
+        // specified precision."
+        return logic_1.ThreeValuedLogic.and(cmp.greaterThanOrEquals(this.start(), other.start(), precision), cmp.lessThanOrEquals(this.end(), other.end(), precision));
     }
-    overlapsAfter(item, precision) {
-        if (this.isUnknownInterval || item == null || item.isUnknownInterval) {
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#overlaps
+    overlaps(other, precision) {
+        // "If either argument is null, the result is null."
+        if (other == null) {
             return null;
         }
-        const high = item != null && item.isInterval ? item.toClosed().high : item;
-        if (this.isBoundlessInterval) {
-            return cmp.lessThan(high, (0, math_1.maxValueForInstance)(high), precision);
-        }
-        else if (item?.isBoundlessInterval) {
-            return false;
-        }
-        const closed = this.toClosed();
-        return logic_1.ThreeValuedLogic.and(cmp.lessThanOrEquals(closed.low, high, precision), cmp.greaterThan(closed.high, high, precision));
+        // "... the ending point of the first interval is greater than or equal to the starting point
+        // of the second interval, and the starting point of the first interval is less than or equal
+        // to the ending point of the second interval... If precision is specified and the point type
+        // is a Date, DateTime, or Time type, comparisons used in the operation are performed at the
+        // specified precision."
+        return logic_1.ThreeValuedLogic.and(cmp.greaterThanOrEquals(this.end(), other.start(), precision), cmp.lessThanOrEquals(this.start(), other.end(), precision));
     }
-    overlapsBefore(item, precision) {
-        if (this.isUnknownInterval || item == null || item.isUnknownInterval) {
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#overlaps
+    overlapsAfter(other, precision) {
+        // "If either argument is null, the result is null."
+        if (other == null) {
             return null;
         }
-        const low = item != null && item.isInterval ? item.toClosed().low : item;
-        if (this.isBoundlessInterval) {
-            return cmp.greaterThan(low, (0, math_1.minValueForInstance)(low), precision);
-        }
-        else if (item?.isBoundlessInterval) {
-            return false;
-        }
-        const closed = this.toClosed();
-        return logic_1.ThreeValuedLogic.and(cmp.lessThan(closed.low, low, precision), cmp.greaterThanOrEquals(closed.high, low, precision));
+        // "... the overlaps after operator returns true if the first interval overlaps the second
+        // and ends after it."
+        return logic_1.ThreeValuedLogic.and(cmp.lessThanOrEquals(this.start(), other.end(), precision), cmp.greaterThan(this.end(), other.end(), precision));
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#overlaps
+    overlapsBefore(other, precision) {
+        // "If either argument is null, the result is null."
+        if (other == null) {
+            return null;
+        }
+        // "The operator overlaps before returns true if the first interval overlaps the second and
+        // starts before it..."
+        return logic_1.ThreeValuedLogic.and(cmp.greaterThanOrEquals(this.end(), other.start(), precision), cmp.lessThan(this.start(), other.start(), precision));
+    }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#union
     union(other) {
-        if (other == null || !other.isInterval) {
-            throw new Error('Argument to union must be an interval');
-        }
-        if (this.isBoundlessInterval) {
-            return this.copy();
-        }
-        else if (other.isBoundlessInterval) {
-            return other.copy();
-        }
-        // Note that interval union is only defined if the arguments overlap or meet.
-        if (this.overlaps(other) || this.meets(other)) {
-            const [a, b] = [this.toClosed(), other.toClosed()];
-            let l, lc;
-            if (cmp.lessThanOrEquals(a.low, b.low)) {
-                [l, lc] = [this.low, this.lowClosed];
-            }
-            else if (cmp.greaterThanOrEquals(a.low, b.low)) {
-                [l, lc] = [other.low, other.lowClosed];
-            }
-            else if (areNumeric(a.low, b.low)) {
-                [l, lc] = [lowestNumericUncertainty(a.low, b.low), true];
-                // TODO: Do we need to support quantities here?
-            }
-            else if (areDateTimes(a.low, b.low) && a.low.isMorePrecise(b.low)) {
-                [l, lc] = [other.low, other.lowClosed];
-            }
-            else {
-                [l, lc] = [this.low, this.lowClosed];
-            }
-            let h, hc;
-            if (cmp.greaterThanOrEquals(a.high, b.high)) {
-                [h, hc] = [this.high, this.highClosed];
-            }
-            else if (cmp.lessThanOrEquals(a.high, b.high)) {
-                [h, hc] = [other.high, other.highClosed];
-            }
-            else if (areNumeric(a.high, b.high)) {
-                [h, hc] = [highestNumericUncertainty(a.high, b.high), true];
-                // TODO: Do we need to support quantities here?
-            }
-            else if (areDateTimes(a.high, b.high) && a.high.isMorePrecise(b.high)) {
-                [h, hc] = [other.high, other.highClosed];
-            }
-            else {
-                [h, hc] = [this.high, this.highClosed];
-            }
-            return new Interval(l, h, lc, hc);
-        }
-        else {
+        // "If either argument is null, the result is null."
+        if (other == null) {
             return null;
         }
+        else if (!other.isInterval) {
+            throw new Error('Argument to union must be an interval');
+        }
+        // "If the arguments do not overlap or meet, this operator returns null."
+        if (!this.overlaps(other) && !this.meets(other)) {
+            return null;
+        }
+        // "... the operator returns the interval that starts at the earliest starting point in either
+        // argument, and ends at the latest ending point in either argument."
+        let earliestStart;
+        const thisIsEarlier = cmp.lessThan(this.start(), other.start());
+        if (thisIsEarlier == null) {
+            earliestStart = lowestUncertainty(this.start(), other.start());
+        }
+        else {
+            earliestStart = thisIsEarlier ? this.start() : other.start();
+        }
+        let latestEnd;
+        const thisIsLater = cmp.greaterThan(this.end(), other.end());
+        if (thisIsLater == null) {
+            latestEnd = highestUncertainty(this.end(), other.end());
+        }
+        else {
+            latestEnd = thisIsLater ? this.end() : other.end();
+        }
+        return normalizeInterval(new Interval(earliestStart, latestEnd, true, true, this.pointType ?? other.pointType));
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#intersect
     intersect(other) {
-        if (other == null || !other.isInterval) {
-            throw new Error('Argument to union must be an interval');
-        }
-        if (this.isBoundlessInterval) {
-            return other.copy();
-        }
-        else if (other.isBoundlessInterval) {
-            return this.copy();
-        }
-        // Note that interval intersect is only defined if the arguments overlap.
-        if (this.overlaps(other)) {
-            const [a, b] = [this.toClosed(), other.toClosed()];
-            let l, lc;
-            if (cmp.greaterThanOrEquals(a.low, b.low)) {
-                [l, lc] = [this.low, this.lowClosed];
-            }
-            else if (cmp.lessThanOrEquals(a.low, b.low)) {
-                [l, lc] = [other.low, other.lowClosed];
-            }
-            else if (areNumeric(a.low, b.low)) {
-                [l, lc] = [highestNumericUncertainty(a.low, b.low), true];
-                // TODO: Do we need to support quantities here?
-            }
-            else if (areDateTimes(a.low, b.low) && b.low.isMorePrecise(a.low)) {
-                [l, lc] = [other.low, other.lowClosed];
-            }
-            else {
-                [l, lc] = [this.low, this.lowClosed];
-            }
-            let h, hc;
-            if (cmp.lessThanOrEquals(a.high, b.high)) {
-                [h, hc] = [this.high, this.highClosed];
-            }
-            else if (cmp.greaterThanOrEquals(a.high, b.high)) {
-                [h, hc] = [other.high, other.highClosed];
-            }
-            else if (areNumeric(a.high, b.high)) {
-                [h, hc] = [lowestNumericUncertainty(a.high, b.high), true];
-                // TODO: Do we need to support quantities here?
-            }
-            else if (areDateTimes(a.high, b.high) && b.high.isMorePrecise(a.high)) {
-                [h, hc] = [other.high, other.highClosed];
-            }
-            else {
-                [h, hc] = [this.high, this.highClosed];
-            }
-            return new Interval(l, h, lc, hc);
-        }
-        else {
+        // "If either argument is null, the result is null."
+        if (other == null) {
             return null;
         }
+        else if (!other.isInterval) {
+            throw new Error('Argument to intersect must be an interval');
+        }
+        // "If the arguments do not overlap, this operator returns null."
+        if (!this.overlaps(other)) {
+            return null;
+        }
+        // "... the operator returns the interval that defines the overlapping portion of both
+        // arguments."
+        // Note: This spec definition isn't very precise, so we'll approach it similar to union:
+        // The interval that starts at the latest starting point in either argument, and ends at the
+        // earliest ending point in either argument.
+        let latestStart;
+        const thisIsLater = cmp.greaterThan(this.start(), other.start());
+        if (thisIsLater == null) {
+            latestStart = highestUncertainty(this.start(), other.start());
+        }
+        else {
+            latestStart = thisIsLater ? this.start() : other.start();
+        }
+        let earliestEnd;
+        const thisIsEarlier = cmp.lessThan(this.end(), other.end());
+        if (thisIsEarlier == null) {
+            earliestEnd = lowestUncertainty(this.end(), other.end());
+        }
+        else {
+            earliestEnd = thisIsEarlier ? this.end() : other.end();
+        }
+        return normalizeInterval(new Interval(latestStart, earliestEnd, true, true, this.pointType ?? other.pointType));
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#except
     except(other) {
+        // "If either argument is null, the result is null."
         if (other === null) {
             return null;
         }
-        if (other == null || !other.isInterval) {
+        else if (!other.isInterval) {
             throw new Error('Argument to except must be an interval');
         }
-        const ol = this.overlaps(other);
-        if (ol === true) {
-            const olb = this.overlapsBefore(other);
-            const ola = this.overlapsAfter(other);
-            if (olb === true && ola === false) {
-                return new Interval(this.low, other.low, this.lowClosed, !other.lowClosed);
-            }
-            else if (ola === true && olb === false) {
-                return new Interval(other.high, this.high, !other.highClosed, this.highClosed);
-            }
-            else {
-                return null;
-            }
+        // "... this operator returns the portion of the first interval that does not overlap with the
+        // second."
+        // Unresolved zulip: https://chat.fhir.org/#narrow/channel/179220-cql/topic/Unions.20on.20Date.20Intervals.20w.2F.20Different.20Precision/near/609516976
+        let precision;
+        if (this.pointType === elmTypes_1.ELM_DATE_TYPE ||
+            this.pointType === elmTypes_1.ELM_DATETIME_TYPE ||
+            this.pointType === elmTypes_1.ELM_TIME_TYPE) {
+            const boundaries = [this.low, this.high, other.low, other.high];
+            const leastPreciseBoundary = boundaries.reduce((least, boundary) => boundary?.isLessPrecise(least) ? boundary : least);
+            precision = leastPreciseBoundary?.getPrecision();
         }
-        else if (ol === false) {
-            return this;
+        if (this.overlaps(other, precision) === false) {
+            return this.copy();
         }
-        else {
-            // ol is null
-            return null;
+        const overlapsBefore = this.overlapsBefore(other, precision);
+        const overlapsAfter = this.overlapsAfter(other, precision);
+        if (overlapsBefore && !overlapsAfter) {
+            return normalizeInterval(new Interval(this.start(), other.start(), true, false, this.pointType));
         }
+        else if (overlapsAfter && !overlapsBefore) {
+            return normalizeInterval(new Interval(other.end(), this.end(), false, true, this.pointType));
+        }
+        return null;
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#same-as-2
     sameAs(other, precision) {
-        // This large if and else if block handles the scenarios where there is an open ended null
-        // If both lows or highs exists, it can be determined that intervals are not Same As
-        if ((this.low != null &&
-            other.low != null &&
-            this.high == null &&
-            other.high != null &&
-            !this.highClosed) ||
-            (this.low != null &&
-                other.low != null &&
-                this.high != null &&
-                other.high == null &&
-                !other.highClosed) ||
-            (this.low != null &&
-                other.low != null &&
-                this.high == null &&
-                other.high == null &&
-                !other.highClosed &&
-                !this.highClosed)) {
-            if (typeof this.low === 'number' || typeof this.low === 'bigint') {
-                if (!(this.start() === other.start())) {
-                    return false;
-                }
-            }
-            else {
-                if (!this.start().sameAs(other.start(), precision)) {
-                    return false;
-                }
-            }
-        }
-        else if ((this.low != null && other.low == null && this.high != null && other.high != null) ||
-            (this.low == null && other.low != null && this.high != null && other.high != null) ||
-            (this.low == null && other.low == null && this.high != null && other.high != null)) {
-            if (typeof this.high === 'number' || typeof this.high === 'bigint') {
-                if (!(this.end() === other.end())) {
-                    return false;
-                }
-            }
-            else {
-                if (!this.end().sameAs(other.end(), precision)) {
-                    return false;
-                }
-            }
-        }
-        // Checks to see if any of the Intervals have a open, null boundary
-        if ((this.low == null && !this.lowClosed) ||
-            (this.high == null && !this.highClosed) ||
-            (other.low == null && !other.lowClosed) ||
-            (other.high == null && !other.highClosed)) {
+        // "If either or both arguments are null, the result is null."
+        if (other === null) {
             return null;
         }
-        // For the special cases where @ is Interval[null,null]
-        if (this.lowClosed && this.low == null && this.highClosed && this.high == null) {
-            return other.lowClosed && other.low == null && other.highClosed && other.high == null;
-        }
-        // For the special case where Interval[...] same as Interval[null,null] should return false.
-        // This accounts for the inverse of the if statement above: where the second Interval is
-        // [null,null] and not the first Interval.
-        // The reason why this isn't caught below is due to how start() and end() work.
-        // There is no way to tell the datatype for MIN and MAX if both boundaries are null.
-        if (other.lowClosed && other.low == null && other.highClosed && other.high == null) {
-            return false;
-        }
-        if (typeof this.low === 'number' || typeof this.low === 'bigint') {
-            return this.start() === other.start() && this.end() === other.end();
+        // "When this operator is called with a mixture of Date- and DateTime-based intervals, the
+        // Date values will be implicitly converted to DateTime values as defined by the ToDateTime
+        // operator."
+        // NOTE: Usually the translator will handle this implicit conversion, but just in case...
+        const [left, right] = performConversionIfNecessary(this, other);
+        // "... the two intervals start and end at the same value, using the semantics described in the
+        // Start and End operators to determine interval boundaries, and for Date, DateTime, or Time
+        // value, performing the comparisons at the specified precision, as described in the Same As
+        // operator for Date, DateTime, or Time values."
+        if (left.pointType === elmTypes_1.ELM_DATE_TYPE ||
+            left.pointType === elmTypes_1.ELM_DATETIME_TYPE ||
+            left.pointType === elmTypes_1.ELM_TIME_TYPE) {
+            return logic_1.ThreeValuedLogic.and(left.start().sameAs(right.start(), precision), left.end().sameAs(right.end(), precision));
         }
         else {
-            return (this.start().sameAs(other.start(), precision) && this.end().sameAs(other.end(), precision));
+            return logic_1.ThreeValuedLogic.and(cmp.equals(left.start(), right.start()), cmp.equals(left.end(), right.end()));
         }
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#same-or-after-2
     sameOrBefore(other, precision) {
-        if (this.isBoundlessInterval || other?.isBoundlessInterval) {
-            return this.equals(other);
-        }
-        if (this.end() == null || other == null || other.start() == null) {
+        // "If either or both arguments are null, the result is null."
+        if (other === null) {
             return null;
         }
-        else {
-            return cmp.lessThanOrEquals(this.end(), other.start(), precision);
+        // "When this operator is called with a mixture of point values and intervals, the point
+        // values are implicitly converted to an interval starting and ending on the given point
+        // value."
+        if (!other.isInterval) {
+            other = new Interval(other, other, true, true, this.pointType);
         }
+        // "When this operator is called with a mixture of Date- and DateTime-based intervals, the
+        // Date values will be implicitly converted to DateTime values as defined by the ToDateTime
+        // operator."
+        // NOTE: Usually the translator will handle this implicit conversion, but just in case...
+        const [left, right] = performConversionIfNecessary(this, other);
+        // "... the first interval ends on or before the second one starts, using the semantics
+        // described in the Start and End operators to determine interval boundaries, and for Date,
+        // DateTime, or Time values, performing the comparisons at the specified precision, as
+        // described in the Same or Before (Date, DateTime, or Time) operator for Date, DateTime, or
+        // Time values."
+        return cmp.lessThanOrEquals(left.end(), right.start(), precision);
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#same-or-after-2
     sameOrAfter(other, precision) {
-        if (this.isBoundlessInterval || other?.isBoundlessInterval) {
-            return this.equals(other);
-        }
-        if (this.start() == null || other == null || other.end() == null) {
+        // "If either or both arguments are null, the result is null."
+        if (other === null) {
             return null;
         }
-        else {
-            return cmp.greaterThanOrEquals(this.start(), other.end(), precision);
+        // "When this operator is called with a mixture of point values and intervals, the point
+        // values are implicitly converted to an interval starting and ending on the given point
+        // value."
+        if (!other.isInterval) {
+            other = new Interval(other, other, true, true, this.pointType);
         }
+        // "When this operator is called with a mixture of Date- and DateTime-based intervals, the
+        // Date values will be implicitly converted to DateTime values as defined by the ToDateTime
+        // operator."
+        // NOTE: Usually the translator will handle this implicit conversion, but just in case...
+        const [left, right] = performConversionIfNecessary(this, other);
+        // "... the first interval starts on or after the second one ends, using the semantics
+        // described in the Start and End operators to determine interval boundaries, and for Date,
+        // DateTime, or Time values, performing the comparisons at the specified precision, as
+        // described in the Same or After (Date, DateTime, or Time) operator for Date, DateTime, or
+        // Time values."
+        return cmp.greaterThanOrEquals(left.start(), right.end(), precision);
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#equal-1
     equals(other) {
-        if (other != null && other.isInterval) {
-            if (this.isBoundlessInterval) {
-                return other.isBoundlessInterval ? true : other.isUnknownInterval ? null : false;
-            }
-            else if (other.isBoundlessInterval) {
-                return this.isUnknownInterval ? null : false;
-            }
-            const [a, b] = [this.toClosed(), other.toClosed()];
-            return logic_1.ThreeValuedLogic.and(cmp.equals(a.low, b.low), cmp.equals(a.high, b.high));
+        // "If either argument is null, the result is null."
+        if (other == null) {
+            return null;
         }
-        else {
+        // "... the intervals are over the same point type..."
+        if (this.pointType !== other.pointType) {
             return false;
         }
+        // ... and they have the same value for the starting and ending points of the intervals as
+        // determined by the Start and End operators."
+        return logic_1.ThreeValuedLogic.and(cmp.equals(this.start(), other.start()), cmp.equals(this.end(), other.end()));
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#after-1
     after(other, precision) {
-        if (this.isBoundlessInterval || other?.isBoundlessInterval) {
-            return false;
+        // "If either argument is null, the result is null."
+        if (other == null) {
+            return null;
         }
-        const closed = this.toClosed();
-        // Meets spec, but not 100% correct (e.g., (null, 5] after [6, 10] --> null)
-        // Simple way to fix it: and w/ not overlaps
-        if (other.toClosed) {
-            return cmp.greaterThan(closed.low, other.toClosed().high, precision);
+        // "... For the interval-point overload, the operator returns true if the given interval
+        // starts after the given point."
+        if (!other.isInterval) {
+            return cmp.greaterThan(this.start(), other, precision);
         }
-        else {
-            return cmp.greaterThan(closed.low, other, precision);
-        }
+        // "... the starting point of the first interval is greater than the ending point of the
+        // second interval."
+        return cmp.greaterThan(this.start(), other.end(), precision);
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#before-1
     before(other, precision) {
-        if (this.isBoundlessInterval || other?.isBoundlessInterval) {
-            return false;
+        // "If either argument is null, the result is null."
+        if (other == null) {
+            return null;
         }
-        const closed = this.toClosed();
-        // Meets spec, but not 100% correct (e.g., (null, 5] after [6, 10] --> null)
-        // Simple way to fix it: and w/ not overlaps
-        if (other.toClosed) {
-            return cmp.lessThan(closed.high, other.toClosed().low, precision);
+        // "For the interval-point overload, the operator returns true if the given interval ends
+        // before the given point."
+        if (!other.isInterval) {
+            return cmp.lessThan(this.end(), other, precision);
         }
-        else {
-            return cmp.lessThan(closed.high, other, precision);
-        }
+        // "... the ending point of the first interval is less than the starting point of the
+        // second interval."
+        return cmp.lessThan(this.end(), other.start(), precision);
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#meets
     meets(other, precision) {
-        if (this.isBoundlessInterval || other?.isBoundlessInterval) {
-            return false;
+        // "If either argument is null, the result is null."
+        if (other == null) {
+            return null;
         }
+        // "... the ending point of the first interval is equal to the predecessor of the starting
+        // point of the second, or... the starting point of the first interval is equal to the
+        // successor of the ending point of the second... If precision is specified and the point type
+        // is a Date, DateTime, or Time type, comparisons used in the operation are performed at the
+        // specified precision."
         return logic_1.ThreeValuedLogic.or(this.meetsBefore(other, precision), this.meetsAfter(other, precision));
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#meets
     meetsAfter(other, precision) {
-        if (this.isBoundlessInterval || other?.isBoundlessInterval) {
-            return false;
+        // "If either argument is null, the result is null."
+        if (other == null) {
+            return null;
         }
+        // "... the starting point of the first interval is equal to the successor of the ending point
+        // of the second... If precision is specified and the point type is a Date, DateTime, or Time
+        // type, comparisons used in the operation are performed at the specified precision."
         try {
-            if (precision != null && this.low != null && this.low.isDateTime) {
-                return this.toClosed().low.sameAs(other.toClosed().high != null ? other.toClosed().high.add(1, precision) : null, precision);
+            if (this.pointType === elmTypes_1.ELM_DATE_TYPE ||
+                this.pointType === elmTypes_1.ELM_DATETIME_TYPE ||
+                this.pointType === elmTypes_1.ELM_TIME_TYPE) {
+                return this.start()?.sameAs((0, math_1.successor)(other.end(), other.pointType, precision), precision);
             }
-            else {
-                return cmp.equals(this.toClosed().low, (0, math_1.successor)(other.toClosed().high, other.pointType));
-            }
+            return cmp.equals(this.start(), (0, math_1.successor)(other.end(), other.pointType));
         }
         catch {
             return false;
         }
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#meets
     meetsBefore(other, precision) {
-        if (this.isBoundlessInterval || other?.isBoundlessInterval) {
-            return false;
+        // "If either argument is null, the result is null."
+        if (other == null) {
+            return null;
         }
+        // "... the ending point of the first interval is equal to the predecessor of the starting
+        // point of the second... If precision is specified and the point type is a Date, DateTime, or
+        // Time type, comparisons used in the operation are performed at the specified precision."
         try {
-            if (precision != null && this.high != null && this.high.isDateTime) {
-                return this.toClosed().high.sameAs(other.toClosed().low != null ? other.toClosed().low.add(-1, precision) : null, precision);
+            if (this.pointType === elmTypes_1.ELM_DATE_TYPE ||
+                this.pointType === elmTypes_1.ELM_DATETIME_TYPE ||
+                this.pointType === elmTypes_1.ELM_TIME_TYPE) {
+                return this.end()?.sameAs((0, math_1.predecessor)(other.start(), other.pointType, precision), precision);
             }
-            else {
-                return cmp.equals(this.toClosed().high, (0, math_1.predecessor)(other.toClosed().low, other.pointType));
-            }
+            return cmp.equals(this.end(), (0, math_1.predecessor)(other.start(), other.pointType));
         }
         catch {
             return false;
         }
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#start
     start() {
+        // "If the low boundary of the interval is closed and null, this operator returns the minimum
+        // value for the point type of the interval."
         if (this.low == null) {
             const quantityInstance = this.high && this.pointType == elmTypes_1.ELM_QUANTITY_TYPE ? this.high : undefined;
             const minValue = (0, math_1.minValueForType)(this.pointType, quantityInstance);
@@ -2295,13 +2248,22 @@ class Interval {
                 return minValue;
             }
             else {
+                // "If the low boundary of the interval is open and null, this operator returns an
+                // uncertainty from the minimum value for the point type of the interval to the high
+                // boundary of the interval (using End operator semantics to determine the high boundary)."
                 const end = ((end) => (end.isUncertainty ? end.high : end))(this.high == null ? (0, math_1.maxValueForType)(this.pointType) : this.end());
                 return new uncertainty_1.Uncertainty(minValue, end);
             }
         }
+        // "If the low boundary of the interval is closed and non-null, this operator returns the low
+        // value of the interval... If the low boundary of the interval is open and non-null, this
+        // operator returns the successor of the low value of the interval."
         return this.lowClosed ? this.low : (0, math_1.successor)(this.low, this.pointType);
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#end
     end() {
+        // "If the high boundary of the interval is closed and null, this operator returns the maximum
+        // value for the point type of the interval."
         if (this.high == null) {
             const quantityInstance = this.low && this.pointType == elmTypes_1.ELM_QUANTITY_TYPE ? this.low : undefined;
             const maxValue = (0, math_1.maxValueForType)(this.pointType, quantityInstance);
@@ -2309,135 +2271,119 @@ class Interval {
                 return maxValue;
             }
             else {
+                // "If the high boundary of the interval is open and null, this operator returns an
+                // uncertainty from the low boundary of the interval (using Start operator semantics to
+                // determine the low boundary) to the maximum value for the point type of the interval."
                 const start = ((start) => (start.isUncertainty ? start.low : start))(this.low == null ? (0, math_1.minValueForType)(this.pointType) : this.start());
                 return new uncertainty_1.Uncertainty(start, maxValue);
             }
         }
+        // "If the high boundary of the interval is closed and non-null, this operator returns the high
+        // value of the interval... If the high boundary of the interval is open and non-null, this
+        // operator returns the predecessor of the high value of the interval."
         return this.highClosed ? this.high : (0, math_1.predecessor)(this.high, this.pointType);
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#starts
     starts(other, precision) {
-        if (this.isBoundlessInterval) {
-            return other.isBoundlessInterval ? true : other.isUnknownInterval ? null : false;
+        // "If either argument is null, the result is null."
+        if (other == null) {
+            return null;
         }
-        else if (other?.isBoundlessInterval) {
-            return this.isUnknownInterval ? null : false;
-        }
-        let startEqual;
-        if (precision != null && this.low != null && this.low.isDateTime) {
-            startEqual = this.low.sameAs(other.low, precision);
+        // "... the starting point of the first is equal to the starting point of the second interval
+        // and the ending point of the first interval is less than or equal to the ending point of the
+        // second interval."
+        if (precision &&
+            [elmTypes_1.ELM_DATETIME_TYPE, elmTypes_1.ELM_DATE_TYPE, elmTypes_1.ELM_TIME_TYPE].includes(this.pointType ?? other.pointType)) {
+            // "If precision is specified and the point type is a Date, DateTime, or Time type,
+            // comparisons used in the operation are performed at the specified precision."
+            return logic_1.ThreeValuedLogic.and(this.start().sameAs(other.start(), precision), cmp.lessThanOrEquals(this.end(), other.end(), precision));
         }
         else {
-            startEqual = cmp.equals(this.low, other.low);
+            return logic_1.ThreeValuedLogic.and(cmp.equals(this.start(), other.start()), cmp.lessThanOrEquals(this.end(), other.end()));
         }
-        const endLessThanOrEqual = cmp.lessThanOrEquals(this.high, other.high, precision);
-        return startEqual && endLessThanOrEqual;
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#ends
     ends(other, precision) {
-        if (this.isBoundlessInterval) {
-            return other.isBoundlessInterval ? true : other.isUnknownInterval ? null : false;
+        // "If either argument is null, the result is null."
+        if (other == null) {
+            return null;
         }
-        else if (other?.isBoundlessInterval) {
-            return this.isUnknownInterval ? null : false;
-        }
-        let endEqual;
-        const startGreaterThanOrEqual = cmp.greaterThanOrEquals(this.low, other.low, precision);
-        if (precision != null && (this.low != null ? this.low.isDateTime : undefined)) {
-            endEqual = this.high.sameAs(other.high, precision);
+        // "... the starting point of the first interval is greater than or equal to the starting point
+        // of the second, and the ending point of the first interval is equal to the ending point of
+        // the second."
+        if (precision &&
+            [elmTypes_1.ELM_DATETIME_TYPE, elmTypes_1.ELM_DATE_TYPE, elmTypes_1.ELM_TIME_TYPE].includes(this.pointType ?? other.pointType)) {
+            // "If precision is specified and the point type is a Date, DateTime, or Time type,
+            // comparisons used in the operation are performed at the specified precision."
+            return logic_1.ThreeValuedLogic.and(cmp.greaterThanOrEquals(this.start(), other.start(), precision), this.end().sameAs(other.end(), precision));
         }
         else {
-            endEqual = cmp.equals(this.high, other.high);
+            return logic_1.ThreeValuedLogic.and(cmp.greaterThanOrEquals(this.start(), other.start()), cmp.equals(this.end(), other.end()));
         }
-        return startGreaterThanOrEqual && endEqual;
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#width
     width() {
-        if ((this.low != null && (this.low.isDateTime || this.low.isDate)) ||
-            (this.high != null && (this.high.isDateTime || this.high.isDate))) {
+        // "Note that because CQL defines duration and difference operations for date and time valued
+        // intervals, width is not defined for intervals of these types."
+        if (this.pointType === elmTypes_1.ELM_DATE_TYPE ||
+            this.pointType === elmTypes_1.ELM_DATETIME_TYPE ||
+            this.pointType === elmTypes_1.ELM_TIME_TYPE) {
             throw new Error('Width of Date, DateTime, and Time intervals is not supported');
         }
-        const closed = this.toClosed();
-        if ((closed.low != null && closed.low.isUncertainty) ||
-            (closed.high != null && closed.high.isUncertainty)) {
-            return null;
-        }
-        else if (closed.low.isQuantity) {
-            if (closed.low.unit !== closed.high.unit) {
-                throw new Error('Cannot calculate width of Quantity Interval with different units');
-            }
-            let diff = closed.high.value - closed.low.value;
-            diff = Math.round(diff * Math.pow(10, 8)) / Math.pow(10, 8);
-            return new quantity_1.Quantity(diff, closed.low.unit);
-        }
-        else if (typeof closed.low === 'bigint') {
-            return closed.high - closed.low;
-        }
-        else {
-            // TODO: Fix precision to 8 decimals in other places that return numbers
-            const diff = closed.high - closed.low;
-            return Math.round(diff * Math.pow(10, 8)) / Math.pow(10, 8);
-        }
+        // "The result of this operator is equivalent to invoking: (end of argument – start of argument)."
+        const end = this.end();
+        const start = this.start();
+        return (0, math_1.limitDecimalPrecision)((0, math_1.subtract)(end, start, this.pointType));
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#size
     size() {
-        if ((this.low != null && (this.low.isDateTime || this.low.isDate)) ||
-            (this.high != null && (this.high.isDateTime || this.high.isDate))) {
+        // "Note that because CQL defines duration and difference operations for date and time valued
+        // intervals, size is not defined for intervals of these types."
+        if (this.pointType === elmTypes_1.ELM_DATE_TYPE ||
+            this.pointType === elmTypes_1.ELM_DATETIME_TYPE ||
+            this.pointType === elmTypes_1.ELM_TIME_TYPE) {
             throw new Error('Size of Date, DateTime, and Time intervals is not supported');
         }
-        const closed = this.toClosed();
-        if ((closed.low != null && closed.low.isUncertainty) ||
-            (closed.high != null && closed.high.isUncertainty)) {
-            return null;
-        }
-        const pointSize = this.getPointSize();
-        if (closed.low.isQuantity) {
-            if (closed.low.unit !== closed.high.unit) {
-                throw new Error('Cannot calculate size of Quantity Interval with different units');
-            }
-            let diff = closed.high.value - closed.low.value + pointSize.value;
-            diff = Math.round(diff * Math.pow(10, 8)) / Math.pow(10, 8);
-            return new quantity_1.Quantity(diff, closed.low.unit);
-        }
-        else if (typeof closed.low === 'bigint') {
-            return closed.high - closed.low + pointSize;
-        }
-        else {
-            const diff = closed.high - closed.low + pointSize;
-            return Math.round(diff * Math.pow(10, 8)) / Math.pow(10, 8);
-        }
+        // "The result of this operator is equivalent to invoking:
+        // (end of argument – start of argument) + point-size, where point-size is determined by
+        // successor of minimum T - minimum T."
+        return (0, math_1.limitDecimalPrecision)((0, math_1.add)((0, math_1.subtract)(this.end(), this.start(), this.pointType), this.getPointSize(), this.pointType));
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#size
     getPointSize() {
-        let pointSize;
-        if (this.low != null) {
-            if (this.low.isDateTime || this.low.isDate || this.low.isTime) {
-                pointSize = new quantity_1.Quantity(1, this.low.getPrecision());
-            }
-            else if (this.low.isQuantity) {
-                pointSize = (0, quantity_1.doSubtraction)((0, math_1.successor)(this.low, this.pointType), this.low);
-            }
-            else {
-                pointSize = (0, math_1.successor)(this.low, this.pointType) - this.low;
-            }
-        }
-        else if (this.high != null) {
-            if (this.high.isDateTime || this.high.isDate || this.high.isTime) {
-                pointSize = new quantity_1.Quantity(1, this.high.getPrecision());
-            }
-            else if (this.high.isQuantity) {
-                pointSize = (0, quantity_1.doSubtraction)(this.high, (0, math_1.predecessor)(this.high, this.pointType));
-            }
-            else {
-                pointSize = this.high - (0, math_1.predecessor)(this.high, this.pointType);
-            }
+        // "... point-size is determined by successor of minimum T - minimum T"
+        let minValue;
+        if (this.pointType != null && this.pointType !== elmTypes_1.ELM_ANY_TYPE) {
+            minValue = (0, math_1.minValueForType)(this.pointType, this.pointType === elmTypes_1.ELM_QUANTITY_TYPE ? (this.low ?? this.high) : undefined);
         }
         else {
-            throw new Error('Point type of interval cannot be determined.');
+            minValue = (0, math_1.minValueForInstance)(this.low ?? this.high);
         }
-        return pointSize;
+        // due to floating point issues in JS, we must use 0.0 for Decimal/Quantity instead of min
+        if (minValue === limits_1.MIN_FLOAT_VALUE) {
+            minValue = 0.0;
+        }
+        else if (minValue.isQuantity) {
+            minValue.value = 0.0;
+        }
+        if (minValue != null) {
+            if (minValue.isDate || minValue.isDatetime || minValue.isTime) {
+                // Legacy approach: we have been using minimum specified precision to get point size for
+                // Date/DateTime/Time intervals. This makes sense to us (vs always using ms) but the spec
+                // doesn't indicate this so we need to verify the expected implementation w/ the spec team.
+                // E.g., point size of Interval[@2012-01, @2012-12] is 1 month, not 1 ms.
+                return new quantity_1.Quantity(1, (this.low ?? this.high).getPrecision());
+            }
+            return (0, math_1.subtract)((0, math_1.successor)(minValue, this.pointType), minValue, this.pointType);
+        }
+        throw new Error('Point type of interval cannot be determined.');
     }
     toClosed() {
         // Calculate the closed flags. Despite the name of this function, if a boundary is null open,
         // we cannot close the boundary because that changes its meaning from "unknown" to "max/min value"
         const lowClosed = this.lowClosed || this.low != null;
         const highClosed = this.highClosed || this.high != null;
-        if (this.pointType != null) {
+        if (this.pointType != null && this.pointType !== elmTypes_1.ELM_ANY_TYPE) {
             let low;
             if (this.lowClosed && this.low == null) {
                 low = (0, math_1.minValueForType)(this.pointType);
@@ -2477,50 +2423,125 @@ class Interval {
     }
 }
 exports.Interval = Interval;
-function areDateTimes(x, y) {
-    return [x, y].every(z => z != null && z.isDateTime);
+// Return an interval that uses the standard null boundary conventions if appropriate:
+// - low closed boundary with min value for the type is changed to null closed boundary
+// - high closed boundary with max value for the type is changed to null closed boundary
+// - low open boundary that is uncertainty from min value of type to max value or interval high
+//   value is changed to null open boundary
+// - high open boundary that is uncertainty from min value of type or interval low value to max
+//   value of type is changed to null open boundary
+//
+// TODO: Is this necessary? Do we care how it is represented if the representations have the same
+// meaning? This does affect test expectations and representation of returned results for callers.
+function normalizeInterval(interval) {
+    const ivl = interval.copy();
+    if (ivl.low != null && ivl.lowClosed !== false) {
+        if (ivl.low.isUncertainty) {
+            const minValue = (0, math_1.minValueForInstance)(ivl.low.low);
+            const maxValue = (0, math_1.maxValueForInstance)(ivl.low.low);
+            if (cmp.equals(ivl.low.low, minValue) &&
+                (cmp.equals(ivl.low.high, maxValue) || cmp.equals(ivl.low.high, ivl.high))) {
+                ivl.low = null;
+                ivl.lowClosed = false;
+            }
+        }
+        else if (cmp.equals(ivl.low, (0, math_1.minValueForInstance)(ivl.low))) {
+            ivl.low = null;
+        }
+    }
+    if (ivl.high != null && ivl.highClosed !== false) {
+        if (ivl.high.isUncertainty) {
+            const minValue = (0, math_1.minValueForInstance)(ivl.high.low);
+            const maxValue = (0, math_1.maxValueForInstance)(ivl.high.low);
+            if (cmp.equals(ivl.high.high, maxValue) &&
+                (cmp.equals(ivl.high.low, minValue) || cmp.equals(ivl.high.low, ivl.low))) {
+                ivl.high = null;
+                ivl.highClosed = false;
+            }
+        }
+        else if (cmp.equals(ivl.high, (0, math_1.maxValueForInstance)(ivl.high))) {
+            ivl.high = null;
+        }
+    }
+    return ivl;
 }
-function areNumeric(x, y) {
-    return [x, y].every(z => {
-        return (typeof z === 'number' ||
-            typeof z === 'bigint' ||
-            (z != null && z.isUncertainty && (typeof z.low === 'number' || typeof z.low === 'bigint')));
-    });
+function performConversionIfNecessary(left, right) {
+    if (left.pointType === elmTypes_1.ELM_DATE_TYPE && right.pointType === elmTypes_1.ELM_DATETIME_TYPE) {
+        left = new Interval(left.low?.getDateTime(), left.high?.getDateTime(), left.lowClosed, left.highClosed, elmTypes_1.ELM_DATETIME_TYPE);
+    }
+    else if (left.pointType === elmTypes_1.ELM_DATETIME_TYPE && right.pointType === elmTypes_1.ELM_DATE_TYPE) {
+        right = new Interval(right.low?.getDateTime(), right.high?.getDateTime(), right.lowClosed, right.highClosed, elmTypes_1.ELM_DATETIME_TYPE);
+    }
+    return [left, right];
 }
-function lowestNumericUncertainty(x, y) {
-    if (x == null || !x.isUncertainty) {
+function lowestUncertainty(x, y) {
+    if (!x?.isUncertainty) {
         x = new uncertainty_1.Uncertainty(x);
     }
-    if (y == null || !y.isUncertainty) {
+    if (!y?.isUncertainty) {
         y = new uncertainty_1.Uncertainty(y);
     }
-    const low = x.low < y.low ? x.low : y.low;
-    const high = x.high < y.high ? x.high : y.high;
-    if (low !== high) {
-        return new uncertainty_1.Uncertainty(low, high);
+    // Note: If the following comparisons result in null, we're dealing with date imprecision.
+    // The spec doesn't currently say what to do; but it will be updated to indicate that the
+    // coursest precision should be used (which is consistent with collapse)
+    // https://chat.fhir.org/#narrow/channel/179220-cql/topic/Unions.20on.20Date.20Intervals.20w.2F.20Different.20Precision/near/609310186
+    let low;
+    const xLowIsLower = cmp.lessThan(x.low, y.low);
+    if (xLowIsLower == null && x.low?.isLessPrecise) {
+        low = x.low.isLessPrecise(y.low) ? x.low : y.low;
     }
     else {
+        low = xLowIsLower ? x.low : y.low;
+    }
+    let high;
+    const xHighIsLower = cmp.lessThan(x.high, y.high);
+    if (xHighIsLower == null && x.high?.isLessPrecise) {
+        high = x.high.isLessPrecise(y.high) ? x.high : y.high;
+    }
+    else {
+        high = xHighIsLower ? x.high : y.high;
+    }
+    // use equivalent to consider nulls equal
+    if (cmp.equivalent(low, high)) {
         return low;
     }
+    return new uncertainty_1.Uncertainty(low, high);
 }
-function highestNumericUncertainty(x, y) {
-    if (x == null || !x.isUncertainty) {
+function highestUncertainty(x, y) {
+    if (!x?.isUncertainty) {
         x = new uncertainty_1.Uncertainty(x);
     }
-    if (y == null || !y.isUncertainty) {
+    if (!y?.isUncertainty) {
         y = new uncertainty_1.Uncertainty(y);
     }
-    const low = x.low > y.low ? x.low : y.low;
-    const high = x.high > y.high ? x.high : y.high;
-    if (low !== high) {
-        return new uncertainty_1.Uncertainty(low, high);
+    // Note: If the following comparisons result in null, we're dealing with date imprecision.
+    // The spec doesn't currently say what to do; but it will be updated to indicate that the
+    // coursest precision should be used (which is consistent with collapse)
+    // https://chat.fhir.org/#narrow/channel/179220-cql/topic/Unions.20on.20Date.20Intervals.20w.2F.20Different.20Precision/near/609310186
+    let low;
+    const xLowIsHigher = cmp.greaterThan(x.low, y.low);
+    if (xLowIsHigher == null && x.low?.isLessPrecise) {
+        low = x.low.isLessPrecise(y.low) ? x.low : y.low;
     }
     else {
+        low = xLowIsHigher ? x.low : y.low;
+    }
+    let high;
+    const xHighIsHigher = cmp.greaterThan(x.high, y.high);
+    if (xHighIsHigher == null && x.high?.isLessPrecise) {
+        high = x.high.isLessPrecise(y.high) ? x.high : y.high;
+    }
+    else {
+        high = xHighIsHigher ? x.high : y.high;
+    }
+    // use equivalent to consider nulls equal
+    if (cmp.equivalent(low, high)) {
         return low;
     }
+    return new uncertainty_1.Uncertainty(low, high);
 }
 
-},{"../util/comparison":53,"../util/elmTypes":55,"../util/math":57,"./logic":11,"./quantity":12,"./uncertainty":14}],11:[function(require,module,exports){
+},{"../util/comparison":53,"../util/elmTypes":55,"../util/limits":57,"../util/math":58,"./logic":11,"./quantity":12,"./uncertainty":14}],11:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ThreeValuedLogic = void 0;
@@ -2582,7 +2603,7 @@ exports.ThreeValuedLogic = ThreeValuedLogic;
 },{}],12:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.MAX_QUANTITY_VALUE = exports.MIN_QUANTITY_VALUE = exports.Quantity = void 0;
+exports.Quantity = void 0;
 exports.parseQuantity = parseQuantity;
 exports.doAddition = doAddition;
 exports.doSubtraction = doSubtraction;
@@ -2722,10 +2743,6 @@ class Quantity {
     }
 }
 exports.Quantity = Quantity;
-// Require MIN/MAX here because math.js requires this file, and when we make this file require
-// math.js before it exports DateTime and Date, it errors due to the circular dependency...
-exports.MIN_QUANTITY_VALUE = new Quantity(math_1.MIN_FLOAT_VALUE, '1');
-exports.MAX_QUANTITY_VALUE = new Quantity(math_1.MAX_FLOAT_VALUE, '1');
 function parseQuantity(str) {
     const components = /([+|-]?\d+\.?\d*)\s*('(.+)')?/.exec(str);
     if (components != null && components[1] != null) {
@@ -2746,33 +2763,11 @@ function parseQuantity(str) {
         return null;
     }
 }
-function doScaledAddition(a, b, scaleForB) {
-    if (a != null && a.isQuantity && b != null && b.isQuantity) {
-        const [val1, unit1, val2, unit2] = (0, units_1.normalizeUnitsWhenPossible)(a.value, a.unit, b.value * scaleForB, b.unit);
-        if (unit1 !== unit2) {
-            // not compatible units, so we can't do addition
-            return null;
-        }
-        const sum = val1 + val2;
-        if ((0, math_1.overflowsOrUnderflows)(sum, elmTypes_1.ELM_DECIMAL_TYPE)) {
-            return null;
-        }
-        return new Quantity(sum, unit1);
-    }
-    else if (a.copy && a.add) {
-        // Date / DateTime require a CQL time unit
-        const cqlUnitB = (0, units_1.convertToCQLDateUnit)(b.unit) || b.unit;
-        return a.copy().add(b.value * scaleForB, cqlUnitB);
-    }
-    else {
-        throw new Error('Unsupported argument types.');
-    }
-}
 function doAddition(a, b) {
-    return doScaledAddition(a, b, 1);
+    return (0, math_1.add)(a, b);
 }
 function doSubtraction(a, b) {
-    return doScaledAddition(a, b, -1);
+    return (0, math_1.subtract)(a, b);
 }
 function doDivision(a, b) {
     if (a != null && a.isQuantity) {
@@ -2788,7 +2783,7 @@ function doMultiplication(a, b) {
     }
 }
 
-},{"../util/elmTypes":55,"../util/math":57,"../util/units":58}],13:[function(require,module,exports){
+},{"../util/elmTypes":55,"../util/math":58,"../util/units":59}],13:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Ratio = void 0;
@@ -2915,6 +2910,30 @@ class Uncertainty {
             (lte(this.low, this.high) ?? false) &&
             (gte(this.low, this.high) ?? false));
     }
+    sameAs(other, precision) {
+        // if this is a point, and other is not an uncertainty or a point, then we can compare directly
+        if (this.isPoint()) {
+            const sameFn = (a, b) => {
+                if (typeof a !== typeof b || a?.constructor !== b?.constructor) {
+                    return false;
+                }
+                if (typeof a.sameAs === 'function') {
+                    return a.sameAs(b, precision);
+                }
+                else {
+                    return (0, comparison_1.equals)(a, b);
+                }
+            };
+            if (!(other instanceof Uncertainty)) {
+                return sameFn(this.low, other);
+            }
+            if (other.isPoint()) {
+                return sameFn(this.low, other.low);
+            }
+        }
+        other = Uncertainty.from(other);
+        return logic_1.ThreeValuedLogic.not(logic_1.ThreeValuedLogic.or(this.lessThan(other, precision), this.greaterThan(other, precision)));
+    }
     equals(other) {
         // if this is a point, and other is not an uncertainty or a point, then we can compare directly
         if (this.isPoint()) {
@@ -2928,13 +2947,13 @@ class Uncertainty {
         other = Uncertainty.from(other);
         return logic_1.ThreeValuedLogic.not(logic_1.ThreeValuedLogic.or(this.lessThan(other), this.greaterThan(other)));
     }
-    lessThan(other) {
+    lessThan(other, precision) {
         const lt = (a, b) => {
             if (typeof a !== typeof b || a?.constructor !== b?.constructor) {
                 return null;
             }
             if (typeof a.before === 'function') {
-                return a.before(b);
+                return a.before(b, precision);
             }
             else {
                 return a < b;
@@ -2950,14 +2969,14 @@ class Uncertainty {
             return null;
         }
     }
-    greaterThan(other) {
-        return Uncertainty.from(other).lessThan(this);
+    greaterThan(other, precision) {
+        return Uncertainty.from(other).lessThan(this, precision);
     }
-    lessThanOrEquals(other) {
-        return logic_1.ThreeValuedLogic.not(this.greaterThan(Uncertainty.from(other)));
+    lessThanOrEquals(other, precision) {
+        return logic_1.ThreeValuedLogic.not(this.greaterThan(Uncertainty.from(other), precision));
     }
-    greaterThanOrEquals(other) {
-        return logic_1.ThreeValuedLogic.not(this.lessThan(Uncertainty.from(other)));
+    greaterThanOrEquals(other, precision) {
+        return logic_1.ThreeValuedLogic.not(this.lessThan(Uncertainty.from(other), precision));
     }
 }
 exports.Uncertainty = Uncertainty;
@@ -3401,7 +3420,7 @@ function medianOfNumbers(numbers) {
     }
 }
 
-},{"../datatypes/datatypes":7,"../datatypes/exception":9,"../util/comparison":53,"../util/elmTypes":55,"../util/math":57,"../util/util":59,"./builder":17,"./expression":23}],16:[function(require,module,exports){
+},{"../datatypes/datatypes":7,"../datatypes/exception":9,"../util/comparison":53,"../util/elmTypes":55,"../util/math":58,"../util/util":60,"./builder":17,"./expression":23}],16:[function(require,module,exports){
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
@@ -3443,7 +3462,9 @@ const MathUtil = __importStar(require("../util/math"));
 const quantity_1 = require("../datatypes/quantity");
 const uncertainty_1 = require("../datatypes/uncertainty");
 const builder_1 = require("./builder");
+const datetime_1 = require("../datatypes/datetime");
 const elmTypes_1 = require("../util/elmTypes");
+const limits_1 = require("../util/limits");
 class Add extends expression_1.Expression {
     constructor(json) {
         super(json);
@@ -3453,35 +3474,7 @@ class Add extends expression_1.Expression {
         if (args == null || args.some((x) => x == null)) {
             return null;
         }
-        const sum = args.reduce((x, y) => {
-            if (x.isUncertainty && !y.isUncertainty) {
-                y = new uncertainty_1.Uncertainty(y, y);
-            }
-            else if (y.isUncertainty && !x.isUncertainty) {
-                x = new uncertainty_1.Uncertainty(x, x);
-            }
-            if (x.isQuantity || x.isDateTime || x.isDate || (x.isTime && x.isTime())) {
-                return (0, quantity_1.doAddition)(x, y);
-            }
-            else if (x.isUncertainty && y.isUncertainty) {
-                if (x.low.isQuantity ||
-                    x.low.isDateTime ||
-                    x.low.isDate ||
-                    (x.low.isTime && x.low.isTime())) {
-                    return new uncertainty_1.Uncertainty((0, quantity_1.doAddition)(x.low, y.low), (0, quantity_1.doAddition)(x.high, y.high));
-                }
-                else {
-                    return new uncertainty_1.Uncertainty(x.low + y.low, x.high + y.high);
-                }
-            }
-            else {
-                return x + y;
-            }
-        });
-        if (MathUtil.overflowsOrUnderflows(sum, this.resultTypeName)) {
-            return null;
-        }
-        return sum;
+        return MathUtil.add(args[0], args[1], this.resultTypeName);
     }
 }
 exports.Add = Add;
@@ -3494,32 +3487,7 @@ class Subtract extends expression_1.Expression {
         if (args == null || args.some((x) => x == null)) {
             return null;
         }
-        const difference = args.reduce((x, y) => {
-            if (x.isUncertainty && !y.isUncertainty) {
-                y = new uncertainty_1.Uncertainty(y, y);
-            }
-            else if (y.isUncertainty && !x.isUncertainty) {
-                x = new uncertainty_1.Uncertainty(x, x);
-            }
-            if (x.isQuantity || x.isDateTime || x.isDate) {
-                return (0, quantity_1.doSubtraction)(x, y);
-            }
-            else if (x.isUncertainty && y.isUncertainty) {
-                if (x.low.isQuantity || x.low.isDateTime || x.low.isDate) {
-                    return new uncertainty_1.Uncertainty((0, quantity_1.doSubtraction)(x.low, y.high), (0, quantity_1.doSubtraction)(x.high, y.low));
-                }
-                else {
-                    return new uncertainty_1.Uncertainty(x.low - y.high, x.high - y.low);
-                }
-            }
-            else {
-                return x - y;
-            }
-        });
-        if (MathUtil.overflowsOrUnderflows(difference, this.resultTypeName)) {
-            return null;
-        }
-        return difference;
+        return MathUtil.subtract(args[0], args[1], this.resultTypeName);
     }
 }
 exports.Subtract = Subtract;
@@ -3868,12 +3836,12 @@ class MinValue extends expression_1.Expression {
 }
 exports.MinValue = MinValue;
 MinValue.MIN_VALUES = {
-    [elmTypes_1.ELM_INTEGER_TYPE]: MathUtil.MIN_INT_VALUE,
-    [elmTypes_1.ELM_LONG_TYPE]: MathUtil.MIN_LONG_VALUE,
-    [elmTypes_1.ELM_DECIMAL_TYPE]: MathUtil.MIN_FLOAT_VALUE,
-    [elmTypes_1.ELM_DATETIME_TYPE]: MathUtil.MIN_DATETIME_VALUE,
-    [elmTypes_1.ELM_DATE_TYPE]: MathUtil.MIN_DATE_VALUE,
-    [elmTypes_1.ELM_TIME_TYPE]: MathUtil.MIN_TIME_VALUE
+    [elmTypes_1.ELM_INTEGER_TYPE]: limits_1.MIN_INT_VALUE,
+    [elmTypes_1.ELM_LONG_TYPE]: limits_1.MIN_LONG_VALUE,
+    [elmTypes_1.ELM_DECIMAL_TYPE]: limits_1.MIN_FLOAT_VALUE,
+    [elmTypes_1.ELM_DATETIME_TYPE]: datetime_1.MIN_DATETIME_VALUE,
+    [elmTypes_1.ELM_DATE_TYPE]: datetime_1.MIN_DATE_VALUE,
+    [elmTypes_1.ELM_TIME_TYPE]: datetime_1.MIN_TIME_VALUE
 };
 class MaxValue extends expression_1.Expression {
     constructor(json) {
@@ -3898,12 +3866,12 @@ class MaxValue extends expression_1.Expression {
 }
 exports.MaxValue = MaxValue;
 MaxValue.MAX_VALUES = {
-    [elmTypes_1.ELM_INTEGER_TYPE]: MathUtil.MAX_INT_VALUE,
-    [elmTypes_1.ELM_LONG_TYPE]: MathUtil.MAX_LONG_VALUE,
-    [elmTypes_1.ELM_DECIMAL_TYPE]: MathUtil.MAX_FLOAT_VALUE,
-    [elmTypes_1.ELM_DATETIME_TYPE]: MathUtil.MAX_DATETIME_VALUE,
-    [elmTypes_1.ELM_DATE_TYPE]: MathUtil.MAX_DATE_VALUE,
-    [elmTypes_1.ELM_TIME_TYPE]: MathUtil.MAX_TIME_VALUE
+    [elmTypes_1.ELM_INTEGER_TYPE]: limits_1.MAX_INT_VALUE,
+    [elmTypes_1.ELM_LONG_TYPE]: limits_1.MAX_LONG_VALUE,
+    [elmTypes_1.ELM_DECIMAL_TYPE]: limits_1.MAX_FLOAT_VALUE,
+    [elmTypes_1.ELM_DATETIME_TYPE]: datetime_1.MAX_DATETIME_VALUE,
+    [elmTypes_1.ELM_DATE_TYPE]: datetime_1.MAX_DATE_VALUE,
+    [elmTypes_1.ELM_TIME_TYPE]: datetime_1.MAX_TIME_VALUE
 };
 class Successor extends expression_1.Expression {
     constructor(json) {
@@ -3960,7 +3928,7 @@ class Predecessor extends expression_1.Expression {
 }
 exports.Predecessor = Predecessor;
 
-},{"../datatypes/quantity":12,"../datatypes/uncertainty":14,"../util/elmTypes":55,"../util/math":57,"./builder":17,"./expression":23}],17:[function(require,module,exports){
+},{"../datatypes/datetime":8,"../datatypes/quantity":12,"../datatypes/uncertainty":14,"../util/elmTypes":55,"../util/limits":57,"../util/math":58,"./builder":17,"./expression":23}],17:[function(require,module,exports){
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
@@ -4029,7 +3997,7 @@ function constructByName(name, json) {
     return new E[name](json);
 }
 
-},{"../util/util":59,"./expressions":24}],18:[function(require,module,exports){
+},{"../util/util":60,"./expressions":24}],18:[function(require,module,exports){
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
@@ -4355,7 +4323,7 @@ function calculateAge(precision, birthDate, asOf, timeZoneOffset) {
     return null;
 }
 
-},{"../datatypes/datatypes":7,"../util/util":59,"./builder":17,"./expression":23}],19:[function(require,module,exports){
+},{"../datatypes/datatypes":7,"../util/util":60,"./builder":17,"./expression":23}],19:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.GreaterOrEqual = exports.Greater = exports.LessOrEqual = exports.Less = void 0;
@@ -4792,6 +4760,9 @@ class Expression {
         if (json.resultTypeName != null) {
             this.resultTypeName = json.resultTypeName;
         }
+        if (json.resultTypeSpecifier != null) {
+            this.resultTypeSpecifier = json.resultTypeSpecifier;
+        }
     }
     async execute(ctx) {
         try {
@@ -4862,7 +4833,7 @@ class UnimplementedExpression extends Expression {
 }
 exports.UnimplementedExpression = UnimplementedExpression;
 
-},{"../util/customErrors":54,"../util/util":59,"./builder":17}],24:[function(require,module,exports){
+},{"../util/customErrors":54,"../util/util":60,"./builder":17}],24:[function(require,module,exports){
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
@@ -4990,7 +4961,7 @@ class Retrieve extends expression_1.Expression {
 }
 exports.Retrieve = Retrieve;
 
-},{"../util/util":59,"./builder":17,"./expression":23}],26:[function(require,module,exports){
+},{"../util/util":60,"./builder":17,"./expression":23}],26:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Instance = void 0;
@@ -5080,6 +5051,7 @@ exports.doUnion = doUnion;
 exports.doExcept = doExcept;
 exports.doIntersect = doIntersect;
 const expression_1 = require("./expression");
+const datetime_1 = require("../datatypes/datetime");
 const quantity_1 = require("../datatypes/quantity");
 const math_1 = require("../util/math");
 const units_1 = require("../util/units");
@@ -5095,6 +5067,7 @@ class Interval extends expression_1.Expression {
         this.highClosedExpression = (0, builder_1.build)(json.highClosedExpression);
         this.low = (0, builder_1.build)(json.low);
         this.high = (0, builder_1.build)(json.high);
+        this.pointType = this.resultTypeSpecifier?.pointType?.name;
     }
     // Define a simple getter to allow type-checking of this class without instanceof
     // and in a way that survives minification (as opposed to checking constructor.name)
@@ -5110,18 +5083,18 @@ class Interval extends expression_1.Expression {
         const highClosed = this.highClosed != null
             ? this.highClosed
             : this.highClosedExpression && (await this.highClosedExpression.execute(ctx));
-        let defaultPointType;
-        if (lowValue == null && highValue == null) {
-            // try to get the default point type from a cast
+        let effectivePointType = this.pointType;
+        if (effectivePointType == null || effectivePointType === elmTypes_1.ELM_ANY_TYPE) {
+            // try to get the point type from a cast
             if (this.low.asTypeSpecifier && this.low.asTypeSpecifier.type === elmTypes_1.ELM_NAMED_TYPE_SPECIFIER) {
-                defaultPointType = this.low.asTypeSpecifier.name;
+                effectivePointType = this.low.asTypeSpecifier.name;
             }
             else if (this.high.asTypeSpecifier &&
                 this.high.asTypeSpecifier.type === elmTypes_1.ELM_NAMED_TYPE_SPECIFIER) {
-                defaultPointType = this.high.asTypeSpecifier.name;
+                effectivePointType = this.high.asTypeSpecifier.name;
             }
         }
-        return new dtivl.Interval(lowValue, highValue, lowClosed, highClosed, defaultPointType);
+        return new dtivl.Interval(lowValue, highValue, lowClosed, highClosed, effectivePointType);
     }
 }
 exports.Interval = Interval;
@@ -5306,7 +5279,7 @@ class Start extends expression_1.Expression {
         }
         const start = interval.start();
         // fix the timezoneOffset of minimum Datetime to match context offset
-        if (start && start.isDateTime && start.equals(math_1.MIN_DATETIME_VALUE)) {
+        if (start && start.isDateTime && start.equals(datetime_1.MIN_DATETIME_VALUE)) {
             start.timezoneOffset = ctx.getTimezoneOffset();
         }
         return start;
@@ -5324,7 +5297,7 @@ class End extends expression_1.Expression {
         }
         const end = interval.end();
         // fix the timezoneOffset of maximum Datetime to match context offset
-        if (end && end.isDateTime && end.equals(math_1.MAX_DATETIME_VALUE)) {
+        if (end && end.isDateTime && end.equals(datetime_1.MAX_DATETIME_VALUE)) {
             end.timezoneOffset = ctx.getTimezoneOffset();
         }
         return end;
@@ -5464,6 +5437,7 @@ function intervalListType(intervals) {
     }
     return type;
 }
+// TODO: Move and refactor Expand implementaton into src/datatypes/interval.ts
 class Expand extends expression_1.Expression {
     constructor(json) {
         super(json);
@@ -5559,12 +5533,12 @@ class Expand extends expression_1.Expression {
         low = this.truncateToPrecision(low, per.unit);
         high = this.truncateToPrecision(high, per.unit);
         let current_high = current_low.add(per.value, per.unit).predecessor();
-        let intervalToAdd = new dtivl.Interval(current_low, current_high, true, true);
+        let intervalToAdd = new dtivl.Interval(current_low, current_high, true, true, interval.pointType);
         while (intervalToAdd.high.sameOrBefore(high)) {
             results.push(intervalToAdd);
             current_low = current_low.add(per.value, per.unit);
             current_high = current_low.add(per.value, per.unit).predecessor();
-            intervalToAdd = new dtivl.Interval(current_low, current_high, true, true);
+            intervalToAdd = new dtivl.Interval(current_low, current_high, true, true, interval.pointType);
         }
         return results;
     }
@@ -5684,6 +5658,7 @@ class Expand extends expression_1.Expression {
     }
 }
 exports.Expand = Expand;
+// TODO: Move and refactor Collapse implementaton into src/datatypes/interval.ts
 class Collapse extends expression_1.Expression {
     constructor(json) {
         super(json);
@@ -5791,7 +5766,7 @@ function collapseIntervals(intervals, perWidth) {
                 }
             }
             else if (b.low && typeof b.low.sameOrBefore === 'function') {
-                if (a.high != null && b.low.sameOrBefore((0, quantity_1.doAddition)(a.high, perWidth))) {
+                if (a.high != null && b.low.sameOrBefore((0, math_1.add)(a.high, perWidth))) {
                     if (b.high == null || b.high.after(a.high)) {
                         a.high = b.high;
                     }
@@ -5832,7 +5807,7 @@ function truncateDecimal(decimal, decimalPlaces) {
     return parseFloat(decimal.toString().match(re)[0]);
 }
 
-},{"../datatypes/interval":10,"../datatypes/quantity":12,"../util/elmTypes":55,"../util/math":57,"../util/units":58,"./builder":17,"./expression":23}],28:[function(require,module,exports){
+},{"../datatypes/datetime":8,"../datatypes/interval":10,"../datatypes/quantity":12,"../util/elmTypes":55,"../util/math":58,"../util/units":59,"./builder":17,"./expression":23}],28:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Library = void 0;
@@ -6223,7 +6198,7 @@ class Slice extends expression_1.Expression {
 exports.Slice = Slice;
 // Length is completely handled by overloaded#Length
 
-},{"../util/comparison":53,"../util/immutableUtil":56,"../util/util":59,"./builder":17,"./expression":23,"immutable":74}],30:[function(require,module,exports){
+},{"../util/comparison":53,"../util/immutableUtil":56,"../util/util":60,"./builder":17,"./expression":23,"immutable":75}],30:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.StringLiteral = exports.DecimalLiteral = exports.LongLiteral = exports.IntegerLiteral = exports.BooleanLiteral = exports.Literal = void 0;
@@ -6924,7 +6899,7 @@ class Precision extends expression_1.Expression {
 }
 exports.Precision = Precision;
 
-},{"../datatypes/datetime":8,"../datatypes/logic":11,"../util/comparison":53,"../util/elmTypes":55,"../util/util":59,"./datetime":21,"./expression":23,"./interval":27,"./list":29}],35:[function(require,module,exports){
+},{"../datatypes/datetime":8,"../datatypes/logic":11,"../util/comparison":53,"../util/elmTypes":55,"../util/util":60,"./datetime":21,"./expression":23,"./interval":27,"./list":29}],35:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ParameterRef = exports.ParameterDef = void 0;
@@ -7316,7 +7291,7 @@ function cartesianProductOf(sources) {
     }, [[]]);
 }
 
-},{"../util/util":59,"./builder":17,"./expression":23,"./list":29}],38:[function(require,module,exports){
+},{"../util/util":60,"./builder":17,"./expression":23,"./list":29}],38:[function(require,module,exports){
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
@@ -7852,6 +7827,7 @@ exports.TupleTypeSpecifier = exports.NamedTypeSpecifier = exports.ListTypeSpecif
 const expression_1 = require("./expression");
 const datetime_1 = require("../datatypes/datetime");
 const clinical_1 = require("../datatypes/clinical");
+const interval_1 = require("../datatypes/interval");
 const quantity_1 = require("../datatypes/quantity");
 const math_1 = require("../util/math");
 const util_1 = require("../util/util");
@@ -7881,6 +7857,16 @@ class As extends expression_1.Expression {
             return null;
         }
         if (ctx.matchesTypeSpecifier(arg, this.asTypeSpecifier)) {
+            // intervals track their point type, so adjust the interval point type if it does not match
+            if (arg.isInterval && this.asTypeSpecifier.type === elmTypes_1.ELM_INTERVAL_TYPE_SPECIFIER) {
+                const argInterval = arg;
+                const asIntervalSpecifier = this.asTypeSpecifier;
+                const asIntervalPointType = asIntervalSpecifier.pointType
+                    ?.name;
+                if (asIntervalPointType && argInterval.pointType !== asIntervalPointType) {
+                    return new interval_1.Interval(argInterval.low, argInterval.high, argInterval.lowClosed, argInterval.highClosed, asIntervalPointType);
+                }
+            }
             // TODO: request patient source to change type identification
             return arg;
         }
@@ -8590,7 +8576,7 @@ class TupleTypeSpecifier extends expression_1.UnimplementedExpression {
 }
 exports.TupleTypeSpecifier = TupleTypeSpecifier;
 
-},{"../datatypes/clinical":6,"../datatypes/datetime":8,"../datatypes/quantity":12,"../datatypes/ratio":13,"../datatypes/uncertainty":14,"../util/elmTypes":55,"../util/math":57,"../util/util":59,"./expression":23}],43:[function(require,module,exports){
+},{"../datatypes/clinical":6,"../datatypes/datetime":8,"../datatypes/interval":10,"../datatypes/quantity":12,"../datatypes/ratio":13,"../datatypes/uncertainty":14,"../util/elmTypes":55,"../util/math":58,"../util/util":60,"./expression":23}],43:[function(require,module,exports){
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
@@ -9050,7 +9036,7 @@ class UnfilteredContext extends Context {
 }
 exports.UnfilteredContext = UnfilteredContext;
 
-},{"../datatypes/datatypes":7,"../datatypes/exception":9,"../util/elmTypes":55,"../util/util":59,"./messageListeners":45}],44:[function(require,module,exports){
+},{"../datatypes/datatypes":7,"../datatypes/exception":9,"../util/elmTypes":55,"../util/util":60,"./messageListeners":45}],44:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Executor = void 0;
@@ -9297,10 +9283,10 @@ function lessThan(a, b, precision) {
         return a.before(b, precision);
     }
     else if (isUncertainty(a)) {
-        return a.lessThan(b);
+        return a.lessThan(b, precision);
     }
     else if (isUncertainty(b)) {
-        return uncertainty_1.Uncertainty.from(a).lessThan(b);
+        return uncertainty_1.Uncertainty.from(a).lessThan(b, precision);
     }
     else {
         return null;
@@ -9314,10 +9300,10 @@ function lessThanOrEquals(a, b, precision) {
         return a.sameOrBefore(b, precision);
     }
     else if (isUncertainty(a)) {
-        return a.lessThanOrEquals(b);
+        return a.lessThanOrEquals(b, precision);
     }
     else if (isUncertainty(b)) {
-        return uncertainty_1.Uncertainty.from(a).lessThanOrEquals(b);
+        return uncertainty_1.Uncertainty.from(a).lessThanOrEquals(b, precision);
     }
     else {
         return null;
@@ -9331,10 +9317,10 @@ function greaterThan(a, b, precision) {
         return a.after(b, precision);
     }
     else if (isUncertainty(a)) {
-        return a.greaterThan(b);
+        return a.greaterThan(b, precision);
     }
     else if (isUncertainty(b)) {
-        return uncertainty_1.Uncertainty.from(a).greaterThan(b);
+        return uncertainty_1.Uncertainty.from(a).greaterThan(b, precision);
     }
     else {
         return null;
@@ -9348,10 +9334,10 @@ function greaterThanOrEquals(a, b, precision) {
         return a.sameOrAfter(b, precision);
     }
     else if (isUncertainty(a)) {
-        return a.greaterThanOrEquals(b);
+        return a.greaterThanOrEquals(b, precision);
     }
     else if (isUncertainty(b)) {
-        return uncertainty_1.Uncertainty.from(a).greaterThanOrEquals(b);
+        return uncertainty_1.Uncertainty.from(a).greaterThanOrEquals(b, precision);
     }
     else {
         return null;
@@ -9533,8 +9519,9 @@ exports.AnnotatedError = AnnotatedError;
 },{}],55:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.ELM_CHOICE_TYPE_SPECIFIER = exports.ELM_INTERVAL_TYPE_SPECIFIER = exports.ELM_TUPLE_TYPE_SPECIFIER = exports.ELM_LIST_TYPE_SPECIFIER = exports.ELM_NAMED_TYPE_SPECIFIER = exports.ELM_TIME_TYPE = exports.ELM_STRING_TYPE = exports.ELM_QUANTITY_TYPE = exports.ELM_LONG_TYPE = exports.ELM_INTEGER_TYPE = exports.ELM_DECIMAL_TYPE = exports.ELM_DATETIME_TYPE = exports.ELM_DATE_TYPE = exports.ELM_CONCEPT_TYPE = exports.ELM_BOOLEAN_TYPE = void 0;
+exports.ELM_CHOICE_TYPE_SPECIFIER = exports.ELM_INTERVAL_TYPE_SPECIFIER = exports.ELM_TUPLE_TYPE_SPECIFIER = exports.ELM_LIST_TYPE_SPECIFIER = exports.ELM_NAMED_TYPE_SPECIFIER = exports.ELM_TIME_TYPE = exports.ELM_STRING_TYPE = exports.ELM_QUANTITY_TYPE = exports.ELM_LONG_TYPE = exports.ELM_INTEGER_TYPE = exports.ELM_DECIMAL_TYPE = exports.ELM_DATETIME_TYPE = exports.ELM_DATE_TYPE = exports.ELM_CONCEPT_TYPE = exports.ELM_BOOLEAN_TYPE = exports.ELM_ANY_TYPE = void 0;
 // Simple Types
+exports.ELM_ANY_TYPE = '{urn:hl7-org:elm-types:r1}Any';
 exports.ELM_BOOLEAN_TYPE = '{urn:hl7-org:elm-types:r1}Boolean';
 exports.ELM_CONCEPT_TYPE = '{urn:hl7-org:elm-types:r1}Concept';
 exports.ELM_DATE_TYPE = '{urn:hl7-org:elm-types:r1}Date';
@@ -9718,14 +9705,37 @@ const toNormalizedKey = (js) => {
 };
 exports.toNormalizedKey = toNormalizedKey;
 
-},{"../datatypes/datatypes":7,"./math":57,"./units":58,"@lhncbc/ucum-lhc":70,"immutable":74}],57:[function(require,module,exports){
+},{"../datatypes/datatypes":7,"./math":58,"./units":59,"@lhncbc/ucum-lhc":71,"immutable":75}],57:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.OverFlowException = exports.MAX_TIME_VALUE = exports.MIN_TIME_VALUE = exports.MAX_DATE_VALUE = exports.MIN_DATE_VALUE = exports.MAX_DATETIME_VALUE = exports.MIN_DATETIME_VALUE = exports.MIN_FLOAT_PRECISION_VALUE = exports.MIN_FLOAT_VALUE = exports.MAX_FLOAT_VALUE = exports.MIN_LONG_VALUE = exports.MAX_LONG_VALUE = exports.MIN_INT_VALUE = exports.MAX_INT_VALUE = void 0;
+exports.MAX_TIME_VALUE_STRING = exports.MIN_TIME_VALUE_STRING = exports.MAX_DATE_VALUE_STRING = exports.MIN_DATE_VALUE_STRING = exports.MAX_DATETIME_VALUE_STRING = exports.MIN_DATETIME_VALUE_STRING = exports.MIN_FLOAT_PRECISION_VALUE = exports.MIN_FLOAT_VALUE = exports.MAX_FLOAT_VALUE = exports.MIN_LONG_VALUE = exports.MAX_LONG_VALUE = exports.MIN_INT_VALUE = exports.MAX_INT_VALUE = void 0;
+// Keep primitive limits and temporal limit literals dependency-free so datatype and utility
+// modules can safely share them without introducing circular module initialization.
+exports.MAX_INT_VALUE = Math.pow(2, 31) - 1; // 2147483647
+exports.MIN_INT_VALUE = Math.pow(-2, 31); // -2147483648
+exports.MAX_LONG_VALUE = 9223372036854775807n;
+exports.MIN_LONG_VALUE = -9223372036854775808n;
+exports.MAX_FLOAT_VALUE = 99999999999999999999.99999999;
+exports.MIN_FLOAT_VALUE = -99999999999999999999.99999999;
+exports.MIN_FLOAT_PRECISION_VALUE = Math.pow(10, -8);
+// The constructed min/max Date/DateTime/Time are exported from src/datatypes/datetime.ts
+exports.MIN_DATETIME_VALUE_STRING = '0001-01-01T00:00:00.000';
+exports.MAX_DATETIME_VALUE_STRING = '9999-12-31T23:59:59.999';
+exports.MIN_DATE_VALUE_STRING = '0001-01-01';
+exports.MAX_DATE_VALUE_STRING = '9999-12-31';
+exports.MIN_TIME_VALUE_STRING = '0000-01-01T00:00:00.000';
+exports.MAX_TIME_VALUE_STRING = '0000-01-01T23:59:59.999';
+
+},{}],58:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.OverFlowException = void 0;
 exports.overflowsOrUnderflows = overflowsOrUnderflows;
 exports.isValidInteger = isValidInteger;
 exports.isValidLong = isValidLong;
 exports.isValidDecimal = isValidDecimal;
+exports.add = add;
+exports.subtract = subtract;
 exports.limitDecimalPrecision = limitDecimalPrecision;
 exports.successor = successor;
 exports.predecessor = predecessor;
@@ -9741,19 +9751,8 @@ const quantity_1 = require("../datatypes/quantity");
 const datetime_1 = require("../datatypes/datetime");
 const uncertainty_1 = require("../datatypes/uncertainty");
 const elmTypes_1 = require("./elmTypes");
-exports.MAX_INT_VALUE = Math.pow(2, 31) - 1; // 2147483647
-exports.MIN_INT_VALUE = Math.pow(-2, 31); // -2147483648
-exports.MAX_LONG_VALUE = 9223372036854775807n;
-exports.MIN_LONG_VALUE = -9223372036854775808n;
-exports.MAX_FLOAT_VALUE = 99999999999999999999.99999999;
-exports.MIN_FLOAT_VALUE = -99999999999999999999.99999999;
-exports.MIN_FLOAT_PRECISION_VALUE = Math.pow(10, -8);
-exports.MIN_DATETIME_VALUE = datetime_1.MIN_DATETIME_VALUE;
-exports.MAX_DATETIME_VALUE = datetime_1.MAX_DATETIME_VALUE;
-exports.MIN_DATE_VALUE = datetime_1.MIN_DATE_VALUE;
-exports.MAX_DATE_VALUE = datetime_1.MAX_DATE_VALUE;
-exports.MIN_TIME_VALUE = datetime_1.MIN_TIME_VALUE;
-exports.MAX_TIME_VALUE = datetime_1.MAX_TIME_VALUE;
+const limits_1 = require("./limits");
+const units_1 = require("./units");
 function overflowsOrUnderflows(value, type) {
     if (value == null) {
         return false;
@@ -9764,26 +9763,26 @@ function overflowsOrUnderflows(value, type) {
         }
     }
     else if (value.isTime && value.isTime()) {
-        if (value.after(exports.MAX_TIME_VALUE)) {
+        if (value.after(datetime_1.MAX_TIME_VALUE)) {
             return true;
         }
-        if (value.before(exports.MIN_TIME_VALUE)) {
+        if (value.before(datetime_1.MIN_TIME_VALUE)) {
             return true;
         }
     }
     else if (value.isDateTime) {
-        if (value.after(exports.MAX_DATETIME_VALUE)) {
+        if (value.after(datetime_1.MAX_DATETIME_VALUE)) {
             return true;
         }
-        if (value.before(exports.MIN_DATETIME_VALUE)) {
+        if (value.before(datetime_1.MIN_DATETIME_VALUE)) {
             return true;
         }
     }
     else if (value.isDate) {
-        if (value.after(exports.MAX_DATE_VALUE)) {
+        if (value.after(datetime_1.MAX_DATE_VALUE)) {
             return true;
         }
-        if (value.before(exports.MIN_DATE_VALUE)) {
+        if (value.before(datetime_1.MIN_DATE_VALUE)) {
             return true;
         }
     }
@@ -9815,10 +9814,10 @@ function isValidInteger(integer) {
     if (!Number.isInteger(integer)) {
         return false;
     }
-    if (integer > exports.MAX_INT_VALUE) {
+    if (integer > limits_1.MAX_INT_VALUE) {
         return false;
     }
-    if (integer < exports.MIN_INT_VALUE) {
+    if (integer < limits_1.MIN_INT_VALUE) {
         return false;
     }
     return true;
@@ -9827,10 +9826,10 @@ function isValidLong(long) {
     if (typeof long !== 'bigint') {
         return false;
     }
-    if (long > exports.MAX_LONG_VALUE) {
+    if (long > limits_1.MAX_LONG_VALUE) {
         return false;
     }
-    if (long < exports.MIN_LONG_VALUE) {
+    if (long < limits_1.MIN_LONG_VALUE) {
         return false;
     }
     return true;
@@ -9842,37 +9841,99 @@ function isValidDecimal(decimal) {
     if (typeof decimal !== 'number') {
         return false;
     }
-    if (decimal > exports.MAX_FLOAT_VALUE) {
+    if (decimal > limits_1.MAX_FLOAT_VALUE) {
         return false;
     }
-    if (decimal < exports.MIN_FLOAT_VALUE) {
+    if (decimal < limits_1.MIN_FLOAT_VALUE) {
         return false;
     }
     return true;
 }
-function limitDecimalPrecision(decimal) {
-    let decimalString = decimal.toString();
-    // For decimals so large that they are represented in scientific notation, javascript has already limited
-    // the decimal to its own constraints, so we can't determine the original precision.  Leave as-is unless
-    // this becomes problematic, in which case we would need our own parseFloat.
-    if (decimalString.indexOf('e') !== -1) {
-        return decimal;
+function add(a, b, type) {
+    if (a == null || b == null) {
+        return null;
     }
-    const splitDecimalString = decimalString.split('.');
-    const decimalPoints = splitDecimalString[1];
-    if (decimalPoints != null && decimalPoints.length > 8) {
-        decimalString = splitDecimalString[0] + '.' + splitDecimalString[1].substring(0, 8);
+    if (a?.isUncertainty || b?.isUncertainty) {
+        const aLow = a?.isUncertainty ? a.low : a;
+        const aHigh = a?.isUncertainty ? a.high : a;
+        const bLow = b?.isUncertainty ? b.low : b;
+        const bHigh = b?.isUncertainty ? b.high : b;
+        const low = add(aLow, bLow, type);
+        const high = add(aHigh, bHigh, type);
+        return low == null || high == null ? null : new uncertainty_1.Uncertainty(low, high);
     }
-    return parseFloat(decimalString);
+    if (typeof a === 'bigint') {
+        const sum = a + (typeof b === 'bigint' ? b : BigInt(b));
+        return overflowsOrUnderflows(sum, elmTypes_1.ELM_LONG_TYPE) ? null : sum;
+    }
+    if (typeof b === 'bigint') {
+        const sum = BigInt(a) + b;
+        return overflowsOrUnderflows(sum, elmTypes_1.ELM_LONG_TYPE) ? null : sum;
+    }
+    if (typeof a === 'number' && typeof b === 'number') {
+        const sum = a + b;
+        const numberType = type ?? (Number.isInteger(a) && Number.isInteger(b) ? elmTypes_1.ELM_INTEGER_TYPE : elmTypes_1.ELM_DECIMAL_TYPE);
+        return overflowsOrUnderflows(sum, numberType) ? null : sum;
+    }
+    if (a?.isQuantity && b?.isQuantity) {
+        const [aValue, aUnit, bValue, bUnit] = (0, units_1.normalizeUnitsWhenPossible)(a.value, a.unit, b.value, b.unit);
+        if (aUnit !== bUnit) {
+            return null;
+        }
+        const sum = aValue + bValue;
+        return overflowsOrUnderflows(sum, elmTypes_1.ELM_DECIMAL_TYPE) ? null : new quantity_1.Quantity(sum, aUnit);
+    }
+    if (b?.isQuantity && (a?.isDate || a?.isDateTime || (a?.isTime && a.isTime()))) {
+        const unit = (0, units_1.convertToCQLDateUnit)(b.unit) || b.unit;
+        const sum = a.copy().add(b.value, unit);
+        return overflowsOrUnderflows(sum) ? null : sum;
+    }
+    throw new Error('Unsupported argument types.');
+}
+function subtract(a, b, type) {
+    if (a == null || b == null) {
+        return null;
+    }
+    if (a?.isUncertainty || b?.isUncertainty) {
+        const aLow = a?.isUncertainty ? a.low : a;
+        const aHigh = a?.isUncertainty ? a.high : a;
+        const bLow = b?.isUncertainty ? b.low : b;
+        const bHigh = b?.isUncertainty ? b.high : b;
+        const low = subtract(aLow, bHigh, type);
+        const high = subtract(aHigh, bLow, type);
+        return low == null || high == null ? null : new uncertainty_1.Uncertainty(low, high);
+    }
+    if (typeof b === 'number' || typeof b === 'bigint') {
+        return add(a, -b, type);
+    }
+    if (b?.isQuantity) {
+        return add(a, { isQuantity: true, value: -b.value, unit: b.unit }, type);
+    }
+    throw new Error('Unsupported argument types.');
+}
+function limitDecimalPrecision(val) {
+    if (val == null) {
+        return val;
+    }
+    else if (typeof val === 'number') {
+        return (Math.round(val * Math.pow(10, 8)) / Math.pow(10, 8));
+    }
+    else if (val.isQuantity) {
+        return new quantity_1.Quantity(limitDecimalPrecision(val.value), val.unit);
+    }
+    else if (val.isUncertainty) {
+        return new uncertainty_1.Uncertainty(limitDecimalPrecision(val.low), limitDecimalPrecision(val.high));
+    }
+    return val;
 }
 class OverFlowException extends exception_1.Exception {
 }
 exports.OverFlowException = OverFlowException;
-function successor(val, type) {
+function successor(val, type, precision) {
     if (typeof val === 'number') {
         const isInteger = type === elmTypes_1.ELM_INTEGER_TYPE || (type == null && Number.isInteger(val));
         if (isInteger) {
-            if (val >= exports.MAX_INT_VALUE) {
+            if (val >= limits_1.MAX_INT_VALUE) {
                 throw new OverFlowException();
             }
             else {
@@ -9880,16 +9941,16 @@ function successor(val, type) {
             }
         }
         else {
-            if (val >= exports.MAX_FLOAT_VALUE) {
+            if (val >= limits_1.MAX_FLOAT_VALUE) {
                 throw new OverFlowException();
             }
             else {
-                return val + exports.MIN_FLOAT_PRECISION_VALUE;
+                return val + limits_1.MIN_FLOAT_PRECISION_VALUE;
             }
         }
     }
     else if (typeof val === 'bigint') {
-        if (val >= exports.MAX_LONG_VALUE) {
+        if (val >= limits_1.MAX_LONG_VALUE) {
             throw new OverFlowException();
         }
         else {
@@ -9897,40 +9958,40 @@ function successor(val, type) {
         }
     }
     else if (val && val.isTime && val.isTime()) {
-        if (val.sameAs(exports.MAX_TIME_VALUE)) {
+        if (val.sameAs(datetime_1.MAX_TIME_VALUE)) {
             throw new OverFlowException();
         }
         else {
-            return val.successor();
+            return val.successor(precision);
         }
     }
     else if (val && val.isDateTime) {
-        if (val.sameAs(exports.MAX_DATETIME_VALUE)) {
+        if (val.sameAs(datetime_1.MAX_DATETIME_VALUE)) {
             throw new OverFlowException();
         }
         else {
-            return val.successor();
+            return val.successor(precision);
         }
     }
     else if (val && val.isDate) {
-        if (val.sameAs(exports.MAX_DATE_VALUE)) {
+        if (val.sameAs(datetime_1.MAX_DATE_VALUE)) {
             throw new OverFlowException();
         }
         else {
-            return val.successor();
+            return val.successor(precision);
         }
     }
     else if (val && val.isUncertainty) {
         // For uncertainties, if the high is the max val, don't increment it
         const high = (() => {
             try {
-                return successor(val.high, type);
+                return successor(val.high, type, precision);
             }
             catch {
                 return val.high;
             }
         })();
-        return new uncertainty_1.Uncertainty(successor(val.low, type), high);
+        return new uncertainty_1.Uncertainty(successor(val.low, type, precision), high);
     }
     else if (val && val.isQuantity) {
         const succ = val.clone();
@@ -9941,11 +10002,11 @@ function successor(val, type) {
         return null;
     }
 }
-function predecessor(val, type) {
+function predecessor(val, type, precision) {
     if (typeof val === 'number') {
         const isInteger = type === elmTypes_1.ELM_INTEGER_TYPE || (type == null && Number.isInteger(val));
         if (isInteger) {
-            if (val <= exports.MIN_INT_VALUE) {
+            if (val <= limits_1.MIN_INT_VALUE) {
                 throw new OverFlowException();
             }
             else {
@@ -9953,16 +10014,16 @@ function predecessor(val, type) {
             }
         }
         else {
-            if (val <= exports.MIN_FLOAT_VALUE) {
+            if (val <= limits_1.MIN_FLOAT_VALUE) {
                 throw new OverFlowException();
             }
             else {
-                return val - exports.MIN_FLOAT_PRECISION_VALUE;
+                return val - limits_1.MIN_FLOAT_PRECISION_VALUE;
             }
         }
     }
     else if (typeof val === 'bigint') {
-        if (val <= exports.MIN_LONG_VALUE) {
+        if (val <= limits_1.MIN_LONG_VALUE) {
             throw new OverFlowException();
         }
         else {
@@ -9970,40 +10031,40 @@ function predecessor(val, type) {
         }
     }
     else if (val && val.isTime && val.isTime()) {
-        if (val.sameAs(exports.MIN_TIME_VALUE)) {
+        if (val.sameAs(datetime_1.MIN_TIME_VALUE)) {
             throw new OverFlowException();
         }
         else {
-            return val.predecessor();
+            return val.predecessor(precision);
         }
     }
     else if (val && val.isDateTime) {
-        if (val.sameAs(exports.MIN_DATETIME_VALUE)) {
+        if (val.sameAs(datetime_1.MIN_DATETIME_VALUE)) {
             throw new OverFlowException();
         }
         else {
-            return val.predecessor();
+            return val.predecessor(precision);
         }
     }
     else if (val && val.isDate) {
-        if (val.sameAs(exports.MIN_DATE_VALUE)) {
+        if (val.sameAs(datetime_1.MIN_DATE_VALUE)) {
             throw new OverFlowException();
         }
         else {
-            return val.predecessor();
+            return val.predecessor(precision);
         }
     }
     else if (val && val.isUncertainty) {
         // For uncertainties, if the low is the min val, don't decrement it
         const low = (() => {
             try {
-                return predecessor(val.low, type);
+                return predecessor(val.low, type, precision);
             }
             catch {
                 return val.low;
             }
         })();
-        return new uncertainty_1.Uncertainty(low, predecessor(val.high, type));
+        return new uncertainty_1.Uncertainty(low, predecessor(val.high, type, precision));
     }
     else if (val && val.isQuantity) {
         const pred = val.clone();
@@ -10017,33 +10078,29 @@ function predecessor(val, type) {
 function maxValueForInstance(val) {
     if (typeof val === 'number') {
         if (Number.isInteger(val)) {
-            return exports.MAX_INT_VALUE;
+            return limits_1.MAX_INT_VALUE;
         }
         else {
-            return exports.MAX_FLOAT_VALUE;
+            return limits_1.MAX_FLOAT_VALUE;
         }
     }
     else if (typeof val === 'bigint') {
-        return exports.MAX_LONG_VALUE;
+        return limits_1.MAX_LONG_VALUE;
     }
     else if (val && val.isTime && val.isTime()) {
-        return exports.MAX_TIME_VALUE?.copy();
+        return datetime_1.MAX_TIME_VALUE?.copy();
     }
     else if (val && val.isDateTime) {
-        return exports.MAX_DATETIME_VALUE?.copy();
+        return datetime_1.MAX_DATETIME_VALUE?.copy();
     }
     else if (val && val.isDate) {
-        return exports.MAX_DATE_VALUE?.copy();
+        return datetime_1.MAX_DATE_VALUE?.copy();
     }
     else if (val && val.isQuantity) {
         // Although the spec says max Quantity has unit '1', it doesn't make sense to change the unit,
         // especially if this is being used in the context of an interval or uncertainty since the
         // left and right sides need to be comparable in those cases.
-        const maxQuantity = quantity_1.MAX_QUANTITY_VALUE.clone();
-        if (val.unit) {
-            maxQuantity.unit = val.unit;
-        }
-        return maxQuantity;
+        return new quantity_1.Quantity(limits_1.MAX_FLOAT_VALUE, val.unit || '1');
     }
     else {
         return null;
@@ -10052,29 +10109,22 @@ function maxValueForInstance(val) {
 function maxValueForType(type, quantityInstance) {
     switch (type) {
         case elmTypes_1.ELM_INTEGER_TYPE:
-            return exports.MAX_INT_VALUE;
+            return limits_1.MAX_INT_VALUE;
         case elmTypes_1.ELM_LONG_TYPE:
-            return exports.MAX_LONG_VALUE;
+            return limits_1.MAX_LONG_VALUE;
         case elmTypes_1.ELM_DECIMAL_TYPE:
-            return exports.MAX_FLOAT_VALUE;
+            return limits_1.MAX_FLOAT_VALUE;
         case elmTypes_1.ELM_DATETIME_TYPE:
-            return exports.MAX_DATETIME_VALUE?.copy();
+            return datetime_1.MAX_DATETIME_VALUE?.copy();
         case elmTypes_1.ELM_DATE_TYPE:
-            return exports.MAX_DATE_VALUE?.copy();
+            return datetime_1.MAX_DATE_VALUE?.copy();
         case elmTypes_1.ELM_TIME_TYPE:
-            return exports.MAX_TIME_VALUE?.copy();
+            return datetime_1.MAX_TIME_VALUE?.copy();
         case elmTypes_1.ELM_QUANTITY_TYPE: {
             // Although the spec says max Quantity has unit '1', it doesn't make sense to change the unit,
             // especially if this is being used in the context of an interval or uncertainty since the
             // left and right sides need to be comparable in those cases.
-            const maxQuantity = quantity_1.MAX_QUANTITY_VALUE.clone();
-            if (quantityInstance == null) {
-                return maxQuantity;
-            }
-            if (quantityInstance.unit) {
-                maxQuantity.unit = quantityInstance.unit;
-            }
-            return maxQuantity;
+            return new quantity_1.Quantity(limits_1.MAX_FLOAT_VALUE, quantityInstance?.unit || '1');
         }
     }
     return null;
@@ -10082,33 +10132,29 @@ function maxValueForType(type, quantityInstance) {
 function minValueForInstance(val) {
     if (typeof val === 'number') {
         if (Number.isInteger(val)) {
-            return exports.MIN_INT_VALUE;
+            return limits_1.MIN_INT_VALUE;
         }
         else {
-            return exports.MIN_FLOAT_VALUE;
+            return limits_1.MIN_FLOAT_VALUE;
         }
     }
     else if (typeof val === 'bigint') {
-        return exports.MIN_LONG_VALUE;
+        return limits_1.MIN_LONG_VALUE;
     }
     else if (val && val.isTime && val.isTime()) {
-        return exports.MIN_TIME_VALUE?.copy();
+        return datetime_1.MIN_TIME_VALUE?.copy();
     }
     else if (val && val.isDateTime) {
-        return exports.MIN_DATETIME_VALUE?.copy();
+        return datetime_1.MIN_DATETIME_VALUE?.copy();
     }
     else if (val && val.isDate) {
-        return exports.MIN_DATE_VALUE?.copy();
+        return datetime_1.MIN_DATE_VALUE?.copy();
     }
     else if (val && val.isQuantity) {
         // Although the spec says max Quantity has unit '1', it doesn't make sense to change the unit,
         // especially if this is being used in the context of an interval or uncertainty since the
         // left and right sides need to be comparable in those cases.
-        const minQuantity = quantity_1.MIN_QUANTITY_VALUE.clone();
-        if (val.unit) {
-            minQuantity.unit = val.unit;
-        }
-        return minQuantity;
+        return new quantity_1.Quantity(limits_1.MIN_FLOAT_VALUE, val.unit || '1');
     }
     else {
         return null;
@@ -10117,29 +10163,22 @@ function minValueForInstance(val) {
 function minValueForType(type, quantityInstance) {
     switch (type) {
         case elmTypes_1.ELM_INTEGER_TYPE:
-            return exports.MIN_INT_VALUE;
+            return limits_1.MIN_INT_VALUE;
         case elmTypes_1.ELM_LONG_TYPE:
-            return exports.MIN_LONG_VALUE;
+            return limits_1.MIN_LONG_VALUE;
         case elmTypes_1.ELM_DECIMAL_TYPE:
-            return exports.MIN_FLOAT_VALUE;
+            return limits_1.MIN_FLOAT_VALUE;
         case elmTypes_1.ELM_DATETIME_TYPE:
-            return exports.MIN_DATETIME_VALUE?.copy();
+            return datetime_1.MIN_DATETIME_VALUE?.copy();
         case elmTypes_1.ELM_DATE_TYPE:
-            return exports.MIN_DATE_VALUE?.copy();
+            return datetime_1.MIN_DATE_VALUE?.copy();
         case elmTypes_1.ELM_TIME_TYPE:
-            return exports.MIN_TIME_VALUE?.copy();
+            return datetime_1.MIN_TIME_VALUE?.copy();
         case elmTypes_1.ELM_QUANTITY_TYPE: {
             // Although the spec says max Quantity has unit '1', it doesn't make sense to change the unit,
             // especially if this is being used in the context of an interval or uncertainty since the
             // left and right sides need to be comparable in those cases.
-            const minQuantity = quantity_1.MIN_QUANTITY_VALUE.clone();
-            if (quantityInstance == null) {
-                return minQuantity;
-            }
-            if (quantityInstance.unit) {
-                minQuantity.unit = quantityInstance.unit;
-            }
-            return minQuantity;
+            return new quantity_1.Quantity(limits_1.MIN_FLOAT_VALUE, quantityInstance?.unit || '1');
         }
     }
     return null;
@@ -10174,7 +10213,7 @@ function decimalLongOrNull(value) {
         : null;
 }
 
-},{"../datatypes/datetime":8,"../datatypes/exception":9,"../datatypes/quantity":12,"../datatypes/uncertainty":14,"./elmTypes":55}],58:[function(require,module,exports){
+},{"../datatypes/datetime":8,"../datatypes/exception":9,"../datatypes/quantity":12,"../datatypes/uncertainty":14,"./elmTypes":55,"./limits":57,"./units":59}],59:[function(require,module,exports){
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
@@ -10475,7 +10514,7 @@ function fixUnit(unit) {
     return fixCQLDateUnit(fixEmptyUnit(unit));
 }
 
-},{"./math":57,"@lhncbc/ucum-lhc":70}],59:[function(require,module,exports){
+},{"./math":58,"@lhncbc/ucum-lhc":71}],60:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.jsDate = exports.typeIsArray = void 0;
@@ -10591,10 +10630,10 @@ async function resolveValueSet(vs, ctx) {
     return vsExpansion;
 }
 
-},{}],60:[function(require,module,exports){
+},{}],61:[function(require,module,exports){
 module.exports={"license":"The following data (prefixes and units) was generated by the UCUM LHC code from the UCUM data and selected LOINC combinations of UCUM units.  The license for the UCUM LHC code (demo and library code as well as the combined units) is located at https://github.com/lhncbc/ucum-lhc/blob/LICENSE.md.","prefixes":{"config":["code_","ciCode_","name_","printSymbol_","value_","exp_"],"data":[["E","EX","exa","E",1000000000000000000,"18"],["G","GA","giga","G",1000000000,"9"],["Gi","GIB","gibi","Gi",1073741824,null],["Ki","KIB","kibi","Ki",1024,null],["M","MA","mega","M",1000000,"6"],["Mi","MIB","mebi","Mi",1048576,null],["P","PT","peta","P",1000000000000000,"15"],["T","TR","tera","T",1000000000000,"12"],["Ti","TIB","tebi","Ti",1099511627776,null],["Y","YA","yotta","Y",1e+24,"24"],["Z","ZA","zetta","Z",1e+21,"21"],["a","A","atto","a",1e-18,"-18"],["c","C","centi","c",0.01,"-2"],["d","D","deci","d",0.1,"-1"],["da","DA","deka","da",10,"1"],["f","F","femto","f",1e-15,"-15"],["h","H","hecto","h",100,"2"],["k","K","kilo","k",1000,"3"],["m","M","milli","m",0.001,"-3"],["n","N","nano","n",1e-9,"-9"],["p","P","pico","p",1e-12,"-12"],["u","U","micro","μ",0.000001,"-6"],["y","YO","yocto","y",1e-24,"-24"],["z","ZO","zepto","z",1e-21,"-21"]]},"units":{"config":["isBase_","name_","csCode_","ciCode_","property_","magnitude_",["dim_","dimVec_"],"printSymbol_","class_","isMetric_","variable_","cnv_","cnvPfx_","isSpecial_","isArbitrary_","moleExp_","equivalentExp_","synonyms_","source_","loincProperty_","category_","guidance_","csUnitString_","ciUnitString_","baseFactorStr_","baseFactor_","defError_"],"data":[[true,"meter","m","M","length",1,[1,0,0,0,0,0,0],"m",null,false,"L",null,1,false,false,0,0,"meters; metres; distance","UCUM","Len","Clinical","unit of length = 1.09361 yards",null,null,null,null,false],[true,"second - time","s","S","time",1,[0,1,0,0,0,0,0],"s",null,false,"T",null,1,false,false,0,0,"seconds","UCUM","Time","Clinical","",null,null,null,null,false],[true,"gram","g","G","mass",1,[0,0,1,0,0,0,0],"g",null,false,"M",null,1,false,false,0,0,"grams; gm","UCUM","Mass","Clinical","",null,null,null,null,false],[true,"radian","rad","RAD","plane angle",1,[0,0,0,1,0,0,0],"rad",null,false,"A",null,1,false,false,0,0,"radians","UCUM","Angle","Clinical","unit of angular measure where 1 radian = 1/2π turn =  57.296 degrees. ",null,null,null,null,false],[true,"degree Kelvin","K","K","temperature",1,[0,0,0,0,1,0,0],"K",null,false,"C",null,1,false,false,0,0,"Kelvin; degrees","UCUM","Temp","Clinical","absolute, thermodynamic temperature scale ",null,null,null,null,false],[true,"coulomb","C","C","electric charge",1,[0,0,0,0,0,1,0],"C",null,false,"Q",null,1,false,false,0,0,"coulombs","UCUM","","Clinical","defined as amount of 1 electron charge = 6.2415093×10^18 e, and equivalent to 1 Ampere-second",null,null,null,null,false],[true,"candela","cd","CD","luminous intensity",1,[0,0,0,0,0,0,1],"cd",null,false,"F",null,1,false,false,0,0,"candelas","UCUM","","Clinical","SI base unit of luminous intensity",null,null,null,null,false],[false,"the number ten for arbitrary powers","10*","10*","number",10,[0,0,0,0,0,0,0],"10","dimless",false,null,null,1,false,false,0,0,"10^; 10 to the arbitrary powers","UCUM","Num","Clinical","10* by itself is the same as 10, but users can add digits after the *. For example, 10*3 = 1000.","1","1","10",10,false],[false,"the number ten for arbitrary powers","10^","10^","number",10,[0,0,0,0,0,0,0],"10","dimless",false,null,null,1,false,false,0,0,"10*; 10 to the arbitrary power","UCUM","Num","Clinical","10* by itself is the same as 10, but users can add digits after the *. For example, 10*3 = 1000.","1","1","10",10,false],[false,"the number pi","[pi]","[PI]","number",3.141592653589793,[0,0,0,0,0,0,0],"π","dimless",false,null,null,1,false,false,0,0,"π","UCUM","","Constant","a mathematical constant; the ratio of a circle's circumference to its diameter ≈ 3.14159","1","1","3.1415926535897932384626433832795028841971693993751058209749445923",3.141592653589793,false],[false,"","%","%","fraction",0.01,[0,0,0,0,0,0,0],"%","dimless",false,null,null,1,false,false,0,0,"percents","UCUM","FR; NFR; MFR; CFR; SFR Rto; etc. ","Clinical","","10*-2","10*-2","1",1,false],[false,"parts per thousand","[ppth]","[PPTH]","fraction",0.001,[0,0,0,0,0,0,0],"ppth","dimless",false,null,null,1,false,false,0,0,"ppth; 10^-3","UCUM","MCnc; MCnt","Clinical","[ppth] is often used in solution concentrations as 1 g/L or 1 g/kg.\n\nCan be ambigous and would be better if the metric units was used directly. ","10*-3","10*-3","1",1,false],[false,"parts per million","[ppm]","[PPM]","fraction",0.000001,[0,0,0,0,0,0,0],"ppm","dimless",false,null,null,1,false,false,0,0,"ppm; 10^-6","UCUM","MCnt; MCnc; SFr","Clinical","[ppm] is often used in solution concentrations as 1 mg/L  or 1 mg/kg. Also used to express mole fractions as 1 mmol/mol.\n\n[ppm] is also used in nuclear magnetic resonance (NMR) to represent chemical shift - the difference of a measured frequency in parts per million from the reference frequency.\n\nCan be ambigous and would be better if the metric units was used directly. ","10*-6","10*-6","1",1,false],[false,"parts per billion","[ppb]","[PPB]","fraction",1e-9,[0,0,0,0,0,0,0],"ppb","dimless",false,null,null,1,false,false,0,0,"ppb; 10^-9","UCUM","MCnt; MCnc; SFr","Clinical","[ppb] is often used in solution concentrations as 1 ug/L  or 1 ug/kg. Also used to express mole fractions as 1 umol/mol.\n\nCan be ambigous and would be better if the metric units was used directly. ","10*-9","10*-9","1",1,false],[false,"parts per trillion","[pptr]","[PPTR]","fraction",1e-12,[0,0,0,0,0,0,0],"pptr","dimless",false,null,null,1,false,false,0,0,"pptr; 10^-12","UCUM","MCnt; MCnc; SFr","Clinical","[pptr] is often used in solution concentrations as 1 ng/L or 1 ng/kg. Also used to express mole fractions as 1 nmol/mol.\n\nCan be ambigous and would be better if the metric units was used directly. ","10*-12","10*-12","1",1,false],[false,"mole","mol","MOL","amount of substance",6.0221367e+23,[0,0,0,0,0,0,0],"mol","si",true,null,null,1,false,false,1,0,"moles","UCUM","Sub","Clinical","Measure the number of molecules ","10*23","10*23","6.0221367",6.0221367,false],[false,"steradian - solid angle","sr","SR","solid angle",1,[0,0,0,2,0,0,0],"sr","si",true,null,null,1,false,false,0,0,"square radian; rad2; rad^2","UCUM","Angle","Clinical","unit of solid angle in three-dimensional geometry analagous to radian; used in photometry which measures the perceived brightness of object by human eye (e.g. radiant intensity = watt/steradian)","rad2","RAD2","1",1,false],[false,"hertz","Hz","HZ","frequency",1,[0,-1,0,0,0,0,0],"Hz","si",true,null,null,1,false,false,0,0,"Herz; frequency; frequencies","UCUM","Freq; Num","Clinical","equal to one cycle per second","s-1","S-1","1",1,false],[false,"newton","N","N","force",1000,[1,-2,1,0,0,0,0],"N","si",true,null,null,1,false,false,0,0,"Newtons","UCUM","Force","Clinical","unit of force with base units kg.m/s2","kg.m/s2","KG.M/S2","1",1,false],[false,"pascal","Pa","PAL","pressure",1000,[-1,-2,1,0,0,0,0],"Pa","si",true,null,null,1,false,false,0,0,"pascals","UCUM","Pres","Clinical","standard unit of pressure equal to 1 newton per square meter (N/m2)","N/m2","N/M2","1",1,false],[false,"joule","J","J","energy",1000,[2,-2,1,0,0,0,0],"J","si",true,null,null,1,false,false,0,0,"joules","UCUM","Enrg","Clinical","unit of energy defined as the work required to move an object 1 m with a force of 1 N (N.m) or an electric charge of 1 C through 1 V (C.V), or to produce 1 W for 1 s (W.s) ","N.m","N.M","1",1,false],[false,"watt","W","W","power",1000,[2,-3,1,0,0,0,0],"W","si",true,null,null,1,false,false,0,0,"watts","UCUM","EngRat","Clinical","unit of power equal to 1 Joule per second (J/s) =  kg⋅m2⋅s−3","J/s","J/S","1",1,false],[false,"Ampere","A","A","electric current",1,[0,-1,0,0,0,1,0],"A","si",true,null,null,1,false,false,0,0,"Amperes","UCUM","ElpotRat","Clinical","unit of electric current equal to flow rate of electrons equal to 6.2415×10^18 elementary charges moving past a boundary in one second or 1 Coulomb/second","C/s","C/S","1",1,false],[false,"volt","V","V","electric potential",1000,[2,-2,1,0,0,-1,0],"V","si",true,null,null,1,false,false,0,0,"volts","UCUM","Elpot","Clinical","unit of electric potential (voltage) = 1 Joule per Coulomb (J/C)","J/C","J/C","1",1,false],[false,"farad","F","F","electric capacitance",0.001,[-2,2,-1,0,0,2,0],"F","si",true,null,null,1,false,false,0,0,"farads; electric capacitance","UCUM","","Clinical","CGS unit of electric capacitance with base units C/V (Coulomb per Volt)","C/V","C/V","1",1,false],[false,"ohm","Ohm","OHM","electric resistance",1000,[2,-1,1,0,0,-2,0],"Ω","si",true,null,null,1,false,false,0,0,"Ω; resistance; ohms","UCUM","","Clinical","unit of electrical resistance with units of Volt per Ampere","V/A","V/A","1",1,false],[false,"siemens","S","SIE","electric conductance",0.001,[-2,1,-1,0,0,2,0],"S","si",true,null,null,1,false,false,0,0,"Reciprocal ohm; mho; Ω−1; conductance","UCUM","","Clinical","unit of electric conductance (the inverse of electrical resistance) equal to ohm^-1","Ohm-1","OHM-1","1",1,false],[false,"weber","Wb","WB","magnetic flux",1000,[2,-1,1,0,0,-1,0],"Wb","si",true,null,null,1,false,false,0,0,"magnetic flux; webers","UCUM","","Clinical","unit of magnetic flux equal to Volt second","V.s","V.S","1",1,false],[false,"degree Celsius","Cel","CEL","temperature",1,[0,0,0,0,1,0,0],"°C","si",true,null,"Cel",1,true,false,0,0,"°C; degrees","UCUM","Temp","Clinical","","K",null,null,1,false],[false,"tesla","T","T","magnetic flux density",1000,[0,-1,1,0,0,-1,0],"T","si",true,null,null,1,false,false,0,0,"Teslas; magnetic field","UCUM","","Clinical","SI unit of magnetic field strength for magnetic field B equal to 1 Weber/square meter =  1 kg/(s2*A)","Wb/m2","WB/M2","1",1,false],[false,"henry","H","H","inductance",1000,[2,0,1,0,0,-2,0],"H","si",true,null,null,1,false,false,0,0,"henries; inductance","UCUM","","Clinical","unit of electrical inductance; usually expressed in millihenrys (mH) or microhenrys (uH).","Wb/A","WB/A","1",1,false],[false,"lumen","lm","LM","luminous flux",1,[0,0,0,2,0,0,1],"lm","si",true,null,null,1,false,false,0,0,"luminous flux; lumens","UCUM","","Clinical","unit of luminous flux defined as 1 lm = 1 cd⋅sr (candela times sphere)","cd.sr","CD.SR","1",1,false],[false,"lux","lx","LX","illuminance",1,[-2,0,0,2,0,0,1],"lx","si",true,null,null,1,false,false,0,0,"illuminance; luxes","UCUM","","Clinical","unit of illuminance equal to one lumen per square meter. ","lm/m2","LM/M2","1",1,false],[false,"becquerel","Bq","BQ","radioactivity",1,[0,-1,0,0,0,0,0],"Bq","si",true,null,null,1,false,false,0,0,"activity; radiation; becquerels","UCUM","","Clinical","measure of the atomic radiation rate with units s^-1","s-1","S-1","1",1,false],[false,"gray","Gy","GY","energy dose",1,[2,-2,0,0,0,0,0],"Gy","si",true,null,null,1,false,false,0,0,"absorbed doses; ionizing radiation doses; kerma; grays","UCUM","EngCnt","Clinical","unit of ionizing radiation dose with base units of 1 joule of radiation energy per kilogram of matter","J/kg","J/KG","1",1,false],[false,"sievert","Sv","SV","dose equivalent",1,[2,-2,0,0,0,0,0],"Sv","si",true,null,null,1,false,false,0,0,"sieverts; radiation dose quantities; equivalent doses; effective dose; operational dose; committed dose","UCUM","","Clinical","SI unit for radiation dose equivalent equal to 1 Joule/kilogram.","J/kg","J/KG","1",1,false],[false,"degree - plane angle","deg","DEG","plane angle",0.017453292519943295,[0,0,0,1,0,0,0],"°","iso1000",false,null,null,1,false,false,0,0,"°; degree of arc; arc degree; arcdegree; angle","UCUM","Angle","Clinical","one degree is equivalent to π/180 radians.","[pi].rad/360","[PI].RAD/360","2",2,false],[false,"gon","gon","GON","plane angle",0.015707963267948967,[0,0,0,1,0,0,0],"□<sup>g</sup>","iso1000",false,null,null,1,false,false,0,0,"gon (grade); gons","UCUM","Angle","Nonclinical","unit of plane angle measurement equal to 1/400 circle","deg","DEG","0.9",0.9,false],[false,"arc minute","'","'","plane angle",0.0002908882086657216,[0,0,0,1,0,0,0],"'","iso1000",false,null,null,1,false,false,0,0,"arcminutes; arcmin; arc minutes; arc mins","UCUM","Angle","Clinical","equal to 1/60 degree; used in optometry and opthamology (e.g. visual acuity tests)","deg/60","DEG/60","1",1,false],[false,"arc second","''","''","plane angle",0.00000484813681109536,[0,0,0,1,0,0,0],"''","iso1000",false,null,null,1,false,false,0,0,"arcseconds; arcsecs","UCUM","Angle","Clinical","equal to 1/60 arcminute = 1/3600 degree; used in optometry and opthamology (e.g. visual acuity tests)","'/60","'/60","1",1,false],[false,"Liters","l","L","volume",0.001,[3,0,0,0,0,0,0],"l","iso1000",true,null,null,1,false,false,0,0,"cubic decimeters; decimeters cubed; decimetres; dm3; dm^3; litres; liters, LT ","UCUM","Vol","Clinical","Because lower case \"l\" can be read as the number \"1\", though this is a valid UCUM units. UCUM strongly reccomends using  \"L\"","dm3","DM3","1",1,false],[false,"Liters","L","L","volume",0.001,[3,0,0,0,0,0,0],"L","iso1000",true,null,null,1,false,false,0,0,"cubic decimeters; decimeters cubed; decimetres; dm3; dm^3; litres; liters, LT ","UCUM","Vol","Clinical","Because lower case \"l\" can be read as the number \"1\", though this is a valid UCUM units. UCUM strongly reccomends using  \"L\"","l",null,"1",1,false],[false,"are","ar","AR","area",100,[2,0,0,0,0,0,0],"a","iso1000",true,null,null,1,false,false,0,0,"100 m2; 100 m^2; 100 square meter; meters squared; metres","UCUM","Area","Clinical","metric base unit for area defined as 100 m^2","m2","M2","100",100,false],[false,"minute","min","MIN","time",60,[0,1,0,0,0,0,0],"min","iso1000",false,null,null,1,false,false,0,0,"minutes","UCUM","Time","Clinical","","s","S","60",60,false],[false,"hour","h","HR","time",3600,[0,1,0,0,0,0,0],"h","iso1000",false,null,null,1,false,false,0,0,"hours; hrs; age","UCUM","Time","Clinical","","min","MIN","60",60,false],[false,"day","d","D","time",86400,[0,1,0,0,0,0,0],"d","iso1000",false,null,null,1,false,false,0,0,"days; age; dy; 24 hours; 24 hrs","UCUM","Time","Clinical","","h","HR","24",24,false],[false,"tropical year","a_t","ANN_T","time",31556925.216,[0,1,0,0,0,0,0],"a<sub>t</sub>","iso1000",false,null,null,1,false,false,0,0,"solar years; a tropical; years","UCUM","Time","Clinical","has an average of 365.242181 days but is constantly changing.","d","D","365.24219",365.24219,false],[false,"mean Julian year","a_j","ANN_J","time",31557600,[0,1,0,0,0,0,0],"a<sub>j</sub>","iso1000",false,null,null,1,false,false,0,0,"mean Julian yr; a julian; years","UCUM","Time","Clinical","has an average of 365.25 days, and in everyday use, has been replaced by the Gregorian year. However, this unit is used in astronomy to calculate light year. ","d","D","365.25",365.25,false],[false,"mean Gregorian year","a_g","ANN_G","time",31556952,[0,1,0,0,0,0,0],"a<sub>g</sub>","iso1000",false,null,null,1,false,false,0,0,"mean Gregorian yr; a gregorian; years","UCUM","Time","Clinical","has an average of 365.2425 days and is the most internationally used civil calendar.","d","D","365.2425",365.2425,false],[false,"year","a","ANN","time",31557600,[0,1,0,0,0,0,0],"a","iso1000",false,null,null,1,false,false,0,0,"years; a; yr, yrs; annum","UCUM","Time","Clinical","","a_j","ANN_J","1",1,false],[false,"week","wk","WK","time",604800,[0,1,0,0,0,0,0],"wk","iso1000",false,null,null,1,false,false,0,0,"weeks; wks","UCUM","Time","Clinical","","d","D","7",7,false],[false,"synodal month","mo_s","MO_S","time",2551442.976,[0,1,0,0,0,0,0],"mo<sub>s</sub>","iso1000",false,null,null,1,false,false,0,0,"Moon; synodic month; lunar month; mo-s; mo s; months; moons","UCUM","Time","Nonclinical","has an average of 29.53 days per month, unit used in astronomy","d","D","29.53059",29.53059,false],[false,"mean Julian month","mo_j","MO_J","time",2629800,[0,1,0,0,0,0,0],"mo<sub>j</sub>","iso1000",false,null,null,1,false,false,0,0,"mo-julian; mo Julian; months","UCUM","Time","Clinical","has an average of 30.435 days per month","a_j/12","ANN_J/12","1",1,false],[false,"mean Gregorian month","mo_g","MO_G","time",2629746,[0,1,0,0,0,0,0],"mo<sub>g</sub>","iso1000",false,null,null,1,false,false,0,0,"months; month-gregorian; mo-gregorian","UCUM","Time","Clinical","has an average 30.436875 days per month and is from the most internationally used civil calendar.","a_g/12","ANN_G/12","1",1,false],[false,"month","mo","MO","time",2629800,[0,1,0,0,0,0,0],"mo","iso1000",false,null,null,1,false,false,0,0,"months; duration","UCUM","Time","Clinical","based on Julian calendar which has an average of 30.435 days per month (this unit is used in astronomy but not in everyday life - see mo_g)","mo_j","MO_J","1",1,false],[false,"metric ton","t","TNE","mass",1000000,[0,0,1,0,0,0,0],"t","iso1000",true,null,null,1,false,false,0,0,"tonnes; megagrams; tons","UCUM","Mass","Nonclinical","equal to 1000 kg used in the US (recognized by NIST as metric ton), and internationally (recognized as tonne)","kg","KG","1e3",1000,false],[false,"bar","bar","BAR","pressure",100000000,[-1,-2,1,0,0,0,0],"bar","iso1000",true,null,null,1,false,false,0,0,"bars","UCUM","Pres","Nonclinical","unit of pressure equal to 10^5 Pascals, primarily used by meteorologists and in weather forecasting","Pa","PAL","1e5",100000,false],[false,"unified atomic mass unit","u","AMU","mass",1.6605402e-24,[0,0,1,0,0,0,0],"u","iso1000",true,null,null,1,false,false,0,0,"unified atomic mass units; amu; Dalton; Da","UCUM","Mass","Clinical","the mass of 1/12 of an unbound Carbon-12 atom nuclide equal to 1.6606x10^-27 kg ","g","G","1.6605402e-24",1.6605402e-24,false],[false,"astronomic unit","AU","ASU","length",149597870691,[1,0,0,0,0,0,0],"AU","iso1000",false,null,null,1,false,false,0,0,"AU; units","UCUM","Len","Clinical","unit of length used in astronomy for measuring distance in Solar system","Mm","MAM","149597.870691",149597.870691,false],[false,"parsec","pc","PRS","length",30856780000000000,[1,0,0,0,0,0,0],"pc","iso1000",true,null,null,1,false,false,0,0,"parsecs","UCUM","Len","Clinical","unit of length equal to 3.26 light years, and used to measure large distances to objects outside our Solar System","m","M","3.085678e16",30856780000000000,false],[false,"velocity of light in a vacuum","[c]","[C]","velocity",299792458,[1,-1,0,0,0,0,0],"<i>c</i>","const",true,null,null,1,false,false,0,0,"speed of light","UCUM","Vel","Constant","equal to 299792458 m/s (approximately 3 x 10^8 m/s)","m/s","M/S","299792458",299792458,false],[false,"Planck constant","[h]","[H]","action",6.6260755e-31,[2,-1,1,0,0,0,0],"<i>h</i>","const",true,null,null,1,false,false,0,0,"Planck's constant","UCUM","","Constant","constant = 6.62607004 × 10-34 m2.kg/s; defined as quantum of action","J.s","J.S","6.6260755e-34",6.6260755e-34,false],[false,"Boltzmann constant","[k]","[K]","(unclassified)",1.380658e-20,[2,-2,1,0,-1,0,0],"<i>k</i>","const",true,null,null,1,false,false,0,0,"k; kB","UCUM","","Constant","physical constant relating energy at the individual particle level with temperature = 1.38064852 ×10^−23 J/K","J/K","J/K","1.380658e-23",1.380658e-23,false],[false,"permittivity of vacuum - electric","[eps_0]","[EPS_0]","electric permittivity",8.854187817000001e-15,[-3,2,-1,0,0,2,0],"<i>ε<sub><r>0</r></sub></i>","const",true,null,null,1,false,false,0,0,"ε0; Electric Constant; vacuum permittivity; permittivity of free space ","UCUM","","Constant","approximately equal to 8.854 × 10^−12 F/m (farads per meter)","F/m","F/M","8.854187817e-12",8.854187817e-12,false],[false,"permeability of vacuum - magnetic","[mu_0]","[MU_0]","magnetic permeability",0.0012566370614359172,[1,0,1,0,0,-2,0],"<i>μ<sub><r>0</r></sub></i>","const",true,null,null,1,false,false,0,0,"μ0; vacuum permeability; permeability of free space; magnetic constant","UCUM","","Constant","equal to 4π×10^−7 N/A2 (Newtons per square ampere) ≈ 1.2566×10^−6 H/m (Henry per meter)","N/A2","4.[PI].10*-7.N/A2","1",0.0000012566370614359173,false],[false,"elementary charge","[e]","[E]","electric charge",1.60217733e-19,[0,0,0,0,0,1,0],"<i>e</i>","const",true,null,null,1,false,false,0,0,"e; q; electric charges","UCUM","","Constant","the magnitude of the electric charge carried by a single electron or proton ≈ 1.60217×10^-19 Coulombs","C","C","1.60217733e-19",1.60217733e-19,false],[false,"electronvolt","eV","EV","energy",1.60217733e-16,[2,-2,1,0,0,0,0],"eV","iso1000",true,null,null,1,false,false,0,0,"Electron Volts; electronvolts","UCUM","Eng","Clinical","unit of kinetic energy = 1 V * 1.602×10^−19 C = 1.6×10−19 Joules","[e].V","[E].V","1",1,false],[false,"electron mass","[m_e]","[M_E]","mass",9.1093897e-28,[0,0,1,0,0,0,0],"<i>m<sub><r>e</r></sub></i>","const",true,null,null,1,false,false,0,0,"electron rest mass; me","UCUM","Mass","Constant","approximately equal to 9.10938356 × 10-31 kg; defined as the mass of a stationary electron","g","g","9.1093897e-28",9.1093897e-28,false],[false,"proton mass","[m_p]","[M_P]","mass",1.6726231e-24,[0,0,1,0,0,0,0],"<i>m<sub><r>p</r></sub></i>","const",true,null,null,1,false,false,0,0,"mp; masses","UCUM","Mass","Constant","approximately equal to 1.672622×10−27 kg","g","g","1.6726231e-24",1.6726231e-24,false],[false,"Newtonian constant of gravitation","[G]","[GC]","(unclassified)",6.67259e-14,[3,-2,-1,0,0,0,0],"<i>G</i>","const",true,null,null,1,false,false,0,0,"G; gravitational constant; Newton's constant","UCUM","","Constant","gravitational constant = 6.674×10−11 N⋅m2/kg2","m3.kg-1.s-2","M3.KG-1.S-2","6.67259e-11",6.67259e-11,false],[false,"standard acceleration of free fall","[g]","[G]","acceleration",9.80665,[1,-2,0,0,0,0,0],"<i>g<sub>n</sub></i>","const",true,null,null,1,false,false,0,0,"standard gravity; g; ɡ0; ɡn","UCUM","Accel","Constant","defined by standard = 9.80665 m/s2","m/s2","M/S2","980665e-5",9.80665,false],[false,"Torr","Torr","Torr","pressure",133322,[-1,-2,1,0,0,0,0],"Torr","const",false,null,null,1,false,false,0,0,"torrs","UCUM","Pres","Clinical","1 torr = 1 mmHg; unit used to measure blood pressure","Pa","PAL","133.322",133.322,false],[false,"standard atmosphere","atm","ATM","pressure",101325000,[-1,-2,1,0,0,0,0],"atm","const",false,null,null,1,false,false,0,0,"reference pressure; atmos; std atmosphere","UCUM","Pres","Clinical","defined as being precisely equal to 101,325 Pa","Pa","PAL","101325",101325,false],[false,"light-year","[ly]","[LY]","length",9460730472580800,[1,0,0,0,0,0,0],"l.y.","const",true,null,null,1,false,false,0,0,"light years; ly","UCUM","Len","Constant","unit of astronomal distance = 5.88×10^12 mi","[c].a_j","[C].ANN_J","1",1,false],[false,"gram-force","gf","GF","force",9.80665,[1,-2,1,0,0,0,0],"gf","const",true,null,null,1,false,false,0,0,"Newtons; gram forces","UCUM","Force","Clinical","May be specific to unit related to cardiac output","g.[g]","G.[G]","1",1,false],[false,"Kayser","Ky","KY","lineic number",100,[-1,0,0,0,0,0,0],"K","cgs",true,null,null,1,false,false,0,0,"wavenumbers; kaysers","UCUM","InvLen","Clinical","unit of wavelength equal to cm^-1","cm-1","CM-1","1",1,false],[false,"Gal","Gal","GL","acceleration",0.01,[1,-2,0,0,0,0,0],"Gal","cgs",true,null,null,1,false,false,0,0,"galileos; Gals","UCUM","Accel","Clinical","unit of acceleration used in gravimetry; equivalent to cm/s2 ","cm/s2","CM/S2","1",1,false],[false,"dyne","dyn","DYN","force",0.01,[1,-2,1,0,0,0,0],"dyn","cgs",true,null,null,1,false,false,0,0,"dynes","UCUM","Force","Clinical","unit of force equal to 10^-5 Newtons","g.cm/s2","G.CM/S2","1",1,false],[false,"erg","erg","ERG","energy",0.0001,[2,-2,1,0,0,0,0],"erg","cgs",true,null,null,1,false,false,0,0,"10^-7 Joules, 10-7 Joules; 100 nJ; 100 nanoJoules; 1 dyne cm; 1 g.cm2/s2","UCUM","Eng","Clinical","unit of energy = 1 dyne centimeter = 10^-7 Joules","dyn.cm","DYN.CM","1",1,false],[false,"Poise","P","P","dynamic viscosity",100.00000000000001,[-1,-1,1,0,0,0,0],"P","cgs",true,null,null,1,false,false,0,0,"dynamic viscosity; poises","UCUM","Visc","Clinical","unit of dynamic viscosity where 1 Poise = 1/10 Pascal second","dyn.s/cm2","DYN.S/CM2","1",1,false],[false,"Biot","Bi","BI","electric current",10,[0,-1,0,0,0,1,0],"Bi","cgs",true,null,null,1,false,false,0,0,"Bi; abamperes; abA","UCUM","ElpotRat","Clinical","equal to 10 amperes","A","A","10",10,false],[false,"Stokes","St","ST","kinematic viscosity",0.00009999999999999999,[2,-1,0,0,0,0,0],"St","cgs",true,null,null,1,false,false,0,0,"kinematic viscosity","UCUM","Visc","Clinical","unit of kimematic viscosity with units cm2/s","cm2/s","CM2/S","1",1,false],[false,"Maxwell","Mx","MX","flux of magnetic induction",0.00001,[2,-1,1,0,0,-1,0],"Mx","cgs",true,null,null,1,false,false,0,0,"magnetix flux; Maxwells","UCUM","","Clinical","unit of magnetic flux","Wb","WB","1e-8",1e-8,false],[false,"Gauss","G","GS","magnetic flux density",0.1,[0,-1,1,0,0,-1,0],"Gs","cgs",true,null,null,1,false,false,0,0,"magnetic fields; magnetic flux density; induction; B","UCUM","magnetic","Clinical","CGS unit of magnetic flux density, known as magnetic field B; defined as one maxwell unit per square centimeter (see Oersted for CGS unit for H field)","T","T","1e-4",0.0001,false],[false,"Oersted","Oe","OE","magnetic field intensity",79.57747154594767,[-1,-1,0,0,0,1,0],"Oe","cgs",true,null,null,1,false,false,0,0,"H magnetic B field; Oersteds","UCUM","","Clinical","CGS unit of the auxiliary magnetic field H defined as 1 dyne per unit pole = 1000/4π amperes per meter (see Gauss for CGS unit for B field)","A/m","/[PI].A/M","250",79.57747154594767,false],[false,"Gilbert","Gb","GB","magnetic tension",0.7957747154594768,[0,-1,0,0,0,1,0],"Gb","cgs",true,null,null,1,false,false,0,0,"Gi; magnetomotive force; Gilberts","UCUM","","Clinical","unit of magnetomotive force (magnetic potential)","Oe.cm","OE.CM","1",1,false],[false,"stilb","sb","SB","lum. intensity density",10000,[-2,0,0,0,0,0,1],"sb","cgs",true,null,null,1,false,false,0,0,"stilbs","UCUM","","Obsolete","unit of luminance; equal to and replaced by unit candela per square centimeter (cd/cm2)","cd/cm2","CD/CM2","1",1,false],[false,"Lambert","Lmb","LMB","brightness",3183.098861837907,[-2,0,0,0,0,0,1],"L","cgs",true,null,null,1,false,false,0,0,"luminance; lamberts","UCUM","","Clinical","unit of luminance defined as 1 lambert = 1/ π candela per square meter","cd/cm2/[pi]","CD/CM2/[PI]","1",1,false],[false,"phot","ph","PHT","illuminance",0.0001,[-2,0,0,2,0,0,1],"ph","cgs",true,null,null,1,false,false,0,0,"phots","UCUM","","Clinical","CGS photometric unit of illuminance, or luminous flux through an area equal to 10000 lumens per square meter = 10000 lux","lx","LX","1e-4",0.0001,false],[false,"Curie","Ci","CI","radioactivity",37000000000,[0,-1,0,0,0,0,0],"Ci","cgs",true,null,null,1,false,false,0,0,"curies","UCUM","","Obsolete","unit for measuring atomic disintegration rate; replaced by the Bequerel (Bq) unit","Bq","BQ","37e9",37000000000,false],[false,"Roentgen","R","ROE","ion dose",2.58e-7,[0,0,-1,0,0,1,0],"R","cgs",true,null,null,1,false,false,0,0,"röntgen; Roentgens","UCUM","","Clinical","unit of exposure of X-rays and gamma rays in air; unit used primarily in the US but strongly discouraged by NIST","C/kg","C/KG","2.58e-4",0.000258,false],[false,"radiation absorbed dose","RAD","[RAD]","energy dose",0.01,[2,-2,0,0,0,0,0],"RAD","cgs",true,null,null,1,false,false,0,0,"doses","UCUM","","Clinical","unit of radiation absorbed dose used primarily in the US with base units 100 ergs per gram of material. Also see the SI unit Gray (Gy).","erg/g","ERG/G","100",100,false],[false,"radiation equivalent man","REM","[REM]","dose equivalent",0.01,[2,-2,0,0,0,0,0],"REM","cgs",true,null,null,1,false,false,0,0,"Roentgen Equivalent in Man; rems; dose equivalents","UCUM","","Clinical","unit of equivalent dose which measures the effect of radiation on humans equal to 0.01 sievert. Used primarily in the US. Also see SI unit Sievert (Sv)","RAD","[RAD]","1",1,false],[false,"inch","[in_i]","[IN_I]","length",0.025400000000000002,[1,0,0,0,0,0,0],"in","intcust",false,null,null,1,false,false,0,0,"inches; in; international inch; body height","UCUM","Len","Clinical","standard unit for inch in the US and internationally","cm","CM","254e-2",2.54,false],[false,"foot","[ft_i]","[FT_I]","length",0.3048,[1,0,0,0,0,0,0],"ft","intcust",false,null,null,1,false,false,0,0,"ft; fts; foot; international foot; feet; international feet; height","UCUM","Len","Clinical","unit used in the US and internationally","[in_i]","[IN_I]","12",12,false],[false,"yard","[yd_i]","[YD_I]","length",0.9144000000000001,[1,0,0,0,0,0,0],"yd","intcust",false,null,null,1,false,false,0,0,"international yards; yds; distance","UCUM","Len","Clinical","standard unit used in the US and internationally","[ft_i]","[FT_I]","3",3,false],[false,"mile","[mi_i]","[MI_I]","length",1609.344,[1,0,0,0,0,0,0],"mi","intcust",false,null,null,1,false,false,0,0,"international miles; mi I; statute mile","UCUM","Len","Clinical","standard unit used in the US and internationally","[ft_i]","[FT_I]","5280",5280,false],[false,"fathom","[fth_i]","[FTH_I]","depth of water",1.8288000000000002,[1,0,0,0,0,0,0],"fth","intcust",false,null,null,1,false,false,0,0,"international fathoms","UCUM","Len","Nonclinical","unit used in the US and internationally to measure depth of water; same length as the US fathom","[ft_i]","[FT_I]","6",6,false],[false,"nautical mile","[nmi_i]","[NMI_I]","length",1852,[1,0,0,0,0,0,0],"n.mi","intcust",false,null,null,1,false,false,0,0,"nautical mile; nautical miles; international nautical mile; international nautical miles; nm; n.m.; nmi","UCUM","Len","Nonclinical","standard unit used in the US and internationally","m","M","1852",1852,false],[false,"knot","[kn_i]","[KN_I]","velocity",0.5144444444444445,[1,-1,0,0,0,0,0],"knot","intcust",false,null,null,1,false,false,0,0,"kn; kt; international knots","UCUM","Vel","Nonclinical","defined as equal to one nautical mile (1.852 km) per hour","[nmi_i]/h","[NMI_I]/H","1",1,false],[false,"square inch","[sin_i]","[SIN_I]","area",0.0006451600000000001,[2,0,0,0,0,0,0],null,"intcust",false,null,null,1,false,false,0,0,"in2; in^2; inches squared; sq inch; inches squared; international","UCUM","Area","Clinical","standard unit used in the US and internationally","[in_i]2","[IN_I]2","1",1,false],[false,"square foot","[sft_i]","[SFT_I]","area",0.09290304,[2,0,0,0,0,0,0],null,"intcust",false,null,null,1,false,false,0,0,"ft2; ft^2; ft squared; sq ft; feet; international","UCUM","Area","Clinical","standard unit used in the US and internationally","[ft_i]2","[FT_I]2","1",1,false],[false,"square yard","[syd_i]","[SYD_I]","area",0.8361273600000002,[2,0,0,0,0,0,0],null,"intcust",false,null,null,1,false,false,0,0,"yd2; yd^2; sq. yds; yards squared; international","UCUM","Area","Clinical","standard unit used in the US and internationally","[yd_i]2","[YD_I]2","1",1,false],[false,"cubic inch","[cin_i]","[CIN_I]","volume",0.000016387064000000006,[3,0,0,0,0,0,0],null,"intcust",false,null,null,1,false,false,0,0,"in3; in^3; in*3; inches^3; inches*3; cu. in; cu in; cubic inches; inches cubed; cin","UCUM","Vol","Clinical","standard unit used in the US and internationally","[in_i]3","[IN_I]3","1",1,false],[false,"cubic foot","[cft_i]","[CFT_I]","volume",0.028316846592000004,[3,0,0,0,0,0,0],null,"intcust",false,null,null,1,false,false,0,0,"ft3; ft^3; ft*3; cu. ft; cubic feet; cubed; [ft_i]3; international","UCUM","Vol","Clinical","","[ft_i]3","[FT_I]3","1",1,false],[false,"cubic yard","[cyd_i]","[CYD_I]","volume",0.7645548579840002,[3,0,0,0,0,0,0],"cu.yd","intcust",false,null,null,1,false,false,0,0,"cubic yards; cubic yds; cu yards; CYs; yards^3; yd^3; yds^3; yd3; yds3","UCUM","Vol","Nonclinical","standard unit used in the US and internationally","[yd_i]3","[YD_I]3","1",1,false],[false,"board foot","[bf_i]","[BF_I]","volume",0.0023597372160000006,[3,0,0,0,0,0,0],null,"intcust",false,null,null,1,false,false,0,0,"BDFT; FBM; BF; board feet; international","UCUM","Vol","Nonclinical","unit of volume used to measure lumber","[in_i]3","[IN_I]3","144",144,false],[false,"cord","[cr_i]","[CR_I]","volume",3.6245563637760005,[3,0,0,0,0,0,0],null,"intcust",false,null,null,1,false,false,0,0,"crd I; international cords","UCUM","Vol","Nonclinical","unit of measure of dry volume used to measure firewood equal 128 ft3","[ft_i]3","[FT_I]3","128",128,false],[false,"mil","[mil_i]","[MIL_I]","length",0.000025400000000000004,[1,0,0,0,0,0,0],"mil","intcust",false,null,null,1,false,false,0,0,"thou, thousandth; mils; international","UCUM","Len","Clinical","equal to 0.001 international inch","[in_i]","[IN_I]","1e-3",0.001,false],[false,"circular mil","[cml_i]","[CML_I]","area",5.067074790974979e-10,[2,0,0,0,0,0,0],"circ.mil","intcust",false,null,null,1,false,false,0,0,"circular mils; cml I; international","UCUM","Area","Clinical","","[pi]/4.[mil_i]2","[PI]/4.[MIL_I]2","1",1,false],[false,"hand","[hd_i]","[HD_I]","height of horses",0.10160000000000001,[1,0,0,0,0,0,0],"hd","intcust",false,null,null,1,false,false,0,0,"hands; international","UCUM","Len","Nonclinical","used to measure horse height","[in_i]","[IN_I]","4",4,false],[false,"foot - US","[ft_us]","[FT_US]","length",0.3048006096012192,[1,0,0,0,0,0,0],"ft<sub>us</sub>","us-lengths",false,null,null,1,false,false,0,0,"US foot; foot US; us ft; ft us; height; visual distance; feet","UCUM","Len","Obsolete","Better to use [ft_i] which refers to the length used worldwide, including in the US;  [ft_us] may be confused with land survey units. ","m/3937","M/3937","1200",1200,false],[false,"yard - US","[yd_us]","[YD_US]","length",0.9144018288036575,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,0,"US yards; us yds; distance","UCUM","Len; Nrat","Obsolete","Better to use [yd_i] which refers to the length used worldwide, including in the US; [yd_us] refers to unit used in land surveys in the US","[ft_us]","[FT_US]","3",3,false],[false,"inch - US","[in_us]","[IN_US]","length",0.0254000508001016,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,0,"US inches; in us; us in; inch US","UCUM","Len","Obsolete","Better to use [in_i] which refers to the length used worldwide, including in the US","[ft_us]/12","[FT_US]/12","1",1,false],[false,"rod - US","[rd_us]","[RD_US]","length",5.029210058420117,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,0,"US rod; US rods; rd US; US rd","UCUM","Len","Obsolete","","[ft_us]","[FT_US]","16.5",16.5,false],[false,"Gunter's chain - US","[ch_us]","[CH_US]","length",20.116840233680467,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,0,"surveyor's chain; Surveyor's chain USA; Gunter’s measurement; surveyor’s measurement; Gunter's Chain USA","UCUM","Len","Obsolete","historical unit used for land survey used only in the US","[rd_us]","[RD_US]","4",4,false],[false,"link for Gunter's chain - US","[lk_us]","[LK_US]","length",0.20116840233680466,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,0,"Links for Gunter's Chain USA","UCUM","Len","Obsolete","","[ch_us]/100","[CH_US]/100","1",1,false],[false,"Ramden's chain - US","[rch_us]","[RCH_US]","length",30.480060960121918,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,0,"Ramsden's chain; engineer's chains","UCUM","Len","Obsolete","distance measuring device used for land survey","[ft_us]","[FT_US]","100",100,false],[false,"link for Ramden's chain - US","[rlk_us]","[RLK_US]","length",0.3048006096012192,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,0,"links for Ramsden's chain","UCUM","Len","Obsolete","","[rch_us]/100","[RCH_US]/100","1",1,false],[false,"fathom - US","[fth_us]","[FTH_US]","length",1.828803657607315,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,0,"US fathoms; fathom USA; fth us","UCUM","Len","Obsolete","same length as the international fathom - better to use international fathom ([fth_i])","[ft_us]","[FT_US]","6",6,false],[false,"furlong - US","[fur_us]","[FUR_US]","length",201.16840233680466,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,0,"US furlongs; fur us","UCUM","Len","Nonclinical","distance unit in horse racing","[rd_us]","[RD_US]","40",40,false],[false,"mile - US","[mi_us]","[MI_US]","length",1609.3472186944373,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,0,"U.S. Survey Miles; US statute miles; survey mi; US mi; distance","UCUM","Len","Nonclinical","Better to use [mi_i] which refers to the length used worldwide, including in the US","[fur_us]","[FUR_US]","8",8,false],[false,"acre - US","[acr_us]","[ACR_US]","area",4046.872609874252,[2,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,0,"Acre USA Survey; Acre USA; survey acres","UCUM","Area","Nonclinical","an older unit based on pre 1959 US statute lengths that is still sometimes used in the US only for land survey purposes. ","[rd_us]2","[RD_US]2","160",160,false],[false,"square rod - US","[srd_us]","[SRD_US]","area",25.292953811714074,[2,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,0,"rod2; rod^2; sq. rod; rods squared","UCUM","Area","Nonclinical","Used only in the US to measure land area, based on US statute land survey length units","[rd_us]2","[RD_US]2","1",1,false],[false,"square mile - US","[smi_us]","[SMI_US]","area",2589998.470319521,[2,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,0,"mi2; mi^2; sq mi; miles squared","UCUM","Area","Nonclinical","historical unit used only in the US for land survey purposes (based on the US survey mile), not the internationally recognized [mi_i]","[mi_us]2","[MI_US]2","1",1,false],[false,"section","[sct]","[SCT]","area",2589998.470319521,[2,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,0,"sct; sections","UCUM","Area","Nonclinical","tract of land approximately equal to 1 mile square containing 640 acres","[mi_us]2","[MI_US]2","1",1,false],[false,"township","[twp]","[TWP]","area",93239944.93150276,[2,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,0,"twp; townships","UCUM","Area","Nonclinical","land measurement equal to 6 mile square","[sct]","[SCT]","36",36,false],[false,"mil - US","[mil_us]","[MIL_US]","length",0.0000254000508001016,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,0,"thou, thousandth; mils","UCUM","Len","Obsolete","better to use [mil_i] which is based on the internationally recognized inch","[in_us]","[IN_US]","1e-3",0.001,false],[false,"inch - British","[in_br]","[IN_BR]","length",0.025399980000000003,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,0,"imperial inches; imp in; br in; british inches","UCUM","Len","Obsolete","","cm","CM","2.539998",2.539998,false],[false,"foot - British","[ft_br]","[FT_BR]","length",0.30479976000000003,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,0,"British Foot; Imperial Foot; feet; imp fts; br fts","UCUM","Len","Obsolete","","[in_br]","[IN_BR]","12",12,false],[false,"rod - British","[rd_br]","[RD_BR]","length",5.02919604,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,0,"British rods; br rd","UCUM","Len","Obsolete","","[ft_br]","[FT_BR]","16.5",16.5,false],[false,"Gunter's chain - British","[ch_br]","[CH_BR]","length",20.11678416,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,0,"Gunter's Chain British; Gunters Chain British; Surveyor's Chain British","UCUM","Len","Obsolete","historical unit used for land survey used only in Great Britain","[rd_br]","[RD_BR]","4",4,false],[false,"link for Gunter's chain - British","[lk_br]","[LK_BR]","length",0.2011678416,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,0,"Links for Gunter's Chain British","UCUM","Len","Obsolete","","[ch_br]/100","[CH_BR]/100","1",1,false],[false,"fathom - British","[fth_br]","[FTH_BR]","length",1.82879856,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,0,"British fathoms; imperial fathoms; br fth; imp fth","UCUM","Len","Obsolete","","[ft_br]","[FT_BR]","6",6,false],[false,"pace - British","[pc_br]","[PC_BR]","length",0.7619994000000001,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,0,"British paces; br pc","UCUM","Len","Nonclinical","traditional unit of length equal to 152.4 centimeters, or 1.52 meter. ","[ft_br]","[FT_BR]","2.5",2.5,false],[false,"yard - British","[yd_br]","[YD_BR]","length",0.91439928,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,0,"British yards; Br yds; distance","UCUM","Len","Obsolete","","[ft_br]","[FT_BR]","3",3,false],[false,"mile - British","[mi_br]","[MI_BR]","length",1609.3427328000002,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,0,"imperial miles; British miles; English statute miles; imp mi, br mi","UCUM","Len","Obsolete","","[ft_br]","[FT_BR]","5280",5280,false],[false,"nautical mile - British","[nmi_br]","[NMI_BR]","length",1853.1825408000002,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,0,"British nautical miles; Imperial nautical miles; Admiralty miles; n.m. br; imp nm","UCUM","Len","Obsolete","","[ft_br]","[FT_BR]","6080",6080,false],[false,"knot - British","[kn_br]","[KN_BR]","velocity",0.5147729280000001,[1,-1,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,0,"British knots; kn br; kt","UCUM","Vel","Obsolete","based on obsolete British nautical mile ","[nmi_br]/h","[NMI_BR]/H","1",1,false],[false,"acre","[acr_br]","[ACR_BR]","area",4046.850049400269,[2,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,0,"Imperial acres; British; a; ac; ar; acr","UCUM","Area","Nonclinical","the standard unit for acre used in the US and internationally","[yd_br]2","[YD_BR]2","4840",4840,false],[false,"gallon - US","[gal_us]","[GAL_US]","fluid volume",0.0037854117840000014,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"US gallons; US liquid gallon; gal us; Queen Anne's wine gallon","UCUM","Vol","Nonclinical","only gallon unit used in the US; [gal_us] is only used in some other countries in South American and Africa to measure gasoline volume","[in_i]3","[IN_I]3","231",231,false],[false,"barrel - US","[bbl_us]","[BBL_US]","fluid volume",0.15898729492800007,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"bbl","UCUM","Vol","Nonclinical","[bbl_us] is the standard unit for oil barrel, which is a unit only used in the US to measure the volume oil. ","[gal_us]","[GAL_US]","42",42,false],[false,"quart - US","[qt_us]","[QT_US]","fluid volume",0.0009463529460000004,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"US quarts; us qts","UCUM","Vol","Clinical","Used only in the US","[gal_us]/4","[GAL_US]/4","1",1,false],[false,"pint - US","[pt_us]","[PT_US]","fluid volume",0.0004731764730000002,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"US pints; pint US; liquid pint; pt us; us pt","UCUM","Vol","Clinical","Used only in the US","[qt_us]/2","[QT_US]/2","1",1,false],[false,"gill - US","[gil_us]","[GIL_US]","fluid volume",0.00011829411825000005,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"US gills; gil us","UCUM","Vol","Nonclinical","only used in the context of alcohol volume in the US","[pt_us]/4","[PT_US]/4","1",1,false],[false,"fluid ounce - US","[foz_us]","[FOZ_US]","fluid volume",0.00002957352956250001,[3,0,0,0,0,0,0],"oz fl","us-volumes",false,null,null,1,false,false,0,0,"US fluid ounces; fl ozs; FO; fl. oz.; foz us","UCUM","Vol","Clinical","unit used only in the US","[gil_us]/4","[GIL_US]/4","1",1,false],[false,"fluid dram - US","[fdr_us]","[FDR_US]","fluid volume",0.0000036966911953125014,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"US fluid drams; fdr us","UCUM","Vol","Nonclinical","equal to 1/8 US fluid ounce = 3.69 mL; used informally to mean small amount of liquor, especially Scotch whiskey","[foz_us]/8","[FOZ_US]/8","1",1,false],[false,"minim - US","[min_us]","[MIN_US]","fluid volume",6.161151992187503e-8,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"min US; US min; ♏ US","UCUM","Vol","Obsolete","","[fdr_us]/60","[FDR_US]/60","1",1,false],[false,"cord - US","[crd_us]","[CRD_US]","fluid volume",3.6245563637760005,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"US cord; US cords; crd us; us crd","UCUM","Vol","Nonclinical","unit of measure of dry volume used to measure firewood equal 128 ft3 (the same as international cord [cr_i])","[ft_i]3","[FT_I]3","128",128,false],[false,"bushel - US","[bu_us]","[BU_US]","dry volume",0.035239070166880014,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"US bushels; US bsh; US bu","UCUM","Vol","Obsolete","Historical unit of dry volume that is rarely used today","[in_i]3","[IN_I]3","2150.42",2150.42,false],[false,"gallon - historical","[gal_wi]","[GAL_WI]","dry volume",0.004404883770860002,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"Corn Gallon British; Dry Gallon US; Gallons Historical; Grain Gallon British; Winchester Corn Gallon; historical winchester gallons; wi gal","UCUM","Vol","Obsolete","historical unit of dry volume no longer used","[bu_us]/8","[BU_US]/8","1",1,false],[false,"peck - US","[pk_us]","[PK_US]","dry volume",0.008809767541720004,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"US pecks; US pk","UCUM","Vol","Nonclinical","unit of dry volume rarely used today (can be used to measure volume of apples)","[bu_us]/4","[BU_US]/4","1",1,false],[false,"dry quart - US","[dqt_us]","[DQT_US]","dry volume",0.0011012209427150004,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"dry quarts; dry quart US; US dry quart; dry qt; us dry qt; dqt; dqt us","UCUM","Vol","Nonclinical","historical unit of dry volume only in the US, but is rarely used today","[pk_us]/8","[PK_US]/8","1",1,false],[false,"dry pint - US","[dpt_us]","[DPT_US]","dry volume",0.0005506104713575002,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"dry pints; dry pint US; US dry pint; dry pt; dpt; dpt us","UCUM","Vol","Nonclinical","historical unit of dry volume only in the US, but is rarely used today","[dqt_us]/2","[DQT_US]/2","1",1,false],[false,"tablespoon - US","[tbs_us]","[TBS_US]","volume",0.000014786764781250006,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"Tbs; tbsp; tbs us; US tablespoons","UCUM","Vol","Clinical","unit defined as 0.5 US fluid ounces or 3 teaspoons - used only in the US. See [tbs_m] for the unit used internationally and in the US for nutrional labelling. ","[foz_us]/2","[FOZ_US]/2","1",1,false],[false,"teaspoon - US","[tsp_us]","[TSP_US]","volume",0.000004928921593750002,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"tsp; t; US teaspoons","UCUM","Vol","Nonclinical","unit defined as 1/6 US fluid ounces - used only in the US. See [tsp_m] for the unit used internationally and in the US for nutrional labelling. ","[tbs_us]/3","[TBS_US]/3","1",1,false],[false,"cup - US customary","[cup_us]","[CUP_US]","volume",0.0002365882365000001,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"cup us; us cups","UCUM","Vol","Nonclinical","Unit defined as 1/2 US pint or 16 US tablespoons ≈ 236.59 mL, which is not the standard unit defined by the FDA of 240 mL - see [cup_m] (metric cup)","[tbs_us]","[TBS_US]","16",16,false],[false,"fluid ounce - metric","[foz_m]","[FOZ_M]","fluid volume",0.000029999999999999997,[3,0,0,0,0,0,0],"oz fl","us-volumes",false,null,null,1,false,false,0,0,"metric fluid ounces; fozs m; fl ozs m","UCUM","Vol","Clinical","unit used only in the US for nutritional labelling, as set by the FDA","mL","ML","30",30,false],[false,"cup - US legal","[cup_m]","[CUP_M]","volume",0.00023999999999999998,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"cup m; metric cups","UCUM","Vol","Clinical","standard unit equal to 240 mL used in the US for nutritional labelling, as defined by the FDA. Note that this is different from the US customary cup (236.59 mL) and the metric cup used in Commonwealth nations (250 mL).","mL","ML","240",240,false],[false,"teaspoon - metric","[tsp_m]","[TSP_M]","volume",0.0000049999999999999996,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"tsp; t; metric teaspoons","UCUM","Vol","Clinical","standard unit used in the US and internationally","mL","mL","5",5,false],[false,"tablespoon - metric","[tbs_m]","[TBS_M]","volume",0.000014999999999999999,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,0,"metric tablespoons; Tbs; tbsp; T; tbs m","UCUM","Vol","Clinical","standard unit used in the US and internationally","mL","mL","15",15,false],[false,"gallon- British","[gal_br]","[GAL_BR]","volume",0.004546090000000001,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,0,"imperial gallons, UK gallons; British gallons; br gal; imp gal","UCUM","Vol","Nonclinical","Used only in Great Britain and other Commonwealth countries","l","L","4.54609",4.54609,false],[false,"peck - British","[pk_br]","[PK_BR]","volume",0.009092180000000002,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,0,"imperial pecks; British pecks; br pk; imp pk","UCUM","Vol","Nonclinical","unit of dry volume rarely used today (can be used to measure volume of apples)","[gal_br]","[GAL_BR]","2",2,false],[false,"bushel - British","[bu_br]","[BU_BR]","volume",0.03636872000000001,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,0,"British bushels; imperial; br bsh; br bu; imp","UCUM","Vol","Obsolete","Historical unit of dry volume that is rarely used today","[pk_br]","[PK_BR]","4",4,false],[false,"quart - British","[qt_br]","[QT_BR]","volume",0.0011365225000000002,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,0,"British quarts; imperial quarts; br qts","UCUM","Vol","Clinical","Used only in Great Britain and other Commonwealth countries","[gal_br]/4","[GAL_BR]/4","1",1,false],[false,"pint - British","[pt_br]","[PT_BR]","volume",0.0005682612500000001,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,0,"British pints; imperial pints; pt br; br pt; imp pt; pt imp","UCUM","Vol","Clinical","Used only in Great Britain and other Commonwealth countries","[qt_br]/2","[QT_BR]/2","1",1,false],[false,"gill - British","[gil_br]","[GIL_BR]","volume",0.00014206531250000003,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,0,"imperial gills; British gills; imp gill, br gill","UCUM","Vol","Nonclinical","only used in the context of alcohol volume in Great Britain","[pt_br]/4","[PT_BR]/4","1",1,false],[false,"fluid ounce - British","[foz_br]","[FOZ_BR]","volume",0.000028413062500000005,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,0,"British fluid ounces; Imperial fluid ounces; br fozs; imp fozs; br fl ozs","UCUM","Vol","Clinical","Used only in Great Britain and other Commonwealth countries","[gil_br]/5","[GIL_BR]/5","1",1,false],[false,"fluid dram - British","[fdr_br]","[FDR_BR]","volume",0.0000035516328125000006,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,0,"British fluid drams; fdr br","UCUM","Vol","Nonclinical","equal to 1/8 Imperial fluid ounce = 3.55 mL; used informally to mean small amount of liquor, especially Scotch whiskey","[foz_br]/8","[FOZ_BR]/8","1",1,false],[false,"minim - British","[min_br]","[MIN_BR]","volume",5.919388020833334e-8,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,0,"min br; br min; ♏ br","UCUM","Vol","Obsolete","","[fdr_br]/60","[FDR_BR]/60","1",1,false],[false,"grain","[gr]","[GR]","mass",0.06479891,[0,0,1,0,0,0,0],null,"avoirdupois",false,null,null,1,false,false,0,0,"gr; grains","UCUM","Mass","Nonclinical","an apothecary measure of mass rarely used today","mg","MG","64.79891",64.79891,false],[false,"pound","[lb_av]","[LB_AV]","mass",453.59237,[0,0,1,0,0,0,0],"lb","avoirdupois",false,null,null,1,false,false,0,0,"avoirdupois pounds, international pounds; av lbs; pounds","UCUM","Mass","Clinical","standard unit used in the US and internationally","[gr]","[GR]","7000",7000,false],[false,"pound force - US","[lbf_av]","[LBF_AV]","force",4448.2216152605,[1,-2,1,0,0,0,0],"lbf","const",false,null,null,1,false,false,0,0,"lbfs; US lbf; US pound forces","UCUM","Force","Clinical","only rarely needed in health care - see [lb_av] which is the more common unit to express weight","[lb_av].[g]","[LB_AV].[G]","1",1,false],[false,"ounce","[oz_av]","[OZ_AV]","mass",28.349523125,[0,0,1,0,0,0,0],"oz","avoirdupois",false,null,null,1,false,false,0,0,"ounces; international ounces; avoirdupois ounces; av ozs","UCUM","Mass","Clinical","standard unit used in the US and internationally","[lb_av]/16","[LB_AV]/16","1",1,false],[false,"Dram mass unit","[dr_av]","[DR_AV]","mass",1.7718451953125,[0,0,1,0,0,0,0],null,"avoirdupois",false,null,null,1,false,false,0,0,"Dram; drams avoirdupois; avoidupois dram; international dram","UCUM","Mass","Clinical","unit from the avoirdupois system, which is used in the US and internationally","[oz_av]/16","[OZ_AV]/16","1",1,false],[false,"short hundredweight","[scwt_av]","[SCWT_AV]","mass",45359.237,[0,0,1,0,0,0,0],null,"avoirdupois",false,null,null,1,false,false,0,0,"hundredweights; s cwt; scwt; avoirdupois","UCUM","Mass","Nonclinical","Used only in the US to equal 100 pounds","[lb_av]","[LB_AV]","100",100,false],[false,"long hundredweight","[lcwt_av]","[LCWT_AV]","mass",50802.345440000005,[0,0,1,0,0,0,0],null,"avoirdupois",false,null,null,1,false,false,0,0,"imperial hundredweights; imp cwt; lcwt; avoirdupois","UCUM","Mass","Obsolete","","[lb_av]","[LB_AV]","112",112,false],[false,"short ton - US","[ston_av]","[STON_AV]","mass",907184.74,[0,0,1,0,0,0,0],null,"avoirdupois",false,null,null,1,false,false,0,0,"ton; US tons; avoirdupois tons","UCUM","Mass","Clinical","Used only in the US","[scwt_av]","[SCWT_AV]","20",20,false],[false,"long ton - British","[lton_av]","[LTON_AV]","mass",1016046.9088000001,[0,0,1,0,0,0,0],null,"avoirdupois",false,null,null,1,false,false,0,0,"imperial tons; weight tons; British long tons; long ton avoirdupois","UCUM","Mass","Nonclinical","Used only in Great Britain and other Commonwealth countries","[lcwt_av]","[LCWT_AV]","20",20,false],[false,"stone - British","[stone_av]","[STONE_AV]","mass",6350.293180000001,[0,0,1,0,0,0,0],null,"avoirdupois",false,null,null,1,false,false,0,0,"British stones; avoirdupois","UCUM","Mass","Nonclinical","Used primarily in the UK and Ireland to measure body weight","[lb_av]","[LB_AV]","14",14,false],[false,"pennyweight - troy","[pwt_tr]","[PWT_TR]","mass",1.5551738400000001,[0,0,1,0,0,0,0],null,"troy",false,null,null,1,false,false,0,0,"dwt; denarius weights","UCUM","Mass","Obsolete","historical unit used to measure mass and cost of precious metals","[gr]","[GR]","24",24,false],[false,"ounce - troy","[oz_tr]","[OZ_TR]","mass",31.103476800000003,[0,0,1,0,0,0,0],null,"troy",false,null,null,1,false,false,0,0,"troy ounces; tr ozs","UCUM","Mass","Nonclinical","unit of mass for precious metals and gemstones only","[pwt_tr]","[PWT_TR]","20",20,false],[false,"pound - troy","[lb_tr]","[LB_TR]","mass",373.2417216,[0,0,1,0,0,0,0],null,"troy",false,null,null,1,false,false,0,0,"troy pounds; tr lbs","UCUM","Mass","Nonclinical","only used for weighing precious metals","[oz_tr]","[OZ_TR]","12",12,false],[false,"scruple","[sc_ap]","[SC_AP]","mass",1.2959782,[0,0,1,0,0,0,0],null,"apoth",false,null,null,1,false,false,0,0,"scruples; sc ap","UCUM","Mass","Obsolete","","[gr]","[GR]","20",20,false],[false,"dram - apothecary","[dr_ap]","[DR_AP]","mass",3.8879346,[0,0,1,0,0,0,0],null,"apoth",false,null,null,1,false,false,0,0,"ʒ; drachm; apothecaries drams; dr ap; dram ap","UCUM","Mass","Nonclinical","unit still used in the US occasionally to measure amount of drugs in pharmacies","[sc_ap]","[SC_AP]","3",3,false],[false,"ounce - apothecary","[oz_ap]","[OZ_AP]","mass",31.1034768,[0,0,1,0,0,0,0],null,"apoth",false,null,null,1,false,false,0,0,"apothecary ounces; oz ap; ap ozs; ozs ap","UCUM","Mass","Obsolete","","[dr_ap]","[DR_AP]","8",8,false],[false,"pound - apothecary","[lb_ap]","[LB_AP]","mass",373.2417216,[0,0,1,0,0,0,0],null,"apoth",false,null,null,1,false,false,0,0,"apothecary pounds; apothecaries pounds; ap lb; lb ap; ap lbs; lbs ap","UCUM","Mass","Obsolete","","[oz_ap]","[OZ_AP]","12",12,false],[false,"ounce - metric","[oz_m]","[OZ_M]","mass",28,[0,0,1,0,0,0,0],null,"apoth",false,null,null,1,false,false,0,0,"metric ounces; m ozs","UCUM","Mass","Clinical","see [oz_av] (the avoirdupois ounce) for the standard ounce used internationally; [oz_m] is equal to 28 grams and is based on the apothecaries' system of mass units which is used in some US pharmacies. ","g","g","28",28,false],[false,"line","[lne]","[LNE]","length",0.002116666666666667,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,0,"British lines; br L; L; l","UCUM","Len","Obsolete","","[in_i]/12","[IN_I]/12","1",1,false],[false,"point (typography)","[pnt]","[PNT]","length",0.0003527777777777778,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,0,"DTP points; desktop publishing point; pt; pnt","UCUM","Len","Nonclinical","typography unit for typesetter's length","[lne]/6","[LNE]/6","1",1,false],[false,"pica (typography)","[pca]","[PCA]","length",0.004233333333333334,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,0,"picas","UCUM","Len","Nonclinical","typography unit for typesetter's length","[pnt]","[PNT]","12",12,false],[false,"Printer's point (typography)","[pnt_pr]","[PNT_PR]","length",0.00035145980000000004,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,0,"pnt pr","UCUM","Len","Nonclinical","typography unit for typesetter's length","[in_i]","[IN_I]","0.013837",0.013837,false],[false,"Printer's pica  (typography)","[pca_pr]","[PCA_PR]","length",0.004217517600000001,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,0,"pca pr; Printer's picas","UCUM","Len","Nonclinical","typography unit for typesetter's length","[pnt_pr]","[PNT_PR]","12",12,false],[false,"pied","[pied]","[PIED]","length",0.3248,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,0,"pieds du roi; Paris foot; royal; French; feet","UCUM","Len","Obsolete","","cm","CM","32.48",32.48,false],[false,"pouce","[pouce]","[POUCE]","length",0.027066666666666666,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,0,"historical French inches; French royal inches","UCUM","Len","Obsolete","","[pied]/12","[PIED]/12","1",1,false],[false,"ligne","[ligne]","[LIGNE]","length",0.0022555555555555554,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,0,"Paris lines; lignes","UCUM","Len","Obsolete","","[pouce]/12","[POUCE]/12","1",1,false],[false,"didot","[didot]","[DIDOT]","length",0.0003759259259259259,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,0,"Didot point; dd; Didots Point; didots; points","UCUM","Len","Obsolete","typography unit for typesetter's length","[ligne]/6","[LIGNE]/6","1",1,false],[false,"cicero","[cicero]","[CICERO]","length",0.004511111111111111,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,0,"Didot's pica; ciceros; picas","UCUM","Len","Obsolete","typography unit for typesetter's length","[didot]","[DIDOT]","12",12,false],[false,"degrees Fahrenheit","[degF]","[DEGF]","temperature",0.5555555555555556,[0,0,0,0,1,0,0],"°F","heat",false,null,"degF",1,true,false,0,0,"°F; deg F","UCUM","Temp","Clinical","","K",null,null,0.5555555555555556,false],[false,"degrees Rankine","[degR]","[degR]","temperature",0.5555555555555556,[0,0,0,0,1,0,0],"°R","heat",false,null,null,1,false,false,0,0,"°R; °Ra; Rankine","UCUM","Temp","Obsolete","Replaced by Kelvin","K/9","K/9","5",5,false],[false,"degrees Réaumur","[degRe]","[degRe]","temperature",1.25,[0,0,0,0,1,0,0],"°Ré","heat",false,null,"degRe",1,true,false,0,0,"°Ré, °Re, °r; Réaumur; degree Reaumur; Reaumur","UCUM","Temp","Obsolete","replaced by Celsius","K",null,null,1.25,false],[false,"calorie at 15°C","cal_[15]","CAL_[15]","energy",4185.8,[2,-2,1,0,0,0,0],"cal<sub>15°C</sub>","heat",true,null,null,1,false,false,0,0,"calorie 15 C; cals 15 C; calories at 15 C","UCUM","Enrg","Nonclinical","equal to 4.1855 joules; calorie most often used in engineering","J","J","4.18580",4.1858,false],[false,"calorie at 20°C","cal_[20]","CAL_[20]","energy",4181.9,[2,-2,1,0,0,0,0],"cal<sub>20°C</sub>","heat",true,null,null,1,false,false,0,0,"calorie 20 C; cal 20 C; calories at 20 C","UCUM","Enrg","Clinical","equal to 4.18190  joules. ","J","J","4.18190",4.1819,false],[false,"mean calorie","cal_m","CAL_M","energy",4190.0199999999995,[2,-2,1,0,0,0,0],"cal<sub>m</sub>","heat",true,null,null,1,false,false,0,0,"mean cals; mean calories","UCUM","Enrg","Clinical","equal to 4.19002 joules. ","J","J","4.19002",4.19002,false],[false,"international table calorie","cal_IT","CAL_IT","energy",4186.8,[2,-2,1,0,0,0,0],"cal<sub>IT</sub>","heat",true,null,null,1,false,false,0,0,"calories IT; IT cals; international steam table calories","UCUM","Enrg","Nonclinical","used in engineering steam tables and defined as 1/860 international watt-hour; equal to 4.1868 joules","J","J","4.1868",4.1868,false],[false,"thermochemical calorie","cal_th","CAL_TH","energy",4184,[2,-2,1,0,0,0,0],"cal<sub>th</sub>","heat",true,null,null,1,false,false,0,0,"thermochemical calories; th cals","UCUM","Enrg","Clinical","equal to 4.184 joules; used as the unit in medicine and biochemistry (equal to cal)","J","J","4.184",4.184,false],[false,"calorie","cal","CAL","energy",4184,[2,-2,1,0,0,0,0],"cal","heat",true,null,null,1,false,false,0,0,"gram calories; small calories","UCUM","Enrg","Clinical","equal to 4.184 joules (the same value as the thermochemical calorie, which is the most common calorie used in medicine and biochemistry)","cal_th","CAL_TH","1",1,false],[false,"nutrition label Calories","[Cal]","[CAL]","energy",4184000,[2,-2,1,0,0,0,0],"Cal","heat",false,null,null,1,false,false,0,0,"food calories; Cal; kcal","UCUM","Eng","Clinical","","kcal_th","KCAL_TH","1",1,false],[false,"British thermal unit at 39°F","[Btu_39]","[BTU_39]","energy",1059670,[2,-2,1,0,0,0,0],"Btu<sub>39°F</sub>","heat",false,null,null,1,false,false,0,0,"BTU 39F; BTU 39 F; B.T.U. 39 F; B.Th.U. 39 F; BThU 39 F; British thermal units","UCUM","Eng","Nonclinical","equal to 1.05967 kJ; used as a measure of power in the electric power, steam generation, heating, and air conditioning industries","kJ","kJ","1.05967",1.05967,false],[false,"British thermal unit at 59°F","[Btu_59]","[BTU_59]","energy",1054800,[2,-2,1,0,0,0,0],"Btu<sub>59°F</sub>","heat",false,null,null,1,false,false,0,0,"BTU 59 F; BTU 59F; B.T.U. 59 F; B.Th.U. 59 F; BThU 59F; British thermal units","UCUM","Eng","Nonclinical","equal to  1.05480 kJ; used as a measure of power in the electric power, steam generation, heating, and air conditioning industries","kJ","kJ","1.05480",1.0548,false],[false,"British thermal unit at 60°F","[Btu_60]","[BTU_60]","energy",1054680,[2,-2,1,0,0,0,0],"Btu<sub>60°F</sub>","heat",false,null,null,1,false,false,0,0,"BTU 60 F; BTU 60F; B.T.U. 60 F; B.Th.U. 60 F; BThU 60 F; British thermal units 60 F","UCUM","Eng","Nonclinical","equal to 1.05468 kJ; used as a measure of power in the electric power, steam generation, heating, and air conditioning industries","kJ","kJ","1.05468",1.05468,false],[false,"mean British thermal unit","[Btu_m]","[BTU_M]","energy",1055870,[2,-2,1,0,0,0,0],"Btu<sub>m</sub>","heat",false,null,null,1,false,false,0,0,"BTU mean; B.T.U. mean; B.Th.U. mean; BThU mean; British thermal units mean; ","UCUM","Eng","Nonclinical","equal to 1.05587 kJ; used as a measure of power in the electric power, steam generation, heating, and air conditioning industries","kJ","kJ","1.05587",1.05587,false],[false,"international table British thermal unit","[Btu_IT]","[BTU_IT]","energy",1055055.85262,[2,-2,1,0,0,0,0],"Btu<sub>IT</sub>","heat",false,null,null,1,false,false,0,0,"BTU IT; B.T.U. IT; B.Th.U. IT; BThU IT; British thermal units IT","UCUM","Eng","Nonclinical","equal to 1.055 kJ; used as a measure of power in the electric power, steam generation, heating, and air conditioning industries","kJ","kJ","1.05505585262",1.05505585262,false],[false,"thermochemical British thermal unit","[Btu_th]","[BTU_TH]","energy",1054350,[2,-2,1,0,0,0,0],"Btu<sub>th</sub>","heat",false,null,null,1,false,false,0,0,"BTU Th; B.T.U. Th; B.Th.U. Th; BThU Th; thermochemical British thermal units","UCUM","Eng","Nonclinical","equal to 1.054350 kJ; used as a measure of power in the electric power, steam generation, heating, and air conditioning industries","kJ","kJ","1.054350",1.05435,false],[false,"British thermal unit","[Btu]","[BTU]","energy",1054350,[2,-2,1,0,0,0,0],"btu","heat",false,null,null,1,false,false,0,0,"BTU; B.T.U. ; B.Th.U.; BThU; British thermal units","UCUM","Eng","Nonclinical","equal to the thermochemical British thermal unit equal to 1.054350 kJ; used as a measure of power in the electric power, steam generation, heating, and air conditioning industries","[Btu_th]","[BTU_TH]","1",1,false],[false,"horsepower - mechanical","[HP]","[HP]","power",745699.8715822703,[2,-3,1,0,0,0,0],null,"heat",false,null,null,1,false,false,0,0,"imperial horsepowers","UCUM","EngRat","Nonclinical","refers to mechanical horsepower, which is unit used to measure engine power primarily in the US. ","[ft_i].[lbf_av]/s","[FT_I].[LBF_AV]/S","550",550,false],[false,"tex","tex","TEX","linear mass density (of textile thread)",0.001,[-1,0,1,0,0,0,0],"tex","heat",true,null,null,1,false,false,0,0,"linear mass density; texes","UCUM","","Clinical","unit of linear mass density for fibers equal to gram per 1000 meters","g/km","G/KM","1",1,false],[false,"Denier (linear mass density)","[den]","[DEN]","linear mass density (of textile thread)",0.0001111111111111111,[-1,0,1,0,0,0,0],"den","heat",false,null,null,1,false,false,0,0,"den; deniers","UCUM","","Nonclinical","equal to the mass in grams per 9000 meters of the fiber (1 denier = 1 strand of silk)","g/9/km","G/9/KM","1",1,false],[false,"meter of water column","m[H2O]","M[H2O]","pressure",9806650,[-1,-2,1,0,0,0,0],"m HO<sub><r>2</r></sub>","clinical",true,null,null,1,false,false,0,0,"mH2O; m H2O; meters of water column; metres; pressure","UCUM","Pres","Clinical","","kPa","KPAL","980665e-5",9.80665,false],[false,"meter of mercury column","m[Hg]","M[HG]","pressure",133322000,[-1,-2,1,0,0,0,0],"m Hg","clinical",true,null,null,1,false,false,0,0,"mHg; m Hg; meters of mercury column; metres; pressure","UCUM","Pres","Clinical","","kPa","KPAL","133.3220",133.322,false],[false,"inch of water column","[in_i'H2O]","[IN_I'H2O]","pressure",249088.91000000003,[-1,-2,1,0,0,0,0],"in HO<sub><r>2</r></sub>","clinical",false,null,null,1,false,false,0,0,"inches WC; inAq; in H2O; inch of water gauge; iwg; pressure","UCUM","Pres","Clinical","unit of pressure, especially in respiratory and ventilation care","m[H2O].[in_i]/m","M[H2O].[IN_I]/M","1",1,false],[false,"inch of mercury column","[in_i'Hg]","[IN_I'HG]","pressure",3386378.8000000003,[-1,-2,1,0,0,0,0],"in Hg","clinical",false,null,null,1,false,false,0,0,"inHg; in Hg; pressure; inches","UCUM","Pres","Clinical","unit of pressure used in US to measure barometric pressure and occasionally blood pressure (see mm[Hg] for unit used internationally)","m[Hg].[in_i]/m","M[HG].[IN_I]/M","1",1,false],[false,"peripheral vascular resistance unit","[PRU]","[PRU]","fluid resistance",133322000000,[-4,-1,1,0,0,0,0],"P.R.U.","clinical",false,null,null,1,false,false,0,0,"peripheral vascular resistance units; peripheral resistance unit; peripheral resistance units; PRU","UCUM","FldResist","Clinical","used to assess blood flow in the capillaries; equal to 1 mmH.min/mL = 133.3 Pa·min/mL","mm[Hg].s/ml","MM[HG].S/ML","1",1,false],[false,"Wood unit","[wood'U]","[WOOD'U]","fluid resistance",7999320000,[-4,-1,1,0,0,0,0],"Wood U.","clinical",false,null,null,1,false,false,0,0,"hybrid reference units; HRU; mmHg.min/L; vascular resistance","UCUM","Pres","Clinical","simplified unit of measurement for for measuring pulmonary vascular resistance that uses pressure; equal to mmHg.min/L","mm[Hg].min/L","MM[HG].MIN/L","1",1,false],[false,"diopter (lens)","[diop]","[DIOP]","refraction of a lens",1,[1,0,0,0,0,0,0],"dpt","clinical",false,null,"inv",1,false,false,0,0,"diopters; diop; dioptre; dpt; refractive power","UCUM","InvLen","Clinical","unit of optical power of lens represented by inverse meters (m^-1)","m","/M","1",1,false],[false,"prism diopter (magnifying power)","[p'diop]","[P'DIOP]","refraction of a prism",1,[0,0,0,1,0,0,0],"PD","clinical",false,null,"tanTimes100",1,true,false,0,0,"diopters; dioptres; p diops; pdiop; dpt; pdptr; Δ; cm/m; centimeter per meter; centimetre; metre","UCUM","Angle","Clinical","unit for prism correction in eyeglass prescriptions","rad",null,null,1,false],[false,"percent of slope","%[slope]","%[SLOPE]","slope",0.017453292519943295,[0,0,0,1,0,0,0],"%","clinical",false,null,"100tan",1,true,false,0,0,"% slope; %slope; percents slopes","UCUM","VelFr; ElpotRatFr; VelRtoFr; AccelFr","Clinical","","deg",null,null,1,false],[false,"mesh","[mesh_i]","[MESH_I]","lineic number",0.025400000000000002,[1,0,0,0,0,0,0],null,"clinical",false,null,"inv",1,false,false,0,0,"meshes","UCUM","NLen (lineic number)","Clinical","traditional unit of length defined as the number of strands or particles per inch","[in_i]","/[IN_I]","1",1,false],[false,"French (catheter gauge) ","[Ch]","[CH]","gauge of catheters",0.0003333333333333333,[1,0,0,0,0,0,0],"Ch","clinical",false,null,null,1,false,false,0,0,"Charrières, French scales; French gauges; Fr, Fg, Ga, FR, Ch","UCUM","Len; Circ; Diam","Clinical","","mm/3","MM/3","1",1,false],[false,"drop - metric (1/20 mL)","[drp]","[DRP]","volume",5e-8,[3,0,0,0,0,0,0],"drp","clinical",false,null,null,1,false,false,0,0,"drop dosing units; metric drops; gtt","UCUM","Vol","Clinical","standard unit used in the US and internationally for clinical medicine but note that although [drp] is defined as 1/20 milliliter, in practice, drop sizes will vary due to external factors","ml/20","ML/20","1",1,false],[false,"Hounsfield unit","[hnsf'U]","[HNSF'U]","x-ray attenuation",1,[0,0,0,0,0,0,0],"HF","clinical",false,null,null,1,false,false,0,0,"HU; units","UCUM","","Clinical","used to measure X-ray attenuation, especially in CT scans.","1","1","1",1,false],[false,"Metabolic Equivalent of Task ","[MET]","[MET]","metabolic cost of physical activity",5.833333333333334e-11,[3,-1,-1,0,0,0,0],"MET","clinical",false,null,null,1,false,false,0,0,"metabolic equivalents","UCUM","RelEngRat","Clinical","unit used to measure rate of energy expenditure per power in treadmill and other functional tests","mL/min/kg","ML/MIN/KG","3.5",3.5,false],[false,"homeopathic potency of decimal series (retired)","[hp'_X]","[HP'_X]","homeopathic potency (retired)",1,[0,0,0,0,0,0,0],"X","clinical",false,null,"hpX",1,true,false,0,0,null,"UCUM",null,null,null,"1",null,null,1,false],[false,"homeopathic potency of centesimal series (retired)","[hp'_C]","[HP'_C]","homeopathic potency (retired)",1,[0,0,0,0,0,0,0],"C","clinical",false,null,"hpC",1,true,false,0,0,null,"UCUM",null,null,null,"1",null,null,1,false],[false,"homeopathic potency of millesimal series (retired)","[hp'_M]","[HP'_M]","homeopathic potency (retired)",1,[0,0,0,0,0,0,0],"M","clinical",false,null,"hpM",1,true,false,0,0,null,"UCUM",null,null,null,"1",null,null,1,false],[false,"homeopathic potency of quintamillesimal series (retired)","[hp'_Q]","[HP'_Q]","homeopathic potency (retired)",1,[0,0,0,0,0,0,0],"Q","clinical",false,null,"hpQ",1,true,false,0,0,null,"UCUM",null,null,null,"1",null,null,1,false],[false,"homeopathic potency of decimal hahnemannian series","[hp_X]","[HP_X]","homeopathic potency (Hahnemann)",1,[0,0,0,0,0,0,0],"X","clinical",false,null,null,1,false,true,0,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"homeopathic potency of centesimal hahnemannian series","[hp_C]","[HP_C]","homeopathic potency (Hahnemann)",1,[0,0,0,0,0,0,0],"C","clinical",false,null,null,1,false,true,0,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"homeopathic potency of millesimal hahnemannian series","[hp_M]","[HP_M]","homeopathic potency (Hahnemann)",1,[0,0,0,0,0,0,0],"M","clinical",false,null,null,1,false,true,0,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"homeopathic potency of quintamillesimal hahnemannian series","[hp_Q]","[HP_Q]","homeopathic potency (Hahnemann)",1,[0,0,0,0,0,0,0],"Q","clinical",false,null,null,1,false,true,0,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"homeopathic potency of decimal korsakovian series","[kp_X]","[KP_X]","homeopathic potency (Korsakov)",1,[0,0,0,0,0,0,0],"X","clinical",false,null,null,1,false,true,0,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"homeopathic potency of centesimal korsakovian series","[kp_C]","[KP_C]","homeopathic potency (Korsakov)",1,[0,0,0,0,0,0,0],"C","clinical",false,null,null,1,false,true,0,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"homeopathic potency of millesimal korsakovian series","[kp_M]","[KP_M]","homeopathic potency (Korsakov)",1,[0,0,0,0,0,0,0],"M","clinical",false,null,null,1,false,true,0,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"homeopathic potency of quintamillesimal korsakovian series","[kp_Q]","[KP_Q]","homeopathic potency (Korsakov)",1,[0,0,0,0,0,0,0],"Q","clinical",false,null,null,1,false,true,0,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"equivalent","eq","EQ","amount of substance",6.0221367e+23,[0,0,0,0,0,0,0],"eq","chemical",true,null,null,1,false,false,0,1,"equivalents","UCUM","Sub","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"osmole","osm","OSM","amount of substance (dissolved particles)",6.0221367e+23,[0,0,0,0,0,0,0],"osm","chemical",true,null,null,1,false,false,1,0,"osmoles; osmols","UCUM","Osmol","Clinical","the number of moles of solute that contribute to the osmotic pressure of a solution","mol","MOL","1",1,false],[false,"pH","[pH]","[PH]","acidity",6.0221366999999994e+26,[-3,0,0,0,0,0,0],"pH","chemical",false,null,"pH",1,true,false,0,0,"pH scale","UCUM","LogCnc","Clinical","Log concentration of H+","mol/l",null,null,1,false],[false,"gram percent","g%","G%","mass concentration",10000,[-3,0,1,0,0,0,0],"g%","chemical",true,null,null,1,false,false,0,0,"gram %; gram%; grams per deciliter; g/dL; gm per dL; gram percents","UCUM","MCnc","Clinical","equivalent to unit gram per deciliter (g/dL), a unit often used in medical tests to represent solution concentrations","g/dl","G/DL","1",1,false],[false,"Svedberg unit","[S]","[S]","sedimentation coefficient",1e-13,[0,1,0,0,0,0,0],"S","chemical",false,null,null,1,false,false,0,0,"Sv; 10^-13 seconds; 100 fs; 100 femtoseconds","UCUM","Time","Clinical","unit of time used in measuring particle's sedimentation rate, usually after centrifugation. ","s","10*-13.S","1",1e-13,false],[false,"high power field (microscope)","[HPF]","[HPF]","view area in microscope",1,[0,0,0,0,0,0,0],"HPF","chemical",false,null,null,1,false,false,0,0,"HPF","UCUM","Area","Clinical","area visible under the maximum magnification power of the objective in microscopy (usually 400x)\n","1","1","1",1,false],[false,"low power field (microscope)","[LPF]","[LPF]","view area in microscope",1,[0,0,0,0,0,0,0],"LPF","chemical",false,null,null,1,false,false,0,0,"LPF; fields","UCUM","Area","Clinical","area visible under the low magnification of the objective in microscopy (usually 100 x)\n","1","1","100",100,false],[false,"katal","kat","KAT","catalytic activity",6.0221367e+23,[0,-1,0,0,0,0,0],"kat","chemical",true,null,null,1,false,false,1,0,"mol/secs; moles per second; mol*sec-1; mol*s-1; mol.s-1; katals; catalytic activity; enzymatic; enzyme units; activities","UCUM","CAct","Clinical","kat is a unit of catalytic activity with base units = mol/s. Rarely used because its units are too large to practically express catalytic activity. See enzyme unit [U] which is the standard unit for catalytic activity.","mol/s","MOL/S","1",1,false],[false,"enzyme unit","U","U","catalytic activity",10036894500000000,[0,-1,0,0,0,0,0],"U","chemical",true,null,null,1,false,false,1,0,"micromoles per minute; umol/min; umol per minute; umol min-1; enzymatic activity; enzyme activity","UCUM","CAct","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"international unit - arbitrary","[iU]","[IU]","arbitrary",1,[0,0,0,0,0,0,0],"IU","chemical",true,null,null,1,false,true,0,0,"international units; IE; F2","UCUM","Arb","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","1","1","1",1,false],[false,"international unit - arbitrary","[IU]","[IU]","arbitrary",1,[0,0,0,0,0,0,0],"i.U.","chemical",true,null,null,1,false,true,0,0,"international units; IE; F2","UCUM","Arb","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"arbitary unit","[arb'U]","[ARB'U]","arbitrary",1,[0,0,0,0,0,0,0],"arb. U","chemical",false,null,null,1,false,true,0,0,"arbitary units; arb units; arbU","UCUM","Arb","Clinical","relative unit of measurement to show the ratio of test measurement to reference measurement","1","1","1",1,false],[false,"United States Pharmacopeia unit","[USP'U]","[USP'U]","arbitrary",1,[0,0,0,0,0,0,0],"U.S.P.","chemical",false,null,null,1,false,true,0,0,"USP U; USP'U","UCUM","Arb","Clinical","a dose unit to express potency of drugs and vitamins defined by the United States Pharmacopoeia; usually 1 USP = 1 IU","1","1","1",1,false],[false,"GPL unit","[GPL'U]","[GPL'U]","biologic activity of anticardiolipin IgG",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,0,"GPL Units; GPL U; IgG anticardiolipin units; IgG Phospholipid","UCUM","ACnc; AMass","Clinical","Units for an antiphospholipid test","1","1","1",1,false],[false,"MPL unit","[MPL'U]","[MPL'U]","biologic activity of anticardiolipin IgM",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,0,"MPL units; MPL U; MPL'U; IgM anticardiolipin units; IgM Phospholipid Units ","UCUM","ACnc","Clinical","units for antiphospholipid test","1","1","1",1,false],[false,"APL unit","[APL'U]","[APL'U]","biologic activity of anticardiolipin IgA",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,0,"APL units; APL U; IgA anticardiolipin; IgA Phospholipid; biologic activity of","UCUM","AMass; ACnc","Clinical","Units for an anti phospholipid syndrome test","1","1","1",1,false],[false,"Bethesda unit","[beth'U]","[BETH'U]","biologic activity of factor VIII inhibitor",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,0,"BU","UCUM","ACnc","Clinical","measures of blood coagulation inhibitior for many blood factors","1","1","1",1,false],[false,"anti factor Xa unit","[anti'Xa'U]","[ANTI'XA'U]","biologic activity of factor Xa inhibitor (heparin)",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,0,"units","UCUM","ACnc","Clinical","[anti'Xa'U] unit is equivalent to and can be converted to IU/mL. ","1","1","1",1,false],[false,"Todd unit","[todd'U]","[TODD'U]","biologic activity antistreptolysin O",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,0,"units","UCUM","InvThres; RtoThres","Clinical","the unit for the results of the testing for antistreptolysin O (ASO)","1","1","1",1,false],[false,"Dye unit","[dye'U]","[DYE'U]","biologic activity of amylase",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,0,"units","UCUM","CCnc","Obsolete","equivalent to the Somogyi unit, which is an enzyme unit for amylase but better to use U, the standard enzyme unit for measuring catalytic activity","1","1","1",1,false],[false,"Somogyi unit","[smgy'U]","[SMGY'U]","biologic activity of amylase",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,0,"Somogyi units; smgy U","UCUM","CAct","Clinical","measures the enzymatic activity of amylase in blood serum - better to use base units mg/mL ","1","1","1",1,false],[false,"Bodansky unit","[bdsk'U]","[BDSK'U]","biologic activity of phosphatase",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,0,"","UCUM","ACnc","Obsolete","Enzyme unit specific to alkaline phosphatase - better to use standard enzyme unit of U","1","1","1",1,false],[false,"King-Armstrong unit","[ka'U]","[KA'U]","biologic activity of phosphatase",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,0,"King-Armstrong Units; King units","UCUM","AMass","Obsolete","enzyme units for acid phosphatase - better to use enzyme unit [U]","1","1","1",1,false],[false,"Kunkel unit","[knk'U]","[KNK'U]","arbitrary biologic activity",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"Mac Lagan unit","[mclg'U]","[MCLG'U]","arbitrary biologic activity",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,0,"galactose index; galactose tolerance test; thymol turbidity test unit; mclg U; units; indexes","UCUM","ACnc","Obsolete","unit for liver tests - previously used in thymol turbidity tests for liver disease diagnoses, and now is sometimes referred to in the oral galactose tolerance test","1","1","1",1,false],[false,"tuberculin unit","[tb'U]","[TB'U]","biologic activity of tuberculin",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,0,"TU; units","UCUM","Arb","Clinical","amount of tuberculin antigen -usually in reference to a TB skin test ","1","1","1",1,false],[false,"50% cell culture infectious dose","[CCID_50]","[CCID_50]","biologic activity (infectivity) of an infectious agent preparation",1,[0,0,0,0,0,0,0],"CCID<sub>50</sub>","chemical",false,null,null,1,false,true,0,0,"CCID50; 50% cell culture infective doses","UCUM","NumThres","Clinical","","1","1","1",1,false],[false,"50% tissue culture infectious dose","[TCID_50]","[TCID_50]","biologic activity (infectivity) of an infectious agent preparation",1,[0,0,0,0,0,0,0],"TCID<sub>50</sub>","chemical",false,null,null,1,false,true,0,0,"TCID50; 50% tissue culture infective dose","UCUM","NumThres","Clinical","","1","1","1",1,false],[false,"50% embryo infectious dose","[EID_50]","[EID_50]","biologic activity (infectivity) of an infectious agent preparation",1,[0,0,0,0,0,0,0],"EID<sub>50</sub>","chemical",false,null,null,1,false,true,0,0,"EID50; 50% embryo infective doses; EID50 Egg Infective Dosage","UCUM","thresNum","Clinical","","1","1","1",1,false],[false,"plaque forming units","[PFU]","[PFU]","amount of an infectious agent",1,[0,0,0,0,0,0,0],"PFU","chemical",false,null,null,1,false,true,0,0,"PFU","UCUM","ACnc","Clinical","tests usually report unit as number of PFU per unit volume","1","1","1",1,false],[false,"focus forming units (cells)","[FFU]","[FFU]","amount of an infectious agent",1,[0,0,0,0,0,0,0],"FFU","chemical",false,null,null,1,false,true,0,0,"FFU","UCUM","EntNum","Clinical","","1","1","1",1,false],[false,"colony forming units","[CFU]","[CFU]","amount of a proliferating organism",1,[0,0,0,0,0,0,0],"CFU","chemical",false,null,null,1,false,true,0,0,"CFU","UCUM","Num","Clinical","","1","1","1",1,false],[false,"index of reactivity (allergen)","[IR]","[IR]","amount of an allergen callibrated through in-vivo testing using the Stallergenes® method.",1,[0,0,0,0,0,0,0],"IR","chemical",false,null,null,1,false,true,0,0,"IR; indexes","UCUM","Acnc","Clinical","amount of an allergen callibrated through in-vivo testing using the Stallergenes method. Usually reported in tests as IR/mL","1","1","1",1,false],[false,"bioequivalent allergen unit","[BAU]","[BAU]","amount of an allergen callibrated through in-vivo testing based on the ID50EAL method of (intradermal dilution for 50mm sum of erythema diameters",1,[0,0,0,0,0,0,0],"BAU","chemical",false,null,null,1,false,true,0,0,"BAU; Bioequivalent Allergy Units; bioequivalent allergen units","UCUM","Arb","Clinical","","1","1","1",1,false],[false,"allergy unit","[AU]","[AU]","procedure defined amount of an allergen using some reference standard",1,[0,0,0,0,0,0,0],"AU","chemical",false,null,null,1,false,true,0,0,"allergy units; allergen units; AU","UCUM","Arb","Clinical","Most standard test allergy units are reported as [IU] or as %. ","1","1","1",1,false],[false,"allergen unit for Ambrosia artemisiifolia","[Amb'a'1'U]","[AMB'A'1'U]","procedure defined amount of the major allergen of ragweed.",1,[0,0,0,0,0,0,0],"Amb a 1 U","chemical",false,null,null,1,false,true,0,0,"Amb a 1 unit; Antigen E; AgE U; allergen units","UCUM","Arb","Clinical","Amb a 1 is the major allergen in short ragweed, and can be converted Bioequivalent allergen units (BAU) where 350 Amb a 1 U/mL = 100,000 BAU/mL","1","1","1",1,false],[false,"protein nitrogen unit (allergen testing)","[PNU]","[PNU]","procedure defined amount of a protein substance",1,[0,0,0,0,0,0,0],"PNU","chemical",false,null,null,1,false,true,0,0,"protein nitrogen units; PNU","UCUM","Mass","Clinical","defined as 0.01 ug of phosphotungstic acid-precipitable protein nitrogen. Being replaced by bioequivalent allergy units (BAU).","1","1","1",1,false],[false,"Limit of flocculation","[Lf]","[LF]","procedure defined amount of an antigen substance",1,[0,0,0,0,0,0,0],"Lf","chemical",false,null,null,1,false,true,0,0,"Lf doses","UCUM","Arb","Clinical","the antigen content  forming 1:1 ratio against 1 unit of antitoxin","1","1","1",1,false],[false,"D-antigen unit (polio)","[D'ag'U]","[D'AG'U]","procedure defined amount of a poliomyelitis d-antigen substance",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,0,"DAgU; units","UCUM","Acnc","Clinical","unit of potency of poliovirus vaccine used for poliomyelitis prevention reported as D antigen units/mL. The unit is poliovirus type-specific.","1","1","1",1,false],[false,"fibrinogen equivalent units","[FEU]","[FEU]","amount of fibrinogen broken down into the measured d-dimers",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,0,"FEU","UCUM","MCnc","Clinical","Note both the FEU and DDU units are used to report D-dimer measurements. 1 DDU = 1/2 FFU","1","1","1",1,false],[false,"ELISA unit","[ELU]","[ELU]","arbitrary ELISA unit",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,0,"Enzyme-Linked Immunosorbent Assay Units; ELU; EL. U","UCUM","ACnc","Clinical","","1","1","1",1,false],[false,"Ehrlich units (urobilinogen)","[EU]","[EU]","Ehrlich unit",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,0,"EU/dL; mg{urobilinogen}/dL","UCUM","ACnc","Clinical","","1","1","1",1,false],[false,"neper","Np","NEP","level",1,[0,0,0,0,0,0,0],"Np","levels",true,null,"ln",1,true,false,0,0,"nepers","UCUM","LogRto","Clinical","logarithmic unit for ratios of measurements of physical field and power quantities, such as gain and loss of electronic signals","1",null,null,1,false],[false,"bel","B","B","level",1,[0,0,0,0,0,0,0],"B","levels",true,null,"lg",1,true,false,0,0,"bels","UCUM","LogRto","Clinical","Logarithm of the ratio of power- or field-type quantities; usually expressed in decibels ","1",null,null,1,false],[false,"bel sound pressure","B[SPL]","B[SPL]","pressure level",0.019999999999999997,[-1,-2,1,0,0,0,0],"B(SPL)","levels",true,null,"lgTimes2",1,true,false,0,0,"bel SPL; B SPL; sound pressure bels","UCUM","LogRto","Clinical","used to measure sound level in acoustics","Pa",null,null,0.000019999999999999998,false],[false,"bel volt","B[V]","B[V]","electric potential level",1000,[2,-2,1,0,0,-1,0],"B(V)","levels",true,null,"lgTimes2",1,true,false,0,0,"bel V; B V; volts bels","UCUM","LogRtoElp","Clinical","used to express power gain in electrical circuits","V",null,null,1,false],[false,"bel millivolt","B[mV]","B[MV]","electric potential level",1,[2,-2,1,0,0,-1,0],"B(mV)","levels",true,null,"lgTimes2",1,true,false,0,0,"bel mV; B mV; millivolt bels; 10^-3V bels; 10*-3V ","UCUM","LogRtoElp","Clinical","used to express power gain in electrical circuits","mV",null,null,1,false],[false,"bel microvolt","B[uV]","B[UV]","electric potential level",0.001,[2,-2,1,0,0,-1,0],"B(μV)","levels",true,null,"lgTimes2",1,true,false,0,0,"bel uV; B uV; microvolts bels; 10^-6V bel; 10*-6V bel","UCUM","LogRto","Clinical","used to express power gain in electrical circuits","uV",null,null,1,false],[false,"bel 10 nanovolt","B[10.nV]","B[10.NV]","electric potential level",0.000010000000000000003,[2,-2,1,0,0,-1,0],"B(10 nV)","levels",true,null,"lgTimes2",1,true,false,0,0,"bel 10 nV; B 10 nV; 10 nanovolts bels","UCUM","LogRtoElp","Clinical","used to express power gain in electrical circuits","nV",null,null,10,false],[false,"bel watt","B[W]","B[W]","power level",1000,[2,-3,1,0,0,0,0],"B(W)","levels",true,null,"lg",1,true,false,0,0,"bel W; b W; b Watt; Watts bels","UCUM","LogRto","Clinical","used to express power","W",null,null,1,false],[false,"bel kilowatt","B[kW]","B[KW]","power level",1000000,[2,-3,1,0,0,0,0],"B(kW)","levels",true,null,"lg",1,true,false,0,0,"bel kW; B kW; kilowatt bel; kW bel; kW B","UCUM","LogRto","Clinical","used to express power","kW",null,null,1,false],[false,"stere","st","STR","volume",1,[3,0,0,0,0,0,0],"st","misc",true,null,null,1,false,false,0,0,"stère; m3; cubic meter; m^3; meters cubed; metre","UCUM","Vol","Nonclinical","equal to one cubic meter, usually used for measuring firewood","m3","M3","1",1,false],[false,"Ångström","Ao","AO","length",1.0000000000000002e-10,[1,0,0,0,0,0,0],"Å","misc",false,null,null,1,false,false,0,0,"Å; Angstroms; Ao; Ångströms","UCUM","Len","Clinical","equal to 10^-10 meters; used to express wave lengths and atom scaled differences ","nm","NM","0.1",0.1,false],[false,"barn","b","BRN","action area",1.0000000000000001e-28,[2,0,0,0,0,0,0],"b","misc",false,null,null,1,false,false,0,0,"barns","UCUM","Area","Clinical","used in high-energy physics to express cross-sectional areas","fm2","FM2","100",100,false],[false,"technical atmosphere","att","ATT","pressure",98066500,[-1,-2,1,0,0,0,0],"at","misc",false,null,null,1,false,false,0,0,"at; tech atm; tech atmosphere; kgf/cm2; atms; atmospheres","UCUM","Pres","Obsolete","non-SI unit of pressure equal to one kilogram-force per square centimeter","kgf/cm2","KGF/CM2","1",1,false],[false,"mho","mho","MHO","electric conductance",0.001,[-2,1,-1,0,0,2,0],"mho","misc",true,null,null,1,false,false,0,0,"siemens; ohm reciprocals; Ω^−1; Ω-1 ","UCUM","","Obsolete","unit of electric conductance (the inverse of electrical resistance) equal to ohm^-1","S","S","1",1,false],[false,"pound per square inch","[psi]","[PSI]","pressure",6894757.293168359,[-1,-2,1,0,0,0,0],"psi","misc",false,null,null,1,false,false,0,0,"psi; lb/in2; lb per in2","UCUM","Pres","Clinical","","[lbf_av]/[in_i]2","[LBF_AV]/[IN_I]2","1",1,false],[false,"circle - plane angle","circ","CIRC","plane angle",6.283185307179586,[0,0,0,1,0,0,0],"circ","misc",false,null,null,1,false,false,0,0,"angles; circles","UCUM","Angle","Clinical","","[pi].rad","[PI].RAD","2",2,false],[false,"spere - solid angle","sph","SPH","solid angle",12.566370614359172,[0,0,0,2,0,0,0],"sph","misc",false,null,null,1,false,false,0,0,"speres","UCUM","Angle","Clinical","equal to the solid angle of an entire sphere = 4πsr (sr = steradian) ","[pi].sr","[PI].SR","4",4,false],[false,"metric carat","[car_m]","[CAR_M]","mass",0.2,[0,0,1,0,0,0,0],"ct<sub>m</sub>","misc",false,null,null,1,false,false,0,0,"carats; ct; car m","UCUM","Mass","Nonclinical","unit of mass for gemstones","g","G","2e-1",0.2,false],[false,"carat of gold alloys","[car_Au]","[CAR_AU]","mass fraction",0.041666666666666664,[0,0,0,0,0,0,0],"ct<sub><r>Au</r></sub>","misc",false,null,null,1,false,false,0,0,"karats; k; kt; car au; carats","UCUM","MFr","Nonclinical","unit of purity for gold alloys","/24","/24","1",1,false],[false,"Smoot","[smoot]","[SMOOT]","length",1.7018000000000002,[1,0,0,0,0,0,0],null,"misc",false,null,null,1,false,false,0,0,"","UCUM","Len","Nonclinical","prank unit of length from MIT","[in_i]","[IN_I]","67",67,false],[false,"meter per square seconds per square root of hertz","[m/s2/Hz^(1/2)]","[M/S2/HZ^(1/2)]","amplitude spectral density",1,[2,-3,0,0,0,0,0],null,"misc",false,null,"sqrt",1,true,false,0,0,"m/s2/(Hz^.5); m/s2/(Hz^(1/2)); m per s2 per Hz^1/2","UCUM","","Constant","measures amplitude spectral density, and is equal to the square root of power spectral density\n ","m2/s4/Hz",null,null,1,false],[false,"bit - logarithmic","bit_s","BIT_S","amount of information",1,[0,0,0,0,0,0,0],"bit<sub>s</sub>","infotech",false,null,"ld",1,true,false,0,0,"bit-s; bit s; bit logarithmic","UCUM","LogA","Nonclinical","defined as the log base 2 of the number of distinct signals; cannot practically be used to express more than 1000 bits\n\nIn information theory, the definition of the amount of self-information and information entropy is often expressed with the binary logarithm (log base 2)","1",null,null,1,false],[false,"bit","bit","BIT","amount of information",1,[0,0,0,0,0,0,0],"bit","infotech",true,null,null,1,false,false,0,0,"bits","UCUM","","Nonclinical","dimensionless information unit of 1 used in computing and digital communications","1","1","1",1,false],[false,"byte","By","BY","amount of information",8,[0,0,0,0,0,0,0],"B","infotech",true,null,null,1,false,false,0,0,"bytes","UCUM","","Nonclinical","equal to 8 bits","bit","bit","8",8,false],[false,"baud","Bd","BD","signal transmission rate",1,[0,1,0,0,0,0,0],"Bd","infotech",true,null,"inv",1,false,false,0,0,"Bd; bauds","UCUM","Freq","Nonclinical","unit to express rate in symbols per second or pulses per second. ","s","/s","1",1,false],[false,"per twelve hour","/(12.h)","1/(12.HR)","",0.000023148148148148147,[0,-1,0,0,0,0,0],"/h",null,false,null,null,1,false,false,0,0,"per 12 hours; 12hrs; 12 hrs; /12hrs","LOINC","Rat","Clinical","",null,null,null,null,false],[false,"per arbitrary unit","/[arb'U]","1/[ARB'U]","",1,[0,0,0,0,0,0,0],"/arb/ U",null,false,null,null,1,false,true,0,0,"/arbU","LOINC","InvA ","Clinical","",null,null,null,null,false],[false,"per high power field","/[HPF]","1/[HPF]","",1,[0,0,0,0,0,0,0],"/HPF",null,false,null,null,1,false,false,0,0,"/HPF; per HPF","LOINC","Naric","Clinical","",null,null,null,null,false],[false,"per international unit","/[IU]","1/[IU]","",1,[0,0,0,0,0,0,0],"/i/U.",null,false,null,null,1,false,true,0,0,"international units; /IU; per IU","LOINC","InvA","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)",null,null,null,null,false],[false,"per low power field","/[LPF]","1/[LPF]","",1,[0,0,0,0,0,0,0],"/LPF",null,false,null,null,1,false,false,0,0,"/LPF; per LPF","LOINC","Naric","Clinical","",null,null,null,null,false],[false,"per 10 billion  ","/10*10","1/(10*10)","",1e-10,[0,0,0,0,0,0,0],"/10<sup>10</sup>",null,false,null,null,1,false,false,0,0,"/10^10; per 10*10","LOINC","NFr","Clinical","used for counting entities, e.g. blood cells; usually these kinds of terms have numerators such as moles or milligrams, and counting that amount per the number in the denominator",null,null,null,null,false],[false,"per trillion ","/10*12","1/(10*12)","",1e-12,[0,0,0,0,0,0,0],"/10<sup>12</sup>",null,false,null,null,1,false,false,0,0,"/10^12; per 10*12","LOINC","NFr","Clinical","used for counting entities, e.g. blood cells; usually these kinds of terms have numerators such as moles or milligrams, and counting that amount per the number in the denominator",null,null,null,null,false],[false,"per thousand","/10*3","1/(10*3)","",0.001,[0,0,0,0,0,0,0],"/10<sup>3</sup>",null,false,null,null,1,false,false,0,0,"/10^3; per 10*3","LOINC","NFr","Clinical","used for counting entities, e.g. blood cells; usually these kinds of terms have numerators such as moles or milligrams, and counting that amount per the number in the denominator",null,null,null,null,false],[false,"per million","/10*6","1/(10*6)","",0.000001,[0,0,0,0,0,0,0],"/10<sup>6</sup>",null,false,null,null,1,false,false,0,0,"/10^6; per 10*6;","LOINC","NFr","Clinical","used for counting entities, e.g. blood cells; usually these kinds of terms have numerators such as moles or milligrams, and counting that amount per the number in the denominator",null,null,null,null,false],[false,"per billion","/10*9","1/(10*9)","",1e-9,[0,0,0,0,0,0,0],"/10<sup>9</sup>",null,false,null,null,1,false,false,0,0,"/10^9; per 10*9","LOINC","NFr","Clinical","used for counting entities, e.g. blood cells; usually these kinds of terms have numerators such as moles or milligrams, and counting that amount per the number in the denominator",null,null,null,null,false],[false,"per 100","/100","1/100","",0.01,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,0,"per hundred; 10^2; 10*2","LOINC","NFr","Clinical","used for counting entities, e.g. blood cells; usually these kinds of terms have numerators such as moles or milligrams, and counting that amount per the number in the denominator",null,null,null,null,false],[false,"per 100 cells","/100{cells}","/100{CELLS}","",0.01,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,0,"/100 cells; /100cells; per hundred","LOINC","EntMass; EntNum; NFr","Clinical","",null,null,null,null,false],[false,"per 100 neutrophils","/100{neutrophils}","/100{NEUTROPHILS}","",0.01,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,0,"/100 neutrophils; /100neutrophils; per hundred","LOINC","EntMass; EntNum; NFr","Clinical","",null,null,null,null,false],[false,"per 100 spermatozoa","/100{spermatozoa}","/100{SPERMATOZOA}","",0.01,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,0,"/100 spermatozoa; /100spermatozoa; per hundred","LOINC","NFr","Clinical","",null,null,null,null,false],[false,"per 100 white blood cells","/100{WBCs}","/100{WBCS}","",0.01,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,0,"/100 WBCs; /100WBCs; per hundred","LOINC","Ratio; NFr","Clinical","",null,null,null,null,false],[false,"per year","/a","1/ANN","",3.168808781402895e-8,[0,-1,0,0,0,0,0],"/a",null,false,null,null,1,false,false,0,0,"/Years; /yrs; yearly","LOINC","NRat","Clinical","",null,null,null,null,false],[false,"per centimeter of water","/cm[H2O]","1/CM[H2O]","",0.000010197162129779282,[1,2,-1,0,0,0,0],"/cm HO<sub><r>2</r></sub>",null,false,null,null,1,false,false,0,0,"/cmH2O; /cm H2O; centimeters; centimetres","LOINC","InvPress","Clinical","",null,null,null,null,false],[false,"per day","/d","1/D","",0.000011574074074074073,[0,-1,0,0,0,0,0],"/d",null,false,null,null,1,false,false,0,0,"/dy; per day","LOINC","NRat","Clinical","",null,null,null,null,false],[false,"per deciliter","/dL","1/DL","",10000,[-3,0,0,0,0,0,0],"/dL",null,false,null,null,1,false,false,0,0,"per dL; /deciliter; decilitre","LOINC","NCnc","Clinical","",null,null,null,null,false],[false,"per gram","/g","1/G","",1,[0,0,-1,0,0,0,0],"/g",null,false,null,null,1,false,false,0,0,"/gm; /gram; per g","LOINC","NCnt","Clinical","",null,null,null,null,false],[false,"per hour","/h","1/HR","",0.0002777777777777778,[0,-1,0,0,0,0,0],"/h",null,false,null,null,1,false,false,0,0,"/hr; /hour; per hr","LOINC","NRat","Clinical","",null,null,null,null,false],[false,"per kilogram","/kg","1/KG","",0.001,[0,0,-1,0,0,0,0],"/kg",null,false,null,null,1,false,false,0,0,"per kg; per kilogram","LOINC","NCnt","Clinical","",null,null,null,null,false],[false,"per liter","/L","1/L","",1000,[-3,0,0,0,0,0,0],"/L",null,false,null,null,1,false,false,0,0,"/liter; litre","LOINC","NCnc","Clinical","",null,null,null,null,false],[false,"per square meter","/m2","1/M2","",1,[-2,0,0,0,0,0,0],"/m<sup>2</sup>",null,false,null,null,1,false,false,0,0,"/m^2; /m*2; /sq. m; per square meter; meter squared; metre","LOINC","Naric","Clinical","",null,null,null,null,false],[false,"per cubic meter","/m3","1/M3","",1,[-3,0,0,0,0,0,0],"/m<sup>3</sup>",null,false,null,null,1,false,false,0,0,"/m^3; /m*3; /cu. m; per cubic meter; meter cubed; per m3; metre","LOINC","NCncn","Clinical","",null,null,null,null,false],[false,"per milligram","/mg","1/MG","",1000,[0,0,-1,0,0,0,0],"/mg",null,false,null,null,1,false,false,0,0,"/milligram; per mg","LOINC","NCnt","Clinical","",null,null,null,null,false],[false,"per minute","/min","1/MIN","",0.016666666666666666,[0,-1,0,0,0,0,0],"/min",null,false,null,null,1,false,false,0,0,"/minute; per mins; breaths beats per minute","LOINC","NRat","Clinical","",null,null,null,null,false],[false,"per milliliter","/mL","1/ML","",1000000,[-3,0,0,0,0,0,0],"/mL",null,false,null,null,1,false,false,0,0,"/milliliter; per mL; millilitre","LOINC","NCncn","Clinical","",null,null,null,null,false],[false,"per millimeter","/mm","1/MM","",1000,[-1,0,0,0,0,0,0],"/mm",null,false,null,null,1,false,false,0,0,"/millimeter; per mm; millimetre","LOINC","InvLen","Clinical","",null,null,null,null,false],[false,"per month","/mo","1/MO","",3.802570537683474e-7,[0,-1,0,0,0,0,0],"/mo",null,false,null,null,1,false,false,0,0,"/month; per mo; monthly; month","LOINC","NRat","Clinical","",null,null,null,null,false],[false,"per second","/s","1/S","",1,[0,-1,0,0,0,0,0],"/s",null,false,null,null,1,false,false,0,0,"/second; /sec; per sec; frequency; Hertz; Herz; Hz; becquerels; Bq; s-1; s^-1","LOINC","NRat","Clinical","",null,null,null,null,false],[false,"per enzyme unit","/U","1/U","",9.963241120049633e-17,[0,1,0,0,0,0,0],"/U",null,false,null,null,1,false,false,-1,0,"/enzyme units; per U","LOINC","InvC; NCat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)",null,null,null,null,false],[false,"per microliter","/uL","1/UL","",999999999.9999999,[-3,0,0,0,0,0,0],"/μL",null,false,null,null,1,false,false,0,0,"/microliter; microlitre; /mcl; per uL","LOINC","ACnc","Clinical","",null,null,null,null,false],[false,"per week","/wk","1/WK","",0.0000016534391534391535,[0,-1,0,0,0,0,0],"/wk",null,false,null,null,1,false,false,0,0,"/week; per wk; weekly, weeks","LOINC","NRat","Clinical","",null,null,null,null,false],[false,"APL unit per milliliter","[APL'U]/mL","[APL'U]/ML","biologic activity of anticardiolipin IgA",1000000,[-3,0,0,0,0,0,0],"/mL","chemical",false,null,null,1,false,true,0,0,"APL/mL; APL'U/mL; APL U/mL; APL/milliliter; IgA anticardiolipin units per milliliter; IgA Phospholipid Units; millilitre; biologic activity of","LOINC","ACnc","Clinical","Units for an anti phospholipid syndrome test","1","1","1",1,false],[false,"arbitrary unit per milliliter","[arb'U]/mL","[ARB'U]/ML","arbitrary",1000000,[-3,0,0,0,0,0,0],"(arb. U)/mL","chemical",false,null,null,1,false,true,0,0,"arb'U/mL; arbU/mL; arb U/mL; arbitrary units per milliliter; millilitre","LOINC","ACnc","Clinical","relative unit of measurement to show the ratio of test measurement to reference measurement","1","1","1",1,false],[false,"colony forming units per liter","[CFU]/L","[CFU]/L","amount of a proliferating organism",1000,[-3,0,0,0,0,0,0],"CFU/L","chemical",false,null,null,1,false,true,0,0,"CFU per Liter; CFU/L","LOINC","NCnc","Clinical","","1","1","1",1,false],[false,"colony forming units per milliliter","[CFU]/mL","[CFU]/ML","amount of a proliferating organism",1000000,[-3,0,0,0,0,0,0],"CFU/mL","chemical",false,null,null,1,false,true,0,0,"CFU per mL; CFU/mL","LOINC","NCnc","Clinical","","1","1","1",1,false],[false,"foot per foot - US","[ft_us]/[ft_us]","[FT_US]/[FT_US]","length",1,[0,0,0,0,0,0,0],"(ft<sub>us</sub>)/(ft<sub>us</sub>)","us-lengths",false,null,null,1,false,false,0,0,"ft/ft; ft per ft; feet per feet; visual acuity","","LenRto","Clinical","distance ratio to measure 20:20 vision","m/3937","M/3937","1200",1200,false],[false,"GPL unit per milliliter","[GPL'U]/mL","[GPL'U]/ML","biologic activity of anticardiolipin IgG",1000000,[-3,0,0,0,0,0,0],"/mL","chemical",false,null,null,1,false,true,0,0,"GPL U/mL; GPL'U/mL; GPL/mL; GPL U per mL; IgG Phospholipid Units per milliliters; IgG anticardiolipin units; millilitres ","LOINC","ACnc; AMass","Clinical","Units for an antiphospholipid test","1","1","1",1,false],[false,"international unit per 2 hour","[IU]/(2.h)","[IU]/(2.HR)","arbitrary",0.0001388888888888889,[0,-1,0,0,0,0,0],"(i.U.)/h","chemical",true,null,null,1,false,true,0,0,"IU/2hrs; IU/2 hours; IU per 2 hrs; international units per 2 hours","LOINC","ARat","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per 24 hour","[IU]/(24.h)","[IU]/(24.HR)","arbitrary",0.000011574074074074073,[0,-1,0,0,0,0,0],"(i.U.)/h","chemical",true,null,null,1,false,true,0,0,"IU/24hr; IU/24 hours; IU per 24 hrs; international units per 24 hours","LOINC","ARat","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per day","[IU]/d","[IU]/D","arbitrary",0.000011574074074074073,[0,-1,0,0,0,0,0],"(i.U.)/d","chemical",true,null,null,1,false,true,0,0,"IU/dy; IU/days; IU per dys; international units per day","LOINC","ARat","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per deciliter","[IU]/dL","[IU]/DL","arbitrary",10000,[-3,0,0,0,0,0,0],"(i.U.)/dL","chemical",true,null,null,1,false,true,0,0,"IU/dL; IU per dL; international units per deciliters; decilitres","LOINC","ACnc","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per gram","[IU]/g","[IU]/G","arbitrary",1,[0,0,-1,0,0,0,0],"(i.U.)/g","chemical",true,null,null,1,false,true,0,0,"IU/gm; IU/gram; IU per gm; IU per g; international units per gram","LOINC","ACnt","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per hour","[IU]/h","[IU]/HR","arbitrary",0.0002777777777777778,[0,-1,0,0,0,0,0],"(i.U.)/h","chemical",true,null,null,1,false,true,0,0,"IU/hrs; IU per hours; international units per hour","LOINC","ARat","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per kilogram","[IU]/kg","[IU]/KG","arbitrary",0.001,[0,0,-1,0,0,0,0],"(i.U.)/kg","chemical",true,null,null,1,false,true,0,0,"IU/kg; IU/kilogram; IU per kg; units","LOINC","ACnt","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per kilogram per day","[IU]/kg/d","([IU]/KG)/D","arbitrary",1.1574074074074074e-8,[0,-1,-1,0,0,0,0],"((i.U.)/kg)/d","chemical",true,null,null,1,false,true,0,0,"IU/kg/dy; IU/kg/day; IU/kilogram/day; IU per kg per day; units","LOINC","ACntRat","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per liter","[IU]/L","[IU]/L","arbitrary",1000,[-3,0,0,0,0,0,0],"(i.U.)/L","chemical",true,null,null,1,false,true,0,0,"IU/L; IU/liter; IU per liter; units; litre","LOINC","ACnc","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per minute","[IU]/min","[IU]/MIN","arbitrary",0.016666666666666666,[0,-1,0,0,0,0,0],"(i.U.)/min","chemical",true,null,null,1,false,true,0,0,"IU/min; IU/minute; IU per minute; international units","LOINC","ARat","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per milliliter","[IU]/mL","[IU]/ML","arbitrary",1000000,[-3,0,0,0,0,0,0],"(i.U.)/mL","chemical",true,null,null,1,false,true,0,0,"IU/mL; IU per mL; international units per milliliter; millilitre","LOINC","ACnc","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"MPL unit per milliliter","[MPL'U]/mL","[MPL'U]/ML","biologic activity of anticardiolipin IgM",1000000,[-3,0,0,0,0,0,0],"/mL","chemical",false,null,null,1,false,true,0,0,"MPL/mL; MPL U/mL; MPL'U/mL; IgM anticardiolipin units; IgM Phospholipid Units; millilitre ","LOINC","ACnc","Clinical","units for antiphospholipid test\n","1","1","1",1,false],[false,"number per high power field","{#}/[HPF]","{#}/[HPF]","",1,[0,0,0,0,0,0,0],"/HPF",null,false,null,null,1,false,false,0,0,"#/HPF; # per HPF; number/HPF; numbers per high power field","LOINC","Naric","Clinical","",null,null,null,null,false],[false,"number per low power field","{#}/[LPF]","{#}/[LPF]","",1,[0,0,0,0,0,0,0],"/LPF",null,false,null,null,1,false,false,0,0,"#/LPF; # per LPF; number/LPF; numbers per low power field","LOINC","Naric","Clinical","",null,null,null,null,false],[false,"IgA antiphosphatidylserine unit ","{APS'U}","{APS'U}","",1,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,0,"APS Unit; Phosphatidylserine Antibody IgA Units","LOINC","ACnc","Clinical","unit for antiphospholipid test",null,null,null,null,false],[false,"EIA index","{EIA_index}","{EIA_index}","",1,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,0,"enzyme immunoassay index","LOINC","ACnc","Clinical","",null,null,null,null,false],[false,"kaolin clotting time","{KCT'U}","{KCT'U}","",1,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,0,"KCT","LOINC","Time","Clinical","sensitive test to detect lupus anticoagulants; measured in seconds",null,null,null,null,false],[false,"IgM antiphosphatidylserine unit","{MPS'U}","{MPS'U}","",1,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,0,"Phosphatidylserine Antibody IgM Measurement ","LOINC","ACnc","Clinical","",null,null,null,null,false],[false,"trillion per liter","10*12/L","(10*12)/L","number",1000000000000000,[-3,0,0,0,0,0,0],"(10<sup>12</sup>)/L","dimless",false,null,null,1,false,false,0,0,"10^12/L; 10*12 per Liter; trillion per liter; litre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"10^3 (used for cell count)","10*3","10*3","number",1000,[0,0,0,0,0,0,0],"10<sup>3</sup>","dimless",false,null,null,1,false,false,0,0,"10^3; thousand","LOINC","Num","Clinical","usually used for counting entities (e.g. blood cells) per volume","1","1","10",10,false],[false,"thousand per liter","10*3/L","(10*3)/L","number",1000000,[-3,0,0,0,0,0,0],"(10<sup>3</sup>)/L","dimless",false,null,null,1,false,false,0,0,"10^3/L; 10*3 per liter; litre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"thousand per milliliter","10*3/mL","(10*3)/ML","number",1000000000,[-3,0,0,0,0,0,0],"(10<sup>3</sup>)/mL","dimless",false,null,null,1,false,false,0,0,"10^3/mL; 10*3 per mL; thousand per milliliter; millilitre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"thousand per microliter","10*3/uL","(10*3)/UL","number",999999999999.9999,[-3,0,0,0,0,0,0],"(10<sup>3</sup>)/μL","dimless",false,null,null,1,false,false,0,0,"10^3/uL; 10*3 per uL; thousand per microliter; microlitre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"10 thousand per microliter","10*4/uL","(10*4)/UL","number",10000000000000,[-3,0,0,0,0,0,0],"(10<sup>4</sup>)/μL","dimless",false,null,null,1,false,false,0,0,"10^4/uL; 10*4 per uL; microlitre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"10^5 ","10*5","10*5","number",100000,[0,0,0,0,0,0,0],"10<sup>5</sup>","dimless",false,null,null,1,false,false,0,0,"one hundred thousand","LOINC","Num","Clinical","","1","1","10",10,false],[false,"10^6","10*6","10*6","number",1000000,[0,0,0,0,0,0,0],"10<sup>6</sup>","dimless",false,null,null,1,false,false,0,0,"","LOINC","Num","Clinical","","1","1","10",10,false],[false,"million colony forming unit per liter","10*6.[CFU]/L","((10*6).[CFU])/L","number",1000000000,[-3,0,0,0,0,0,0],"((10<sup>6</sup>).CFU)/L","dimless",false,null,null,1,false,true,0,0,"10*6 CFU/L; 10^6 CFU/L; 10^6CFU; 10^6 CFU per liter; million colony forming units; litre","LOINC","ACnc","Clinical","","1","1","10",10,false],[false,"million international unit","10*6.[IU]","(10*6).[IU]","number",1000000,[0,0,0,0,0,0,0],"(10<sup>6</sup>).(i.U.)","dimless",false,null,null,1,false,true,0,0,"10*6 IU; 10^6 IU; international units","LOINC","arb","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","1","1","10",10,false],[false,"million per 24 hour","10*6/(24.h)","(10*6)/(24.HR)","number",11.574074074074074,[0,-1,0,0,0,0,0],"(10<sup>6</sup>)/h","dimless",false,null,null,1,false,false,0,0,"10*6/24hrs; 10^6/24 hrs; 10*6 per 24 hrs; 10^6 per 24 hours","LOINC","NRat","Clinical","","1","1","10",10,false],[false,"million per kilogram","10*6/kg","(10*6)/KG","number",1000,[0,0,-1,0,0,0,0],"(10<sup>6</sup>)/kg","dimless",false,null,null,1,false,false,0,0,"10^6/kg; 10*6 per kg; 10*6 per kilogram; millions","LOINC","NCnt","Clinical","","1","1","10",10,false],[false,"million per liter","10*6/L","(10*6)/L","number",1000000000,[-3,0,0,0,0,0,0],"(10<sup>6</sup>)/L","dimless",false,null,null,1,false,false,0,0,"10^6/L; 10*6 per Liter; 10^6 per Liter; litre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"million per milliliter","10*6/mL","(10*6)/ML","number",1000000000000,[-3,0,0,0,0,0,0],"(10<sup>6</sup>)/mL","dimless",false,null,null,1,false,false,0,0,"10^6/mL; 10*6 per mL; 10*6 per milliliter; millilitre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"million per microliter","10*6/uL","(10*6)/UL","number",1000000000000000,[-3,0,0,0,0,0,0],"(10<sup>6</sup>)/μL","dimless",false,null,null,1,false,false,0,0,"10^6/uL; 10^6 per uL; 10^6/mcl; 10^6 per mcl; 10^6 per microliter; microlitre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"10^8","10*8","10*8","number",100000000,[0,0,0,0,0,0,0],"10<sup>8</sup>","dimless",false,null,null,1,false,false,0,0,"100 million; one hundred million; 10^8","LOINC","Num","Clinical","","1","1","10",10,false],[false,"billion per liter","10*9/L","(10*9)/L","number",1000000000000,[-3,0,0,0,0,0,0],"(10<sup>9</sup>)/L","dimless",false,null,null,1,false,false,0,0,"10^9/L; 10*9 per Liter; litre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"billion per milliliter","10*9/mL","(10*9)/ML","number",1000000000000000,[-3,0,0,0,0,0,0],"(10<sup>9</sup>)/mL","dimless",false,null,null,1,false,false,0,0,"10^9/mL; 10*9 per mL; 10^9 per mL; 10*9 per milliliter; millilitre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"billion per microliter","10*9/uL","(10*9)/UL","number",1000000000000000000,[-3,0,0,0,0,0,0],"(10<sup>9</sup>)/μL","dimless",false,null,null,1,false,false,0,0,"10^9/uL; 10^9 per uL; 10^9/mcl; 10^9 per mcl; 10*9 per uL; 10*9 per mcl; 10*9/mcl; 10^9 per microliter; microlitre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"10 liter per minute per square meter","10.L/(min.m2)","(10.L)/(MIN.M2)","",0.00016666666666666666,[1,-1,0,0,0,0,0],"L/(min.(m<sup>2</sup>))",null,false,null,null,1,false,false,0,0,"10 liters per minutes per square meter; 10 L per min per m2; m^2; 10 L/(min*m2); 10L/(min*m^2); litres; sq. meter; metre; meters squared","LOINC","ArVRat","Clinical","",null,null,null,null,false],[false,"10 liter per minute","10.L/min","(10.L)/MIN","",0.00016666666666666666,[3,-1,0,0,0,0,0],"L/min",null,false,null,null,1,false,false,0,0,"10 liters per minute; 10 L per min; 10L; 10 L/min; litre","LOINC","VRat","Clinical","",null,null,null,null,false],[false,"10 micronewton second per centimeter to the fifth power per square meter","10.uN.s/(cm5.m2)","((10.UN).S)/(CM5.M2)","",100000000,[-6,-1,1,0,0,0,0],"(μN.s)/(cm<sup>5</sup>).(m<sup>2</sup>)",null,false,null,null,1,false,false,0,0,"dyne seconds per centimeter5 and square meter; dyn.s/(cm5.m2); dyn.s/cm5/m2; cm^5; m^2","LOINC","","Clinical","unit to measure systemic vascular resistance per body surface area",null,null,null,null,false],[false,"24 hour","24.h","24.HR","",86400,[0,1,0,0,0,0,0],"h",null,false,null,null,1,false,false,0,0,"24hrs; 24 hrs; 24 hours; days; dy","LOINC","Time","Clinical","",null,null,null,null,false],[false,"ampere per meter","A/m","A/M","electric current",1,[-1,-1,0,0,0,1,0],"A/m","si",true,null,null,1,false,false,0,0,"A/m; amp/meter; magnetic field strength; H; B; amperes per meter; metre","LOINC","","Clinical","unit of magnetic field strength","C/s","C/S","1",1,false],[false,"centigram","cg","CG","mass",0.01,[0,0,1,0,0,0,0],"cg",null,false,"M",null,1,false,false,0,0,"centigrams; cg; cgm","LOINC","Mass","Clinical","",null,null,null,null,false],[false,"centiliter","cL","CL","volume",0.00001,[3,0,0,0,0,0,0],"cL","iso1000",true,null,null,1,false,false,0,0,"centiliters; centilitres","LOINC","Vol","Clinical","","l",null,"1",1,false],[false,"centimeter","cm","CM","length",0.01,[1,0,0,0,0,0,0],"cm",null,false,"L",null,1,false,false,0,0,"centimeters; centimetres","LOINC","Len","Clinical","",null,null,null,null,false],[false,"centimeter of water","cm[H2O]","CM[H2O]","pressure",98066.5,[-1,-2,1,0,0,0,0],"cm HO<sub><r>2</r></sub>","clinical",true,null,null,1,false,false,0,0,"cm H2O; cmH2O; centimetres; pressure","LOINC","Pres","Clinical","unit of pressure mostly applies to blood pressure","kPa","KPAL","980665e-5",9.80665,false],[false,"centimeter of water per liter per second","cm[H2O]/L/s","(CM[H2O]/L)/S","pressure",98066500,[-4,-3,1,0,0,0,0],"((cm HO<sub><r>2</r></sub>)/L)/s","clinical",true,null,null,1,false,false,0,0,"cm[H2O]/(L/s); cm[H2O].s/L; cm H2O/L/sec; cmH2O/L/sec; cmH2O/Liter; cmH2O per L per secs; centimeters of water per liters per second; centimetres; litres; cm[H2O]/(L/s)","LOINC","PresRat","Clinical","unit used to measure mean pulmonary resistance","kPa","KPAL","980665e-5",9.80665,false],[false,"centimeter of water per second per meter","cm[H2O]/s/m","(CM[H2O]/S)/M","pressure",98066.5,[-2,-3,1,0,0,0,0],"((cm HO<sub><r>2</r></sub>)/s)/m","clinical",true,null,null,1,false,false,0,0,"cm[H2O]/(s.m); cm H2O/s/m; cmH2O; cmH2O/sec/m; cmH2O per secs per meters; centimeters of water per seconds per meter; centimetres; metre","LOINC","PresRat","Clinical","unit used to measure pulmonary pressure time product","kPa","KPAL","980665e-5",9.80665,false],[false,"centimeter of mercury","cm[Hg]","CM[HG]","pressure",1333220,[-1,-2,1,0,0,0,0],"cm Hg","clinical",true,null,null,1,false,false,0,0,"centimeters of mercury; centimetres; cmHg; cm Hg","LOINC","Pres","Clinical","unit of pressure where 1 cmHg = 10 torr","kPa","KPAL","133.3220",133.322,false],[false,"square centimeter","cm2","CM2","length",0.0001,[2,0,0,0,0,0,0],"cm<sup>2</sup>",null,false,"L",null,1,false,false,0,0,"cm^2; sq cm; centimeters squared; square centimeters; centimetre; area","LOINC","Area","Clinical","",null,null,null,null,false],[false,"square centimeter per second","cm2/s","CM2/S","length",0.0001,[2,-1,0,0,0,0,0],"(cm<sup>2</sup>)/s",null,false,"L",null,1,false,false,0,0,"cm^2/sec; square centimeters per second; sq cm per sec; cm2; centimeters squared; centimetres","LOINC","AreaRat","Clinical","",null,null,null,null,false],[false,"centipoise","cP","CP","dynamic viscosity",1.0000000000000002,[-1,-1,1,0,0,0,0],"cP","cgs",true,null,null,1,false,false,0,0,"cps; centiposes","LOINC","Visc","Clinical","unit of dynamic viscosity in the CGS system with base units: 10^−3 Pa.s = 1 mPa·.s (1 millipascal second)","dyn.s/cm2","DYN.S/CM2","1",1,false],[false,"centistoke","cSt","CST","kinematic viscosity",0.000001,[2,-1,0,0,0,0,0],"cSt","cgs",true,null,null,1,false,false,0,0,"centistokes","LOINC","Visc","Clinical","unit for kinematic viscosity with base units of mm^2/s (square millimeter per second)","cm2/s","CM2/S","1",1,false],[false,"dekaliter per minute","daL/min","DAL/MIN","volume",0.00016666666666666666,[3,-1,0,0,0,0,0],"daL/min","iso1000",true,null,null,1,false,false,0,0,"dekalitres; dekaliters per minute; per min","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"dekaliter per minute per square meter","daL/min/m2","(DAL/MIN)/M2","volume",0.00016666666666666666,[1,-1,0,0,0,0,0],"(daL/min)/(m<sup>2</sup>)","iso1000",true,null,null,1,false,false,0,0,"daL/min/m^2; daL/minute/m2; sq. meter; dekaliters per minutes per square meter; meter squared; dekalitres; metre","LOINC","ArVRat","Clinical","The area usually is the body surface area used to normalize cardiovascular measures for patient's size","l",null,"1",1,false],[false,"decibel","dB","DB","level",1,[0,0,0,0,0,0,0],"dB","levels",true,null,"lg",0.1,true,false,0,0,"decibels","LOINC","LogRto","Clinical","unit most commonly used in acoustics as unit of sound pressure level. (also see B[SPL] or bel sound pressure level). ","1",null,null,1,false],[false,"degree per second","deg/s","DEG/S","plane angle",0.017453292519943295,[0,-1,0,1,0,0,0],"°/s","iso1000",false,null,null,1,false,false,0,0,"deg/sec; deg per sec; °/sec; twist rate; angular speed; rotational speed","LOINC","ARat","Clinical","unit of angular (rotational) speed used to express turning rate","[pi].rad/360","[PI].RAD/360","2",2,false],[false,"decigram","dg","DG","mass",0.1,[0,0,1,0,0,0,0],"dg",null,false,"M",null,1,false,false,0,0,"decigrams; dgm; 0.1 grams; 1/10 gm","LOINC","Mass","Clinical","equal to 1/10 gram",null,null,null,null,false],[false,"deciliter","dL","DL","volume",0.0001,[3,0,0,0,0,0,0],"dL","iso1000",true,null,null,1,false,false,0,0,"deciliters; decilitres; 0.1 liters; 1/10 L","LOINC","Vol","Clinical","equal to 1/10 liter","l",null,"1",1,false],[false,"decimeter","dm","DM","length",0.1,[1,0,0,0,0,0,0],"dm",null,false,"L",null,1,false,false,0,0,"decimeters; decimetres; 0.1 meters; 1/10 m; 10 cm; centimeters","LOINC","Len","Clinical","equal to 1/10 meter or 10 centimeters",null,null,null,null,false],[false,"square decimeter per square second","dm2/s2","DM2/S2","length",0.010000000000000002,[2,-2,0,0,0,0,0],"(dm<sup>2</sup>)/(s<sup>2</sup>)",null,false,"L",null,1,false,false,0,0,"dm2 per s2; dm^2/s^2; decimeters squared per second squared; sq dm; sq sec","LOINC","EngMass (massic energy)","Clinical","units for energy per unit mass or Joules per kilogram (J/kg = kg.m2/s2/kg = m2/s2) ",null,null,null,null,false],[false,"dyne second per centimeter per square meter","dyn.s/(cm.m2)","(DYN.S)/(CM.M2)","force",1,[-2,-1,1,0,0,0,0],"(dyn.s)/(cm.(m<sup>2</sup>))","cgs",true,null,null,1,false,false,0,0,"(dyn*s)/(cm*m2); (dyn*s)/(cm*m^2); dyn s per cm per m2; m^2; dyne seconds per centimeters per square meter; centimetres; sq. meter; squared","LOINC","","Clinical","","g.cm/s2","G.CM/S2","1",1,false],[false,"dyne second per centimeter","dyn.s/cm","(DYN.S)/CM","force",1,[0,-1,1,0,0,0,0],"(dyn.s)/cm","cgs",true,null,null,1,false,false,0,0,"(dyn*s)/cm; dyn sec per cm; seconds; centimetre; dyne seconds","LOINC","","Clinical","","g.cm/s2","G.CM/S2","1",1,false],[false,"equivalent per liter","eq/L","EQ/L","amount of substance",6.0221366999999994e+26,[-3,0,0,0,0,0,0],"eq/L","chemical",true,null,null,1,false,false,0,1,"eq/liter; eq/litre; eqs; equivalents per liter; litre","LOINC","SCnc","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"equivalent per milliliter","eq/mL","EQ/ML","amount of substance",6.0221367e+29,[-3,0,0,0,0,0,0],"eq/mL","chemical",true,null,null,1,false,false,0,1,"equivalent/milliliter; equivalents per milliliter; eq per mL; millilitre","LOINC","SCnc","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"equivalent per millimole","eq/mmol","EQ/MMOL","amount of substance",1000,[0,0,0,0,0,0,0],"eq/mmol","chemical",true,null,null,1,false,false,-1,1,"equivalent/millimole; equivalents per millimole; eq per mmol","LOINC","SRto","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"equivalent per micromole","eq/umol","EQ/UMOL","amount of substance",1000000,[0,0,0,0,0,0,0],"eq/μmol","chemical",true,null,null,1,false,false,-1,1,"equivalent/micromole; equivalents per micromole; eq per umol","LOINC","SRto","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"femtogram","fg","FG","mass",1e-15,[0,0,1,0,0,0,0],"fg",null,false,"M",null,1,false,false,0,0,"fg; fgm; femtograms; weight","LOINC","Mass","Clinical","equal to 10^-15 grams",null,null,null,null,false],[false,"femtoliter","fL","FL","volume",1e-18,[3,0,0,0,0,0,0],"fL","iso1000",true,null,null,1,false,false,0,0,"femtolitres; femtoliters","LOINC","Vol; EntVol","Clinical","equal to 10^-15 liters","l",null,"1",1,false],[false,"femtometer","fm","FM","length",1e-15,[1,0,0,0,0,0,0],"fm",null,false,"L",null,1,false,false,0,0,"femtometres; femtometers","LOINC","Len","Clinical","equal to 10^-15 meters",null,null,null,null,false],[false,"femtomole","fmol","FMOL","amount of substance",602213670,[0,0,0,0,0,0,0],"fmol","si",true,null,null,1,false,false,1,0,"femtomoles","LOINC","EntSub","Clinical","equal to 10^-15 moles","10*23","10*23","6.0221367",6.0221367,false],[false,"femtomole per gram","fmol/g","FMOL/G","amount of substance",602213670,[0,0,-1,0,0,0,0],"fmol/g","si",true,null,null,1,false,false,1,0,"femtomoles; fmol/gm; fmol per gm","LOINC","SCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"femtomole per liter","fmol/L","FMOL/L","amount of substance",602213670000,[-3,0,0,0,0,0,0],"fmol/L","si",true,null,null,1,false,false,1,0,"femtomoles; fmol per liter; litre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"femtomole per milligram","fmol/mg","FMOL/MG","amount of substance",602213670000,[0,0,-1,0,0,0,0],"fmol/mg","si",true,null,null,1,false,false,1,0,"fmol per mg; femtomoles","LOINC","SCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"femtomole per milliliter","fmol/mL","FMOL/ML","amount of substance",602213670000000,[-3,0,0,0,0,0,0],"fmol/mL","si",true,null,null,1,false,false,1,0,"femtomoles; millilitre; fmol per mL; fmol per milliliter","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"gram meter","g.m","G.M","mass",1,[1,0,1,0,0,0,0],"g.m",null,false,"M",null,1,false,false,0,0,"g*m; gxm; meters; metres","LOINC","Enrg","Clinical","Unit for measuring stroke work (heart work)",null,null,null,null,false],[false,"gram per 100 gram","g/(100.g)","G/(100.G)","mass",0.01,[0,0,0,0,0,0,0],"g/g",null,false,"M",null,1,false,false,0,0,"g/100 gm; 100gm; grams per 100 grams; gm per 100 gm","LOINC","MCnt","Clinical","",null,null,null,null,false],[false,"gram per 12 hour","g/(12.h)","G/(12.HR)","mass",0.000023148148148148147,[0,-1,1,0,0,0,0],"g/h",null,false,"M",null,1,false,false,0,0,"gm/12hrs; 12 hrs; gm per 12 hrs; 12hrs; grams per 12 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"gram per 24 hour","g/(24.h)","G/(24.HR)","mass",0.000011574074074074073,[0,-1,1,0,0,0,0],"g/h",null,false,"M",null,1,false,false,0,0,"gm/24hrs; gm/24 hrs; gm per 24 hrs; 24hrs; grams per 24 hours; gm/dy; gm per dy; grams per day","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"gram per 3 days","g/(3.d)","G/(3.D)","mass",0.000003858024691358025,[0,-1,1,0,0,0,0],"g/d",null,false,"M",null,1,false,false,0,0,"gm/3dy; gm/3 dy; gm per 3 days; grams","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"gram per 4 hour","g/(4.h)","G/(4.HR)","mass",0.00006944444444444444,[0,-1,1,0,0,0,0],"g/h",null,false,"M",null,1,false,false,0,0,"gm/4hrs; gm/4 hrs; gm per 4 hrs; 4hrs; grams per 4 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"gram per 48 hour","g/(48.h)","G/(48.HR)","mass",0.000005787037037037037,[0,-1,1,0,0,0,0],"g/h",null,false,"M",null,1,false,false,0,0,"gm/48hrs; gm/48 hrs; gm per 48 hrs; 48hrs; grams per 48 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"gram per 5 hour","g/(5.h)","G/(5.HR)","mass",0.00005555555555555556,[0,-1,1,0,0,0,0],"g/h",null,false,"M",null,1,false,false,0,0,"gm/5hrs; gm/5 hrs; gm per 5 hrs; 5hrs; grams per 5 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"gram per 6 hour","g/(6.h)","G/(6.HR)","mass",0.000046296296296296294,[0,-1,1,0,0,0,0],"g/h",null,false,"M",null,1,false,false,0,0,"gm/6hrs; gm/6 hrs; gm per 6 hrs; 6hrs; grams per 6 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"gram per 72 hour","g/(72.h)","G/(72.HR)","mass",0.000003858024691358025,[0,-1,1,0,0,0,0],"g/h",null,false,"M",null,1,false,false,0,0,"gm/72hrs; gm/72 hrs; gm per 72 hrs; 72hrs; grams per 72 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"gram per cubic centimeter","g/cm3","G/CM3","mass",999999.9999999999,[-3,0,1,0,0,0,0],"g/(cm<sup>3</sup>)",null,false,"M",null,1,false,false,0,0,"g/cm^3; gm per cm3; g per cm^3; grams per centimeter cubed; cu. cm; centimetre; g/mL; gram per milliliter; millilitre","LOINC","MCnc","Clinical","g/cm3 = g/mL",null,null,null,null,false],[false,"gram per day","g/d","G/D","mass",0.000011574074074074073,[0,-1,1,0,0,0,0],"g/d",null,false,"M",null,1,false,false,0,0,"gm/dy; gm per dy; grams per day; gm/24hrs; gm/24 hrs; gm per 24 hrs; 24hrs; grams per 24 hours; serving","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"gram per deciliter","g/dL","G/DL","mass",10000,[-3,0,1,0,0,0,0],"g/dL",null,false,"M",null,1,false,false,0,0,"gm/dL; gm per dL; grams per deciliter; decilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"gram per gram","g/g","G/G","mass",1,[0,0,0,0,0,0,0],"g/g",null,false,"M",null,1,false,false,0,0,"gm; grams","LOINC","MRto ","Clinical","",null,null,null,null,false],[false,"gram per hour","g/h","G/HR","mass",0.0002777777777777778,[0,-1,1,0,0,0,0],"g/h",null,false,"M",null,1,false,false,0,0,"gm/hr; gm per hr; grams; intake; output","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"gram per hour per square meter","g/h/m2","(G/HR)/M2","mass",0.0002777777777777778,[-2,-1,1,0,0,0,0],"(g/h)/(m<sup>2</sup>)",null,false,"M",null,1,false,false,0,0,"gm/hr/m2; gm/h/m2; /m^2; sq. m; g per hr per m2; grams per hours per square meter; meter squared; metre","LOINC","ArMRat","Clinical","",null,null,null,null,false],[false,"gram per kilogram","g/kg ","G/KG","mass",0.001,[0,0,0,0,0,0,0],"g/kg",null,false,"M",null,1,false,false,0,0,"g per kg; gram per kilograms","LOINC","MCnt","Clinical","",null,null,null,null,false],[false,"gram per kilogram per 8 hour ","g/kg/(8.h)","(G/KG)/(8.HR)","mass",3.472222222222222e-8,[0,-1,0,0,0,0,0],"(g/kg)/h",null,false,"M",null,1,false,false,0,0,"g/(8.kg.h); gm/kg/8hrs; 8 hrs; g per kg per 8 hrs; 8hrs; grams per kilograms per 8 hours; shift","LOINC","MCntRat; RelMRat","Clinical","unit often used to describe mass in grams of protein consumed in a 8 hours, divided by the subject's body weight in kilograms. Also used to measure mass dose rate per body mass",null,null,null,null,false],[false,"gram per kilogram per day","g/kg/d","(G/KG)/D","mass",1.1574074074074074e-8,[0,-1,0,0,0,0,0],"(g/kg)/d",null,false,"M",null,1,false,false,0,0,"g/(kg.d); gm/kg/dy; gm per kg per dy; grams per kilograms per day","LOINC","RelMRat","Clinical","unit often used to describe mass in grams of protein consumed in a day, divided by the subject's body weight in kilograms. Also used to measure mass dose rate per body mass",null,null,null,null,false],[false,"gram per kilogram per hour","g/kg/h","(G/KG)/HR","mass",2.7777777777777776e-7,[0,-1,0,0,0,0,0],"(g/kg)/h",null,false,"M",null,1,false,false,0,0,"g/(kg.h); g/kg/hr; g per kg per hrs; grams per kilograms per hour","LOINC","MCntRat; RelMRat","Clinical","unit used to measure mass dose rate per body mass",null,null,null,null,false],[false,"gram per kilogram per minute","g/kg/min","(G/KG)/MIN","mass",0.000016666666666666667,[0,-1,0,0,0,0,0],"(g/kg)/min",null,false,"M",null,1,false,false,0,0,"g/(kg.min); g/kg/min; g per kg per min; grams per kilograms per minute","LOINC","MCntRat; RelMRat","Clinical","unit used to measure mass dose rate per body mass",null,null,null,null,false],[false,"gram per liter","g/L","G/L","mass",1000,[-3,0,1,0,0,0,0],"g/L",null,false,"M",null,1,false,false,0,0,"gm per liter; g/liter; grams per liter; litre","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"gram per square meter","g/m2","G/M2","mass",1,[-2,0,1,0,0,0,0],"g/(m<sup>2</sup>)",null,false,"M",null,1,false,false,0,0,"g/m^2; gram/square meter; g/sq m; g per m2; g per m^2; grams per square meter; meters squared; metre","LOINC","ArMass","Clinical","Tests measure myocardial mass (heart ventricle system) per body surface area; unit used to measure mass dose per body surface area",null,null,null,null,false],[false,"gram per milligram","g/mg","G/MG","mass",1000,[0,0,0,0,0,0,0],"g/mg",null,false,"M",null,1,false,false,0,0,"g per mg; grams per milligram","LOINC","MCnt; MRto","Clinical","",null,null,null,null,false],[false,"gram per minute","g/min","G/MIN","mass",0.016666666666666666,[0,-1,1,0,0,0,0],"g/min",null,false,"M",null,1,false,false,0,0,"g per min; grams per minute; gram/minute","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"gram per milliliter","g/mL","G/ML","mass",1000000,[-3,0,1,0,0,0,0],"g/mL",null,false,"M",null,1,false,false,0,0,"g per mL; grams per milliliter; millilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"gram per millimole","g/mmol","G/MMOL","mass",1.6605401866749388e-21,[0,0,1,0,0,0,0],"g/mmol",null,false,"M",null,1,false,false,-1,0,"grams per millimole; g per mmol","LOINC","Ratio","Clinical","",null,null,null,null,false],[false,"joule per liter","J/L","J/L","energy",1000000,[-1,-2,1,0,0,0,0],"J/L","si",true,null,null,1,false,false,0,0,"joules per liter; litre; J per L","LOINC","EngCnc","Clinical","","N.m","N.M","1",1,false],[false,"degree Kelvin per Watt","K/W","K/W","temperature",0.001,[-2,3,-1,0,1,0,0],"K/W",null,false,"C",null,1,false,false,0,0,"degree Kelvin/Watt; K per W; thermal ohm; thermal resistance; degrees","LOINC","TempEngRat","Clinical","unit for absolute thermal resistance equal to the reciprocal of thermal conductance. Unit used for tests to measure work of breathing",null,null,null,null,false],[false,"kilo international unit per liter","k[IU]/L","K[IU]/L","arbitrary",1000000,[-3,0,0,0,0,0,0],"(ki.U.)/L","chemical",true,null,null,1,false,true,0,0,"kIU/L; kIU per L; kIU per liter; kilo international units; litre; allergens; allergy units","LOINC","ACnc","Clinical","IgE has an WHO reference standard so IgE allergen testing can be reported as k[IU]/L","[iU]","[IU]","1",1,false],[false,"kilo international unit per milliliter","k[IU]/mL","K[IU]/ML","arbitrary",1000000000,[-3,0,0,0,0,0,0],"(ki.U.)/mL","chemical",true,null,null,1,false,true,0,0,"kIU/mL; kIU per mL; kIU per milliliter; kilo international units; millilitre; allergens; allergy units","LOINC","ACnc","Clinical","IgE has an WHO reference standard so IgE allergen testing can be reported as k[IU]/mL","[iU]","[IU]","1",1,false],[false,"katal per kilogram","kat/kg","KAT/KG","catalytic activity",602213670000000000000,[0,-1,-1,0,0,0,0],"kat/kg","chemical",true,null,null,1,false,false,1,0,"kat per kg; katals per kilogram; mol/s/kg; moles per seconds per kilogram","LOINC","CCnt","Clinical","kat is a unit of catalytic activity with base units = mol/s. Rarely used because its units are too large to practically express catalytic activity. See enzyme unit [U] which is the standard unit for catalytic activity.","mol/s","MOL/S","1",1,false],[false,"katal per liter","kat/L","KAT/L","catalytic activity",6.0221366999999994e+26,[-3,-1,0,0,0,0,0],"kat/L","chemical",true,null,null,1,false,false,1,0,"kat per L; katals per liter; litre; mol/s/L; moles per seconds per liter","LOINC","CCnc","Clinical","kat is a unit of catalytic activity with base units = mol/s. Rarely used because its units are too large to practically express catalytic activity. See enzyme unit [U] which is the standard unit for catalytic activity.","mol/s","MOL/S","1",1,false],[false,"kilocalorie","kcal","KCAL","energy",4184000,[2,-2,1,0,0,0,0],"kcal","heat",true,null,null,1,false,false,0,0,"kilogram calories; large calories; food calories; kcals","LOINC","EngRat","Clinical","It is equal to 1000 calories (equal to 4.184 kJ). But in practical usage, kcal refers to food calories which excludes caloric content in fiber and other constitutes that is not digestible by humans. Also see nutrition label Calories ([Cal])","cal_th","CAL_TH","1",1,false],[false,"kilocalorie per 24 hour","kcal/(24.h)","KCAL/(24.HR)","energy",48.425925925925924,[2,-3,1,0,0,0,0],"kcal/h","heat",true,null,null,1,false,false,0,0,"kcal/24hrs; kcal/24 hrs; kcal per 24hrs; kilocalories per 24 hours; kilojoules; kJ/24hr; kJ/(24.h); kJ/dy; kilojoules per days; intake; calories burned; metabolic rate; food calories","","EngRat","Clinical","","cal_th","CAL_TH","1",1,false],[false,"kilocalorie per ounce","kcal/[oz_av]","KCAL/[OZ_AV]","energy",147586.25679704445,[2,-2,0,0,0,0,0],"kcal/oz","heat",true,null,null,1,false,false,0,0,"kcal/oz; kcal per ozs; large calories per ounces; food calories; servings; international","LOINC","EngCnt","Clinical","used in nutrition to represent calorie of food","cal_th","CAL_TH","1",1,false],[false,"kilocalorie per day","kcal/d","KCAL/D","energy",48.425925925925924,[2,-3,1,0,0,0,0],"kcal/d","heat",true,null,null,1,false,false,0,0,"kcal/dy; kcal per day; kilocalories per days; kilojoules; kJ/dy; kilojoules per days; intake; calories burned; metabolic rate; food calories","LOINC","EngRat","Clinical","unit in nutrition for food intake (measured in calories) in a day","cal_th","CAL_TH","1",1,false],[false,"kilocalorie per hour","kcal/h","KCAL/HR","energy",1162.2222222222222,[2,-3,1,0,0,0,0],"kcal/h","heat",true,null,null,1,false,false,0,0,"kcal/hrs; kcals per hr; intake; kilocalories per hours; kilojoules","LOINC","EngRat","Clinical","used in nutrition to represent caloric requirement or consumption","cal_th","CAL_TH","1",1,false],[false,"kilocalorie per kilogram per 24 hour","kcal/kg/(24.h)","(KCAL/KG)/(24.HR)","energy",0.04842592592592593,[2,-3,0,0,0,0,0],"(kcal/kg)/h","heat",true,null,null,1,false,false,0,0,"kcal/kg/24hrs; 24 hrs; kcal per kg per 24hrs; kilocalories per kilograms per 24 hours; kilojoules","LOINC","EngCntRat","Clinical","used in nutrition to represent caloric requirement per day based on subject's body weight in kilograms","cal_th","CAL_TH","1",1,false],[false,"kilogram","kg","KG","mass",1000,[0,0,1,0,0,0,0],"kg",null,false,"M",null,1,false,false,0,0,"kilograms; kgs","LOINC","Mass","Clinical","",null,null,null,null,false],[false,"kilogram meter per second","kg.m/s","(KG.M)/S","mass",1000,[1,-1,1,0,0,0,0],"(kg.m)/s",null,false,"M",null,1,false,false,0,0,"kg*m/s; kg.m per sec; kg*m per sec; p; momentum","LOINC","","Clinical","unit for momentum =  mass times velocity",null,null,null,null,false],[false,"kilogram per second per square meter","kg/(s.m2)","KG/(S.M2)","mass",1000,[-2,-1,1,0,0,0,0],"kg/(s.(m<sup>2</sup>))",null,false,"M",null,1,false,false,0,0,"kg/(s*m2); kg/(s*m^2); kg per s per m2; per sec; per m^2; kilograms per seconds per square meter; meter squared; metre","LOINC","ArMRat","Clinical","",null,null,null,null,false],[false,"kilogram per hour","kg/h","KG/HR","mass",0.2777777777777778,[0,-1,1,0,0,0,0],"kg/h",null,false,"M",null,1,false,false,0,0,"kg/hr; kg per hr; kilograms per hour","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"kilogram per liter","kg/L","KG/L","mass",1000000,[-3,0,1,0,0,0,0],"kg/L",null,false,"M",null,1,false,false,0,0,"kg per liter; litre; kilograms","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"kilogram per square meter","kg/m2","KG/M2","mass",1000,[-2,0,1,0,0,0,0],"kg/(m<sup>2</sup>)",null,false,"M",null,1,false,false,0,0,"kg/m^2; kg/sq. m; kg per m2; per m^2; per sq. m; kilograms; meter squared; metre; BMI","LOINC","Ratio","Clinical","units for body mass index (BMI)",null,null,null,null,false],[false,"kilogram per cubic meter","kg/m3","KG/M3","mass",1000,[-3,0,1,0,0,0,0],"kg/(m<sup>3</sup>)",null,false,"M",null,1,false,false,0,0,"kg/m^3; kg/cu. m; kg per m3; per m^3; per cu. m; kilograms; meters cubed; metre","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"kilogram per minute","kg/min","KG/MIN","mass",16.666666666666668,[0,-1,1,0,0,0,0],"kg/min",null,false,"M",null,1,false,false,0,0,"kilogram/minute; kg per min; kilograms per minute","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"kilogram per mole","kg/mol","KG/MOL","mass",1.6605401866749388e-21,[0,0,1,0,0,0,0],"kg/mol",null,false,"M",null,1,false,false,-1,0,"kilogram/mole; kg per mol; kilograms per mole","LOINC","SCnt","Clinical","",null,null,null,null,false],[false,"kilogram per second","kg/s","KG/S","mass",1000,[0,-1,1,0,0,0,0],"kg/s",null,false,"M",null,1,false,false,0,0,"kg/sec; kilogram/second; kg per sec; kilograms; second","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"kiloliter","kL","KL","volume",1,[3,0,0,0,0,0,0],"kL","iso1000",true,null,null,1,false,false,0,0,"kiloliters; kilolitres; m3; m^3; meters cubed; metre","LOINC","Vol","Clinical","","l",null,"1",1,false],[false,"kilometer","km","KM","length",1000,[1,0,0,0,0,0,0],"km",null,false,"L",null,1,false,false,0,0,"kilometers; kilometres; distance","LOINC","Len","Clinical","",null,null,null,null,false],[false,"kilopascal","kPa","KPAL","pressure",1000000,[-1,-2,1,0,0,0,0],"kPa","si",true,null,null,1,false,false,0,0,"kilopascals; pressure","LOINC","Pres; PPresDiff","Clinical","","N/m2","N/M2","1",1,false],[false,"kilosecond","ks","KS","time",1000,[0,1,0,0,0,0,0],"ks",null,false,"T",null,1,false,false,0,0,"kiloseconds; ksec","LOINC","Time","Clinical","",null,null,null,null,false],[false,"kilo enzyme unit","kU","KU","catalytic activity",10036894500000000000,[0,-1,0,0,0,0,0],"kU","chemical",true,null,null,1,false,false,1,0,"units; mmol/min; millimoles per minute","LOINC","CAct","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 kU = 1 mmol/min","umol/min","UMOL/MIN","1",1,false],[false,"kilo enzyme unit per gram","kU/g","KU/G","catalytic activity",10036894500000000000,[0,-1,-1,0,0,0,0],"kU/g","chemical",true,null,null,1,false,false,1,0,"units per grams; kU per gm","LOINC","CCnt","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 kU = 1 mmol/min","umol/min","UMOL/MIN","1",1,false],[false,"kilo enzyme unit per liter","kU/L","KU/L","catalytic activity",1.00368945e+22,[-3,-1,0,0,0,0,0],"kU/L","chemical",true,null,null,1,false,false,1,0,"units per liter; litre; enzymatic activity; enzyme activity per volume; activities","LOINC","ACnc; CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 kU = 1 mmol/min","umol/min","UMOL/MIN","1",1,false],[false,"kilo enzyme unit per milliliter","kU/mL","KU/ML","catalytic activity",1.00368945e+25,[-3,-1,0,0,0,0,0],"kU/mL","chemical",true,null,null,1,false,false,1,0,"kU per mL; units per milliliter; millilitre; enzymatic activity per volume; enzyme activities","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 kU = 1 mmol/min","umol/min","UMOL/MIN","1",1,false],[false,"Liters per 24 hour","L/(24.h)","L/(24.HR)","volume",1.1574074074074074e-8,[3,-1,0,0,0,0,0],"L/h","iso1000",true,null,null,1,false,false,0,0,"L/24hrs; L/24 hrs; L per 24hrs; liters per 24 hours; day; dy; litres; volume flow rate","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"Liters per 8 hour","L/(8.h)","L/(8.HR)","volume",3.472222222222222e-8,[3,-1,0,0,0,0,0],"L/h","iso1000",true,null,null,1,false,false,0,0,"L/8hrs; L/8 hrs; L per 8hrs; liters per 8 hours; litres; volume flow rate; shift","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"Liters per minute per square meter","L/(min.m2) ","L/(MIN.M2)","volume",0.000016666666666666667,[1,-1,0,0,0,0,0],"L/(min.(m<sup>2</sup>))","iso1000",true,null,null,1,false,false,0,0,"L/(min.m2); L/min/m^2; L/min/sq. meter; L per min per m2; m^2; liters per minutes per square meter; meter squared; litres; metre ","LOINC","ArVRat","Clinical","unit for tests that measure cardiac output per body surface area (cardiac index)","l",null,"1",1,false],[false,"Liters per day","L/d","L/D","volume",1.1574074074074074e-8,[3,-1,0,0,0,0,0],"L/d","iso1000",true,null,null,1,false,false,0,0,"L/dy; L per day; 24hrs; 24 hrs; 24 hours; liters; litres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"Liters per hour","L/h","L/HR","volume",2.7777777777777776e-7,[3,-1,0,0,0,0,0],"L/h","iso1000",true,null,null,1,false,false,0,0,"L/hr; L per hr; litres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"Liters per kilogram","L/kg","L/KG","volume",0.000001,[3,0,-1,0,0,0,0],"L/kg","iso1000",true,null,null,1,false,false,0,0,"L per kg; litre","LOINC","VCnt","Clinical","","l",null,"1",1,false],[false,"Liters per liter","L/L","L/L","volume",1,[0,0,0,0,0,0,0],"L/L","iso1000",true,null,null,1,false,false,0,0,"L per L; liter/liter; litre","LOINC","VFr","Clinical","","l",null,"1",1,false],[false,"Liters per minute","L/min","L/MIN","volume",0.000016666666666666667,[3,-1,0,0,0,0,0],"L/min","iso1000",true,null,null,1,false,false,0,0,"liters per minute; litre","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"Liters per minute per square meter","L/min/m2","(L/MIN)/M2","volume",0.000016666666666666667,[1,-1,0,0,0,0,0],"(L/min)/(m<sup>2</sup>)","iso1000",true,null,null,1,false,false,0,0,"L/(min.m2); L/min/m^2; L/min/sq. meter; L per min per m2; m^2; liters per minutes per square meter; meter squared; litres; metre ","","ArVRat","Clinical","unit for tests that measure cardiac output per body surface area (cardiac index)","l",null,"1",1,false],[false,"Liters per second","L/s","L/S","volume",0.001,[3,-1,0,0,0,0,0],"L/s","iso1000",true,null,null,1,false,false,0,0,"L per sec; litres","LOINC","VRat","Clinical","unit used often to measure gas flow and peak expiratory flow","l",null,"1",1,false],[false,"Liters per second per square second","L/s/s2","(L/S)/S2","volume",0.001,[3,-3,0,0,0,0,0],"(L/s)/(s<sup>2</sup>)","iso1000",true,null,null,1,false,false,0,0,"L/s/s^2; L/sec/sec2; L/sec/sec^2; L/sec/sq. sec; L per s per s2; L per sec per sec2; s^2; sec^2; liters per seconds per square second; second squared; litres ","LOINC","ArVRat","Clinical","unit for tests that measure cardiac output/body surface area","l",null,"1",1,false],[false,"lumen square meter","lm.m2","LM.M2","luminous flux",1,[2,0,0,2,0,0,1],"lm.(m<sup>2</sup>)","si",true,null,null,1,false,false,0,0,"lm*m2; lm*m^2; lumen meters squared; lumen sq. meters; metres","LOINC","","Clinical","","cd.sr","CD.SR","1",1,false],[false,"meter per second","m/s","M/S","length",1,[1,-1,0,0,0,0,0],"m/s",null,false,"L",null,1,false,false,0,0,"meter/second; m per sec; meters per second; metres; velocity; speed","LOINC","Vel","Clinical","unit of velocity",null,null,null,null,false],[false,"meter per square second","m/s2","M/S2","length",1,[1,-2,0,0,0,0,0],"m/(s<sup>2</sup>)",null,false,"L",null,1,false,false,0,0,"m/s^2; m/sq. sec; m per s2; per s^2; meters per square second; second squared; sq second; metres; acceleration","LOINC","Accel","Clinical","unit of acceleration",null,null,null,null,false],[false,"milli international unit per liter","m[IU]/L","M[IU]/L","arbitrary",1,[-3,0,0,0,0,0,0],"(mi.U.)/L","chemical",true,null,null,1,false,true,0,0,"mIU/L; m IU/L; mIU per liter; units; litre","LOINC","ACnc","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"milli  international unit per milliliter","m[IU]/mL","M[IU]/ML","arbitrary",1000.0000000000001,[-3,0,0,0,0,0,0],"(mi.U.)/mL","chemical",true,null,null,1,false,true,0,0,"mIU/mL; m IU/mL; mIU per mL; milli international units per milliliter; millilitre","LOINC","ACnc","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"square meter","m2","M2","length",1,[2,0,0,0,0,0,0],"m<sup>2</sup>",null,false,"L",null,1,false,false,0,0,"m^2; sq m; square meters; meters squared; metres","LOINC","Area","Clinical","unit often used to represent body surface area",null,null,null,null,false],[false,"square meter per second","m2/s","M2/S","length",1,[2,-1,0,0,0,0,0],"(m<sup>2</sup>)/s",null,false,"L",null,1,false,false,0,0,"m^2/sec; m2 per sec; m^2 per sec; sq m/sec; meters squared/seconds; sq m per sec; meters squared; metres","LOINC","ArRat","Clinical","",null,null,null,null,false],[false,"cubic meter per second","m3/s","M3/S","length",1,[3,-1,0,0,0,0,0],"(m<sup>3</sup>)/s",null,false,"L",null,1,false,false,0,0,"m^3/sec; m3 per sec; m^3 per sec; cu m/sec; cubic meters per seconds; meters cubed; metres","LOINC","VRat","Clinical","",null,null,null,null,false],[false,"milliampere","mA","MA","electric current",0.001,[0,-1,0,0,0,1,0],"mA","si",true,null,null,1,false,false,0,0,"mamp; milliamperes","LOINC","ElpotRat","Clinical","unit of electric current","C/s","C/S","1",1,false],[false,"millibar","mbar","MBAR","pressure",100000,[-1,-2,1,0,0,0,0],"mbar","iso1000",true,null,null,1,false,false,0,0,"millibars","LOINC","Pres","Clinical","unit of pressure","Pa","PAL","1e5",100000,false],[false,"millibar second per liter","mbar.s/L","(MBAR.S)/L","pressure",100000000,[-4,-1,1,0,0,0,0],"(mbar.s)/L","iso1000",true,null,null,1,false,false,0,0,"mbar*s/L; mbar.s per L; mbar*s per L; millibar seconds per liter; millibar second per litre","LOINC","","Clinical","unit to measure expiratory resistance","Pa","PAL","1e5",100000,false],[false,"millibar per liter per second","mbar/L/s","(MBAR/L)/S","pressure",100000000,[-4,-3,1,0,0,0,0],"(mbar/L)/s","iso1000",true,null,null,1,false,false,0,0,"mbar/(L.s); mbar/L/sec; mbar/liter/second; mbar per L per sec; mbar per liter per second; millibars per liters per seconds; litres","LOINC","PresCncRat","Clinical","unit to measure expiratory resistance","Pa","PAL","1e5",100000,false],[false,"milliequivalent","meq","MEQ","amount of substance",602213670000000000000,[0,0,0,0,0,0,0],"meq","chemical",true,null,null,1,false,false,0,1,"milliequivalents; meqs","LOINC","Sub","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per 2 hour","meq/(2.h)","MEQ/(2.HR)","amount of substance",83640787500000000,[0,-1,0,0,0,0,0],"meq/h","chemical",true,null,null,1,false,false,0,1,"meq/2hrs; meq/2 hrs; meq per 2 hrs; milliequivalents per 2 hours","LOINC","SRat","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per 24 hour","meq/(24.h)","MEQ/(24.HR)","amount of substance",6970065625000000,[0,-1,0,0,0,0,0],"meq/h","chemical",true,null,null,1,false,false,0,1,"meq/24hrs; meq/24 hrs; meq per 24 hrs; milliequivalents per 24 hours","LOINC","SRat","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per 8 hour","meq/(8.h)","MEQ/(8.HR)","amount of substance",20910196875000000,[0,-1,0,0,0,0,0],"meq/h","chemical",true,null,null,1,false,false,0,1,"meq/8hrs; meq/8 hrs; meq per 8 hrs; milliequivalents per 8 hours; shift","LOINC","SRat","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per day","meq/d","MEQ/D","amount of substance",6970065625000000,[0,-1,0,0,0,0,0],"meq/d","chemical",true,null,null,1,false,false,0,1,"meq/dy; meq per day; milliquivalents per days; meq/24hrs; meq/24 hrs; meq per 24 hrs; milliequivalents per 24 hours","LOINC","SRat","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per deciliter","meq/dL","MEQ/DL","amount of substance",6.022136699999999e+24,[-3,0,0,0,0,0,0],"meq/dL","chemical",true,null,null,1,false,false,0,1,"meq per dL; milliequivalents per deciliter; decilitre","LOINC","SCnc","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per gram","meq/g","MEQ/G","amount of substance",602213670000000000000,[0,0,-1,0,0,0,0],"meq/g","chemical",true,null,null,1,false,false,0,1,"mgq/gm; meq per gm; milliequivalents per gram","LOINC","MCnt","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per hour","meq/h","MEQ/HR","amount of substance",167281575000000000,[0,-1,0,0,0,0,0],"meq/h","chemical",true,null,null,1,false,false,0,1,"meq/hrs; meq per hrs; milliequivalents per hour","LOINC","SRat","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per kilogram","meq/kg","MEQ/KG","amount of substance",602213670000000000,[0,0,-1,0,0,0,0],"meq/kg","chemical",true,null,null,1,false,false,0,1,"meq per kg; milliequivalents per kilogram","LOINC","SCnt","Clinical","equivalence equals moles per valence; used to measure dose per patient body mass","mol","MOL","1",1,false],[false,"milliequivalent per kilogram per hour","meq/kg/h","(MEQ/KG)/HR","amount of substance",167281575000000,[0,-1,-1,0,0,0,0],"(meq/kg)/h","chemical",true,null,null,1,false,false,0,1,"meq/(kg.h); meq/kg/hr; meq per kg per hr; milliequivalents per kilograms per hour","LOINC","SCntRat","Clinical","equivalence equals moles per valence; unit used to measure dose rate per patient body mass","mol","MOL","1",1,false],[false,"milliequivalent per liter","meq/L","MEQ/L","amount of substance",6.0221367e+23,[-3,0,0,0,0,0,0],"meq/L","chemical",true,null,null,1,false,false,0,1,"milliequivalents per liter; litre; meq per l; acidity","LOINC","SCnc","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per square meter","meq/m2","MEQ/M2","amount of substance",602213670000000000000,[-2,0,0,0,0,0,0],"meq/(m<sup>2</sup>)","chemical",true,null,null,1,false,false,0,1,"meq/m^2; meq/sq. m; milliequivalents per square meter; meter squared; metre","LOINC","ArSub","Clinical","equivalence equals moles per valence; note that the use of m2 in clinical units ofter refers to body surface area","mol","MOL","1",1,false],[false,"milliequivalent per minute","meq/min","MEQ/MIN","amount of substance",10036894500000000000,[0,-1,0,0,0,0,0],"meq/min","chemical",true,null,null,1,false,false,0,1,"meq per min; milliequivalents per minute","LOINC","SRat","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per milliliter","meq/mL","MEQ/ML","amount of substance",6.0221367e+26,[-3,0,0,0,0,0,0],"meq/mL","chemical",true,null,null,1,false,false,0,1,"meq per mL; milliequivalents per milliliter; millilitre","LOINC","SCnc","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milligram","mg","MG","mass",0.001,[0,0,1,0,0,0,0],"mg",null,false,"M",null,1,false,false,0,0,"milligrams","LOINC","Mass","Clinical","",null,null,null,null,false],[false,"milligram per 10 hour","mg/(10.h)","MG/(10.HR)","mass",2.7777777777777777e-8,[0,-1,1,0,0,0,0],"mg/h",null,false,"M",null,1,false,false,0,0,"mg/10hrs; mg/10 hrs; mg per 10 hrs; milligrams per 10 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"milligram per 12 hour","mg/(12.h)","MG/(12.HR)","mass",2.3148148148148148e-8,[0,-1,1,0,0,0,0],"mg/h",null,false,"M",null,1,false,false,0,0,"mg/12hrs; mg/12 hrs; per 12 hrs; 12hrs; milligrams per 12 hours","LOINC","MRat","Clinical","units used for tests in urine",null,null,null,null,false],[false,"milligram per 2 hour","mg/(2.h)","MG/(2.HR)","mass",1.3888888888888888e-7,[0,-1,1,0,0,0,0],"mg/h",null,false,"M",null,1,false,false,0,0,"mg/2hrs; mg/2 hrs; mg per 2 hrs; 2hrs; milligrams per 2 hours","LOINC","MRat","Clinical","units used for tests in urine",null,null,null,null,false],[false,"milligram per 24 hour","mg/(24.h)","MG/(24.HR)","mass",1.1574074074074074e-8,[0,-1,1,0,0,0,0],"mg/h",null,false,"M",null,1,false,false,0,0,"mg/24hrs; mg/24 hrs; milligrams per 24 hours; mg/kg/dy; mg per kg per day; milligrams per kilograms per days","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"milligram per 6 hour","mg/(6.h)","MG/(6.HR)","mass",4.6296296296296295e-8,[0,-1,1,0,0,0,0],"mg/h",null,false,"M",null,1,false,false,0,0,"mg/6hrs; mg/6 hrs; mg per 6 hrs; 6hrs; milligrams per 6 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"milligram per 72 hour","mg/(72.h)","MG/(72.HR)","mass",3.858024691358025e-9,[0,-1,1,0,0,0,0],"mg/h",null,false,"M",null,1,false,false,0,0,"mg/72hrs; mg/72 hrs; 72 hrs; 72hrs; milligrams per 72 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"milligram per 8 hour","mg/(8.h)","MG/(8.HR)","mass",3.472222222222222e-8,[0,-1,1,0,0,0,0],"mg/h",null,false,"M",null,1,false,false,0,0,"mg/8hrs; mg/8 hrs; milligrams per 8 hours; shift","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"milligram per day","mg/d","MG/D","mass",1.1574074074074074e-8,[0,-1,1,0,0,0,0],"mg/d",null,false,"M",null,1,false,false,0,0,"mg/24hrs; mg/24 hrs; milligrams per 24 hours; mg/dy; mg per day; milligrams","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"milligram per deciliter","mg/dL","MG/DL","mass",10,[-3,0,1,0,0,0,0],"mg/dL",null,false,"M",null,1,false,false,0,0,"mg per dL; milligrams per deciliter; decilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"milligram per gram","mg/g","MG/G","mass",0.001,[0,0,0,0,0,0,0],"mg/g",null,false,"M",null,1,false,false,0,0,"mg per gm; milligrams per gram","LOINC","MCnt; MRto","Clinical","",null,null,null,null,false],[false,"milligram per hour","mg/h","MG/HR","mass",2.7777777777777776e-7,[0,-1,1,0,0,0,0],"mg/h",null,false,"M",null,1,false,false,0,0,"mg/hr; mg per hr; milligrams","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"milligram per kilogram","mg/kg","MG/KG","mass",0.000001,[0,0,0,0,0,0,0],"mg/kg",null,false,"M",null,1,false,false,0,0,"mg per kg; milligrams per kilograms","LOINC","MCnt","Clinical","",null,null,null,null,false],[false,"milligram per kilogram per 8 hour","mg/kg/(8.h)","(MG/KG)/(8.HR)","mass",3.472222222222222e-11,[0,-1,0,0,0,0,0],"(mg/kg)/h",null,false,"M",null,1,false,false,0,0,"mg/(8.h.kg); mg/kg/8hrs; mg/kg/8 hrs; mg per kg per 8hrs; 8 hrs; milligrams per kilograms per 8 hours; shift","LOINC","RelMRat; MCntRat","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[false,"milligram per kilogram per day","mg/kg/d","(MG/KG)/D","mass",1.1574074074074074e-11,[0,-1,0,0,0,0,0],"(mg/kg)/d",null,false,"M",null,1,false,false,0,0,"mg/(kg.d); mg/(kg.24.h)mg/kg/dy; mg per kg per day; milligrams per kilograms per days; mg/kg/(24.h); mg/kg/24hrs; 24 hrs; 24 hours","LOINC","RelMRat ","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[false,"milligram per kilogram per hour","mg/kg/h","(MG/KG)/HR","mass",2.7777777777777777e-10,[0,-1,0,0,0,0,0],"(mg/kg)/h",null,false,"M",null,1,false,false,0,0,"mg/(kg.h); mg/kg/hr; mg per kg per hr; milligrams per kilograms per hour","LOINC","RelMRat; MCntRat","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[false,"milligram per kilogram per minute","mg/kg/min","(MG/KG)/MIN","mass",1.6666666666666667e-8,[0,-1,0,0,0,0,0],"(mg/kg)/min",null,false,"M",null,1,false,false,0,0,"mg/(kg.min); mg per kg per min; milligrams per kilograms per minute","LOINC","RelMRat; MCntRat","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[false,"milligram per liter","mg/L","MG/L","mass",1,[-3,0,1,0,0,0,0],"mg/L",null,false,"M",null,1,false,false,0,0,"mg per l; milligrams per liter; litre","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"milligram per square meter","mg/m2","MG/M2","mass",0.001,[-2,0,1,0,0,0,0],"mg/(m<sup>2</sup>)",null,false,"M",null,1,false,false,0,0,"mg/m^2; mg/sq. m; mg per m2; mg per m^2; mg per sq. milligrams; meter squared; metre","LOINC","ArMass","Clinical","",null,null,null,null,false],[false,"milligram per cubic meter","mg/m3","MG/M3","mass",0.001,[-3,0,1,0,0,0,0],"mg/(m<sup>3</sup>)",null,false,"M",null,1,false,false,0,0,"mg/m^3; mg/cu. m; mg per m3; milligrams per cubic meter; meter cubed; metre","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"milligram per milligram","mg/mg","MG/MG","mass",1,[0,0,0,0,0,0,0],"mg/mg",null,false,"M",null,1,false,false,0,0,"mg per mg; milligrams; milligram/milligram","LOINC","MRto","Clinical","",null,null,null,null,false],[false,"milligram per minute","mg/min","MG/MIN","mass",0.000016666666666666667,[0,-1,1,0,0,0,0],"mg/min",null,false,"M",null,1,false,false,0,0,"mg per min; milligrams per minutes; milligram/minute","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"milligram per milliliter","mg/mL","MG/ML","mass",1000.0000000000001,[-3,0,1,0,0,0,0],"mg/mL",null,false,"M",null,1,false,false,0,0,"mg per mL; milligrams per milliliters; millilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"milligram per millimole","mg/mmol","MG/MMOL","mass",1.660540186674939e-24,[0,0,1,0,0,0,0],"mg/mmol",null,false,"M",null,1,false,false,-1,0,"mg per mmol; milligrams per millimole; ","LOINC","Ratio","Clinical","",null,null,null,null,false],[false,"milligram per week","mg/wk","MG/WK","mass",1.6534391534391535e-9,[0,-1,1,0,0,0,0],"mg/wk",null,false,"M",null,1,false,false,0,0,"mg/week; mg per wk; milligrams per weeks; milligram/week","LOINC","Mrat","Clinical","",null,null,null,null,false],[false,"milliliter","mL","ML","volume",0.000001,[3,0,0,0,0,0,0],"mL","iso1000",true,null,null,1,false,false,0,0,"milliliters; millilitres","LOINC","Vol","Clinical","","l",null,"1",1,false],[false,"milliliter per 10 hour","mL/(10.h)","ML/(10.HR)","volume",2.7777777777777777e-11,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,0,"ml/10hrs; ml/10 hrs; mL per 10hrs; 10 hrs; milliliters per 10 hours; millilitres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 12 hour","mL/(12.h)","ML/(12.HR)","volume",2.3148148148148147e-11,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,0,"ml/12hrs; ml/12 hrs; mL per 12hrs; 12 hrs; milliliters per 12 hours; millilitres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 2 hour","mL/(2.h)","ML/(2.HR)","volume",1.3888888888888888e-10,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,0,"ml/2hrs; ml/2 hrs; mL per 2hrs; 2 hrs; milliliters per 2 hours; millilitres ","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 24 hour","mL/(24.h)","ML/(24.HR)","volume",1.1574074074074074e-11,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,0,"ml/24hrs; ml/24 hrs; mL per 24hrs; 24 hrs; milliliters per 24 hours; millilitres; ml/dy; /day; ml per dy; days; fluid outputs; fluid inputs; flow rate","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 4 hour","mL/(4.h)","ML/(4.HR)","volume",6.944444444444444e-11,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,0,"ml/4hrs; ml/4 hrs; mL per 4hrs; 4 hrs; milliliters per 4 hours; millilitres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 5 hour","mL/(5.h)","ML/(5.HR)","volume",5.5555555555555553e-11,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,0,"ml/5hrs; ml/5 hrs; mL per 5hrs; 5 hrs; milliliters per 5 hours; millilitres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 6 hour","mL/(6.h)","ML/(6.HR)","volume",4.6296296296296294e-11,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,0,"ml/6hrs; ml/6 hrs; mL per 6hrs; 6 hrs; milliliters per 6 hours; millilitres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 72 hour","mL/(72.h)","ML/(72.HR)","volume",3.8580246913580245e-12,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,0,"ml/72hrs; ml/72 hrs; mL per 72hrs; 72 hrs; milliliters per 72 hours; millilitres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 8 hour","mL/(8.h)","ML/(8.HR)","volume",3.472222222222222e-11,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,0,"ml/8hrs; ml/8 hrs; mL per 8hrs; 8 hrs; milliliters per 8 hours; millilitres; shift","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 8 hour per kilogram","mL/(8.h)/kg","(ML/(8.HR))/KG","volume",3.472222222222222e-14,[3,-1,-1,0,0,0,0],"(mL/h)/kg","iso1000",true,null,null,1,false,false,0,0,"mL/kg/(8.h); ml/8h/kg; ml/8 h/kg; ml/8hr/kg; ml/8 hr/kgr; mL per 8h per kg; 8 h; 8hr; 8 hr; milliliters per 8 hours per kilogram; millilitres; shift","LOINC","VRatCnt","Clinical","unit used to measure renal excretion volume rate per body mass","l",null,"1",1,false],[false,"milliliter per square inch (international)","mL/[sin_i]","ML/[SIN_I]","volume",0.0015500031000061998,[1,0,0,0,0,0,0],"mL","iso1000",true,null,null,1,false,false,0,0,"mL/sin; mL/in2; mL/in^2; mL per sin; in2; in^2; sq. in; milliliters per square inch; inch squared","LOINC","ArVol","Clinical","","l",null,"1",1,false],[false,"milliliter per centimeter of water","mL/cm[H2O]","ML/CM[H2O]","volume",1.0197162129779282e-11,[4,2,-1,0,0,0,0],"mL/(cm HO<sub><r>2</r></sub>)","iso1000",true,null,null,1,false,false,0,0,"milliliters per centimeter of water; millilitre per centimetre of water; millilitres per centimetre of water; mL/cmH2O; mL/cm H2O; mL per cmH2O; mL per cm H2O","LOINC","Compli","Clinical","unit used to measure dynamic lung compliance","l",null,"1",1,false],[false,"milliliter per day","mL/d","ML/D","volume",1.1574074074074074e-11,[3,-1,0,0,0,0,0],"mL/d","iso1000",true,null,null,1,false,false,0,0,"ml/day; ml per day; milliliters per day; 24 hours; 24hrs; millilitre;","LOINC","VRat","Clinical","usually used to measure fluid output or input; flow rate","l",null,"1",1,false],[false,"milliliter per deciliter","mL/dL","ML/DL","volume",0.009999999999999998,[0,0,0,0,0,0,0],"mL/dL","iso1000",true,null,null,1,false,false,0,0,"mL per dL; millilitres; decilitre; milliliters","LOINC","VFr; VFrDiff","Clinical","","l",null,"1",1,false],[false,"milliliter per hour","mL/h","ML/HR","volume",2.7777777777777777e-10,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,0,"mL/hr; mL per hr; milliliters per hour; millilitres; fluid intake; fluid output","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per kilogram","mL/kg","ML/KG","volume",9.999999999999999e-10,[3,0,-1,0,0,0,0],"mL/kg","iso1000",true,null,null,1,false,false,0,0,"mL per kg; milliliters per kilogram; millilitres","LOINC","VCnt","Clinical","","l",null,"1",1,false],[false,"milliliter per kilogram per 8 hour","mL/kg/(8.h)","(ML/KG)/(8.HR)","volume",3.472222222222222e-14,[3,-1,-1,0,0,0,0],"(mL/kg)/h","iso1000",true,null,null,1,false,false,0,0,"mL/(8.h.kg); mL/kg/8hrs; mL/kg/8 hrs; mL per kg per 8hrs; 8 hrs; milliliters per kilograms per 8 hours; millilitres; shift","LOINC","VCntRat; RelEngRat","Clinical","unit used to measure renal excretion volume rate per body mass","l",null,"1",1,false],[false,"milliliter per kilogram per day","mL/kg/d","(ML/KG)/D","volume",1.1574074074074072e-14,[3,-1,-1,0,0,0,0],"(mL/kg)/d","iso1000",true,null,null,1,false,false,0,0,"mL/(kg.d); mL/kg/dy; mL per kg per day; milliliters per kilograms per day; mg/kg/24hrs; 24 hrs; per 24 hours millilitres","LOINC","VCntRat; RelEngRat","Clinical","unit used to measure renal excretion volume rate per body mass","l",null,"1",1,false],[false,"milliliter per kilogram per hour","mL/kg/h","(ML/KG)/HR","volume",2.7777777777777774e-13,[3,-1,-1,0,0,0,0],"(mL/kg)/h","iso1000",true,null,null,1,false,false,0,0,"mL/(kg.h); mL/kg/hr; mL per kg per hr; milliliters per kilograms per hour; millilitres","LOINC","VCntRat; RelEngRat","Clinical","unit used to measure renal excretion volume rate per body mass","l",null,"1",1,false],[false,"milliliter per kilogram per minute","mL/kg/min","(ML/KG)/MIN","volume",1.6666666666666664e-11,[3,-1,-1,0,0,0,0],"(mL/kg)/min","iso1000",true,null,null,1,false,false,0,0,"mL/(kg.min); mL/kg/dy; mL per kg per day; milliliters per kilograms per day; millilitres","LOINC","RelEngRat","Clinical","used for tests that measure activity metabolic rate compared to standard resting metabolic rate ","l",null,"1",1,false],[false,"milliliter per square meter","mL/m2","ML/M2","volume",0.000001,[1,0,0,0,0,0,0],"mL/(m<sup>2</sup>)","iso1000",true,null,null,1,false,false,0,0,"mL/m^2; mL/sq. meter; mL per m2; m^2; sq. meter; milliliters per square meter; millilitres; meter squared","LOINC","ArVol","Clinical","used for tests that relate to heart work - e.g. ventricular stroke volume; atrial volume per body surface area","l",null,"1",1,false],[false,"milliliter per millibar","mL/mbar","ML/MBAR","volume",1e-11,[4,2,-1,0,0,0,0],"mL/mbar","iso1000",true,null,null,1,false,false,0,0,"mL per mbar; milliliters per millibar; millilitres","LOINC","","Clinical","unit used to measure dynamic lung compliance","l",null,"1",1,false],[false,"milliliter per minute","mL/min","ML/MIN","volume",1.6666666666666667e-8,[3,-1,0,0,0,0,0],"mL/min","iso1000",true,null,null,1,false,false,0,0,"mL per min; milliliters; millilitres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per minute per square meter","mL/min/m2","(ML/MIN)/M2","volume",1.6666666666666667e-8,[1,-1,0,0,0,0,0],"(mL/min)/(m<sup>2</sup>)","iso1000",true,null,null,1,false,false,0,0,"ml/min/m^2; ml/min/sq. meter; mL per min per m2; m^2; sq. meter; milliliters per minutes per square meter; millilitres; metre; meter squared","LOINC","ArVRat","Clinical","unit used to measure volume per body surface area; oxygen consumption index","l",null,"1",1,false],[false,"milliliter per millimeter","mL/mm","ML/MM","volume",0.001,[2,0,0,0,0,0,0],"mL/mm","iso1000",true,null,null,1,false,false,0,0,"mL per mm; milliliters per millimeter; millilitres; millimetre","LOINC","Lineic Volume","Clinical","","l",null,"1",1,false],[false,"milliliter per second","mL/s","ML/S","volume",0.000001,[3,-1,0,0,0,0,0],"mL/s","iso1000",true,null,null,1,false,false,0,0,"ml/sec; mL per sec; milliliters per second; millilitres","LOINC","Vel; VelRat; VRat","Clinical","","l",null,"1",1,false],[false,"millimeter","mm","MM","length",0.001,[1,0,0,0,0,0,0],"mm",null,false,"L",null,1,false,false,0,0,"millimeters; millimetres; height; length; diameter; thickness; axis; curvature; size","LOINC","Len","Clinical","",null,null,null,null,false],[false,"millimeter per hour","mm/h","MM/HR","length",2.7777777777777776e-7,[1,-1,0,0,0,0,0],"mm/h",null,false,"L",null,1,false,false,0,0,"mm/hr; mm per hr; millimeters per hour; millimetres","LOINC","Vel","Clinical","unit to measure sedimentation rate",null,null,null,null,false],[false,"millimeter per minute","mm/min","MM/MIN","length",0.000016666666666666667,[1,-1,0,0,0,0,0],"mm/min",null,false,"L",null,1,false,false,0,0,"mm per min; millimeters per minute; millimetres","LOINC","Vel","Clinical","",null,null,null,null,false],[false,"millimeter of water","mm[H2O]","MM[H2O]","pressure",9806.65,[-1,-2,1,0,0,0,0],"mm HO<sub><r>2</r></sub>","clinical",true,null,null,1,false,false,0,0,"mmH2O; mm H2O; millimeters of water; millimetres","LOINC","Pres","Clinical","","kPa","KPAL","980665e-5",9.80665,false],[false,"millimeter of mercury","mm[Hg]","MM[HG]","pressure",133322,[-1,-2,1,0,0,0,0],"mm Hg","clinical",true,null,null,1,false,false,0,0,"mmHg; mm Hg; millimeters of mercury; millimetres","LOINC","Pres; PPres; Ratio","Clinical","1 mm[Hg] = 1 torr; unit to measure blood pressure","kPa","KPAL","133.3220",133.322,false],[false,"square millimeter","mm2","MM2","length",0.000001,[2,0,0,0,0,0,0],"mm<sup>2</sup>",null,false,"L",null,1,false,false,0,0,"mm^2; sq. mm.; sq. millimeters; millimeters squared; millimetres","LOINC","Area","Clinical","",null,null,null,null,false],[false,"millimole","mmol","MMOL","amount of substance",602213670000000000000,[0,0,0,0,0,0,0],"mmol","si",true,null,null,1,false,false,1,0,"millimoles","LOINC","Sub","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per 12 hour","mmol/(12.h)","MMOL/(12.HR)","amount of substance",13940131250000000,[0,-1,0,0,0,0,0],"mmol/h","si",true,null,null,1,false,false,1,0,"mmol/12hrs; mmol/12 hrs; mmol per 12 hrs; 12hrs; millimoles per 12 hours","LOINC","SRat","Clinical","unit for tests related to urine","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per 2 hour","mmol/(2.h)","MMOL/(2.HR)","amount of substance",83640787500000000,[0,-1,0,0,0,0,0],"mmol/h","si",true,null,null,1,false,false,1,0,"mmol/2hrs; mmol/2 hrs; mmol per 2 hrs; 2hrs; millimoles per 2 hours","LOINC","SRat","Clinical","unit for tests related to urine","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per 24 hour","mmol/(24.h)","MMOL/(24.HR)","amount of substance",6970065625000000,[0,-1,0,0,0,0,0],"mmol/h","si",true,null,null,1,false,false,1,0,"mmol/24hrs; mmol/24 hrs; mmol per 24 hrs; 24hrs; millimoles per 24 hours","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per 5 hour","mmol/(5.h)","MMOL/(5.HR)","amount of substance",33456315000000000,[0,-1,0,0,0,0,0],"mmol/h","si",true,null,null,1,false,false,1,0,"mmol/5hrs; mmol/5 hrs; mmol per 5 hrs; 5hrs; millimoles per 5 hours","LOINC","SRat","Clinical","unit for tests related to doses","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per 6 hour","mmol/(6.h)","MMOL/(6.HR)","amount of substance",27880262500000000,[0,-1,0,0,0,0,0],"mmol/h","si",true,null,null,1,false,false,1,0,"mmol/6hrs; mmol/6 hrs; mmol per 6 hrs; 6hrs; millimoles per 6 hours","LOINC","SRat","Clinical","unit for tests related to urine","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per 8 hour","mmol/(8.h)","MMOL/(8.HR)","amount of substance",20910196875000000,[0,-1,0,0,0,0,0],"mmol/h","si",true,null,null,1,false,false,1,0,"mmol/8hrs; mmol/8 hrs; mmol per 8 hrs; 8hrs; millimoles per 8 hours; shift","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per day","mmol/d","MMOL/D","amount of substance",6970065625000000,[0,-1,0,0,0,0,0],"mmol/d","si",true,null,null,1,false,false,1,0,"mmol/24hrs; mmol/24 hrs; mmol per 24 hrs; 24hrs; millimoles per 24 hours","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per deciliter","mmol/dL","MMOL/DL","amount of substance",6.022136699999999e+24,[-3,0,0,0,0,0,0],"mmol/dL","si",true,null,null,1,false,false,1,0,"mmol per dL; millimoles; decilitre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per gram","mmol/g","MMOL/G","amount of substance",602213670000000000000,[0,0,-1,0,0,0,0],"mmol/g","si",true,null,null,1,false,false,1,0,"mmol per gram; millimoles","LOINC","SCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per hour","mmol/h","MMOL/HR","amount of substance",167281575000000000,[0,-1,0,0,0,0,0],"mmol/h","si",true,null,null,1,false,false,1,0,"mmol/hr; mmol per hr; millimoles per hour","LOINC","SRat","Clinical","unit for tests related to urine","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per kilogram","mmol/kg","MMOL/KG","amount of substance",602213670000000000,[0,0,-1,0,0,0,0],"mmol/kg","si",true,null,null,1,false,false,1,0,"mmol per kg; millimoles per kilogram","LOINC","SCnt","Clinical","unit for tests related to stool","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per kilogram per 8 hour","mmol/kg/(8.h)","(MMOL/KG)/(8.HR)","amount of substance",20910196875000,[0,-1,-1,0,0,0,0],"(mmol/kg)/h","si",true,null,null,1,false,false,1,0,"mmol/(8.h.kg); mmol/kg/8hrs; mmol/kg/8 hrs; mmol per kg per 8hrs; 8 hrs; millimoles per kilograms per 8 hours; shift","LOINC","CCnt","Clinical","unit used to measure molar dose rate per patient body mass","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per kilogram per day","mmol/kg/d","(MMOL/KG)/D","amount of substance",6970065625000,[0,-1,-1,0,0,0,0],"(mmol/kg)/d","si",true,null,null,1,false,false,1,0,"mmol/kg/dy; mmol/kg/day; mmol per kg per dy; millimoles per kilograms per day","LOINC","RelSRat","Clinical","unit used to measure molar dose rate per patient body mass","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per kilogram per hour","mmol/kg/h","(MMOL/KG)/HR","amount of substance",167281575000000,[0,-1,-1,0,0,0,0],"(mmol/kg)/h","si",true,null,null,1,false,false,1,0,"mmol/kg/hr; mmol per kg per hr; millimoles per kilograms per hour","LOINC","CCnt","Clinical","unit used to measure molar dose rate per patient body mass","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per kilogram per minute","mmol/kg/min","(MMOL/KG)/MIN","amount of substance",10036894500000000,[0,-1,-1,0,0,0,0],"(mmol/kg)/min","si",true,null,null,1,false,false,1,0,"mmol/(kg.min); mmol/kg/min; mmol per kg per min; millimoles per kilograms per minute","LOINC","CCnt","Clinical","unit used to measure molar dose rate per patient body mass; note that the unit for the enzyme unit U = umol/min. mmol/kg/min = kU/kg; ","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per liter","mmol/L","MMOL/L","amount of substance",6.0221367e+23,[-3,0,0,0,0,0,0],"mmol/L","si",true,null,null,1,false,false,1,0,"mmol per L; millimoles per liter; litre","LOINC","SCnc","Clinical","unit for tests related to doses","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per square meter","mmol/m2","MMOL/M2","amount of substance",602213670000000000000,[-2,0,0,0,0,0,0],"mmol/(m<sup>2</sup>)","si",true,null,null,1,false,false,1,0,"mmol/m^2; mmol/sq. meter; mmol per m2; m^2; sq. meter; millimoles; meter squared; metre","LOINC","ArSub","Clinical","unit used to measure molar dose per patient body surface area","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per minute","mmol/min","MMOL/MIN","amount of substance",10036894500000000000,[0,-1,0,0,0,0,0],"mmol/min","si",true,null,null,1,false,false,1,0,"mmol per min; millimoles per minute","LOINC","Srat; CAct","Clinical","unit for the enzyme unit U = umol/min. mmol/min = kU","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per millimole","mmol/mmol","MMOL/MMOL","amount of substance",1,[0,0,0,0,0,0,0],"mmol/mmol","si",true,null,null,1,false,false,0,0,"mmol per mmol; millimoles per millimole","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per mole","mmol/mol","MMOL/MOL","amount of substance",0.001,[0,0,0,0,0,0,0],"mmol/mol","si",true,null,null,1,false,false,0,0,"mmol per mol; millimoles per mole","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per second per liter","mmol/s/L","(MMOL/S)/L","amount of substance",6.0221367e+23,[-3,-1,0,0,0,0,0],"(mmol/s)/L","si",true,null,null,1,false,false,1,0,"mmol/sec/L; mmol per s per L; per sec; millimoles per seconds per liter; litre","LOINC","CCnc ","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"mole per kilogram","mol/kg","MOL/KG","amount of substance",602213670000000000000,[0,0,-1,0,0,0,0],"mol/kg","si",true,null,null,1,false,false,1,0,"mol per kg; moles; mols","LOINC","SCnt","Clinical","unit for tests related to stool","10*23","10*23","6.0221367",6.0221367,false],[false,"mole per kilogram per second","mol/kg/s","(MOL/KG)/S","amount of substance",602213670000000000000,[0,-1,-1,0,0,0,0],"(mol/kg)/s","si",true,null,null,1,false,false,1,0,"mol/kg/sec; mol per kg per sec; moles per kilograms per second; mols","LOINC","CCnt","Clinical","unit of catalytic activity (mol/s) per mass (kg)","10*23","10*23","6.0221367",6.0221367,false],[false,"mole per liter","mol/L","MOL/L","amount of substance",6.0221366999999994e+26,[-3,0,0,0,0,0,0],"mol/L","si",true,null,null,1,false,false,1,0,"mol per L; moles per liter; litre; moles; mols","LOINC","SCnc","Clinical","unit often used in tests measuring oxygen content","10*23","10*23","6.0221367",6.0221367,false],[false,"mole per cubic meter","mol/m3","MOL/M3","amount of substance",6.0221367e+23,[-3,0,0,0,0,0,0],"mol/(m<sup>3</sup>)","si",true,null,null,1,false,false,1,0,"mol/m^3; mol/cu. m; mol per m3; m^3; cu. meter; mols; moles; meters cubed; metre; mole per kiloliter; kilolitre; mol/kL","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"mole per milliliter","mol/mL","MOL/ML","amount of substance",6.0221367e+29,[-3,0,0,0,0,0,0],"mol/mL","si",true,null,null,1,false,false,1,0,"mol per mL; moles; millilitre; mols","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"mole per mole","mol/mol","MOL/MOL","amount of substance",1,[0,0,0,0,0,0,0],"mol/mol","si",true,null,null,1,false,false,0,0,"mol per mol; moles per mol; mols","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"mole per second","mol/s","MOL/S","amount of substance",6.0221367e+23,[0,-1,0,0,0,0,0],"mol/s","si",true,null,null,1,false,false,1,0,"mol per sec; moles per second; mols","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"milliosmole","mosm","MOSM","amount of substance (dissolved particles)",602213670000000000000,[0,0,0,0,0,0,0],"mosm","chemical",true,null,null,1,false,false,1,0,"milliosmoles","LOINC","Osmol","Clinical","equal to 1/1000 of an osmole","mol","MOL","1",1,false],[false,"milliosmole per kilogram","mosm/kg","MOSM/KG","amount of substance (dissolved particles)",602213670000000000,[0,0,-1,0,0,0,0],"mosm/kg","chemical",true,null,null,1,false,false,1,0,"mosm per kg; milliosmoles per kilogram","LOINC","Osmol","Clinical","","mol","MOL","1",1,false],[false,"milliosmole per liter","mosm/L","MOSM/L","amount of substance (dissolved particles)",6.0221367e+23,[-3,0,0,0,0,0,0],"mosm/L","chemical",true,null,null,1,false,false,1,0,"mosm per liter; litre; milliosmoles","LOINC","Osmol","Clinical","","mol","MOL","1",1,false],[false,"millipascal","mPa","MPAL","pressure",1,[-1,-2,1,0,0,0,0],"mPa","si",true,null,null,1,false,false,0,0,"millipascals","LOINC","Pres","Clinical","unit of pressure","N/m2","N/M2","1",1,false],[false,"millipascal second","mPa.s","MPAL.S","pressure",1,[-1,-1,1,0,0,0,0],"mPa.s","si",true,null,null,1,false,false,0,0,"mPa*s; millipoise; mP; dynamic viscosity","LOINC","Visc","Clinical","base units for millipoise, a measurement of dynamic viscosity","N/m2","N/M2","1",1,false],[false,"megasecond","Ms","MAS","time",1000000,[0,1,0,0,0,0,0],"Ms",null,false,"T",null,1,false,false,0,0,"megaseconds","LOINC","Time","Clinical","",null,null,null,null,false],[false,"millisecond","ms","MS","time",0.001,[0,1,0,0,0,0,0],"ms",null,false,"T",null,1,false,false,0,0,"milliseconds; duration","LOINC","Time","Clinical","",null,null,null,null,false],[false,"milli enzyme unit per gram","mU/g","MU/G","catalytic activity",10036894500000,[0,-1,-1,0,0,0,0],"mU/g","chemical",true,null,null,1,false,false,1,0,"mU per gm; milli enzyme units per gram; enzyme activity; enzymatic activity per mass","LOINC","CCnt","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 mU = 1 nmol/min","umol/min","UMOL/MIN","1",1,false],[false,"milli enzyme unit per liter","mU/L","MU/L","catalytic activity",10036894500000000,[-3,-1,0,0,0,0,0],"mU/L","chemical",true,null,null,1,false,false,1,0,"mU per liter; litre; milli enzyme units enzymatic activity per volume; enzyme activity","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 mU = 1 nmol/min","umol/min","UMOL/MIN","1",1,false],[false,"milli enzyme unit per milligram","mU/mg","MU/MG","catalytic activity",10036894500000000,[0,-1,-1,0,0,0,0],"mU/mg","chemical",true,null,null,1,false,false,1,0,"mU per mg; milli enzyme units per milligram","LOINC","CCnt","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 mU = 1 nmol/min","umol/min","UMOL/MIN","1",1,false],[false,"milli enzyme unit per milliliter","mU/mL","MU/ML","catalytic activity",10036894500000000000,[-3,-1,0,0,0,0,0],"mU/mL","chemical",true,null,null,1,false,false,1,0,"mU per mL; milli enzyme units per milliliter; millilitre; enzymatic activity per volume; enzyme activity","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 mU = 1 nmol/min","umol/min","UMOL/MIN","1",1,false],[false,"milli enzyme unit per milliliter per minute","mU/mL/min","(MU/ML)/MIN","catalytic activity",167281575000000000,[-3,-2,0,0,0,0,0],"(mU/mL)/min","chemical",true,null,null,1,false,false,1,0,"mU per mL per min; mU per milliliters per minute; millilitres; milli enzyme units; enzymatic activity; enzyme activity","LOINC","CCncRat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 mU = 1 nmol/min","umol/min","UMOL/MIN","1",1,false],[false,"millivolt","mV","MV","electric potential",1,[2,-2,1,0,0,-1,0],"mV","si",true,null,null,1,false,false,0,0,"millivolts","LOINC","Elpot","Clinical","unit of electric potential (voltage)","J/C","J/C","1",1,false],[false,"Newton centimeter","N.cm","N.CM","force",10,[2,-2,1,0,0,0,0],"N.cm","si",true,null,null,1,false,false,0,0,"N*cm; Ncm; N cm; Newton*centimeters; Newton* centimetres; torque; work","LOINC","","Clinical","as a measurement of work, N.cm = 1/100 Joules;\nnote that N.m is the standard unit of measurement for torque (although dimensionally equivalent to Joule), and N.cm can also be thought of as a torqe unit","kg.m/s2","KG.M/S2","1",1,false],[false,"Newton second","N.s","N.S","force",1000,[1,-1,1,0,0,0,0],"N.s","si",true,null,null,1,false,false,0,0,"Newton*seconds; N*s; N s; Ns; impulse; imp","LOINC","","Clinical","standard unit of impulse","kg.m/s2","KG.M/S2","1",1,false],[false,"nanogram","ng","NG","mass",1e-9,[0,0,1,0,0,0,0],"ng",null,false,"M",null,1,false,false,0,0,"nanograms","LOINC","Mass","Clinical","",null,null,null,null,false],[false,"nanogram per 24 hour","ng/(24.h)","NG/(24.HR)","mass",1.1574074074074075e-14,[0,-1,1,0,0,0,0],"ng/h",null,false,"M",null,1,false,false,0,0,"ng/24hrs; ng/24 hrs; nanograms per 24 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"nanogram per 8 hour","ng/(8.h)","NG/(8.HR)","mass",3.4722222222222224e-14,[0,-1,1,0,0,0,0],"ng/h",null,false,"M",null,1,false,false,0,0,"ng/8hrs; ng/8 hrs; nanograms per 8 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"nanogram per million","ng/10*6","NG/(10*6)","mass",1e-15,[0,0,1,0,0,0,0],"ng/(10<sup>6</sup>)",null,false,"M",null,1,false,false,0,0,"ng/10^6; ng per 10*6; 10^6; nanograms","LOINC","MNum","Clinical","",null,null,null,null,false],[false,"nanogram per day","ng/d","NG/D","mass",1.1574074074074075e-14,[0,-1,1,0,0,0,0],"ng/d",null,false,"M",null,1,false,false,0,0,"ng/dy; ng per day; nanograms ","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"nanogram per deciliter","ng/dL","NG/DL","mass",0.00001,[-3,0,1,0,0,0,0],"ng/dL",null,false,"M",null,1,false,false,0,0,"ng per dL; nanograms per deciliter; decilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"nanogram per gram","ng/g","NG/G","mass",1e-9,[0,0,0,0,0,0,0],"ng/g",null,false,"M",null,1,false,false,0,0,"ng/gm; ng per gm; nanograms per gram","LOINC","MCnt","Clinical","",null,null,null,null,false],[false,"nanogram per hour","ng/h","NG/HR","mass",2.777777777777778e-13,[0,-1,1,0,0,0,0],"ng/h",null,false,"M",null,1,false,false,0,0,"ng/hr; ng per hr; nanograms per hour","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"nanogram per kilogram","ng/kg","NG/KG","mass",1e-12,[0,0,0,0,0,0,0],"ng/kg",null,false,"M",null,1,false,false,0,0,"ng per kg; nanograms per kilogram","LOINC","MCnt","Clinical","",null,null,null,null,false],[false,"nanogram per kilogram per 8 hour","ng/kg/(8.h)","(NG/KG)/(8.HR)","mass",3.472222222222222e-17,[0,-1,0,0,0,0,0],"(ng/kg)/h",null,false,"M",null,1,false,false,0,0,"ng/(8.h.kg); ng/kg/8hrs; ng/kg/8 hrs; ng per kg per 8hrs; 8 hrs; nanograms per kilograms per 8 hours; shift","LOINC","MRtoRat ","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[false,"nanogram per kilogram per hour","ng/kg/h","(NG/KG)/HR","mass",2.7777777777777775e-16,[0,-1,0,0,0,0,0],"(ng/kg)/h",null,false,"M",null,1,false,false,0,0,"ng/(kg.h); ng/kg/hr; ng per kg per hr; nanograms per kilograms per hour","LOINC","MRtoRat ","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[false,"nanogram per kilogram per minute","ng/kg/min","(NG/KG)/MIN","mass",1.6666666666666667e-14,[0,-1,0,0,0,0,0],"(ng/kg)/min",null,false,"M",null,1,false,false,0,0,"ng/(kg.min); ng per kg per min; nanograms per kilograms per minute","LOINC","MRtoRat ","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[false,"nanogram per liter","ng/L","NG/L","mass",0.000001,[-3,0,1,0,0,0,0],"ng/L",null,false,"M",null,1,false,false,0,0,"ng per L; nanograms per liter; litre","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"nanogram per square meter","ng/m2","NG/M2","mass",1e-9,[-2,0,1,0,0,0,0],"ng/(m<sup>2</sup>)",null,false,"M",null,1,false,false,0,0,"ng/m^2; ng/sq. m; ng per m2; m^2; sq. meter; nanograms; meter squared; metre","LOINC","ArMass","Clinical","unit used to measure mass dose per patient body surface area",null,null,null,null,false],[false,"nanogram per milligram","ng/mg","NG/MG","mass",0.000001,[0,0,0,0,0,0,0],"ng/mg",null,false,"M",null,1,false,false,0,0,"ng per mg; nanograms","LOINC","MCnt","Clinical","",null,null,null,null,false],[false,"nanogram per milligram per hour","ng/mg/h","(NG/MG)/HR","mass",2.7777777777777777e-10,[0,-1,0,0,0,0,0],"(ng/mg)/h",null,false,"M",null,1,false,false,0,0,"ng/mg/hr; ng per mg per hr; nanograms per milligrams per hour","LOINC","MRtoRat ","Clinical","",null,null,null,null,false],[false,"nanogram per minute","ng/min","NG/MIN","mass",1.6666666666666667e-11,[0,-1,1,0,0,0,0],"ng/min",null,false,"M",null,1,false,false,0,0,"ng per min; nanograms","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"nanogram per millliiter","ng/mL","NG/ML","mass",0.001,[-3,0,1,0,0,0,0],"ng/mL",null,false,"M",null,1,false,false,0,0,"ng per mL; nanograms; millilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"nanogram per milliliter per hour","ng/mL/h","(NG/ML)/HR","mass",2.7777777777777776e-7,[-3,-1,1,0,0,0,0],"(ng/mL)/h",null,false,"M",null,1,false,false,0,0,"ng/mL/hr; ng per mL per mL; nanograms per milliliter per hour; nanogram per millilitre per hour; nanograms per millilitre per hour; enzymatic activity per volume; enzyme activity per milliliters","LOINC","CCnc","Clinical","tests that measure enzymatic activity",null,null,null,null,false],[false,"nanogram per second","ng/s","NG/S","mass",1e-9,[0,-1,1,0,0,0,0],"ng/s",null,false,"M",null,1,false,false,0,0,"ng/sec; ng per sec; nanograms per second","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"nanogram per enzyme unit","ng/U","NG/U","mass",9.963241120049634e-26,[0,1,1,0,0,0,0],"ng/U",null,false,"M",null,1,false,false,-1,0,"ng per U; nanograms per enzyme unit","LOINC","CMass","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)",null,null,null,null,false],[false,"nanokatal","nkat","NKAT","catalytic activity",602213670000000,[0,-1,0,0,0,0,0],"nkat","chemical",true,null,null,1,false,false,1,0,"nanokatals","LOINC","CAct","Clinical","kat is a unit of catalytic activity with base units = mol/s. Rarely used because its units are too large to practically express catalytic activity. See enzyme unit [U] which is the standard unit for catalytic activity.","mol/s","MOL/S","1",1,false],[false,"nanoliter","nL","NL","volume",1.0000000000000002e-12,[3,0,0,0,0,0,0],"nL","iso1000",true,null,null,1,false,false,0,0,"nanoliters; nanolitres","LOINC","Vol","Clinical","","l",null,"1",1,false],[false,"nanometer","nm","NM","length",1e-9,[1,0,0,0,0,0,0],"nm",null,false,"L",null,1,false,false,0,0,"nanometers; nanometres","LOINC","Len","Clinical","",null,null,null,null,false],[false,"nanometer per second per liter","nm/s/L","(NM/S)/L","length",0.000001,[-2,-1,0,0,0,0,0],"(nm/s)/L",null,false,"L",null,1,false,false,0,0,"nm/sec/liter; nm/sec/litre; nm per s per l; nm per sec per l; nanometers per second per liter; nanometre per second per litre; nanometres per second per litre","LOINC","VelCnc","Clinical","",null,null,null,null,false],[false,"nanomole","nmol","NMOL","amount of substance",602213670000000,[0,0,0,0,0,0,0],"nmol","si",true,null,null,1,false,false,1,0,"nanomoles","LOINC","Sub","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per 24 hour","nmol/(24.h)","NMOL/(24.HR)","amount of substance",6970065625,[0,-1,0,0,0,0,0],"nmol/h","si",true,null,null,1,false,false,1,0,"nmol/24hr; nmol/24 hr; nanomoles per 24 hours; nmol/day; nanomoles per day; nmol per day; nanomole/day; nanomol/day","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per day","nmol/d","NMOL/D","amount of substance",6970065625,[0,-1,0,0,0,0,0],"nmol/d","si",true,null,null,1,false,false,1,0,"nmol/day; nanomoles per day; nmol per day; nanomole/day; nanomol/day; nmol/24hr; nmol/24 hr; nanomoles per 24 hours; ","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per deciliter","nmol/dL","NMOL/DL","amount of substance",6022136700000000000,[-3,0,0,0,0,0,0],"nmol/dL","si",true,null,null,1,false,false,1,0,"nmol per dL; nanomoles per deciliter; nanomole per decilitre; nanomoles per decilitre; nanomole/deciliter; nanomole/decilitre; nanomol/deciliter; nanomol/decilitre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per gram","nmol/g","NMOL/G","amount of substance",602213670000000,[0,0,-1,0,0,0,0],"nmol/g","si",true,null,null,1,false,false,1,0,"nmol per gram; nanomoles per gram; nanomole/gram","LOINC","SCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per hour per liter","nmol/h/L","(NMOL/HR)/L","amount of substance",167281575000000,[-3,-1,0,0,0,0,0],"(nmol/h)/L","si",true,null,null,1,false,false,1,0,"nmol/hrs/L; nmol per hrs per L; nanomoles per hours per liter; litre; enzymatic activity per volume; enzyme activities","LOINC","CCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per liter","nmol/L","NMOL/L","amount of substance",602213670000000000,[-3,0,0,0,0,0,0],"nmol/L","si",true,null,null,1,false,false,1,0,"nmol per L; nanomoles per liter; litre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per milligram","nmol/mg","NMOL/MG","amount of substance",602213670000000000,[0,0,-1,0,0,0,0],"nmol/mg","si",true,null,null,1,false,false,1,0,"nmol per mg; nanomoles per milligram","LOINC","SCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per milligram per hour","nmol/mg/h","(NMOL/MG)/HR","amount of substance",167281575000000,[0,-1,-1,0,0,0,0],"(nmol/mg)/h","si",true,null,null,1,false,false,1,0,"nmol/mg/hr; nmol per mg per hr; nanomoles per milligrams per hour","LOINC","SCntRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per milligram of protein","nmol/mg{prot}","NMOL/MG","amount of substance",602213670000000000,[0,0,-1,0,0,0,0],"nmol/mg","si",true,null,null,1,false,false,1,0,"nanomoles; nmol/mg prot; nmol per mg prot","LOINC","Ratio; CCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per minute","nmol/min","NMOL/MIN","amount of substance",10036894500000,[0,-1,0,0,0,0,0],"nmol/min","si",true,null,null,1,false,false,1,0,"nmol per min; nanomoles per minute; milli enzyme units; enzyme activity per volume; enzymatic activity","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min. nmol/min = mU (milli enzyme unit)","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per minute per milliliter","nmol/min/mL","(NMOL/MIN)/ML","amount of substance",10036894500000000000,[-3,-1,0,0,0,0,0],"(nmol/min)/mL","si",true,null,null,1,false,false,1,0,"nmol per min per mL; nanomoles per minutes per milliliter; millilitre; milli enzyme units per volume; enzyme activity; enzymatic activity","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min. nmol/mL/min = mU/mL","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per milliliter","nmol/mL","NMOL/ML","amount of substance",602213670000000000000,[-3,0,0,0,0,0,0],"nmol/mL","si",true,null,null,1,false,false,1,0,"nmol per mL; nanomoles per milliliter; millilitre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per milliliter per hour","nmol/mL/h","(NMOL/ML)/HR","amount of substance",167281575000000000,[-3,-1,0,0,0,0,0],"(nmol/mL)/h","si",true,null,null,1,false,false,1,0,"nmol/mL/hr; nmol per mL per hr; nanomoles per milliliters per hour; millilitres; milli enzyme units per volume; enzyme activity; enzymatic activity","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min.","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per milliliter per minute","nmol/mL/min","(NMOL/ML)/MIN","amount of substance",10036894500000000000,[-3,-1,0,0,0,0,0],"(nmol/mL)/min","si",true,null,null,1,false,false,1,0,"nmol per mL per min; nanomoles per milliliters per min; millilitres; milli enzyme units per volume; enzyme activity; enzymatic activity","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min. nmol/mL/min = mU/mL","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per millimole","nmol/mmol","NMOL/MMOL","amount of substance",0.000001,[0,0,0,0,0,0,0],"nmol/mmol","si",true,null,null,1,false,false,0,0,"nmol per mmol; nanomoles per millimole","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per millimole of creatinine","nmol/mmol{creat}","NMOL/MMOL","amount of substance",0.000001,[0,0,0,0,0,0,0],"nmol/mmol","si",true,null,null,1,false,false,0,0,"nanomoles","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per mole","nmol/mol","NMOL/MOL","amount of substance",1e-9,[0,0,0,0,0,0,0],"nmol/mol","si",true,null,null,1,false,false,0,0,"nmol per mole; nanomoles","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per nanomole","nmol/nmol","NMOL/NMOL","amount of substance",1,[0,0,0,0,0,0,0],"nmol/nmol","si",true,null,null,1,false,false,0,0,"nmol per nmol; nanomoles","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per second","nmol/s","NMOL/S","amount of substance",602213670000000,[0,-1,0,0,0,0,0],"nmol/s","si",true,null,null,1,false,false,1,0,"nmol/sec; nmol per sec; nanomoles per sercond; milli enzyme units; enzyme activity; enzymatic activity","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min.","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per second per liter","nmol/s/L","(NMOL/S)/L","amount of substance",602213670000000000,[-3,-1,0,0,0,0,0],"(nmol/s)/L","si",true,null,null,1,false,false,1,0,"nmol/sec/L; nmol per s per L; nmol per sec per L; nanomoles per seconds per liter; litre; milli enzyme units per volume; enzyme activity; enzymatic activity","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min.","10*23","10*23","6.0221367",6.0221367,false],[false,"nanosecond","ns","NS","time",1e-9,[0,1,0,0,0,0,0],"ns",null,false,"T",null,1,false,false,0,0,"nanoseconds","LOINC","Time","Clinical","",null,null,null,null,false],[false,"nanoenzyme unit per milliliter","nU/mL","NU/ML","catalytic activity",10036894500000,[-3,-1,0,0,0,0,0],"nU/mL","chemical",true,null,null,1,false,false,1,0,"nU per mL; nanoenzyme units per milliliter; millilitre; enzymatic activity per volume; enzyme activity","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 fU = pmol/min","umol/min","UMOL/MIN","1",1,false],[false,"Ohm meter","Ohm.m","OHM.M","electric resistance",1000,[3,-1,1,0,0,-2,0],"Ω.m","si",true,null,null,1,false,false,0,0,"electric resistivity; meters; metres","LOINC","","Clinical","unit of electric resistivity","V/A","V/A","1",1,false],[false,"osmole per kilogram","osm/kg","OSM/KG","amount of substance (dissolved particles)",602213670000000000000,[0,0,-1,0,0,0,0],"osm/kg","chemical",true,null,null,1,false,false,1,0,"osm per kg; osmoles per kilogram; osmols","LOINC","Osmol","Clinical","","mol","MOL","1",1,false],[false,"osmole per liter","osm/L","OSM/L","amount of substance (dissolved particles)",6.0221366999999994e+26,[-3,0,0,0,0,0,0],"osm/L","chemical",true,null,null,1,false,false,1,0,"osm per L; osmoles per liter; litre; osmols","LOINC","Osmol","Clinical","","mol","MOL","1",1,false],[false,"picoampere","pA","PA","electric current",1e-12,[0,-1,0,0,0,1,0],"pA","si",true,null,null,1,false,false,0,0,"picoamperes","LOINC","","Clinical","equal to 10^-12 amperes","C/s","C/S","1",1,false],[false,"picogram","pg","PG","mass",1e-12,[0,0,1,0,0,0,0],"pg",null,false,"M",null,1,false,false,0,0,"picograms","LOINC","Mass; EntMass","Clinical","",null,null,null,null,false],[false,"picogram per deciliter","pg/dL","PG/DL","mass",9.999999999999999e-9,[-3,0,1,0,0,0,0],"pg/dL",null,false,"M",null,1,false,false,0,0,"pg per dL; picograms; decilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"picogram per liter","pg/L","PG/L","mass",1e-9,[-3,0,1,0,0,0,0],"pg/L",null,false,"M",null,1,false,false,0,0,"pg per L; picograms; litre","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"picogram per milligram","pg/mg","PG/MG","mass",1e-9,[0,0,0,0,0,0,0],"pg/mg",null,false,"M",null,1,false,false,0,0,"pg per mg; picograms","LOINC","MCnt","Clinical","",null,null,null,null,false],[false,"picogram per milliliter","pg/mL","PG/ML","mass",0.000001,[-3,0,1,0,0,0,0],"pg/mL",null,false,"M",null,1,false,false,0,0,"pg per mL; picograms per milliliter; millilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"picogram per millimeter","pg/mm","PG/MM","mass",1e-9,[-1,0,1,0,0,0,0],"pg/mm",null,false,"M",null,1,false,false,0,0,"pg per mm; picogram/millimeter; picogram/millimetre; picograms per millimeter; millimetre","LOINC","Lineic Mass","Clinical","",null,null,null,null,false],[false,"picokatal","pkat","PKAT","catalytic activity",602213670000,[0,-1,0,0,0,0,0],"pkat","chemical",true,null,null,1,false,false,1,0,"pkats; picokatals","LOINC","CAct","Clinical","kat is a unit of catalytic activity with base units = mol/s. Rarely used because its units are too large to practically express catalytic activity. See enzyme unit [U] which is the standard unit for catalytic activity.","mol/s","MOL/S","1",1,false],[false,"picoliter","pL","PL","volume",1e-15,[3,0,0,0,0,0,0],"pL","iso1000",true,null,null,1,false,false,0,0,"picoliters; picolitres","LOINC","Vol","Clinical","","l",null,"1",1,false],[false,"picometer","pm","PM","length",1e-12,[1,0,0,0,0,0,0],"pm",null,false,"L",null,1,false,false,0,0,"picometers; picometres","LOINC","Len","Clinical","",null,null,null,null,false],[false,"picomole","pmol","PMOL","amount of substance",602213670000,[0,0,0,0,0,0,0],"pmol","si",true,null,null,1,false,false,1,0,"picomoles; pmols","LOINC","Sub","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per 24 hour","pmol/(24.h)","PMOL/(24.HR)","amount of substance",6970065.625,[0,-1,0,0,0,0,0],"pmol/h","si",true,null,null,1,false,false,1,0,"pmol/24hrs; pmol/24 hrs; pmol per 24 hrs; 24hrs; days; dy; picomoles per 24 hours","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per day","pmol/d","PMOL/D","amount of substance",6970065.625,[0,-1,0,0,0,0,0],"pmol/d","si",true,null,null,1,false,false,1,0,"pmol/dy; pmol per day; 24 hours; 24hrs; 24 hrs; picomoles","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per deciliter","pmol/dL","PMOL/DL","amount of substance",6022136700000000,[-3,0,0,0,0,0,0],"pmol/dL","si",true,null,null,1,false,false,1,0,"pmol per dL; picomoles per deciliter; decilitre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per gram","pmol/g","PMOL/G","amount of substance",602213670000,[0,0,-1,0,0,0,0],"pmol/g","si",true,null,null,1,false,false,1,0,"pmol per gm; picomoles per gram; picomole/gram","LOINC","SCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per hour per milliliter ","pmol/h/mL","(PMOL/HR)/ML","amount of substance",167281575000000,[-3,-1,0,0,0,0,0],"(pmol/h)/mL","si",true,null,null,1,false,false,1,0,"pmol/hrs/mL; pmol per hrs per mL; picomoles per hour per milliliter; millilitre; micro enzyme units per volume; enzymatic activity; enzyme activity","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min. ","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per liter","pmol/L","PMOL/L","amount of substance",602213670000000,[-3,0,0,0,0,0,0],"pmol/L","si",true,null,null,1,false,false,1,0,"picomole/liter; pmol per L; picomoles; litre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per minute","pmol/min","PMOL/MIN","amount of substance",10036894500,[0,-1,0,0,0,0,0],"pmol/min","si",true,null,null,1,false,false,1,0,"picomole/minute; pmol per min; picomoles per minute; micro enzyme units; enzymatic activity; enzyme activity","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min. pmol/min = uU (micro enzyme unit)","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per milliliter","pmol/mL","PMOL/ML","amount of substance",602213670000000000,[-3,0,0,0,0,0,0],"pmol/mL","si",true,null,null,1,false,false,1,0,"picomole/milliliter; picomole/millilitre; pmol per mL; picomoles; millilitre; picomols; pmols","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per micromole","pmol/umol","PMOL/UMOL","amount of substance",0.000001,[0,0,0,0,0,0,0],"pmol/μmol","si",true,null,null,1,false,false,0,0,"pmol/mcgmol; picomole/micromole; pmol per umol; pmol per mcgmol; picomoles ","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"picosecond","ps","PS","time",1e-12,[0,1,0,0,0,0,0],"ps",null,false,"T",null,1,false,false,0,0,"picoseconds; psec","LOINC","Time","Clinical","",null,null,null,null,false],[false,"picotesla","pT","PT","magnetic flux density",1e-9,[0,-1,1,0,0,-1,0],"pT","si",true,null,null,1,false,false,0,0,"picoteslas","LOINC","","Clinical","SI unit of magnetic field strength for magnetic field B","Wb/m2","WB/M2","1",1,false],[false,"enzyme unit per 12 hour","U/(12.h)","U/(12.HR)","catalytic activity",232335520833.33334,[0,-2,0,0,0,0,0],"U/h","chemical",true,null,null,1,false,false,1,0,"U/12hrs; U/ 12hrs; U per 12 hrs; 12hrs; enzyme units per 12 hours; enzyme activity; enzymatic activity per time; umol per min per 12 hours; micromoles per minute per 12 hours; umol/min/12hr","LOINC","CRat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per 2 hour","U/(2.h)","U/(2.HR)","catalytic activity",1394013125000,[0,-2,0,0,0,0,0],"U/h","chemical",true,null,null,1,false,false,1,0,"U/2hrs; U/ 2hrs; U per 2 hrs; 2hrs; enzyme units per 2 hours; enzyme activity; enzymatic activity per time; umol per minute per 2 hours; micromoles per minute; umol/min/2hr; umol per min per 2hr","LOINC","CRat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per 24 hour","U/(24.h)","U/(24.HR)","catalytic activity",116167760416.66667,[0,-2,0,0,0,0,0],"U/h","chemical",true,null,null,1,false,false,1,0,"U/24hrs; U/ 24hrs; U per 24 hrs; 24hrs; enzyme units per 24 hours; enzyme activity; enzymatic activity per time; micromoles per minute per 24 hours; umol/min/24hr; umol per min per 24hr","LOINC","CRat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per 10","U/10","U/10","catalytic activity",1003689450000000,[0,-1,0,0,0,0,0],"U","chemical",true,null,null,1,false,false,1,0,"enzyme unit/10; U per 10; enzyme units per 10; enzymatic activity; enzyme activity; micromoles per minute; umol/min/10","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per 10 billion","U/10*10","U/(10*10)","catalytic activity",1003689.45,[0,-1,0,0,0,0,0],"U/(10<sup>10</sup>)","chemical",true,null,null,1,false,false,1,0,"U per 10*10; enzyme units per 10*10; U per 10 billion; enzyme units; enzymatic activity; micromoles per minute per 10 billion; umol/min/10*10","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per trillion","U/10*12","U/(10*12)","catalytic activity",10036.8945,[0,-1,0,0,0,0,0],"U/(10<sup>12</sup>)","chemical",true,null,null,1,false,false,1,0,"enzyme unit/10*12; U per 10*12; enzyme units per 10*12; enzyme units per trillion; enzymatic activity; micromoles per minute per trillion; umol/min/10*12; umol per min per 10*12","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per million","U/10*6","U/(10*6)","catalytic activity",10036894500,[0,-1,0,0,0,0,0],"U/(10<sup>6</sup>)","chemical",true,null,null,1,false,false,1,0,"enzyme unit/10*6; U per 10*6; enzyme units per 10*6; enzyme units; enzymatic activity per volume; micromoles per minute per million; umol/min/10*6; umol per min per 10*6","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per billion","U/10*9","U/(10*9)","catalytic activity",10036894.5,[0,-1,0,0,0,0,0],"U/(10<sup>9</sup>)","chemical",true,null,null,1,false,false,1,0,"enzyme unit/10*9; U per 10*9; enzyme units per 10*9; enzymatic activity per volume; micromoles per minute per billion; umol/min/10*9; umol per min per 10*9","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per day","U/d","U/D","catalytic activity",116167760416.66667,[0,-2,0,0,0,0,0],"U/d","chemical",true,null,null,1,false,false,1,0,"U/dy; enzyme units per day; enzyme units; enzyme activity; enzymatic activity per time; micromoles per minute per day; umol/min/day; umol per min per day","LOINC","CRat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per deciliter","U/dL","U/DL","catalytic activity",100368945000000000000,[-3,-1,0,0,0,0,0],"U/dL","chemical",true,null,null,1,false,false,1,0,"U per dL; enzyme units per deciliter; decilitre; micromoles per minute per deciliter; umol/min/dL; umol per min per dL","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per gram","U/g","U/G","catalytic activity",10036894500000000,[0,-1,-1,0,0,0,0],"U/g","chemical",true,null,null,1,false,false,1,0,"U/gm; U per gm; enzyme units per gram; micromoles per minute per gram; umol/min/g; umol per min per g","LOINC","CCnt","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per hour","U/h","U/HR","catalytic activity",2788026250000,[0,-2,0,0,0,0,0],"U/h","chemical",true,null,null,1,false,false,1,0,"U/hr; U per hr; enzyme units per hour; micromoles per minute per hour; umol/min/hr; umol per min per hr","LOINC","CRat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per liter","U/L","U/L","catalytic activity",10036894500000000000,[-3,-1,0,0,0,0,0],"U/L","chemical",true,null,null,1,false,false,1,0,"enzyme unit/liter; enzyme unit/litre; U per L; enzyme units per liter; enzyme unit per litre; micromoles per minute per liter; umol/min/L; umol per min per L","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per minute","U/min","U/MIN","catalytic activity",167281575000000,[0,-2,0,0,0,0,0],"U/min","chemical",true,null,null,1,false,false,1,0,"enzyme unit/minute; U per min; enzyme units; umol/min/min; micromoles per minute per minute; micromoles per min per min; umol","LOINC","CRat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per milliliter","U/mL","U/ML","catalytic activity",1.00368945e+22,[-3,-1,0,0,0,0,0],"U/mL","chemical",true,null,null,1,false,false,1,0,"U per mL; enzyme units per milliliter; millilitre; micromoles per minute per milliliter; umol/min/mL; umol per min per mL","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per second","U/s","U/S","catalytic activity",10036894500000000,[0,-2,0,0,0,0,0],"U/s","chemical",true,null,null,1,false,false,1,0,"U/sec; U per second; enzyme units per second; micromoles per minute per second; umol/min/sec; umol per min per sec","LOINC","CRat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"micro international unit","u[IU]","U[IU]","arbitrary",0.000001,[0,0,0,0,0,0,0],"μi.U.","chemical",true,null,null,1,false,true,0,0,"uIU; u IU; microinternational units","LOINC","Arb","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"micro international unit per liter","u[IU]/L","U[IU]/L","arbitrary",0.001,[-3,0,0,0,0,0,0],"(μi.U.)/L","chemical",true,null,null,1,false,true,0,0,"uIU/L; u IU/L; uIU per L; microinternational units per liter; litre; ","LOINC","ACnc","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"micro international unit per milliliter","u[IU]/mL","U[IU]/ML","arbitrary",1,[-3,0,0,0,0,0,0],"(μi.U.)/mL","chemical",true,null,null,1,false,true,0,0,"uIU/mL; u IU/mL; uIU per mL; microinternational units per milliliter; millilitre","LOINC","ACnc","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"microequivalent","ueq","UEQ","amount of substance",602213670000000000,[0,0,0,0,0,0,0],"μeq","chemical",true,null,null,1,false,false,0,1,"microequivalents; 10^-6 equivalents; 10-6 equivalents","LOINC","Sub","Clinical","","mol","MOL","1",1,false],[false,"microequivalent per liter","ueq/L","UEQ/L","amount of substance",602213670000000000000,[-3,0,0,0,0,0,0],"μeq/L","chemical",true,null,null,1,false,false,0,1,"ueq per liter; litre; microequivalents","LOINC","MCnc","Clinical","","mol","MOL","1",1,false],[false,"microequivalent per milliliter","ueq/mL","UEQ/ML","amount of substance",6.0221367000000003e+23,[-3,0,0,0,0,0,0],"μeq/mL","chemical",true,null,null,1,false,false,0,1,"ueq per milliliter; millilitre; microequivalents","LOINC","MCnc","Clinical","","mol","MOL","1",1,false],[false,"microgram","ug","UG","mass",0.000001,[0,0,1,0,0,0,0],"μg",null,false,"M",null,1,false,false,0,0,"mcg; micrograms; 10^-6 grams; 10-6 grams","LOINC","Mass","Clinical","",null,null,null,null,false],[false,"microgram per 100 gram","ug/(100.g)","UG/(100.G)","mass",1e-8,[0,0,0,0,0,0,0],"μg/g",null,false,"M",null,1,false,false,0,0,"ug/100gm; ug/100 gm; mcg; ug per 100g; 100 gm; mcg per 100g; micrograms per 100 grams","LOINC","MCnt","Clinical","",null,null,null,null,false],[false,"microgram per 24 hour","ug/(24.h)","UG/(24.HR)","mass",1.1574074074074074e-11,[0,-1,1,0,0,0,0],"μg/h",null,false,"M",null,1,false,false,0,0,"ug/24hrs; ug/24 hrs; mcg/24hrs; ug per 24hrs; mcg per 24hrs; 24 hrs; micrograms per 24 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"microgram per 8 hour","ug/(8.h)","UG/(8.HR)","mass",3.472222222222222e-11,[0,-1,1,0,0,0,0],"μg/h",null,false,"M",null,1,false,false,0,0,"ug/8hrs; ug/8 hrs; mcg/8hrs; ug per 8hrs; mcg per 8hrs; 8 hrs; micrograms per 8 hours; shift","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"microgram per square foot (international)","ug/[sft_i]","UG/[SFT_I]","mass",0.000010763910416709721,[-2,0,1,0,0,0,0],"μg",null,false,"M",null,1,false,false,0,0,"ug/sft; ug/ft2; ug/ft^2; ug/sq. ft; micrograms; sq. foot; foot squared","LOINC","ArMass","Clinical","",null,null,null,null,false],[false,"microgram per day","ug/d","UG/D","mass",1.1574074074074074e-11,[0,-1,1,0,0,0,0],"μg/d",null,false,"M",null,1,false,false,0,0,"ug/dy; mcg/dy; ug per day; mcg; micrograms per day","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"microgram per deciliter","ug/dL","UG/DL","mass",0.009999999999999998,[-3,0,1,0,0,0,0],"μg/dL",null,false,"M",null,1,false,false,0,0,"ug per dL; mcg/dl; mcg per dl; micrograms per deciliter; decilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"microgram per gram","ug/g","UG/G","mass",0.000001,[0,0,0,0,0,0,0],"μg/g",null,false,"M",null,1,false,false,0,0,"ug per gm; mcg/gm; mcg per g; micrograms per gram","LOINC","MCnt","Clinical","",null,null,null,null,false],[false,"microgram per hour","ug/h","UG/HR","mass",2.7777777777777777e-10,[0,-1,1,0,0,0,0],"μg/h",null,false,"M",null,1,false,false,0,0,"ug/hr; mcg/hr; mcg per hr; ug per hr; ug per hour; micrograms","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"microgram per kilogram","ug/kg","UG/KG","mass",9.999999999999999e-10,[0,0,0,0,0,0,0],"μg/kg",null,false,"M",null,1,false,false,0,0,"ug per kg; mcg/kg; mcg per kg; micrograms per kilogram","LOINC","MCnt","Clinical","",null,null,null,null,false],[false,"microgram per kilogram per 8 hour","ug/kg/(8.h)","(UG/KG)/(8.HR)","mass",3.472222222222222e-14,[0,-1,0,0,0,0,0],"(μg/kg)/h",null,false,"M",null,1,false,false,0,0,"ug/kg/8hrs; mcg/kg/8hrs; ug/kg/8 hrs; mcg/kg/8 hrs; ug per kg per 8hrs; 8 hrs; mcg per kg per 8hrs; micrograms per kilograms per 8 hours; shift","LOINC","","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[false,"microgram per kilogram per day","ug/kg/d","(UG/KG)/D","mass",1.1574074074074072e-14,[0,-1,0,0,0,0,0],"(μg/kg)/d",null,false,"M",null,1,false,false,0,0,"ug/(kg.d); ug/kg/dy; mcg/kg/day; ug per kg per dy; 24 hours; 24hrs; mcg; kilograms; microgram per kilogram and day","LOINC","","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[false,"microgram per kilogram per hour","ug/kg/h","(UG/KG)/HR","mass",2.7777777777777774e-13,[0,-1,0,0,0,0,0],"(μg/kg)/h",null,false,"M",null,1,false,false,0,0,"ug/(kg.h); ug/kg/hr; mcg/kg/hr; ug per kg per hr; mcg per kg per hr; kilograms","LOINC","","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[false,"microgram per kilogram per minute","ug/kg/min","(UG/KG)/MIN","mass",1.6666666666666664e-11,[0,-1,0,0,0,0,0],"(μg/kg)/min",null,false,"M",null,1,false,false,0,0,"ug/kg/min; ug/kg/min; mcg/kg/min; ug per kg per min; mcg; micrograms per kilograms per minute ","LOINC","","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[false,"microgram per liter","ug/L","UG/L","mass",0.001,[-3,0,1,0,0,0,0],"μg/L",null,false,"M",null,1,false,false,0,0,"mcg/L; ug per L; mcg; micrograms per liter; litre ","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"microgram per liter per 24 hour","ug/L/(24.h)","(UG/L)/(24.HR)","mass",1.1574074074074074e-8,[-3,-1,1,0,0,0,0],"(μg/L)/h",null,false,"M",null,1,false,false,0,0,"ug/L/24hrs; ug/L/24 hrs; mcg/L/24hrs; ug per L per 24hrs; 24 hrs; day; dy mcg; micrograms per liters per 24 hours; litres","LOINC","","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[false,"microgram per square meter","ug/m2","UG/M2","mass",0.000001,[-2,0,1,0,0,0,0],"μg/(m<sup>2</sup>)",null,false,"M",null,1,false,false,0,0,"ug/m^2; ug/sq. m; mcg/m2; mcg/m^2; mcg/sq. m; ug per m2; m^2; sq. meter; mcg; micrograms per square meter; meter squared; metre","LOINC","ArMass","Clinical","unit used to measure mass dose per patient body surface area",null,null,null,null,false],[false,"microgram per cubic meter","ug/m3","UG/M3","mass",0.000001,[-3,0,1,0,0,0,0],"μg/(m<sup>3</sup>)",null,false,"M",null,1,false,false,0,0,"ug/m^3; ug/cu. m; mcg/m3; mcg/m^3; mcg/cu. m; ug per m3; ug per m^3; ug per cu. m; mcg; micrograms per cubic meter; meter cubed; metre","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"microgram per milligram","ug/mg","UG/MG","mass",0.001,[0,0,0,0,0,0,0],"μg/mg",null,false,"M",null,1,false,false,0,0,"ug per mg; mcg/mg; mcg per mg; micromilligrams per milligram","LOINC","MCnt","Clinical","",null,null,null,null,false],[false,"microgram per minute","ug/min","UG/MIN","mass",1.6666666666666667e-8,[0,-1,1,0,0,0,0],"μg/min",null,false,"M",null,1,false,false,0,0,"ug per min; mcg/min; mcg per min; microminutes per minute","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"microgram per milliliter","ug/mL","UG/ML","mass",1,[-3,0,1,0,0,0,0],"μg/mL",null,false,"M",null,1,false,false,0,0,"ug per mL; mcg/mL; mcg per mL; micrograms per milliliter; millilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[false,"microgram per millimole","ug/mmol","UG/MMOL","mass",1.660540186674939e-27,[0,0,1,0,0,0,0],"μg/mmol",null,false,"M",null,1,false,false,-1,0,"ug per mmol; mcg/mmol; mcg per mmol; micrograms per millimole","LOINC","Ratio","Clinical","",null,null,null,null,false],[false,"microgram per nanogram","ug/ng","UG/NG","mass",999.9999999999999,[0,0,0,0,0,0,0],"μg/ng",null,false,"M",null,1,false,false,0,0,"ug per ng; mcg/ng; mcg per ng; micrograms per nanogram","LOINC","MCnt","Clinical","",null,null,null,null,false],[false,"microkatal","ukat","UKAT","catalytic activity",602213670000000000,[0,-1,0,0,0,0,0],"μkat","chemical",true,null,null,1,false,false,1,0,"microkatals; ukats","LOINC","CAct","Clinical","kat is a unit of catalytic activity with base units = mol/s. Rarely used because its units are too large to practically express catalytic activity. See enzyme unit [U] which is the standard unit for catalytic activity.","mol/s","MOL/S","1",1,false],[false,"microliter","uL","UL","volume",1e-9,[3,0,0,0,0,0,0],"μL","iso1000",true,null,null,1,false,false,0,0,"microliters; microlitres; mcl","LOINC","Vol","Clinical","","l",null,"1",1,false],[false,"microliter per 2 hour","uL/(2.h)","UL/(2.HR)","volume",1.388888888888889e-13,[3,-1,0,0,0,0,0],"μL/h","iso1000",true,null,null,1,false,false,0,0,"uL/2hrs; uL/2 hrs; mcg/2hr; mcg per 2hr; uL per 2hr; uL per 2 hrs; microliters per 2 hours; microlitres ","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"microliter per hour","uL/h","UL/HR","volume",2.777777777777778e-13,[3,-1,0,0,0,0,0],"μL/h","iso1000",true,null,null,1,false,false,0,0,"uL/hr; mcg/hr; mcg per hr; uL per hr; microliters per hour; microlitres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"micrometer","um","UM","length",0.000001,[1,0,0,0,0,0,0],"μm",null,false,"L",null,1,false,false,0,0,"micrometers; micrometres; μm; microns","LOINC","Len","Clinical","Unit of length that is usually used in tests related to the eye",null,null,null,null,false],[false,"microns per second","um/s","UM/S","length",0.000001,[1,-1,0,0,0,0,0],"μm/s",null,false,"L",null,1,false,false,0,0,"um/sec; micron/second; microns/second; um per sec; micrometers per second; micrometres","LOINC","Vel","Clinical","",null,null,null,null,false],[false,"micromole","umol","UMOL","amount of substance",602213670000000000,[0,0,0,0,0,0,0],"μmol","si",true,null,null,1,false,false,1,0,"micromoles; umols","LOINC","Sub","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per 2 hour","umol/(2.h)","UMOL/(2.HR)","amount of substance",83640787500000,[0,-1,0,0,0,0,0],"μmol/h","si",true,null,null,1,false,false,1,0,"umol/2hrs; umol/2 hrs; umol per 2 hrs; 2hrs; micromoles per 2 hours","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per 24 hour","umol/(24.h)","UMOL/(24.HR)","amount of substance",6970065625000,[0,-1,0,0,0,0,0],"μmol/h","si",true,null,null,1,false,false,1,0,"umol/24hrs; umol/24 hrs; umol per 24 hrs; per 24hrs; micromoles per 24 hours","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per 8 hour","umol/(8.h)","UMOL/(8.HR)","amount of substance",20910196875000,[0,-1,0,0,0,0,0],"μmol/h","si",true,null,null,1,false,false,1,0,"umol/8hr; umol/8 hr; umol per 8 hr; umol per 8hr; umols per 8hr; umol per 8 hours; micromoles per 8 hours; shift","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per day","umol/d","UMOL/D","amount of substance",6970065625000,[0,-1,0,0,0,0,0],"μmol/d","si",true,null,null,1,false,false,1,0,"umol/day; umol per day; umols per day; umol per days; micromoles per days; umol/24hr; umol/24 hr; umol per 24 hr; umol per 24hr; umols per 24hr; umol per 24 hours; micromoles per 24 hours","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per deciliter","umol/dL","UMOL/DL","amount of substance",6.0221367e+21,[-3,0,0,0,0,0,0],"μmol/dL","si",true,null,null,1,false,false,1,0,"micromole/deciliter; micromole/decilitre; umol per dL; micromoles per deciliters; micromole per decilitres","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per gram","umol/g","UMOL/G","amount of substance",602213670000000000,[0,0,-1,0,0,0,0],"μmol/g","si",true,null,null,1,false,false,1,0,"micromole/gram; umol per g; micromoles per gram","LOINC","SCnt; Ratio","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per hour","umol/h","UMOL/HR","amount of substance",167281575000000,[0,-1,0,0,0,0,0],"μmol/h","si",true,null,null,1,false,false,1,0,"umol/hr; umol per hr; umol per hour; micromoles per hours","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per kilogram","umol/kg","UMOL/KG","amount of substance",602213670000000,[0,0,-1,0,0,0,0],"μmol/kg","si",true,null,null,1,false,false,1,0,"umol per kg; micromoles per kilogram","LOINC","SCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per liter","umol/L","UMOL/L","amount of substance",602213670000000000000,[-3,0,0,0,0,0,0],"μmol/L","si",true,null,null,1,false,false,1,0,"micromole/liter; micromole/litre; umol per liter; micromoles per liter; litre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per liter per hour","umol/L/h","(UMOL/L)/HR","amount of substance",167281575000000000,[-3,-1,0,0,0,0,0],"(μmol/L)/h","si",true,null,null,1,false,false,1,0,"umol/liter/hr; umol/litre/hr; umol per L per hr; umol per liter per hour; micromoles per liters per hour; litre","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min; umol/L/h is a derived unit of enzyme units","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per milligram","umol/mg","UMOL/MG","amount of substance",602213670000000000000,[0,0,-1,0,0,0,0],"μmol/mg","si",true,null,null,1,false,false,1,0,"micromole/milligram; umol per mg; micromoles per milligram","LOINC","SCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per minute","umol/min","UMOL/MIN","amount of substance",10036894500000000,[0,-1,0,0,0,0,0],"μmol/min","si",true,null,null,1,false,false,1,0,"micromole/minute; umol per min; micromoles per minute; enzyme units","LOINC","CAct","Clinical","unit for the enzyme unit U = umol/min","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per minute per gram","umol/min/g","(UMOL/MIN)/G","amount of substance",10036894500000000,[0,-1,-1,0,0,0,0],"(μmol/min)/g","si",true,null,null,1,false,false,1,0,"umol/min/gm; umol per min per gm; micromoles per minutes per gram; U/g; enzyme units","LOINC","CCnt","Clinical","unit for the enzyme unit U = umol/min. umol/min/g = U/g","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per minute per liter","umol/min/L","(UMOL/MIN)/L","amount of substance",10036894500000000000,[-3,-1,0,0,0,0,0],"(μmol/min)/L","si",true,null,null,1,false,false,1,0,"umol/min/liter; umol/minute/liter; micromoles per minutes per liter; litre; enzyme units; U/L","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min. umol/min/L = U/L","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per milliliter","umol/mL","UMOL/ML","amount of substance",6.0221367000000003e+23,[-3,0,0,0,0,0,0],"μmol/mL","si",true,null,null,1,false,false,1,0,"umol per mL; micromoles per milliliter; millilitre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per milliliter per minute","umol/mL/min","(UMOL/ML)/MIN","amount of substance",1.00368945e+22,[-3,-1,0,0,0,0,0],"(μmol/mL)/min","si",true,null,null,1,false,false,1,0,"umol per mL per min; micromoles per milliliters per minute; millilitres","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min. umol/mL/min = U/mL","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per millimole","umol/mmol","UMOL/MMOL","amount of substance",0.001,[0,0,0,0,0,0,0],"μmol/mmol","si",true,null,null,1,false,false,0,0,"umol per mmol; micromoles per millimole","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per mole","umol/mol","UMOL/MOL","amount of substance",0.000001,[0,0,0,0,0,0,0],"μmol/mol","si",true,null,null,1,false,false,0,0,"umol per mol; micromoles per mole","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per micromole","umol/umol","UMOL/UMOL","amount of substance",1,[0,0,0,0,0,0,0],"μmol/μmol","si",true,null,null,1,false,false,0,0,"umol per umol; micromoles per micromole","LOINC","Srto; SFr; EntSRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"microOhm","uOhm","UOHM","electric resistance",0.001,[2,-1,1,0,0,-2,0],"μΩ","si",true,null,null,1,false,false,0,0,"microOhms; µΩ","LOINC","","Clinical","unit of electric resistance","V/A","V/A","1",1,false],[false,"microsecond","us","US","time",0.000001,[0,1,0,0,0,0,0],"μs",null,false,"T",null,1,false,false,0,0,"microseconds","LOINC","Time","Clinical","",null,null,null,null,false],[false,"micro enzyme unit per gram","uU/g","UU/G","catalytic activity",10036894500,[0,-1,-1,0,0,0,0],"μU/g","chemical",true,null,null,1,false,false,1,0,"uU per gm; micro enzyme units per gram; micro enzymatic activity per mass; enzyme activity","LOINC","CCnt","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 uU = 1pmol/min","umol/min","UMOL/MIN","1",1,false],[false,"micro enzyme unit per liter","uU/L","UU/L","catalytic activity",10036894500000,[-3,-1,0,0,0,0,0],"μU/L","chemical",true,null,null,1,false,false,1,0,"uU per L; micro enzyme units per liter; litre; enzymatic activity per volume; enzyme activity ","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 uU = 1pmol/min","umol/min","UMOL/MIN","1",1,false],[false,"micro enzyme unit per milliliter","uU/mL","UU/ML","catalytic activity",10036894500000000,[-3,-1,0,0,0,0,0],"μU/mL","chemical",true,null,null,1,false,false,1,0,"uU per mL; micro enzyme units per milliliter; millilitre; enzymatic activity per volume; enzyme activity","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 uU = 1pmol/min","umol/min","UMOL/MIN","1",1,false],[false,"microvolt","uV","UV","electric potential",0.001,[2,-2,1,0,0,-1,0],"μV","si",true,null,null,1,false,false,0,0,"microvolts","LOINC","Elpot","Clinical","unit of electric potential (voltage)","J/C","J/C","1",1,false]]}}
 
-},{}],61:[function(require,module,exports){
+},{}],62:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -10718,7 +10757,7 @@ var Ucum = exports.Ucum = {
 };
 
 
-},{}],62:[function(require,module,exports){
+},{}],63:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -11031,7 +11070,7 @@ class Dimension {
 exports.Dimension = Dimension;
 
 
-},{"./config.js":61,"is-integer":76}],63:[function(require,module,exports){
+},{"./config.js":62,"is-integer":77}],64:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -11153,7 +11192,7 @@ function unpackArray(obj) {
 }
 
 
-},{}],64:[function(require,module,exports){
+},{}],65:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -11297,7 +11336,7 @@ class Prefix {
 exports.Prefix = Prefix;
 
 
-},{"./config.js":61}],65:[function(require,module,exports){
+},{"./config.js":62}],66:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -11427,7 +11466,7 @@ const PrefixTables = exports.PrefixTables = {
 };
 
 
-},{}],66:[function(require,module,exports){
+},{}],67:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -11662,7 +11701,7 @@ class UcumFunctions {
 var _default = exports.default = new UcumFunctions(); // one singleton instance
 
 
-},{}],67:[function(require,module,exports){
+},{}],68:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -11761,7 +11800,7 @@ function getSynonyms(theSyn) {
 } // end getSynonyms
 
 
-},{"./unitTables.js":73}],68:[function(require,module,exports){
+},{"./unitTables.js":74}],69:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -11815,7 +11854,7 @@ exports.UcumJsonDefs = UcumJsonDefs;
 var ucumJsonDefs = exports.ucumJsonDefs = new UcumJsonDefs();
 
 
-},{"../data/ucumDefs.min.json":60,"./jsonArrayPack.js":63,"./prefix.js":64,"./prefixTables.js":65,"./unit.js":71,"./unitTables.js":73}],69:[function(require,module,exports){
+},{"../data/ucumDefs.min.json":61,"./jsonArrayPack.js":64,"./prefix.js":65,"./prefixTables.js":66,"./unit.js":72,"./unitTables.js":74}],70:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -12502,7 +12541,7 @@ UcumLhcUtils.getInstance = function () {
 };
 
 
-},{"./config.js":61,"./ucumInternalUtils.js":67,"./ucumJsonDefs.js":68,"./unitString.js":72,"./unitTables.js":73}],70:[function(require,module,exports){
+},{"./config.js":62,"./ucumInternalUtils.js":68,"./ucumJsonDefs.js":69,"./unitString.js":73,"./unitTables.js":74}],71:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -12521,7 +12560,7 @@ var UcumLhcUtils = exports.UcumLhcUtils = require("./ucumLhcUtils.js").UcumLhcUt
 var UnitTables = exports.UnitTables = require("./unitTables.js").UnitTables;
 
 
-},{"./config.js":61,"./ucumLhcUtils.js":69,"./unitTables.js":73}],71:[function(require,module,exports){
+},{"./config.js":62,"./ucumLhcUtils.js":70,"./unitTables.js":74}],72:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -13579,7 +13618,7 @@ class Unit {
 exports.Unit = Unit;
 
 
-},{"./config.js":61,"./dimension.js":62,"./ucumFunctions.js":66,"./ucumInternalUtils.js":67,"./unitTables.js":73,"is-integer":76}],72:[function(require,module,exports){
+},{"./config.js":62,"./dimension.js":63,"./ucumFunctions.js":67,"./ucumInternalUtils.js":68,"./unitTables.js":74,"is-integer":77}],73:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -15088,7 +15127,7 @@ UnitString.getInstance();
 */
 
 
-},{"./config.js":61,"./prefixTables.js":65,"./ucumInternalUtils.js":67,"./unit.js":71,"./unitTables.js":73}],73:[function(require,module,exports){
+},{"./config.js":62,"./prefixTables.js":66,"./ucumInternalUtils.js":68,"./unit.js":72,"./unitTables.js":74}],74:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -15709,7 +15748,7 @@ const UnitTables = exports.UnitTables = {
 };
 
 
-},{"./config.js":61}],74:[function(require,module,exports){
+},{"./config.js":62}],75:[function(require,module,exports){
 /**
  * @license
  * MIT License
@@ -21966,14 +22005,14 @@ const UnitTables = exports.UnitTables = {
 
 }));
 
-},{}],75:[function(require,module,exports){
+},{}],76:[function(require,module,exports){
 'use strict';
 
 module.exports = Number.isFinite || function (value) {
 	return !(typeof value !== 'number' || value !== value || value === Infinity || value === -Infinity);
 };
 
-},{}],76:[function(require,module,exports){
+},{}],77:[function(require,module,exports){
 // https://github.com/paulmillr/es6-shim
 // http://people.mozilla.org/~jorendorff/es6-draft.html#sec-number.isinteger
 var isFinite = require("is-finite");
@@ -21983,7 +22022,7 @@ module.exports = Number.isInteger || function(val) {
     Math.floor(val) === val;
 };
 
-},{"is-finite":75}],77:[function(require,module,exports){
+},{"is-finite":76}],78:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', { value: true });

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -1856,18 +1856,21 @@ class Interval {
         if (this.high != null && typeof this.high.copy === 'function') {
             newHigh = this.high.copy();
         }
-        return new Interval(newLow, newHigh, this.lowClosed, this.highClosed);
+        return new Interval(newLow, newHigh, this.lowClosed, this.highClosed, this.defaultPointType);
     }
     contains(item, precision) {
-        // These first two checks ensure correct handling of edge case where an item equals the closed boundary
+        if (item != null && item.isInterval) {
+            throw new Error('Argument to contains must be a point');
+        }
+        if (this.isBoundlessInterval) {
+            return true;
+        }
+        // Ensure correct handling of edge case where an item equals the closed boundary
         if (this.lowClosed && this.low != null && cmp.equals(this.low, item)) {
             return true;
         }
         if (this.highClosed && this.high != null && cmp.equals(this.high, item)) {
             return true;
-        }
-        if (item != null && item.isInterval) {
-            throw new Error('Argument to contains must be a point');
         }
         let lowFn;
         if (this.lowClosed && this.low == null) {
@@ -1907,6 +1910,12 @@ class Interval {
         return logic_1.ThreeValuedLogic.and(this.includes(other, precision), logic_1.ThreeValuedLogic.not(other.includes(this, precision)));
     }
     includes(other, precision) {
+        if (this.isBoundlessInterval) {
+            return true;
+        }
+        else if (other?.isBoundlessInterval) {
+            return this.isUnknownInterval ? null : false;
+        }
         if (other == null || !other.isInterval) {
             return this.contains(other, precision);
         }
@@ -1974,6 +1983,12 @@ class Interval {
         if (other == null || !other.isInterval) {
             throw new Error('Argument to union must be an interval');
         }
+        if (this.isBoundlessInterval) {
+            return this.copy();
+        }
+        else if (other.isBoundlessInterval) {
+            return other.copy();
+        }
         // Note that interval union is only defined if the arguments overlap or meet.
         if (this.overlaps(other) || this.meets(other)) {
             const [a, b] = [this.toClosed(), other.toClosed()];
@@ -2021,7 +2036,13 @@ class Interval {
         if (other == null || !other.isInterval) {
             throw new Error('Argument to union must be an interval');
         }
-        // Note that interval union is only defined if the arguments overlap.
+        if (this.isBoundlessInterval) {
+            return other.copy();
+        }
+        else if (other.isBoundlessInterval) {
+            return this.copy();
+        }
+        // Note that interval intersect is only defined if the arguments overlap.
         if (this.overlaps(other)) {
             const [a, b] = [this.toClosed(), other.toClosed()];
             let l, lc;
@@ -2164,6 +2185,9 @@ class Interval {
         }
     }
     sameOrBefore(other, precision) {
+        if (this.isBoundlessInterval || other?.isBoundlessInterval) {
+            return this.equals(other);
+        }
         if (this.end() == null || other == null || other.start() == null) {
             return null;
         }
@@ -2172,6 +2196,9 @@ class Interval {
         }
     }
     sameOrAfter(other, precision) {
+        if (this.isBoundlessInterval || other?.isBoundlessInterval) {
+            return this.equals(other);
+        }
         if (this.start() == null || other == null || other.end() == null) {
             return null;
         }
@@ -2181,6 +2208,12 @@ class Interval {
     }
     equals(other) {
         if (other != null && other.isInterval) {
+            if (this.isBoundlessInterval) {
+                return other.isBoundlessInterval ? true : other.isUnknownInterval ? null : false;
+            }
+            else if (other.isBoundlessInterval) {
+                return this.isUnknownInterval ? null : false;
+            }
             const [a, b] = [this.toClosed(), other.toClosed()];
             return logic_1.ThreeValuedLogic.and(cmp.equals(a.low, b.low), cmp.equals(a.high, b.high));
         }
@@ -2189,6 +2222,9 @@ class Interval {
         }
     }
     after(other, precision) {
+        if (this.isBoundlessInterval || other?.isBoundlessInterval) {
+            return false;
+        }
         const closed = this.toClosed();
         // Meets spec, but not 100% correct (e.g., (null, 5] after [6, 10] --> null)
         // Simple way to fix it: and w/ not overlaps
@@ -2200,6 +2236,9 @@ class Interval {
         }
     }
     before(other, precision) {
+        if (this.isBoundlessInterval || other?.isBoundlessInterval) {
+            return false;
+        }
         const closed = this.toClosed();
         // Meets spec, but not 100% correct (e.g., (null, 5] after [6, 10] --> null)
         // Simple way to fix it: and w/ not overlaps
@@ -2211,9 +2250,15 @@ class Interval {
         }
     }
     meets(other, precision) {
+        if (this.isBoundlessInterval || other?.isBoundlessInterval) {
+            return false;
+        }
         return logic_1.ThreeValuedLogic.or(this.meetsBefore(other, precision), this.meetsAfter(other, precision));
     }
     meetsAfter(other, precision) {
+        if (this.isBoundlessInterval || other?.isBoundlessInterval) {
+            return false;
+        }
         try {
             if (precision != null && this.low != null && this.low.isDateTime) {
                 return this.toClosed().low.sameAs(other.toClosed().high != null ? other.toClosed().high.add(1, precision) : null, precision);
@@ -2227,6 +2272,9 @@ class Interval {
         }
     }
     meetsBefore(other, precision) {
+        if (this.isBoundlessInterval || other?.isBoundlessInterval) {
+            return false;
+        }
         try {
             if (precision != null && this.high != null && this.high.isDateTime) {
                 return this.toClosed().high.sameAs(other.toClosed().low != null ? other.toClosed().low.add(-1, precision) : null, precision);
@@ -2262,6 +2310,12 @@ class Interval {
         return this.toClosed().high;
     }
     starts(other, precision) {
+        if (this.isBoundlessInterval) {
+            return other.isBoundlessInterval ? true : other.isUnknownInterval ? null : false;
+        }
+        else if (other?.isBoundlessInterval) {
+            return this.isUnknownInterval ? null : false;
+        }
         let startEqual;
         if (precision != null && this.low != null && this.low.isDateTime) {
             startEqual = this.low.sameAs(other.low, precision);
@@ -2273,6 +2327,12 @@ class Interval {
         return startEqual && endLessThanOrEqual;
     }
     ends(other, precision) {
+        if (this.isBoundlessInterval) {
+            return other.isBoundlessInterval ? true : other.isUnknownInterval ? null : false;
+        }
+        else if (other?.isBoundlessInterval) {
+            return this.isUnknownInterval ? null : false;
+        }
         let endEqual;
         const startGreaterThanOrEqual = cmp.greaterThanOrEquals(this.low, other.low, precision);
         if (precision != null && (this.low != null ? this.low.isDateTime : undefined)) {

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -1874,20 +1874,23 @@ class Interval {
         // comparisons used in the operation are performed at the specified precision."
         return logic_1.ThreeValuedLogic.and(cmp.greaterThanOrEquals(item, this.start(), precision), cmp.lessThanOrEquals(item, this.end(), precision));
     }
+    // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#properly-includes
     properContains(item, precision) {
+        // From contains: "If the second argument is null, the result is null."
         if (item == null) {
             return null;
         }
         else if (item.isInterval) {
             throw new Error('Argument to contains must be a point');
         }
-        return logic_1.ThreeValuedLogic.and(cmp.lessThan(this.start(), item, precision), cmp.greaterThan(this.end(), item, precision));
+        // "For the interval-point overload, this operator returns true if the interval contains
+        // (i.e. includes) the point, and the interval is not a unit interval containing only the
+        // point."
+        return logic_1.ThreeValuedLogic.and(this.contains(item, precision), logic_1.ThreeValuedLogic.not(cmp.equals(this.start(), this.end())));
     }
     // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#properly-includes
     properlyIncludes(other, precision) {
-        // TODO: "For the interval-point overload, this operator returns true if the interval contains
-        // (i.e. includes) the point, and the interval is not a unit interval containing only the
-        // point."
+        // "For the interval-interval overload, if either argument is null, the result is null."
         if (other == null || !other.isInterval) {
             throw new Error('Argument to properlyIncludes must be an interval');
         }

--- a/src/cql-patient.ts
+++ b/src/cql-patient.ts
@@ -1,6 +1,6 @@
 import * as DT from './datatypes/datatypes';
 import { DataProvider, NamedTypeSpecifier, PatientObject, RecordObject } from './types';
-import { ELM_NAMED_TYPE_SPECIFIER } from './util/elmTypes';
+import { ELM_ANY_TYPE, ELM_NAMED_TYPE_SPECIFIER } from './util/elmTypes';
 
 export class Record implements RecordObject {
   json: any;
@@ -27,7 +27,7 @@ export class Record implements RecordObject {
         name: '{https://github.com/cqframework/cql-execution/simple}Record',
         type: ELM_NAMED_TYPE_SPECIFIER
       },
-      { name: '{urn:hl7-org:elm-types:r1}Any', type: ELM_NAMED_TYPE_SPECIFIER }
+      { name: ELM_ANY_TYPE, type: ELM_NAMED_TYPE_SPECIFIER }
     ];
   }
 

--- a/src/datatypes/datetime.ts
+++ b/src/datatypes/datetime.ts
@@ -12,6 +12,14 @@ import {
   DateTime as LuxonDateTime,
   FixedOffsetZone
 } from 'luxon';
+import {
+  MAX_DATE_VALUE_STRING,
+  MAX_DATETIME_VALUE_STRING,
+  MAX_TIME_VALUE_STRING,
+  MIN_DATE_VALUE_STRING,
+  MIN_DATETIME_VALUE_STRING,
+  MIN_TIME_VALUE_STRING
+} from '../util/limits';
 
 // It's easiest and most performant to organize formats by length of the supported strings.
 // This way we can test strings only against the formats that have a chance of working.
@@ -550,7 +558,7 @@ abstract class AbstractDate {
       case 'millisecond':
         return 999;
       default:
-        throw new Error('Tried to clieling a field that has no cieling value: ' + field);
+        throw new Error('Tried to ceiling a field that has no cieling value: ' + field);
     }
   }
 }
@@ -722,8 +730,10 @@ export class DateTime extends AbstractDate {
     );
   }
 
-  successor() {
-    if (this.millisecond != null) {
+  successor(precision?: string) {
+    if (precision) {
+      return this.add(1, precision);
+    } else if (this.millisecond != null) {
       return this.add(1, DateTime.Unit.MILLISECOND);
     } else if (this.second != null) {
       return this.add(1, DateTime.Unit.SECOND);
@@ -740,8 +750,10 @@ export class DateTime extends AbstractDate {
     }
   }
 
-  predecessor() {
-    if (this.millisecond != null) {
+  predecessor(precision?: string) {
+    if (precision) {
+      return this.add(-1, precision);
+    } else if (this.millisecond != null) {
       return this.add(-1, DateTime.Unit.MILLISECOND);
     } else if (this.second != null) {
       return this.add(-1, DateTime.Unit.SECOND);
@@ -1078,8 +1090,10 @@ export class Date extends AbstractDate {
     return new Date(this.year, this.month, this.day);
   }
 
-  successor() {
-    if (this.day != null) {
+  successor(precision?: string) {
+    if (precision) {
+      return this.add(1, precision);
+    } else if (this.day != null) {
       return this.add(1, Date.Unit.DAY);
     } else if (this.month != null) {
       return this.add(1, Date.Unit.MONTH);
@@ -1088,8 +1102,10 @@ export class Date extends AbstractDate {
     }
   }
 
-  predecessor() {
-    if (this.day != null) {
+  predecessor(precision?: string) {
+    if (precision) {
+      return this.add(-1, precision);
+    } else if (this.day != null) {
       return this.add(-1, Date.Unit.DAY);
     } else if (this.month != null) {
       return this.add(-1, Date.Unit.MONTH);
@@ -1252,15 +1268,12 @@ export class Date extends AbstractDate {
   }
 }
 
-// Require MIN/MAX here because math.js requires this file, and when we make this file require
-// math.js before it exports DateTime and Date, it errors due to the circular dependency...
-// const { MAX_DATETIME_VALUE, MIN_DATETIME_VALUE } = require('../util/math');
-export const MIN_DATETIME_VALUE = DateTime.parse('0001-01-01T00:00:00.000');
-export const MAX_DATETIME_VALUE = DateTime.parse('9999-12-31T23:59:59.999');
-export const MIN_DATE_VALUE = Date.parse('0001-01-01');
-export const MAX_DATE_VALUE = Date.parse('9999-12-31');
-export const MIN_TIME_VALUE = DateTime.parse('0000-01-01T00:00:00.000')?.getTime();
-export const MAX_TIME_VALUE = DateTime.parse('0000-01-01T23:59:59.999')?.getTime();
+export const MIN_DATETIME_VALUE = DateTime.parse(MIN_DATETIME_VALUE_STRING);
+export const MAX_DATETIME_VALUE = DateTime.parse(MAX_DATETIME_VALUE_STRING);
+export const MIN_DATE_VALUE = Date.parse(MIN_DATE_VALUE_STRING);
+export const MAX_DATE_VALUE = Date.parse(MAX_DATE_VALUE_STRING);
+export const MIN_TIME_VALUE = DateTime.parse(MIN_TIME_VALUE_STRING)?.getTime();
+export const MAX_TIME_VALUE = DateTime.parse(MAX_TIME_VALUE_STRING)?.getTime();
 
 const DATETIME_PRECISION_VALUE_MAP = (() => {
   const dtpvMap = new Map();

--- a/src/datatypes/interval.ts
+++ b/src/datatypes/interval.ts
@@ -1,13 +1,15 @@
 import { Uncertainty } from './uncertainty';
-import { Quantity, doSubtraction } from './quantity';
 import { ThreeValuedLogic } from './logic';
 import {
   successor,
   predecessor,
-  maxValueForInstance,
-  minValueForInstance,
   maxValueForType,
-  minValueForType
+  minValueForType,
+  minValueForInstance,
+  maxValueForInstance,
+  limitDecimalPrecision,
+  subtract,
+  add
 } from '../util/math';
 import * as cmp from '../util/comparison';
 import {
@@ -17,8 +19,11 @@ import {
   ELM_TIME_TYPE,
   ELM_DATE_TYPE,
   ELM_DATETIME_TYPE,
-  ELM_QUANTITY_TYPE
+  ELM_QUANTITY_TYPE,
+  ELM_ANY_TYPE
 } from '../util/elmTypes';
+import { MIN_FLOAT_VALUE } from '../util/limits';
+import { Quantity } from './quantity';
 
 export class Interval {
   constructor(
@@ -26,46 +31,38 @@ export class Interval {
     public high: any,
     public lowClosed?: boolean | null,
     public highClosed?: boolean | null,
-    public defaultPointType?: any // defaultPointType is used in the case that both endpoints are null
+    public pointType: any = ELM_ANY_TYPE
   ) {
     this.lowClosed = lowClosed != null ? lowClosed : true;
     this.highClosed = highClosed != null ? highClosed : true;
+    if (this.pointType == null || this.pointType === ELM_ANY_TYPE) {
+      let point = low ?? high;
+      if (point?.isUncertainty) {
+        point = (point as Uncertainty).low ?? (point as Uncertainty).high;
+      }
+      if (point != null) {
+        if (typeof point === 'number') {
+          this.pointType = Number.isInteger(point) ? ELM_INTEGER_TYPE : ELM_DECIMAL_TYPE;
+        } else if (typeof point === 'bigint') {
+          this.pointType = ELM_LONG_TYPE;
+        } else if (point.isTime && point.isTime()) {
+          this.pointType = ELM_TIME_TYPE;
+        } else if (point.isDate) {
+          this.pointType = ELM_DATE_TYPE;
+        } else if (point.isDateTime) {
+          this.pointType = ELM_DATETIME_TYPE;
+        } else if (point.isQuantity) {
+          this.pointType = ELM_QUANTITY_TYPE;
+        }
+      }
+      if (this.pointType == null) {
+        this.pointType = ELM_ANY_TYPE;
+      }
+    }
   }
 
   get isInterval() {
     return true;
-  }
-
-  get isBoundlessInterval() {
-    return this.low == null && this.lowClosed && this.high == null && this.highClosed;
-  }
-
-  get isUnknownInterval() {
-    return this.low == null && !this.lowClosed && this.high == null && !this.highClosed;
-  }
-
-  get pointType() {
-    let pointType = null;
-    const point = this.low != null ? this.low : this.high;
-    if (point != null) {
-      if (typeof point === 'number') {
-        pointType = Number.isInteger(point) ? ELM_INTEGER_TYPE : ELM_DECIMAL_TYPE;
-      } else if (typeof point === 'bigint') {
-        pointType = ELM_LONG_TYPE;
-      } else if (point.isTime && point.isTime()) {
-        pointType = ELM_TIME_TYPE;
-      } else if (point.isDate) {
-        pointType = ELM_DATE_TYPE;
-      } else if (point.isDateTime) {
-        pointType = ELM_DATETIME_TYPE;
-      } else if (point.isQuantity) {
-        pointType = ELM_QUANTITY_TYPE;
-      }
-    }
-    if (pointType == null && this.defaultPointType != null) {
-      pointType = this.defaultPointType;
-    }
-    return pointType;
   }
 
   copy() {
@@ -78,42 +75,21 @@ export class Interval {
       newHigh = this.high.copy();
     }
 
-    return new Interval(newLow, newHigh, this.lowClosed, this.highClosed, this.defaultPointType);
+    return new Interval(newLow, newHigh, this.lowClosed, this.highClosed, this.pointType);
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#contains
   contains(item: any, precision?: any) {
     if (item != null && item.isInterval) {
       throw new Error('Argument to contains must be a point');
     }
-    if (this.isBoundlessInterval) {
-      return true;
-    }
-    // Ensure correct handling of edge case where an item equals the closed boundary
-    if (this.lowClosed && this.low != null && cmp.equals(this.low, item)) {
-      return true;
-    }
-    if (this.highClosed && this.high != null && cmp.equals(this.high, item)) {
-      return true;
-    }
-    let lowFn;
-    if (this.lowClosed && this.low == null) {
-      lowFn = () => true;
-    } else if (this.lowClosed) {
-      lowFn = cmp.lessThanOrEquals;
-    } else {
-      lowFn = cmp.lessThan;
-    }
-    let highFn;
-    if (this.highClosed && this.high == null) {
-      highFn = () => true;
-    } else if (this.highClosed) {
-      highFn = cmp.greaterThanOrEquals;
-    } else {
-      highFn = cmp.greaterThan;
-    }
+    // "The contains operator for intervals returns true if the given point is equal to the starting
+    // or ending point of the interval, or greater than the starting point and less than the ending
+    // point... If precision is specified and the point type is a Date, DateTime, or Time type,
+    // comparisons used in the operation are performed at the specified precision."
     return ThreeValuedLogic.and(
-      lowFn(this.low, item, precision),
-      highFn(this.high, item, precision)
+      cmp.greaterThanOrEquals(item, this.start(), precision),
+      cmp.lessThanOrEquals(item, this.end(), precision)
     );
   }
 
@@ -129,402 +105,451 @@ export class Interval {
     );
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#properly-includes
   properlyIncludes(other: any, precision?: any) {
+    // TODO: "For the interval-point overload, this operator returns true if the interval contains
+    // (i.e. includes) the point, and the interval is not a unit interval containing only the
+    // point."
     if (other == null || !other.isInterval) {
       throw new Error('Argument to properlyIncludes must be an interval');
     }
+    // "... the starting point of the first interval is less than or equal to the starting point of
+    // the second interval, and the ending point of the first interval is greater than or equal to
+    // the ending point of the second interval, and they are not the same interval... If precision
+    // is specified and the point type is a Date, DateTime, or Time type, comparisons used in the
+    // operation are performed at the specified precision."
     return ThreeValuedLogic.and(
-      this.includes(other, precision),
+      cmp.lessThanOrEquals(this.start(), other.start(), precision),
+      cmp.greaterThanOrEquals(this.end(), other.end(), precision),
       ThreeValuedLogic.not(other.includes(this, precision))
     );
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#includes
   includes(other: any, precision?: any) {
-    if (this.isBoundlessInterval) {
-      return true;
-    } else if (other?.isBoundlessInterval) {
-      return this.isUnknownInterval ? null : false;
+    // "For the interval-interval overload, if either argument is null, the result is null."
+    if (other == null) {
+      return null;
     }
-    if (other == null || !other.isInterval) {
+    // "For the point-interval overload, this operator is a synonym for the contains operator."
+    else if (!other.isInterval) {
       return this.contains(other, precision);
     }
-    const a = this.toClosed();
-    const b = other.toClosed();
+    // "... the starting point of the first interval is less than or equal to the starting point of
+    // the second interval, and the ending point of the first interval is greater than or equal to
+    // the ending point of the second interval... If precision is specified and the point type is a
+    // Date, DateTime, or Time type, comparisons used in the operation are performed at the
+    // specified precision."
     return ThreeValuedLogic.and(
-      cmp.lessThanOrEquals(a.low, b.low, precision),
-      cmp.greaterThanOrEquals(a.high, b.high, precision)
+      cmp.lessThanOrEquals(this.start(), other.start(), precision),
+      cmp.greaterThanOrEquals(this.end(), other.end(), precision)
     );
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#included-in
   includedIn(other: any, precision?: any) {
-    // For the point overload, this operator is a synonym for the in operator
-    if (other == null || !other.isInterval) {
-      return this.contains(other, precision);
-    } else {
-      return other.includes(this);
-    }
-  }
-
-  overlaps(item: any, precision?: any) {
-    if (this.isUnknownInterval || item == null || item.isUnknownInterval) {
+    // "For the interval-interval overload, if either argument is null, the result is null."
+    if (other == null) {
       return null;
-    } else if (this.isBoundlessInterval || item?.isBoundlessInterval) {
-      return true;
+    } else if (other == null || !other.isInterval) {
+      throw new Error('Argument to includedIn must be an interval');
     }
-    const closed = this.toClosed();
-    const [low, high] = (() => {
-      if (item != null && item.isInterval) {
-        const itemClosed = item.toClosed();
-        return [itemClosed.low, itemClosed.high];
-      } else {
-        return [item, item];
-      }
-    })();
+    // "... the starting point of the first interval is greater than or equal to the starting point
+    // of the second interval, and the ending point of the first interval is less than or equal to
+    // the ending point of the second interval... If precision is specified and the point type is a
+    // Date, DateTime, or Time type, comparisons used in the operation are performed at the
+    // specified precision."
     return ThreeValuedLogic.and(
-      cmp.lessThanOrEquals(closed.low, high, precision),
-      cmp.greaterThanOrEquals(closed.high, low, precision)
+      cmp.greaterThanOrEquals(this.start(), other.start(), precision),
+      cmp.lessThanOrEquals(this.end(), other.end(), precision)
     );
   }
 
-  overlapsAfter(item: any, precision?: any) {
-    if (this.isUnknownInterval || item == null || item.isUnknownInterval) {
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#overlaps
+  overlaps(other: any, precision?: any) {
+    // "If either argument is null, the result is null."
+    if (other == null) {
       return null;
     }
-    const high = item != null && item.isInterval ? item.toClosed().high : item;
-    if (this.isBoundlessInterval) {
-      return cmp.lessThan(high, maxValueForInstance(high), precision);
-    } else if (item?.isBoundlessInterval) {
-      return false;
-    }
-    const closed = this.toClosed();
+    // "... the ending point of the first interval is greater than or equal to the starting point
+    // of the second interval, and the starting point of the first interval is less than or equal
+    // to the ending point of the second interval... If precision is specified and the point type
+    // is a Date, DateTime, or Time type, comparisons used in the operation are performed at the
+    // specified precision."
     return ThreeValuedLogic.and(
-      cmp.lessThanOrEquals(closed.low, high, precision),
-      cmp.greaterThan(closed.high, high, precision)
+      cmp.greaterThanOrEquals(this.end(), other.start(), precision),
+      cmp.lessThanOrEquals(this.start(), other.end(), precision)
     );
   }
 
-  overlapsBefore(item: any, precision?: any) {
-    if (this.isUnknownInterval || item == null || item.isUnknownInterval) {
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#overlaps
+  overlapsAfter(other: any, precision?: any) {
+    // "If either argument is null, the result is null."
+    if (other == null) {
       return null;
     }
-    const low = item != null && item.isInterval ? item.toClosed().low : item;
-    if (this.isBoundlessInterval) {
-      return cmp.greaterThan(low, minValueForInstance(low), precision);
-    } else if (item?.isBoundlessInterval) {
-      return false;
-    }
-    const closed = this.toClosed();
+    // "... the overlaps after operator returns true if the first interval overlaps the second
+    // and ends after it."
     return ThreeValuedLogic.and(
-      cmp.lessThan(closed.low, low, precision),
-      cmp.greaterThanOrEquals(closed.high, low, precision)
+      cmp.lessThanOrEquals(this.start(), other.end(), precision),
+      cmp.greaterThan(this.end(), other.end(), precision)
     );
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#overlaps
+  overlapsBefore(other: any, precision?: any) {
+    // "If either argument is null, the result is null."
+    if (other == null) {
+      return null;
+    }
+    // "The operator overlaps before returns true if the first interval overlaps the second and
+    // starts before it..."
+    return ThreeValuedLogic.and(
+      cmp.greaterThanOrEquals(this.end(), other.start(), precision),
+      cmp.lessThan(this.start(), other.start(), precision)
+    );
+  }
+
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#union
   union(other: any) {
-    if (other == null || !other.isInterval) {
+    // "If either argument is null, the result is null."
+    if (other == null) {
+      return null;
+    } else if (!other.isInterval) {
       throw new Error('Argument to union must be an interval');
     }
-    if (this.isBoundlessInterval) {
-      return this.copy();
-    } else if (other.isBoundlessInterval) {
-      return other.copy();
-    }
-    // Note that interval union is only defined if the arguments overlap or meet.
-    if (this.overlaps(other) || this.meets(other)) {
-      const [a, b] = [this.toClosed(), other.toClosed()];
-      let l, lc;
-      if (cmp.lessThanOrEquals(a.low, b.low)) {
-        [l, lc] = [this.low, this.lowClosed];
-      } else if (cmp.greaterThanOrEquals(a.low, b.low)) {
-        [l, lc] = [other.low, other.lowClosed];
-      } else if (areNumeric(a.low, b.low)) {
-        [l, lc] = [lowestNumericUncertainty(a.low, b.low), true];
-        // TODO: Do we need to support quantities here?
-      } else if (areDateTimes(a.low, b.low) && a.low.isMorePrecise(b.low)) {
-        [l, lc] = [other.low, other.lowClosed];
-      } else {
-        [l, lc] = [this.low, this.lowClosed];
-      }
-      let h, hc;
-      if (cmp.greaterThanOrEquals(a.high, b.high)) {
-        [h, hc] = [this.high, this.highClosed];
-      } else if (cmp.lessThanOrEquals(a.high, b.high)) {
-        [h, hc] = [other.high, other.highClosed];
-      } else if (areNumeric(a.high, b.high)) {
-        [h, hc] = [highestNumericUncertainty(a.high, b.high), true];
-        // TODO: Do we need to support quantities here?
-      } else if (areDateTimes(a.high, b.high) && a.high.isMorePrecise(b.high)) {
-        [h, hc] = [other.high, other.highClosed];
-      } else {
-        [h, hc] = [this.high, this.highClosed];
-      }
-      return new Interval(l, h, lc, hc);
-    } else {
+
+    // "If the arguments do not overlap or meet, this operator returns null."
+    if (!this.overlaps(other) && !this.meets(other)) {
       return null;
     }
+
+    // "... the operator returns the interval that starts at the earliest starting point in either
+    // argument, and ends at the latest ending point in either argument."
+    let earliestStart;
+
+    const thisIsEarlier = cmp.lessThan(this.start(), other.start());
+    if (thisIsEarlier == null) {
+      earliestStart = lowestUncertainty(this.start(), other.start());
+    } else {
+      earliestStart = thisIsEarlier ? this.start() : other.start();
+    }
+    let latestEnd;
+
+    const thisIsLater = cmp.greaterThan(this.end(), other.end());
+    if (thisIsLater == null) {
+      latestEnd = highestUncertainty(this.end(), other.end());
+    } else {
+      latestEnd = thisIsLater ? this.end() : other.end();
+    }
+
+    return normalizeInterval(
+      new Interval(earliestStart, latestEnd, true, true, this.pointType ?? other.pointType)
+    );
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#intersect
   intersect(other: any) {
-    if (other == null || !other.isInterval) {
-      throw new Error('Argument to union must be an interval');
+    // "If either argument is null, the result is null."
+    if (other == null) {
+      return null;
+    } else if (!other.isInterval) {
+      throw new Error('Argument to intersect must be an interval');
     }
-    if (this.isBoundlessInterval) {
-      return other.copy();
-    } else if (other.isBoundlessInterval) {
-      return this.copy();
-    }
-    // Note that interval intersect is only defined if the arguments overlap.
-    if (this.overlaps(other)) {
-      const [a, b] = [this.toClosed(), other.toClosed()];
-      let l, lc;
-      if (cmp.greaterThanOrEquals(a.low, b.low)) {
-        [l, lc] = [this.low, this.lowClosed];
-      } else if (cmp.lessThanOrEquals(a.low, b.low)) {
-        [l, lc] = [other.low, other.lowClosed];
-      } else if (areNumeric(a.low, b.low)) {
-        [l, lc] = [highestNumericUncertainty(a.low, b.low), true];
-        // TODO: Do we need to support quantities here?
-      } else if (areDateTimes(a.low, b.low) && b.low.isMorePrecise(a.low)) {
-        [l, lc] = [other.low, other.lowClosed];
-      } else {
-        [l, lc] = [this.low, this.lowClosed];
-      }
-      let h, hc;
-      if (cmp.lessThanOrEquals(a.high, b.high)) {
-        [h, hc] = [this.high, this.highClosed];
-      } else if (cmp.greaterThanOrEquals(a.high, b.high)) {
-        [h, hc] = [other.high, other.highClosed];
-      } else if (areNumeric(a.high, b.high)) {
-        [h, hc] = [lowestNumericUncertainty(a.high, b.high), true];
-        // TODO: Do we need to support quantities here?
-      } else if (areDateTimes(a.high, b.high) && b.high.isMorePrecise(a.high)) {
-        [h, hc] = [other.high, other.highClosed];
-      } else {
-        [h, hc] = [this.high, this.highClosed];
-      }
-      return new Interval(l, h, lc, hc);
-    } else {
+
+    // "If the arguments do not overlap, this operator returns null."
+    if (!this.overlaps(other)) {
       return null;
     }
+
+    // "... the operator returns the interval that defines the overlapping portion of both
+    // arguments."
+    // Note: This spec definition isn't very precise, so we'll approach it similar to union:
+    // The interval that starts at the latest starting point in either argument, and ends at the
+    // earliest ending point in either argument.
+    let latestStart;
+    const thisIsLater = cmp.greaterThan(this.start(), other.start());
+    if (thisIsLater == null) {
+      latestStart = highestUncertainty(this.start(), other.start());
+    } else {
+      latestStart = thisIsLater ? this.start() : other.start();
+    }
+    let earliestEnd;
+    const thisIsEarlier = cmp.lessThan(this.end(), other.end());
+    if (thisIsEarlier == null) {
+      earliestEnd = lowestUncertainty(this.end(), other.end());
+    } else {
+      earliestEnd = thisIsEarlier ? this.end() : other.end();
+    }
+
+    return normalizeInterval(
+      new Interval(latestStart, earliestEnd, true, true, this.pointType ?? other.pointType)
+    );
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#except
   except(other: any) {
+    // "If either argument is null, the result is null."
     if (other === null) {
       return null;
-    }
-    if (other == null || !other.isInterval) {
+    } else if (!other.isInterval) {
       throw new Error('Argument to except must be an interval');
     }
 
-    const ol = this.overlaps(other);
-    if (ol === true) {
-      const olb = this.overlapsBefore(other);
-      const ola = this.overlapsAfter(other);
-      if (olb === true && ola === false) {
-        return new Interval(this.low, other.low, this.lowClosed, !other.lowClosed);
-      } else if (ola === true && olb === false) {
-        return new Interval(other.high, this.high, !other.highClosed, this.highClosed);
-      } else {
-        return null;
-      }
-    } else if (ol === false) {
-      return this;
-    } else {
-      // ol is null
-      return null;
+    // "... this operator returns the portion of the first interval that does not overlap with the
+    // second."
+    // Unresolved zulip: https://chat.fhir.org/#narrow/channel/179220-cql/topic/Unions.20on.20Date.20Intervals.20w.2F.20Different.20Precision/near/609516976
+    let precision;
+    if (
+      this.pointType === ELM_DATE_TYPE ||
+      this.pointType === ELM_DATETIME_TYPE ||
+      this.pointType === ELM_TIME_TYPE
+    ) {
+      const boundaries = [this.low, this.high, other.low, other.high];
+      const leastPreciseBoundary = boundaries.reduce((least, boundary) =>
+        boundary?.isLessPrecise(least) ? boundary : least
+      );
+      precision = leastPreciseBoundary?.getPrecision();
     }
+
+    if (this.overlaps(other, precision) === false) {
+      return this.copy();
+    }
+
+    const overlapsBefore = this.overlapsBefore(other, precision);
+    const overlapsAfter = this.overlapsAfter(other, precision);
+    if (overlapsBefore && !overlapsAfter) {
+      return normalizeInterval(
+        new Interval(this.start(), other.start(), true, false, this.pointType)
+      );
+    } else if (overlapsAfter && !overlapsBefore) {
+      return normalizeInterval(new Interval(other.end(), this.end(), false, true, this.pointType));
+    }
+
+    return null;
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#same-as-2
   sameAs(other: any, precision?: any) {
-    // This large if and else if block handles the scenarios where there is an open ended null
-    // If both lows or highs exists, it can be determined that intervals are not Same As
-    if (
-      (this.low != null &&
-        other.low != null &&
-        this.high == null &&
-        other.high != null &&
-        !this.highClosed) ||
-      (this.low != null &&
-        other.low != null &&
-        this.high != null &&
-        other.high == null &&
-        !other.highClosed) ||
-      (this.low != null &&
-        other.low != null &&
-        this.high == null &&
-        other.high == null &&
-        !other.highClosed &&
-        !this.highClosed)
-    ) {
-      if (typeof this.low === 'number' || typeof this.low === 'bigint') {
-        if (!(this.start() === other.start())) {
-          return false;
-        }
-      } else {
-        if (!this.start().sameAs(other.start(), precision)) {
-          return false;
-        }
-      }
-    } else if (
-      (this.low != null && other.low == null && this.high != null && other.high != null) ||
-      (this.low == null && other.low != null && this.high != null && other.high != null) ||
-      (this.low == null && other.low == null && this.high != null && other.high != null)
-    ) {
-      if (typeof this.high === 'number' || typeof this.high === 'bigint') {
-        if (!(this.end() === other.end())) {
-          return false;
-        }
-      } else {
-        if (!this.end().sameAs(other.end(), precision)) {
-          return false;
-        }
-      }
-    }
-
-    // Checks to see if any of the Intervals have a open, null boundary
-    if (
-      (this.low == null && !this.lowClosed) ||
-      (this.high == null && !this.highClosed) ||
-      (other.low == null && !other.lowClosed) ||
-      (other.high == null && !other.highClosed)
-    ) {
+    // "If either or both arguments are null, the result is null."
+    if (other === null) {
       return null;
     }
 
-    // For the special cases where @ is Interval[null,null]
-    if (this.lowClosed && this.low == null && this.highClosed && this.high == null) {
-      return other.lowClosed && other.low == null && other.highClosed && other.high == null;
-    }
+    // "When this operator is called with a mixture of Date- and DateTime-based intervals, the
+    // Date values will be implicitly converted to DateTime values as defined by the ToDateTime
+    // operator."
+    // NOTE: Usually the translator will handle this implicit conversion, but just in case...
+    const [left, right] = performConversionIfNecessary(this, other);
 
-    // For the special case where Interval[...] same as Interval[null,null] should return false.
-    // This accounts for the inverse of the if statement above: where the second Interval is
-    // [null,null] and not the first Interval.
-    // The reason why this isn't caught below is due to how start() and end() work.
-    // There is no way to tell the datatype for MIN and MAX if both boundaries are null.
-    if (other.lowClosed && other.low == null && other.highClosed && other.high == null) {
-      return false;
-    }
-
-    if (typeof this.low === 'number' || typeof this.low === 'bigint') {
-      return this.start() === other.start() && this.end() === other.end();
+    // "... the two intervals start and end at the same value, using the semantics described in the
+    // Start and End operators to determine interval boundaries, and for Date, DateTime, or Time
+    // value, performing the comparisons at the specified precision, as described in the Same As
+    // operator for Date, DateTime, or Time values."
+    if (
+      left.pointType === ELM_DATE_TYPE ||
+      left.pointType === ELM_DATETIME_TYPE ||
+      left.pointType === ELM_TIME_TYPE
+    ) {
+      return ThreeValuedLogic.and(
+        left.start().sameAs(right.start(), precision),
+        left.end().sameAs(right.end(), precision)
+      );
     } else {
-      return (
-        this.start().sameAs(other.start(), precision) && this.end().sameAs(other.end(), precision)
+      return ThreeValuedLogic.and(
+        cmp.equals(left.start(), right.start()),
+        cmp.equals(left.end(), right.end())
       );
     }
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#same-or-after-2
   sameOrBefore(other: any, precision?: any) {
-    if (this.isBoundlessInterval || other?.isBoundlessInterval) {
-      return this.equals(other);
-    }
-    if (this.end() == null || other == null || other.start() == null) {
+    // "If either or both arguments are null, the result is null."
+    if (other === null) {
       return null;
-    } else {
-      return cmp.lessThanOrEquals(this.end(), other.start(), precision);
     }
+
+    // "When this operator is called with a mixture of point values and intervals, the point
+    // values are implicitly converted to an interval starting and ending on the given point
+    // value."
+    if (!other.isInterval) {
+      other = new Interval(other, other, true, true, this.pointType);
+    }
+
+    // "When this operator is called with a mixture of Date- and DateTime-based intervals, the
+    // Date values will be implicitly converted to DateTime values as defined by the ToDateTime
+    // operator."
+    // NOTE: Usually the translator will handle this implicit conversion, but just in case...
+    const [left, right] = performConversionIfNecessary(this, other);
+
+    // "... the first interval ends on or before the second one starts, using the semantics
+    // described in the Start and End operators to determine interval boundaries, and for Date,
+    // DateTime, or Time values, performing the comparisons at the specified precision, as
+    // described in the Same or Before (Date, DateTime, or Time) operator for Date, DateTime, or
+    // Time values."
+    return cmp.lessThanOrEquals(left.end(), right.start(), precision);
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#same-or-after-2
   sameOrAfter(other: any, precision?: any) {
-    if (this.isBoundlessInterval || other?.isBoundlessInterval) {
-      return this.equals(other);
-    }
-    if (this.start() == null || other == null || other.end() == null) {
+    // "If either or both arguments are null, the result is null."
+    if (other === null) {
       return null;
-    } else {
-      return cmp.greaterThanOrEquals(this.start(), other.end(), precision);
     }
+
+    // "When this operator is called with a mixture of point values and intervals, the point
+    // values are implicitly converted to an interval starting and ending on the given point
+    // value."
+    if (!other.isInterval) {
+      other = new Interval(other, other, true, true, this.pointType);
+    }
+
+    // "When this operator is called with a mixture of Date- and DateTime-based intervals, the
+    // Date values will be implicitly converted to DateTime values as defined by the ToDateTime
+    // operator."
+    // NOTE: Usually the translator will handle this implicit conversion, but just in case...
+    const [left, right] = performConversionIfNecessary(this, other);
+
+    // "... the first interval starts on or after the second one ends, using the semantics
+    // described in the Start and End operators to determine interval boundaries, and for Date,
+    // DateTime, or Time values, performing the comparisons at the specified precision, as
+    // described in the Same or After (Date, DateTime, or Time) operator for Date, DateTime, or
+    // Time values."
+    return cmp.greaterThanOrEquals(left.start(), right.end(), precision);
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#equal-1
   equals(other: any) {
-    if (other != null && other.isInterval) {
-      if (this.isBoundlessInterval) {
-        return other.isBoundlessInterval ? true : other.isUnknownInterval ? null : false;
-      } else if (other.isBoundlessInterval) {
-        return this.isUnknownInterval ? null : false;
-      }
-      const [a, b] = [this.toClosed(), other.toClosed()];
-      return ThreeValuedLogic.and(cmp.equals(a.low, b.low), cmp.equals(a.high, b.high));
-    } else {
+    // "If either argument is null, the result is null."
+    if (other == null) {
+      return null;
+    }
+
+    // "... the intervals are over the same point type..."
+    if (this.pointType !== other.pointType) {
       return false;
     }
+
+    // ... and they have the same value for the starting and ending points of the intervals as
+    // determined by the Start and End operators."
+    return ThreeValuedLogic.and(
+      cmp.equals(this.start(), other.start()),
+      cmp.equals(this.end(), other.end())
+    );
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#after-1
   after(other: any, precision?: any) {
-    if (this.isBoundlessInterval || other?.isBoundlessInterval) {
-      return false;
+    // "If either argument is null, the result is null."
+    if (other == null) {
+      return null;
     }
-    const closed = this.toClosed();
-    // Meets spec, but not 100% correct (e.g., (null, 5] after [6, 10] --> null)
-    // Simple way to fix it: and w/ not overlaps
-    if (other.toClosed) {
-      return cmp.greaterThan(closed.low, other.toClosed().high, precision);
-    } else {
-      return cmp.greaterThan(closed.low, other, precision);
+
+    // "... For the interval-point overload, the operator returns true if the given interval
+    // starts after the given point."
+    if (!other.isInterval) {
+      return cmp.greaterThan(this.start(), other, precision);
     }
+
+    // "... the starting point of the first interval is greater than the ending point of the
+    // second interval."
+    return cmp.greaterThan(this.start(), other.end(), precision);
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#before-1
   before(other: any, precision?: any) {
-    if (this.isBoundlessInterval || other?.isBoundlessInterval) {
-      return false;
+    // "If either argument is null, the result is null."
+    if (other == null) {
+      return null;
     }
-    const closed = this.toClosed();
-    // Meets spec, but not 100% correct (e.g., (null, 5] after [6, 10] --> null)
-    // Simple way to fix it: and w/ not overlaps
-    if (other.toClosed) {
-      return cmp.lessThan(closed.high, other.toClosed().low, precision);
-    } else {
-      return cmp.lessThan(closed.high, other, precision);
+
+    // "For the interval-point overload, the operator returns true if the given interval ends
+    // before the given point."
+    if (!other.isInterval) {
+      return cmp.lessThan(this.end(), other, precision);
     }
+
+    // "... the ending point of the first interval is less than the starting point of the
+    // second interval."
+    return cmp.lessThan(this.end(), other.start(), precision);
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#meets
   meets(other: any, precision?: any) {
-    if (this.isBoundlessInterval || other?.isBoundlessInterval) {
-      return false;
+    // "If either argument is null, the result is null."
+    if (other == null) {
+      return null;
     }
+
+    // "... the ending point of the first interval is equal to the predecessor of the starting
+    // point of the second, or... the starting point of the first interval is equal to the
+    // successor of the ending point of the second... If precision is specified and the point type
+    // is a Date, DateTime, or Time type, comparisons used in the operation are performed at the
+    // specified precision."
     return ThreeValuedLogic.or(
       this.meetsBefore(other, precision),
       this.meetsAfter(other, precision)
     );
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#meets
   meetsAfter(other: any, precision?: any) {
-    if (this.isBoundlessInterval || other?.isBoundlessInterval) {
-      return false;
+    // "If either argument is null, the result is null."
+    if (other == null) {
+      return null;
     }
+
+    // "... the starting point of the first interval is equal to the successor of the ending point
+    // of the second... If precision is specified and the point type is a Date, DateTime, or Time
+    // type, comparisons used in the operation are performed at the specified precision."
     try {
-      if (precision != null && this.low != null && this.low.isDateTime) {
-        return this.toClosed().low.sameAs(
-          other.toClosed().high != null ? other.toClosed().high.add(1, precision) : null,
-          precision
-        );
-      } else {
-        return cmp.equals(this.toClosed().low, successor(other.toClosed().high, other.pointType));
+      if (
+        this.pointType === ELM_DATE_TYPE ||
+        this.pointType === ELM_DATETIME_TYPE ||
+        this.pointType === ELM_TIME_TYPE
+      ) {
+        return this.start()?.sameAs(successor(other.end(), other.pointType, precision), precision);
       }
+
+      return cmp.equals(this.start(), successor(other.end(), other.pointType));
     } catch {
       return false;
     }
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#meets
   meetsBefore(other: any, precision?: any) {
-    if (this.isBoundlessInterval || other?.isBoundlessInterval) {
-      return false;
+    // "If either argument is null, the result is null."
+    if (other == null) {
+      return null;
     }
+
+    // "... the ending point of the first interval is equal to the predecessor of the starting
+    // point of the second... If precision is specified and the point type is a Date, DateTime, or
+    // Time type, comparisons used in the operation are performed at the specified precision."
     try {
-      if (precision != null && this.high != null && this.high.isDateTime) {
-        return this.toClosed().high.sameAs(
-          other.toClosed().low != null ? other.toClosed().low.add(-1, precision) : null,
+      if (
+        this.pointType === ELM_DATE_TYPE ||
+        this.pointType === ELM_DATETIME_TYPE ||
+        this.pointType === ELM_TIME_TYPE
+      ) {
+        return this.end()?.sameAs(
+          predecessor(other.start(), other.pointType, precision),
           precision
         );
-      } else {
-        return cmp.equals(this.toClosed().high, predecessor(other.toClosed().low, other.pointType));
       }
+
+      return cmp.equals(this.end(), predecessor(other.start(), other.pointType));
     } catch {
       return false;
     }
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#start
   start() {
+    // "If the low boundary of the interval is closed and null, this operator returns the minimum
+    // value for the point type of the interval."
     if (this.low == null) {
       const quantityInstance =
         this.high && this.pointType == ELM_QUANTITY_TYPE ? this.high : undefined;
@@ -532,16 +557,25 @@ export class Interval {
       if (this.lowClosed || minValue == null) {
         return minValue;
       } else {
+        // "If the low boundary of the interval is open and null, this operator returns an
+        // uncertainty from the minimum value for the point type of the interval to the high
+        // boundary of the interval (using End operator semantics to determine the high boundary)."
         const end = ((end: any) => (end.isUncertainty ? end.high : end))(
           this.high == null ? maxValueForType(this.pointType) : this.end()
         );
         return new Uncertainty(minValue, end);
       }
     }
+    // "If the low boundary of the interval is closed and non-null, this operator returns the low
+    // value of the interval... If the low boundary of the interval is open and non-null, this
+    // operator returns the successor of the low value of the interval."
     return this.lowClosed ? this.low : successor(this.low, this.pointType);
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#end
   end() {
+    // "If the high boundary of the interval is closed and null, this operator returns the maximum
+    // value for the point type of the interval."
     if (this.high == null) {
       const quantityInstance =
         this.low && this.pointType == ELM_QUANTITY_TYPE ? this.low : undefined;
@@ -549,134 +583,147 @@ export class Interval {
       if (this.highClosed || maxValue == null) {
         return maxValue;
       } else {
+        // "If the high boundary of the interval is open and null, this operator returns an
+        // uncertainty from the low boundary of the interval (using Start operator semantics to
+        // determine the low boundary) to the maximum value for the point type of the interval."
         const start = ((start: any) => (start.isUncertainty ? start.low : start))(
           this.low == null ? minValueForType(this.pointType) : this.start()
         );
         return new Uncertainty(start, maxValue);
       }
     }
+    // "If the high boundary of the interval is closed and non-null, this operator returns the high
+    // value of the interval... If the high boundary of the interval is open and non-null, this
+    // operator returns the predecessor of the high value of the interval."
     return this.highClosed ? this.high : predecessor(this.high, this.pointType);
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#starts
   starts(other: any, precision?: any) {
-    if (this.isBoundlessInterval) {
-      return other.isBoundlessInterval ? true : other.isUnknownInterval ? null : false;
-    } else if (other?.isBoundlessInterval) {
-      return this.isUnknownInterval ? null : false;
+    // "If either argument is null, the result is null."
+    if (other == null) {
+      return null;
     }
-    let startEqual;
-    if (precision != null && this.low != null && this.low.isDateTime) {
-      startEqual = this.low.sameAs(other.low, precision);
-    } else {
-      startEqual = cmp.equals(this.low, other.low);
-    }
-    const endLessThanOrEqual = cmp.lessThanOrEquals(this.high, other.high, precision);
-    return startEqual && endLessThanOrEqual;
-  }
 
-  ends(other: any, precision?: any) {
-    if (this.isBoundlessInterval) {
-      return other.isBoundlessInterval ? true : other.isUnknownInterval ? null : false;
-    } else if (other?.isBoundlessInterval) {
-      return this.isUnknownInterval ? null : false;
-    }
-    let endEqual;
-    const startGreaterThanOrEqual = cmp.greaterThanOrEquals(this.low, other.low, precision);
-    if (precision != null && (this.low != null ? this.low.isDateTime : undefined)) {
-      endEqual = this.high.sameAs(other.high, precision);
-    } else {
-      endEqual = cmp.equals(this.high, other.high);
-    }
-    return startGreaterThanOrEqual && endEqual;
-  }
-
-  width() {
+    // "... the starting point of the first is equal to the starting point of the second interval
+    // and the ending point of the first interval is less than or equal to the ending point of the
+    // second interval."
     if (
-      (this.low != null && (this.low.isDateTime || this.low.isDate)) ||
-      (this.high != null && (this.high.isDateTime || this.high.isDate))
+      precision &&
+      [ELM_DATETIME_TYPE, ELM_DATE_TYPE, ELM_TIME_TYPE].includes(this.pointType ?? other.pointType)
+    ) {
+      // "If precision is specified and the point type is a Date, DateTime, or Time type,
+      // comparisons used in the operation are performed at the specified precision."
+      return ThreeValuedLogic.and(
+        this.start().sameAs(other.start(), precision),
+        cmp.lessThanOrEquals(this.end(), other.end(), precision)
+      );
+    } else {
+      return ThreeValuedLogic.and(
+        cmp.equals(this.start(), other.start()),
+        cmp.lessThanOrEquals(this.end(), other.end())
+      );
+    }
+  }
+
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#ends
+  ends(other: any, precision?: any) {
+    // "If either argument is null, the result is null."
+    if (other == null) {
+      return null;
+    }
+
+    // "... the starting point of the first interval is greater than or equal to the starting point
+    // of the second, and the ending point of the first interval is equal to the ending point of
+    // the second."
+    if (
+      precision &&
+      [ELM_DATETIME_TYPE, ELM_DATE_TYPE, ELM_TIME_TYPE].includes(this.pointType ?? other.pointType)
+    ) {
+      // "If precision is specified and the point type is a Date, DateTime, or Time type,
+      // comparisons used in the operation are performed at the specified precision."
+      return ThreeValuedLogic.and(
+        cmp.greaterThanOrEquals(this.start(), other.start(), precision),
+        this.end().sameAs(other.end(), precision)
+      );
+    } else {
+      return ThreeValuedLogic.and(
+        cmp.greaterThanOrEquals(this.start(), other.start()),
+        cmp.equals(this.end(), other.end())
+      );
+    }
+  }
+
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#width
+  width() {
+    // "Note that because CQL defines duration and difference operations for date and time valued
+    // intervals, width is not defined for intervals of these types."
+    if (
+      this.pointType === ELM_DATE_TYPE ||
+      this.pointType === ELM_DATETIME_TYPE ||
+      this.pointType === ELM_TIME_TYPE
     ) {
       throw new Error('Width of Date, DateTime, and Time intervals is not supported');
     }
 
-    const closed = this.toClosed();
-    if (
-      (closed.low != null && closed.low.isUncertainty) ||
-      (closed.high != null && closed.high.isUncertainty)
-    ) {
-      return null;
-    } else if (closed.low.isQuantity) {
-      if (closed.low.unit !== closed.high.unit) {
-        throw new Error('Cannot calculate width of Quantity Interval with different units');
-      }
-
-      let diff = closed.high.value - closed.low.value;
-      diff = Math.round(diff * Math.pow(10, 8)) / Math.pow(10, 8);
-      return new Quantity(diff, closed.low.unit);
-    } else if (typeof closed.low === 'bigint') {
-      return closed.high - closed.low;
-    } else {
-      // TODO: Fix precision to 8 decimals in other places that return numbers
-      const diff = closed.high - closed.low;
-      return Math.round(diff * Math.pow(10, 8)) / Math.pow(10, 8);
-    }
+    // "The result of this operator is equivalent to invoking: (end of argument – start of argument)."
+    const end = this.end();
+    const start = this.start();
+    return limitDecimalPrecision(subtract(end, start, this.pointType));
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#size
   size() {
+    // "Note that because CQL defines duration and difference operations for date and time valued
+    // intervals, size is not defined for intervals of these types."
     if (
-      (this.low != null && (this.low.isDateTime || this.low.isDate)) ||
-      (this.high != null && (this.high.isDateTime || this.high.isDate))
+      this.pointType === ELM_DATE_TYPE ||
+      this.pointType === ELM_DATETIME_TYPE ||
+      this.pointType === ELM_TIME_TYPE
     ) {
       throw new Error('Size of Date, DateTime, and Time intervals is not supported');
     }
 
-    const closed = this.toClosed();
-    if (
-      (closed.low != null && closed.low.isUncertainty) ||
-      (closed.high != null && closed.high.isUncertainty)
-    ) {
-      return null;
-    }
-
-    const pointSize = this.getPointSize();
-    if (closed.low.isQuantity) {
-      if (closed.low.unit !== closed.high.unit) {
-        throw new Error('Cannot calculate size of Quantity Interval with different units');
-      }
-
-      let diff = closed.high.value - closed.low.value + pointSize.value;
-      diff = Math.round(diff * Math.pow(10, 8)) / Math.pow(10, 8);
-      return new Quantity(diff, closed.low.unit);
-    } else if (typeof closed.low === 'bigint') {
-      return closed.high - closed.low + pointSize;
-    } else {
-      const diff = closed.high - closed.low + pointSize;
-      return Math.round(diff * Math.pow(10, 8)) / Math.pow(10, 8);
-    }
+    // "The result of this operator is equivalent to invoking:
+    // (end of argument – start of argument) + point-size, where point-size is determined by
+    // successor of minimum T - minimum T."
+    return limitDecimalPrecision(
+      add(subtract(this.end(), this.start(), this.pointType), this.getPointSize(), this.pointType)
+    );
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#size
   getPointSize() {
-    let pointSize;
-    if (this.low != null) {
-      if (this.low.isDateTime || this.low.isDate || this.low.isTime) {
-        pointSize = new Quantity(1, this.low.getPrecision());
-      } else if (this.low.isQuantity) {
-        pointSize = doSubtraction(successor(this.low, this.pointType), this.low);
-      } else {
-        pointSize = successor(this.low, this.pointType) - this.low;
-      }
-    } else if (this.high != null) {
-      if (this.high.isDateTime || this.high.isDate || this.high.isTime) {
-        pointSize = new Quantity(1, this.high.getPrecision());
-      } else if (this.high.isQuantity) {
-        pointSize = doSubtraction(this.high, predecessor(this.high, this.pointType));
-      } else {
-        pointSize = this.high - predecessor(this.high, this.pointType);
-      }
+    // "... point-size is determined by successor of minimum T - minimum T"
+    let minValue;
+    if (this.pointType != null && this.pointType !== ELM_ANY_TYPE) {
+      minValue = minValueForType(
+        this.pointType,
+        this.pointType === ELM_QUANTITY_TYPE ? (this.low ?? this.high) : undefined
+      );
     } else {
-      throw new Error('Point type of interval cannot be determined.');
+      minValue = minValueForInstance(this.low ?? this.high);
     }
 
-    return pointSize;
+    // due to floating point issues in JS, we must use 0.0 for Decimal/Quantity instead of min
+    if (minValue === MIN_FLOAT_VALUE) {
+      minValue = 0.0;
+    } else if ((minValue as any).isQuantity) {
+      (minValue as Quantity).value = 0.0;
+    }
+
+    if (minValue != null) {
+      if ((minValue as any).isDate || (minValue as any).isDatetime || (minValue as any).isTime) {
+        // Legacy approach: we have been using minimum specified precision to get point size for
+        // Date/DateTime/Time intervals. This makes sense to us (vs always using ms) but the spec
+        // doesn't indicate this so we need to verify the expected implementation w/ the spec team.
+        // E.g., point size of Interval[@2012-01, @2012-12] is 1 month, not 1 ms.
+        return new Quantity(1, (this.low ?? this.high).getPrecision());
+      }
+      return subtract(successor(minValue, this.pointType), minValue, this.pointType);
+    }
+
+    throw new Error('Point type of interval cannot be determined.');
   }
 
   toClosed() {
@@ -684,7 +731,7 @@ export class Interval {
     // we cannot close the boundary because that changes its meaning from "unknown" to "max/min value"
     const lowClosed = this.lowClosed || this.low != null;
     const highClosed = this.highClosed || this.high != null;
-    if (this.pointType != null) {
+    if (this.pointType != null && this.pointType !== ELM_ANY_TYPE) {
       let low;
       if (this.lowClosed && this.low == null) {
         low = minValueForType(this.pointType);
@@ -720,48 +767,136 @@ export class Interval {
   }
 }
 
-function areDateTimes(x: any, y: any) {
-  return [x, y].every(z => z != null && z.isDateTime);
+// Return an interval that uses the standard null boundary conventions if appropriate:
+// - low closed boundary with min value for the type is changed to null closed boundary
+// - high closed boundary with max value for the type is changed to null closed boundary
+// - low open boundary that is uncertainty from min value of type to max value or interval high
+//   value is changed to null open boundary
+// - high open boundary that is uncertainty from min value of type or interval low value to max
+//   value of type is changed to null open boundary
+//
+// TODO: Is this necessary? Do we care how it is represented if the representations have the same
+// meaning? This does affect test expectations and representation of returned results for callers.
+function normalizeInterval(interval: Interval) {
+  const ivl = interval.copy();
+  if (ivl.low != null && ivl.lowClosed !== false) {
+    if (ivl.low.isUncertainty) {
+      const minValue = minValueForInstance(ivl.low.low);
+      const maxValue = maxValueForInstance(ivl.low.low);
+      if (
+        cmp.equals(ivl.low.low, minValue) &&
+        (cmp.equals(ivl.low.high, maxValue) || cmp.equals(ivl.low.high, ivl.high))
+      ) {
+        ivl.low = null;
+        ivl.lowClosed = false;
+      }
+    } else if (cmp.equals(ivl.low, minValueForInstance(ivl.low))) {
+      ivl.low = null;
+    }
+  }
+  if (ivl.high != null && ivl.highClosed !== false) {
+    if (ivl.high.isUncertainty) {
+      const minValue = minValueForInstance(ivl.high.low);
+      const maxValue = maxValueForInstance(ivl.high.low);
+      if (
+        cmp.equals(ivl.high.high, maxValue) &&
+        (cmp.equals(ivl.high.low, minValue) || cmp.equals(ivl.high.low, ivl.low))
+      ) {
+        ivl.high = null;
+        ivl.highClosed = false;
+      }
+    } else if (cmp.equals(ivl.high, maxValueForInstance(ivl.high))) {
+      ivl.high = null;
+    }
+  }
+
+  return ivl;
 }
 
-function areNumeric(x: any, y: any) {
-  return [x, y].every(z => {
-    return (
-      typeof z === 'number' ||
-      typeof z === 'bigint' ||
-      (z != null && z.isUncertainty && (typeof z.low === 'number' || typeof z.low === 'bigint'))
+function performConversionIfNecessary(left: Interval, right: Interval) {
+  if (left.pointType === ELM_DATE_TYPE && right.pointType === ELM_DATETIME_TYPE) {
+    left = new Interval(
+      left.low?.getDateTime(),
+      left.high?.getDateTime(),
+      left.lowClosed,
+      left.highClosed,
+      ELM_DATETIME_TYPE
     );
-  });
+  } else if (left.pointType === ELM_DATETIME_TYPE && right.pointType === ELM_DATE_TYPE) {
+    right = new Interval(
+      right.low?.getDateTime(),
+      right.high?.getDateTime(),
+      right.lowClosed,
+      right.highClosed,
+      ELM_DATETIME_TYPE
+    );
+  }
+  return [left, right];
 }
 
-function lowestNumericUncertainty(x: any, y: any) {
-  if (x == null || !x.isUncertainty) {
+function lowestUncertainty(x: any, y: any) {
+  if (!x?.isUncertainty) {
     x = new Uncertainty(x);
   }
-  if (y == null || !y.isUncertainty) {
+  if (!y?.isUncertainty) {
     y = new Uncertainty(y);
   }
-  const low = x.low < y.low ? x.low : y.low;
-  const high = x.high < y.high ? x.high : y.high;
-  if (low !== high) {
-    return new Uncertainty(low, high);
+
+  // Note: If the following comparisons result in null, we're dealing with date imprecision.
+  // The spec doesn't currently say what to do; but it will be updated to indicate that the
+  // coursest precision should be used (which is consistent with collapse)
+  // https://chat.fhir.org/#narrow/channel/179220-cql/topic/Unions.20on.20Date.20Intervals.20w.2F.20Different.20Precision/near/609310186
+  let low;
+  const xLowIsLower = cmp.lessThan(x.low, y.low);
+  if (xLowIsLower == null && x.low?.isLessPrecise) {
+    low = x.low.isLessPrecise(y.low) ? x.low : y.low;
   } else {
+    low = xLowIsLower ? x.low : y.low;
+  }
+  let high;
+  const xHighIsLower = cmp.lessThan(x.high, y.high);
+  if (xHighIsLower == null && x.high?.isLessPrecise) {
+    high = x.high.isLessPrecise(y.high) ? x.high : y.high;
+  } else {
+    high = xHighIsLower ? x.high : y.high;
+  }
+  // use equivalent to consider nulls equal
+  if (cmp.equivalent(low, high)) {
     return low;
   }
+  return new Uncertainty(low, high);
 }
 
-function highestNumericUncertainty(x: any, y: any) {
-  if (x == null || !x.isUncertainty) {
+function highestUncertainty(x: any, y: any) {
+  if (!x?.isUncertainty) {
     x = new Uncertainty(x);
   }
-  if (y == null || !y.isUncertainty) {
+  if (!y?.isUncertainty) {
     y = new Uncertainty(y);
   }
-  const low = x.low > y.low ? x.low : y.low;
-  const high = x.high > y.high ? x.high : y.high;
-  if (low !== high) {
-    return new Uncertainty(low, high);
+
+  // Note: If the following comparisons result in null, we're dealing with date imprecision.
+  // The spec doesn't currently say what to do; but it will be updated to indicate that the
+  // coursest precision should be used (which is consistent with collapse)
+  // https://chat.fhir.org/#narrow/channel/179220-cql/topic/Unions.20on.20Date.20Intervals.20w.2F.20Different.20Precision/near/609310186
+  let low;
+  const xLowIsHigher = cmp.greaterThan(x.low, y.low);
+  if (xLowIsHigher == null && x.low?.isLessPrecise) {
+    low = x.low.isLessPrecise(y.low) ? x.low : y.low;
   } else {
+    low = xLowIsHigher ? x.low : y.low;
+  }
+  let high;
+  const xHighIsHigher = cmp.greaterThan(x.high, y.high);
+  if (xHighIsHigher == null && x.high?.isLessPrecise) {
+    high = x.high.isLessPrecise(y.high) ? x.high : y.high;
+  } else {
+    high = xHighIsHigher ? x.high : y.high;
+  }
+
+  // use equivalent to consider nulls equal
+  if (cmp.equivalent(low, high)) {
     return low;
   }
+  return new Uncertainty(low, high);
 }

--- a/src/datatypes/interval.ts
+++ b/src/datatypes/interval.ts
@@ -526,24 +526,36 @@ export class Interval {
 
   start() {
     if (this.low == null) {
-      if (this.lowClosed) {
-        return minValueForInstance(this.high);
+      const quantityInstance =
+        this.high && this.pointType == ELM_QUANTITY_TYPE ? this.high : undefined;
+      const minValue = minValueForType(this.pointType, quantityInstance);
+      if (this.lowClosed || minValue == null) {
+        return minValue;
       } else {
-        return this.low;
+        const end = ((end: any) => (end.isUncertainty ? end.high : end))(
+          this.high == null ? maxValueForType(this.pointType) : this.end()
+        );
+        return new Uncertainty(minValue, end);
       }
     }
-    return this.toClosed().low;
+    return this.lowClosed ? this.low : successor(this.low, this.pointType);
   }
 
   end() {
     if (this.high == null) {
-      if (this.highClosed) {
-        return maxValueForInstance(this.low);
+      const quantityInstance =
+        this.low && this.pointType == ELM_QUANTITY_TYPE ? this.low : undefined;
+      const maxValue = maxValueForType(this.pointType, quantityInstance);
+      if (this.highClosed || maxValue == null) {
+        return maxValue;
       } else {
-        return this.high;
+        const start = ((start: any) => (start.isUncertainty ? start.low : start))(
+          this.low == null ? minValueForType(this.pointType) : this.start()
+        );
+        return new Uncertainty(start, maxValue);
       }
     }
-    return this.toClosed().high;
+    return this.highClosed ? this.high : predecessor(this.high, this.pointType);
   }
 
   starts(other: any, precision?: any) {

--- a/src/datatypes/interval.ts
+++ b/src/datatypes/interval.ts
@@ -78,19 +78,22 @@ export class Interval {
       newHigh = this.high.copy();
     }
 
-    return new Interval(newLow, newHigh, this.lowClosed, this.highClosed);
+    return new Interval(newLow, newHigh, this.lowClosed, this.highClosed, this.defaultPointType);
   }
 
   contains(item: any, precision?: any) {
-    // These first two checks ensure correct handling of edge case where an item equals the closed boundary
+    if (item != null && item.isInterval) {
+      throw new Error('Argument to contains must be a point');
+    }
+    if (this.isBoundlessInterval) {
+      return true;
+    }
+    // Ensure correct handling of edge case where an item equals the closed boundary
     if (this.lowClosed && this.low != null && cmp.equals(this.low, item)) {
       return true;
     }
     if (this.highClosed && this.high != null && cmp.equals(this.high, item)) {
       return true;
-    }
-    if (item != null && item.isInterval) {
-      throw new Error('Argument to contains must be a point');
     }
     let lowFn;
     if (this.lowClosed && this.low == null) {
@@ -137,6 +140,11 @@ export class Interval {
   }
 
   includes(other: any, precision?: any) {
+    if (this.isBoundlessInterval) {
+      return true;
+    } else if (other?.isBoundlessInterval) {
+      return this.isUnknownInterval ? null : false;
+    }
     if (other == null || !other.isInterval) {
       return this.contains(other, precision);
     }
@@ -216,6 +224,11 @@ export class Interval {
     if (other == null || !other.isInterval) {
       throw new Error('Argument to union must be an interval');
     }
+    if (this.isBoundlessInterval) {
+      return this.copy();
+    } else if (other.isBoundlessInterval) {
+      return other.copy();
+    }
     // Note that interval union is only defined if the arguments overlap or meet.
     if (this.overlaps(other) || this.meets(other)) {
       const [a, b] = [this.toClosed(), other.toClosed()];
@@ -255,7 +268,12 @@ export class Interval {
     if (other == null || !other.isInterval) {
       throw new Error('Argument to union must be an interval');
     }
-    // Note that interval union is only defined if the arguments overlap.
+    if (this.isBoundlessInterval) {
+      return other.copy();
+    } else if (other.isBoundlessInterval) {
+      return this.copy();
+    }
+    // Note that interval intersect is only defined if the arguments overlap.
     if (this.overlaps(other)) {
       const [a, b] = [this.toClosed(), other.toClosed()];
       let l, lc;
@@ -397,6 +415,9 @@ export class Interval {
   }
 
   sameOrBefore(other: any, precision?: any) {
+    if (this.isBoundlessInterval || other?.isBoundlessInterval) {
+      return this.equals(other);
+    }
     if (this.end() == null || other == null || other.start() == null) {
       return null;
     } else {
@@ -405,6 +426,9 @@ export class Interval {
   }
 
   sameOrAfter(other: any, precision?: any) {
+    if (this.isBoundlessInterval || other?.isBoundlessInterval) {
+      return this.equals(other);
+    }
     if (this.start() == null || other == null || other.end() == null) {
       return null;
     } else {
@@ -414,6 +438,11 @@ export class Interval {
 
   equals(other: any) {
     if (other != null && other.isInterval) {
+      if (this.isBoundlessInterval) {
+        return other.isBoundlessInterval ? true : other.isUnknownInterval ? null : false;
+      } else if (other.isBoundlessInterval) {
+        return this.isUnknownInterval ? null : false;
+      }
       const [a, b] = [this.toClosed(), other.toClosed()];
       return ThreeValuedLogic.and(cmp.equals(a.low, b.low), cmp.equals(a.high, b.high));
     } else {
@@ -422,6 +451,9 @@ export class Interval {
   }
 
   after(other: any, precision?: any) {
+    if (this.isBoundlessInterval || other?.isBoundlessInterval) {
+      return false;
+    }
     const closed = this.toClosed();
     // Meets spec, but not 100% correct (e.g., (null, 5] after [6, 10] --> null)
     // Simple way to fix it: and w/ not overlaps
@@ -433,6 +465,9 @@ export class Interval {
   }
 
   before(other: any, precision?: any) {
+    if (this.isBoundlessInterval || other?.isBoundlessInterval) {
+      return false;
+    }
     const closed = this.toClosed();
     // Meets spec, but not 100% correct (e.g., (null, 5] after [6, 10] --> null)
     // Simple way to fix it: and w/ not overlaps
@@ -444,6 +479,9 @@ export class Interval {
   }
 
   meets(other: any, precision?: any) {
+    if (this.isBoundlessInterval || other?.isBoundlessInterval) {
+      return false;
+    }
     return ThreeValuedLogic.or(
       this.meetsBefore(other, precision),
       this.meetsAfter(other, precision)
@@ -451,6 +489,9 @@ export class Interval {
   }
 
   meetsAfter(other: any, precision?: any) {
+    if (this.isBoundlessInterval || other?.isBoundlessInterval) {
+      return false;
+    }
     try {
       if (precision != null && this.low != null && this.low.isDateTime) {
         return this.toClosed().low.sameAs(
@@ -466,6 +507,9 @@ export class Interval {
   }
 
   meetsBefore(other: any, precision?: any) {
+    if (this.isBoundlessInterval || other?.isBoundlessInterval) {
+      return false;
+    }
     try {
       if (precision != null && this.high != null && this.high.isDateTime) {
         return this.toClosed().high.sameAs(
@@ -503,6 +547,11 @@ export class Interval {
   }
 
   starts(other: any, precision?: any) {
+    if (this.isBoundlessInterval) {
+      return other.isBoundlessInterval ? true : other.isUnknownInterval ? null : false;
+    } else if (other?.isBoundlessInterval) {
+      return this.isUnknownInterval ? null : false;
+    }
     let startEqual;
     if (precision != null && this.low != null && this.low.isDateTime) {
       startEqual = this.low.sameAs(other.low, precision);
@@ -514,6 +563,11 @@ export class Interval {
   }
 
   ends(other: any, precision?: any) {
+    if (this.isBoundlessInterval) {
+      return other.isBoundlessInterval ? true : other.isUnknownInterval ? null : false;
+    } else if (other?.isBoundlessInterval) {
+      return this.isUnknownInterval ? null : false;
+    }
     let endEqual;
     const startGreaterThanOrEqual = cmp.greaterThanOrEquals(this.low, other.low, precision);
     if (precision != null && (this.low != null ? this.low.isDateTime : undefined)) {

--- a/src/datatypes/interval.ts
+++ b/src/datatypes/interval.ts
@@ -93,23 +93,26 @@ export class Interval {
     );
   }
 
+  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#properly-includes
   properContains(item: any, precision?: any) {
+    // From contains: "If the second argument is null, the result is null."
     if (item == null) {
       return null;
     } else if (item.isInterval) {
       throw new Error('Argument to contains must be a point');
     }
+    // "For the interval-point overload, this operator returns true if the interval contains
+    // (i.e. includes) the point, and the interval is not a unit interval containing only the
+    // point."
     return ThreeValuedLogic.and(
-      cmp.lessThan(this.start(), item, precision),
-      cmp.greaterThan(this.end(), item, precision)
+      this.contains(item, precision),
+      ThreeValuedLogic.not(cmp.equals(this.start(), this.end()))
     );
   }
 
   // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#properly-includes
   properlyIncludes(other: any, precision?: any) {
-    // TODO: "For the interval-point overload, this operator returns true if the interval contains
-    // (i.e. includes) the point, and the interval is not a unit interval containing only the
-    // point."
+    // "For the interval-interval overload, if either argument is null, the result is null."
     if (other == null || !other.isInterval) {
       throw new Error('Argument to properlyIncludes must be an interval');
     }

--- a/src/datatypes/quantity.ts
+++ b/src/datatypes/quantity.ts
@@ -1,5 +1,11 @@
 import { ELM_DECIMAL_TYPE } from '../util/elmTypes';
-import { decimalAdjust, isValidDecimal, overflowsOrUnderflows } from '../util/math';
+import {
+  decimalAdjust,
+  isValidDecimal,
+  MIN_FLOAT_VALUE,
+  MAX_FLOAT_VALUE,
+  overflowsOrUnderflows
+} from '../util/math';
 import {
   checkUnit,
   convertUnit,
@@ -156,6 +162,11 @@ export class Quantity {
     return new Quantity(decimalAdjust('round', resultValue, -8), resultUnit);
   }
 }
+
+// Require MIN/MAX here because math.js requires this file, and when we make this file require
+// math.js before it exports DateTime and Date, it errors due to the circular dependency...
+export const MIN_QUANTITY_VALUE = new Quantity(MIN_FLOAT_VALUE, '1');
+export const MAX_QUANTITY_VALUE = new Quantity(MAX_FLOAT_VALUE, '1');
 
 export function parseQuantity(str: string) {
   const components = /([+|-]?\d+\.?\d*)\s*('(.+)')?/.exec(str);

--- a/src/datatypes/quantity.ts
+++ b/src/datatypes/quantity.ts
@@ -1,16 +1,9 @@
 import { ELM_DECIMAL_TYPE } from '../util/elmTypes';
-import {
-  decimalAdjust,
-  isValidDecimal,
-  MIN_FLOAT_VALUE,
-  MAX_FLOAT_VALUE,
-  overflowsOrUnderflows
-} from '../util/math';
+import { decimalAdjust, add, subtract, isValidDecimal, overflowsOrUnderflows } from '../util/math';
 import {
   checkUnit,
   convertUnit,
   normalizeUnitsWhenPossible,
-  convertToCQLDateUnit,
   getProductOfUnits,
   getQuotientOfUnits
 } from '../util/units';
@@ -163,11 +156,6 @@ export class Quantity {
   }
 }
 
-// Require MIN/MAX here because math.js requires this file, and when we make this file require
-// math.js before it exports DateTime and Date, it errors due to the circular dependency...
-export const MIN_QUANTITY_VALUE = new Quantity(MIN_FLOAT_VALUE, '1');
-export const MAX_QUANTITY_VALUE = new Quantity(MAX_FLOAT_VALUE, '1');
-
 export function parseQuantity(str: string) {
   const components = /([+|-]?\d+\.?\d*)\s*('(.+)')?/.exec(str);
   if (components != null && components[1] != null) {
@@ -187,38 +175,12 @@ export function parseQuantity(str: string) {
   }
 }
 
-function doScaledAddition(a: any, b: any, scaleForB: any) {
-  if (a != null && a.isQuantity && b != null && b.isQuantity) {
-    const [val1, unit1, val2, unit2] = normalizeUnitsWhenPossible(
-      a.value,
-      a.unit,
-      b.value * scaleForB,
-      b.unit
-    );
-    if (unit1 !== unit2) {
-      // not compatible units, so we can't do addition
-      return null;
-    }
-    const sum = val1 + val2;
-    if (overflowsOrUnderflows(sum, ELM_DECIMAL_TYPE)) {
-      return null;
-    }
-    return new Quantity(sum, unit1);
-  } else if (a.copy && a.add) {
-    // Date / DateTime require a CQL time unit
-    const cqlUnitB = convertToCQLDateUnit(b.unit) || b.unit;
-    return a.copy().add(b.value * scaleForB, cqlUnitB);
-  } else {
-    throw new Error('Unsupported argument types.');
-  }
-}
-
 export function doAddition(a: any, b: any) {
-  return doScaledAddition(a, b, 1);
+  return add(a, b);
 }
 
 export function doSubtraction(a: any, b: any) {
-  return doScaledAddition(a, b, -1);
+  return subtract(a, b);
 }
 
 export function doDivision(a: any, b: any) {

--- a/src/datatypes/uncertainty.ts
+++ b/src/datatypes/uncertainty.ts
@@ -89,6 +89,36 @@ export class Uncertainty {
     );
   }
 
+  sameAs(other: any, precision?: any) {
+    // if this is a point, and other is not an uncertainty or a point, then we can compare directly
+    if (this.isPoint()) {
+      const sameFn = (a: any, b: any) => {
+        if (typeof a !== typeof b || a?.constructor !== b?.constructor) {
+          return false;
+        }
+
+        if (typeof a.sameAs === 'function') {
+          return a.sameAs(b, precision);
+        } else {
+          return equals(a, b);
+        }
+      };
+
+      if (!(other instanceof Uncertainty)) {
+        return sameFn(this.low, other);
+      }
+
+      if (other.isPoint()) {
+        return sameFn(this.low, other.low);
+      }
+    }
+
+    other = Uncertainty.from(other);
+    return ThreeValuedLogic.not(
+      ThreeValuedLogic.or(this.lessThan(other, precision), this.greaterThan(other, precision))
+    );
+  }
+
   equals(other: any) {
     // if this is a point, and other is not an uncertainty or a point, then we can compare directly
     if (this.isPoint()) {
@@ -105,14 +135,14 @@ export class Uncertainty {
     return ThreeValuedLogic.not(ThreeValuedLogic.or(this.lessThan(other), this.greaterThan(other)));
   }
 
-  lessThan(other: any) {
+  lessThan(other: any, precision?: any) {
     const lt = (a: any, b: any) => {
       if (typeof a !== typeof b || a?.constructor !== b?.constructor) {
         return null;
       }
 
       if (typeof a.before === 'function') {
-        return a.before(b);
+        return a.before(b, precision);
       } else {
         return a < b;
       }
@@ -127,15 +157,15 @@ export class Uncertainty {
     }
   }
 
-  greaterThan(other: any) {
-    return Uncertainty.from(other).lessThan(this);
+  greaterThan(other: any, precision?: any) {
+    return Uncertainty.from(other).lessThan(this, precision);
   }
 
-  lessThanOrEquals(other: any) {
-    return ThreeValuedLogic.not(this.greaterThan(Uncertainty.from(other)));
+  lessThanOrEquals(other: any, precision?: any) {
+    return ThreeValuedLogic.not(this.greaterThan(Uncertainty.from(other), precision));
   }
 
-  greaterThanOrEquals(other: any) {
-    return ThreeValuedLogic.not(this.lessThan(Uncertainty.from(other)));
+  greaterThanOrEquals(other: any, precision?: any) {
+    return ThreeValuedLogic.not(this.lessThan(Uncertainty.from(other), precision));
   }
 }

--- a/src/elm/arithmetic.ts
+++ b/src/elm/arithmetic.ts
@@ -1,16 +1,18 @@
 import { Expression } from './expression';
 import * as MathUtil from '../util/math';
-import {
-  Quantity,
-  doAddition,
-  doSubtraction,
-  doMultiplication,
-  doDivision
-} from '../datatypes/quantity';
+import { Quantity, doMultiplication, doDivision } from '../datatypes/quantity';
 import { Uncertainty } from '../datatypes/uncertainty';
 import { Context } from '../runtime/context';
 import { build } from './builder';
-import { DateTime } from '../datatypes/datetime';
+import {
+  DateTime,
+  MAX_DATE_VALUE,
+  MAX_DATETIME_VALUE,
+  MAX_TIME_VALUE,
+  MIN_DATE_VALUE,
+  MIN_DATETIME_VALUE,
+  MIN_TIME_VALUE
+} from '../datatypes/datetime';
 import {
   ELM_DECIMAL_TYPE,
   ELM_DATETIME_TYPE,
@@ -19,6 +21,14 @@ import {
   ELM_LONG_TYPE,
   ELM_TIME_TYPE
 } from '../util/elmTypes';
+import {
+  MAX_FLOAT_VALUE,
+  MAX_INT_VALUE,
+  MAX_LONG_VALUE,
+  MIN_FLOAT_VALUE,
+  MIN_INT_VALUE,
+  MIN_LONG_VALUE
+} from '../util/limits';
 
 export class Add extends Expression {
   constructor(json: any) {
@@ -31,35 +41,7 @@ export class Add extends Expression {
       return null;
     }
 
-    const sum = args.reduce((x: any, y: any) => {
-      if (x.isUncertainty && !y.isUncertainty) {
-        y = new Uncertainty(y, y);
-      } else if (y.isUncertainty && !x.isUncertainty) {
-        x = new Uncertainty(x, x);
-      }
-
-      if (x.isQuantity || x.isDateTime || x.isDate || (x.isTime && x.isTime())) {
-        return doAddition(x, y);
-      } else if (x.isUncertainty && y.isUncertainty) {
-        if (
-          x.low.isQuantity ||
-          x.low.isDateTime ||
-          x.low.isDate ||
-          (x.low.isTime && x.low.isTime())
-        ) {
-          return new Uncertainty(doAddition(x.low, y.low), doAddition(x.high, y.high));
-        } else {
-          return new Uncertainty(x.low + y.low, x.high + y.high);
-        }
-      } else {
-        return x + y;
-      }
-    });
-
-    if (MathUtil.overflowsOrUnderflows(sum, this.resultTypeName)) {
-      return null;
-    }
-    return sum;
+    return MathUtil.add(args[0], args[1], this.resultTypeName);
   }
 }
 
@@ -74,30 +56,7 @@ export class Subtract extends Expression {
       return null;
     }
 
-    const difference = args.reduce((x: any, y: any) => {
-      if (x.isUncertainty && !y.isUncertainty) {
-        y = new Uncertainty(y, y);
-      } else if (y.isUncertainty && !x.isUncertainty) {
-        x = new Uncertainty(x, x);
-      }
-
-      if (x.isQuantity || x.isDateTime || x.isDate) {
-        return doSubtraction(x, y);
-      } else if (x.isUncertainty && y.isUncertainty) {
-        if (x.low.isQuantity || x.low.isDateTime || x.low.isDate) {
-          return new Uncertainty(doSubtraction(x.low, y.high), doSubtraction(x.high, y.low));
-        } else {
-          return new Uncertainty(x.low - y.high, x.high - y.low);
-        }
-      } else {
-        return x - y;
-      }
-    });
-
-    if (MathUtil.overflowsOrUnderflows(difference, this.resultTypeName)) {
-      return null;
-    }
-    return difference;
+    return MathUtil.subtract(args[0], args[1], this.resultTypeName);
   }
 }
 
@@ -448,12 +407,12 @@ function doPower(x: any, y: any) {
 
 export class MinValue extends Expression {
   static readonly MIN_VALUES = {
-    [ELM_INTEGER_TYPE]: MathUtil.MIN_INT_VALUE,
-    [ELM_LONG_TYPE]: MathUtil.MIN_LONG_VALUE,
-    [ELM_DECIMAL_TYPE]: MathUtil.MIN_FLOAT_VALUE,
-    [ELM_DATETIME_TYPE]: MathUtil.MIN_DATETIME_VALUE,
-    [ELM_DATE_TYPE]: MathUtil.MIN_DATE_VALUE,
-    [ELM_TIME_TYPE]: MathUtil.MIN_TIME_VALUE
+    [ELM_INTEGER_TYPE]: MIN_INT_VALUE,
+    [ELM_LONG_TYPE]: MIN_LONG_VALUE,
+    [ELM_DECIMAL_TYPE]: MIN_FLOAT_VALUE,
+    [ELM_DATETIME_TYPE]: MIN_DATETIME_VALUE,
+    [ELM_DATE_TYPE]: MIN_DATE_VALUE,
+    [ELM_TIME_TYPE]: MIN_TIME_VALUE
   };
 
   valueType: keyof typeof MinValue.MIN_VALUES;
@@ -480,12 +439,12 @@ export class MinValue extends Expression {
 
 export class MaxValue extends Expression {
   static readonly MAX_VALUES = {
-    [ELM_INTEGER_TYPE]: MathUtil.MAX_INT_VALUE,
-    [ELM_LONG_TYPE]: MathUtil.MAX_LONG_VALUE,
-    [ELM_DECIMAL_TYPE]: MathUtil.MAX_FLOAT_VALUE,
-    [ELM_DATETIME_TYPE]: MathUtil.MAX_DATETIME_VALUE,
-    [ELM_DATE_TYPE]: MathUtil.MAX_DATE_VALUE,
-    [ELM_TIME_TYPE]: MathUtil.MAX_TIME_VALUE
+    [ELM_INTEGER_TYPE]: MAX_INT_VALUE,
+    [ELM_LONG_TYPE]: MAX_LONG_VALUE,
+    [ELM_DECIMAL_TYPE]: MAX_FLOAT_VALUE,
+    [ELM_DATETIME_TYPE]: MAX_DATETIME_VALUE,
+    [ELM_DATE_TYPE]: MAX_DATE_VALUE,
+    [ELM_TIME_TYPE]: MAX_TIME_VALUE
   };
 
   valueType: keyof typeof MaxValue.MAX_VALUES;

--- a/src/elm/expression.ts
+++ b/src/elm/expression.ts
@@ -3,6 +3,7 @@ import { typeIsArray } from '../util/util';
 import { AnnotatedError } from '../util/customErrors';
 import { build } from './builder';
 import { Library } from './library';
+import { AnyTypeSpecifier } from '../types';
 
 export class Expression {
   localId?: string;
@@ -10,6 +11,7 @@ export class Expression {
   arg?: Expression;
   args?: Expression[];
   resultTypeName?: string;
+  resultTypeSpecifier?: AnyTypeSpecifier;
 
   constructor(json: any) {
     if (json.operand != null) {
@@ -31,6 +33,10 @@ export class Expression {
 
     if (json.resultTypeName != null) {
       this.resultTypeName = json.resultTypeName;
+    }
+
+    if (json.resultTypeSpecifier != null) {
+      this.resultTypeSpecifier = json.resultTypeSpecifier;
     }
   }
 

--- a/src/elm/interval.ts
+++ b/src/elm/interval.ts
@@ -1,11 +1,13 @@
 import { Expression } from './expression';
-import { Quantity, doAddition } from '../datatypes/quantity';
-import { successor, predecessor, MAX_DATETIME_VALUE, MIN_DATETIME_VALUE } from '../util/math';
+import { MAX_DATETIME_VALUE, MIN_DATETIME_VALUE } from '../datatypes/datetime';
+import { Quantity } from '../datatypes/quantity';
+import { add, successor, predecessor } from '../util/math';
 import { convertUnit, compareUnits, convertToCQLDateUnit } from '../util/units';
 import * as dtivl from '../datatypes/interval';
 import { Context } from '../runtime/context';
 import { build } from './builder';
-import { ELM_NAMED_TYPE_SPECIFIER } from '../util/elmTypes';
+import { IntervalTypeSpecifier, NamedTypeSpecifier } from '../types/type-specifiers.interfaces';
+import { ELM_ANY_TYPE, ELM_NAMED_TYPE_SPECIFIER } from '../util/elmTypes';
 
 export class Interval extends Expression {
   lowClosed: boolean;
@@ -14,6 +16,7 @@ export class Interval extends Expression {
   highClosedExpression: any;
   low: any;
   high: any;
+  pointType?: string;
 
   constructor(json: any) {
     super(json);
@@ -23,6 +26,9 @@ export class Interval extends Expression {
     this.highClosedExpression = build(json.highClosedExpression);
     this.low = build(json.low);
     this.high = build(json.high);
+    this.pointType = (
+      (this.resultTypeSpecifier as IntervalTypeSpecifier)?.pointType as NamedTypeSpecifier
+    )?.name;
   }
 
   // Define a simple getter to allow type-checking of this class without instanceof
@@ -42,19 +48,19 @@ export class Interval extends Expression {
       this.highClosed != null
         ? this.highClosed
         : this.highClosedExpression && (await this.highClosedExpression.execute(ctx));
-    let defaultPointType;
-    if (lowValue == null && highValue == null) {
-      // try to get the default point type from a cast
+    let effectivePointType = this.pointType;
+    if (effectivePointType == null || effectivePointType === ELM_ANY_TYPE) {
+      // try to get the point type from a cast
       if (this.low.asTypeSpecifier && this.low.asTypeSpecifier.type === ELM_NAMED_TYPE_SPECIFIER) {
-        defaultPointType = this.low.asTypeSpecifier.name;
+        effectivePointType = this.low.asTypeSpecifier.name;
       } else if (
         this.high.asTypeSpecifier &&
         this.high.asTypeSpecifier.type === ELM_NAMED_TYPE_SPECIFIER
       ) {
-        defaultPointType = this.high.asTypeSpecifier.name;
+        effectivePointType = this.high.asTypeSpecifier.name;
       }
     }
-    return new dtivl.Interval(lowValue, highValue, lowClosed, highClosed, defaultPointType);
+    return new dtivl.Interval(lowValue, highValue, lowClosed, highClosed, effectivePointType);
   }
 }
 
@@ -414,6 +420,7 @@ function intervalListType(intervals: any) {
   return type;
 }
 
+// TODO: Move and refactor Expand implementaton into src/datatypes/interval.ts
 export class Expand extends Expression {
   constructor(json: any) {
     super(json);
@@ -523,12 +530,18 @@ export class Expand extends Expression {
     high = this.truncateToPrecision(high, per.unit);
 
     let current_high = current_low.add(per.value, per.unit).predecessor();
-    let intervalToAdd = new dtivl.Interval(current_low, current_high, true, true);
+    let intervalToAdd = new dtivl.Interval(
+      current_low,
+      current_high,
+      true,
+      true,
+      interval.pointType
+    );
     while (intervalToAdd.high.sameOrBefore(high)) {
       results.push(intervalToAdd);
       current_low = current_low.add(per.value, per.unit);
       current_high = current_low.add(per.value, per.unit).predecessor();
-      intervalToAdd = new dtivl.Interval(current_low, current_high, true, true);
+      intervalToAdd = new dtivl.Interval(current_low, current_high, true, true, interval.pointType);
     }
 
     return results;
@@ -687,6 +700,7 @@ export class Expand extends Expression {
   }
 }
 
+// TODO: Move and refactor Collapse implementaton into src/datatypes/interval.ts
 export class Collapse extends Expression {
   constructor(json: any) {
     super(json);
@@ -791,7 +805,7 @@ function collapseIntervals(intervals: any, perWidth: any) {
           a = b;
         }
       } else if (b.low && typeof b.low.sameOrBefore === 'function') {
-        if (a.high != null && b.low.sameOrBefore(doAddition(a.high, perWidth))) {
+        if (a.high != null && b.low.sameOrBefore(add(a.high, perWidth))) {
           if (b.high == null || b.high.after(a.high)) {
             a.high = b.high;
           }

--- a/src/elm/type.ts
+++ b/src/elm/type.ts
@@ -3,10 +3,15 @@ import { Context } from '../runtime/context';
 import { Expression, UnimplementedExpression } from './expression';
 import { DateTime, Date } from '../datatypes/datetime';
 import { Concept } from '../datatypes/clinical';
+import { Interval as dtInterval } from '../datatypes/interval';
 import { Quantity, parseQuantity } from '../datatypes/quantity';
 import { isValidDecimal, isValidInteger, isValidLong, limitDecimalPrecision } from '../util/math';
 import { normalizeMillisecondsField } from '../util/util';
 import { Ratio } from '../datatypes/ratio';
+import {
+  IntervalTypeSpecifier as IntervalTypeSpecifierType,
+  NamedTypeSpecifier as NamedTypedSpecifierType
+} from '../types/type-specifiers.interfaces';
 import { Uncertainty } from '../datatypes/uncertainty';
 import {
   ELM_NAMED_TYPE_SPECIFIER,
@@ -25,6 +30,7 @@ import {
   ELM_INTERVAL_TYPE_SPECIFIER,
   ELM_CHOICE_TYPE_SPECIFIER
 } from '../util/elmTypes';
+import { Interval } from './interval';
 
 // TODO: Casting and Conversion needs unit tests!
 
@@ -53,6 +59,22 @@ export class As extends Expression {
       return null;
     }
     if (ctx.matchesTypeSpecifier(arg, this.asTypeSpecifier)) {
+      // intervals track their point type, so adjust the interval point type if it does not match
+      if (arg.isInterval && this.asTypeSpecifier.type === ELM_INTERVAL_TYPE_SPECIFIER) {
+        const argInterval = arg as Interval;
+        const asIntervalSpecifier = this.asTypeSpecifier as IntervalTypeSpecifierType;
+        const asIntervalPointType = (asIntervalSpecifier.pointType as NamedTypedSpecifierType)
+          ?.name;
+        if (asIntervalPointType && argInterval.pointType !== asIntervalPointType) {
+          return new dtInterval(
+            argInterval.low,
+            argInterval.high,
+            argInterval.lowClosed,
+            argInterval.highClosed,
+            asIntervalPointType
+          );
+        }
+      }
       // TODO: request patient source to change type identification
       return arg;
     } else if (this.strict) {

--- a/src/util/comparison.ts
+++ b/src/util/comparison.ts
@@ -1,4 +1,4 @@
-import { Uncertainty } from '../datatypes/datatypes';
+import { Uncertainty } from '../datatypes/uncertainty';
 
 function areNumbers(a: any, b: any) {
   return typeof a === 'number' && typeof b === 'number';

--- a/src/util/comparison.ts
+++ b/src/util/comparison.ts
@@ -30,9 +30,9 @@ export function lessThan(a: any, b: any, precision?: any) {
   } else if (areDateTimesOrQuantities(a, b)) {
     return a.before(b, precision);
   } else if (isUncertainty(a)) {
-    return a.lessThan(b);
+    return a.lessThan(b, precision);
   } else if (isUncertainty(b)) {
-    return Uncertainty.from(a).lessThan(b);
+    return Uncertainty.from(a).lessThan(b, precision);
   } else {
     return null;
   }
@@ -44,9 +44,9 @@ export function lessThanOrEquals(a: any, b: any, precision?: any) {
   } else if (areDateTimesOrQuantities(a, b)) {
     return a.sameOrBefore(b, precision);
   } else if (isUncertainty(a)) {
-    return a.lessThanOrEquals(b);
+    return a.lessThanOrEquals(b, precision);
   } else if (isUncertainty(b)) {
-    return Uncertainty.from(a).lessThanOrEquals(b);
+    return Uncertainty.from(a).lessThanOrEquals(b, precision);
   } else {
     return null;
   }
@@ -58,9 +58,9 @@ export function greaterThan(a: any, b: any, precision?: any) {
   } else if (areDateTimesOrQuantities(a, b)) {
     return a.after(b, precision);
   } else if (isUncertainty(a)) {
-    return a.greaterThan(b);
+    return a.greaterThan(b, precision);
   } else if (isUncertainty(b)) {
-    return Uncertainty.from(a).greaterThan(b);
+    return Uncertainty.from(a).greaterThan(b, precision);
   } else {
     return null;
   }
@@ -72,9 +72,9 @@ export function greaterThanOrEquals(a: any, b: any, precision?: any) {
   } else if (areDateTimesOrQuantities(a, b)) {
     return a.sameOrAfter(b, precision);
   } else if (isUncertainty(a)) {
-    return a.greaterThanOrEquals(b);
+    return a.greaterThanOrEquals(b, precision);
   } else if (isUncertainty(b)) {
-    return Uncertainty.from(a).greaterThanOrEquals(b);
+    return Uncertainty.from(a).greaterThanOrEquals(b, precision);
   } else {
     return null;
   }

--- a/src/util/elmTypes.ts
+++ b/src/util/elmTypes.ts
@@ -1,4 +1,5 @@
 // Simple Types
+export const ELM_ANY_TYPE = '{urn:hl7-org:elm-types:r1}Any';
 export const ELM_BOOLEAN_TYPE = '{urn:hl7-org:elm-types:r1}Boolean';
 export const ELM_CONCEPT_TYPE = '{urn:hl7-org:elm-types:r1}Concept';
 export const ELM_DATE_TYPE = '{urn:hl7-org:elm-types:r1}Date';

--- a/src/util/limits.ts
+++ b/src/util/limits.ts
@@ -1,0 +1,17 @@
+// Keep primitive limits and temporal limit literals dependency-free so datatype and utility
+// modules can safely share them without introducing circular module initialization.
+export const MAX_INT_VALUE = Math.pow(2, 31) - 1; // 2147483647
+export const MIN_INT_VALUE = Math.pow(-2, 31); // -2147483648
+export const MAX_LONG_VALUE = 9223372036854775807n;
+export const MIN_LONG_VALUE = -9223372036854775808n;
+export const MAX_FLOAT_VALUE = 99999999999999999999.99999999;
+export const MIN_FLOAT_VALUE = -99999999999999999999.99999999;
+export const MIN_FLOAT_PRECISION_VALUE = Math.pow(10, -8);
+
+// The constructed min/max Date/DateTime/Time are exported from src/datatypes/datetime.ts
+export const MIN_DATETIME_VALUE_STRING = '0001-01-01T00:00:00.000';
+export const MAX_DATETIME_VALUE_STRING = '9999-12-31T23:59:59.999';
+export const MIN_DATE_VALUE_STRING = '0001-01-01';
+export const MAX_DATE_VALUE_STRING = '9999-12-31';
+export const MIN_TIME_VALUE_STRING = '0000-01-01T00:00:00.000';
+export const MAX_TIME_VALUE_STRING = '0000-01-01T23:59:59.999';

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -1,12 +1,12 @@
 import { Exception } from '../datatypes/exception';
-import { Quantity, MIN_QUANTITY_VALUE, MAX_QUANTITY_VALUE } from '../datatypes/quantity';
+import { Quantity } from '../datatypes/quantity';
 import {
-  MIN_DATETIME_VALUE as dtMinDateTimeValue,
-  MAX_DATETIME_VALUE as dtMaxDateTimeValue,
-  MIN_DATE_VALUE as dtMinDateValue,
-  MAX_DATE_VALUE as dtMaxDateValue,
-  MIN_TIME_VALUE as dtMinTimeValue,
-  MAX_TIME_VALUE as dtMaxTimeValue
+  MIN_DATETIME_VALUE,
+  MAX_DATETIME_VALUE,
+  MIN_DATE_VALUE,
+  MAX_DATE_VALUE,
+  MIN_TIME_VALUE,
+  MAX_TIME_VALUE
 } from '../datatypes/datetime';
 import { Uncertainty } from '../datatypes/uncertainty';
 import {
@@ -18,20 +18,16 @@ import {
   ELM_TIME_TYPE,
   ELM_QUANTITY_TYPE
 } from './elmTypes';
-
-export const MAX_INT_VALUE = Math.pow(2, 31) - 1; // 2147483647
-export const MIN_INT_VALUE = Math.pow(-2, 31); // -2147483648
-export const MAX_LONG_VALUE = 9223372036854775807n;
-export const MIN_LONG_VALUE = -9223372036854775808n;
-export const MAX_FLOAT_VALUE = 99999999999999999999.99999999;
-export const MIN_FLOAT_VALUE = -99999999999999999999.99999999;
-export const MIN_FLOAT_PRECISION_VALUE = Math.pow(10, -8);
-export const MIN_DATETIME_VALUE = dtMinDateTimeValue;
-export const MAX_DATETIME_VALUE = dtMaxDateTimeValue;
-export const MIN_DATE_VALUE = dtMinDateValue;
-export const MAX_DATE_VALUE = dtMaxDateValue;
-export const MIN_TIME_VALUE = dtMinTimeValue;
-export const MAX_TIME_VALUE = dtMaxTimeValue;
+import {
+  MAX_FLOAT_VALUE,
+  MAX_INT_VALUE,
+  MAX_LONG_VALUE,
+  MIN_FLOAT_PRECISION_VALUE,
+  MIN_FLOAT_VALUE,
+  MIN_INT_VALUE,
+  MIN_LONG_VALUE
+} from './limits';
+import { convertToCQLDateUnit, normalizeUnitsWhenPossible } from './units';
 
 export function overflowsOrUnderflows(value: any, type?: string): boolean {
   if (value == null) {
@@ -126,26 +122,103 @@ export function isValidDecimal(decimal: any) {
   return true;
 }
 
-export function limitDecimalPrecision(decimal: any) {
-  let decimalString = decimal.toString();
-  // For decimals so large that they are represented in scientific notation, javascript has already limited
-  // the decimal to its own constraints, so we can't determine the original precision.  Leave as-is unless
-  // this becomes problematic, in which case we would need our own parseFloat.
-  if (decimalString.indexOf('e') !== -1) {
-    return decimal;
+export function add(a: any, b: any, type?: string): any {
+  if (a == null || b == null) {
+    return null;
+  }
+  if (a?.isUncertainty || b?.isUncertainty) {
+    const aLow = a?.isUncertainty ? a.low : a;
+    const aHigh = a?.isUncertainty ? a.high : a;
+    const bLow = b?.isUncertainty ? b.low : b;
+    const bHigh = b?.isUncertainty ? b.high : b;
+    const low = add(aLow, bLow, type);
+    const high = add(aHigh, bHigh, type);
+    return low == null || high == null ? null : new Uncertainty(low, high);
   }
 
-  const splitDecimalString = decimalString.split('.');
-  const decimalPoints = splitDecimalString[1];
-  if (decimalPoints != null && decimalPoints.length > 8) {
-    decimalString = splitDecimalString[0] + '.' + splitDecimalString[1].substring(0, 8);
+  if (typeof a === 'bigint') {
+    const sum = a + (typeof b === 'bigint' ? b : BigInt(b));
+    return overflowsOrUnderflows(sum, ELM_LONG_TYPE) ? null : sum;
   }
-  return parseFloat(decimalString);
+  if (typeof b === 'bigint') {
+    const sum = BigInt(a) + b;
+    return overflowsOrUnderflows(sum, ELM_LONG_TYPE) ? null : sum;
+  }
+  if (typeof a === 'number' && typeof b === 'number') {
+    const sum = a + b;
+    const numberType =
+      type ?? (Number.isInteger(a) && Number.isInteger(b) ? ELM_INTEGER_TYPE : ELM_DECIMAL_TYPE);
+    return overflowsOrUnderflows(sum, numberType) ? null : sum;
+  }
+  if (a?.isQuantity && b?.isQuantity) {
+    const [aValue, aUnit, bValue, bUnit] = normalizeUnitsWhenPossible(
+      a.value,
+      a.unit,
+      b.value,
+      b.unit
+    );
+    if (aUnit !== bUnit) {
+      return null;
+    }
+    const sum = aValue + bValue;
+    return overflowsOrUnderflows(sum, ELM_DECIMAL_TYPE) ? null : new Quantity(sum, aUnit);
+  }
+  if (b?.isQuantity && (a?.isDate || a?.isDateTime || (a?.isTime && a.isTime()))) {
+    const unit = convertToCQLDateUnit(b.unit) || b.unit;
+    const sum = a.copy().add(b.value, unit);
+    return overflowsOrUnderflows(sum) ? null : sum;
+  }
+
+  throw new Error('Unsupported argument types.');
+}
+
+export function subtract(a: any, b: any, type?: string): any {
+  if (a == null || b == null) {
+    return null;
+  }
+  if (a?.isUncertainty || b?.isUncertainty) {
+    const aLow = a?.isUncertainty ? a.low : a;
+    const aHigh = a?.isUncertainty ? a.high : a;
+    const bLow = b?.isUncertainty ? b.low : b;
+    const bHigh = b?.isUncertainty ? b.high : b;
+    const low = subtract(aLow, bHigh, type);
+    const high = subtract(aHigh, bLow, type);
+    return low == null || high == null ? null : new Uncertainty(low, high);
+  }
+  if (typeof b === 'number' || typeof b === 'bigint') {
+    return add(a, -b, type);
+  }
+  if (b?.isQuantity) {
+    return add(a, { isQuantity: true, value: -b.value, unit: b.unit }, type);
+  }
+
+  throw new Error('Unsupported argument types.');
+}
+
+export function limitDecimalPrecision<T extends number | bigint | Quantity | Uncertainty>(
+  val?: T
+): T | undefined {
+  if (val == null) {
+    return val;
+  } else if (typeof val === 'number') {
+    return (Math.round(val * Math.pow(10, 8)) / Math.pow(10, 8)) as T;
+  } else if ((val as Quantity).isQuantity) {
+    return new Quantity(
+      limitDecimalPrecision((val as Quantity).value),
+      (val as Quantity).unit
+    ) as T;
+  } else if ((val as Uncertainty).isUncertainty) {
+    return new Uncertainty(
+      limitDecimalPrecision((val as Uncertainty).low),
+      limitDecimalPrecision((val as Uncertainty).high)
+    ) as T;
+  }
+  return val;
 }
 
 export class OverFlowException extends Exception {}
 
-export function successor(val: any, type?: string): any {
+export function successor(val: any, type?: string, precision?: string): any {
   if (typeof val === 'number') {
     const isInteger = type === ELM_INTEGER_TYPE || (type == null && Number.isInteger(val));
     if (isInteger) {
@@ -171,30 +244,30 @@ export function successor(val: any, type?: string): any {
     if (val.sameAs(MAX_TIME_VALUE)) {
       throw new OverFlowException();
     } else {
-      return val.successor();
+      return val.successor(precision);
     }
   } else if (val && val.isDateTime) {
     if (val.sameAs(MAX_DATETIME_VALUE)) {
       throw new OverFlowException();
     } else {
-      return val.successor();
+      return val.successor(precision);
     }
   } else if (val && val.isDate) {
     if (val.sameAs(MAX_DATE_VALUE)) {
       throw new OverFlowException();
     } else {
-      return val.successor();
+      return val.successor(precision);
     }
   } else if (val && val.isUncertainty) {
     // For uncertainties, if the high is the max val, don't increment it
     const high = (() => {
       try {
-        return successor(val.high, type);
+        return successor(val.high, type, precision);
       } catch {
         return val.high;
       }
     })();
-    return new Uncertainty(successor(val.low, type), high);
+    return new Uncertainty(successor(val.low, type, precision), high);
   } else if (val && val.isQuantity) {
     const succ = val.clone();
     succ.value = successor(val.value, ELM_DECIMAL_TYPE);
@@ -204,7 +277,7 @@ export function successor(val: any, type?: string): any {
   }
 }
 
-export function predecessor(val: any, type?: string): any {
+export function predecessor(val: any, type?: string, precision?: string): any {
   if (typeof val === 'number') {
     const isInteger = type === ELM_INTEGER_TYPE || (type == null && Number.isInteger(val));
     if (isInteger) {
@@ -230,30 +303,30 @@ export function predecessor(val: any, type?: string): any {
     if (val.sameAs(MIN_TIME_VALUE)) {
       throw new OverFlowException();
     } else {
-      return val.predecessor();
+      return val.predecessor(precision);
     }
   } else if (val && val.isDateTime) {
     if (val.sameAs(MIN_DATETIME_VALUE)) {
       throw new OverFlowException();
     } else {
-      return val.predecessor();
+      return val.predecessor(precision);
     }
   } else if (val && val.isDate) {
     if (val.sameAs(MIN_DATE_VALUE)) {
       throw new OverFlowException();
     } else {
-      return val.predecessor();
+      return val.predecessor(precision);
     }
   } else if (val && val.isUncertainty) {
     // For uncertainties, if the low is the min val, don't decrement it
     const low = ((): any => {
       try {
-        return predecessor(val.low, type);
+        return predecessor(val.low, type, precision);
       } catch {
         return val.low;
       }
     })();
-    return new Uncertainty(low, predecessor(val.high, type));
+    return new Uncertainty(low, predecessor(val.high, type, precision));
   } else if (val && val.isQuantity) {
     const pred = val.clone();
     pred.value = predecessor(val.value, ELM_DECIMAL_TYPE);
@@ -282,11 +355,7 @@ export function maxValueForInstance(val: any) {
     // Although the spec says max Quantity has unit '1', it doesn't make sense to change the unit,
     // especially if this is being used in the context of an interval or uncertainty since the
     // left and right sides need to be comparable in those cases.
-    const maxQuantity = MAX_QUANTITY_VALUE.clone();
-    if (val.unit) {
-      maxQuantity.unit = val.unit;
-    }
-    return maxQuantity;
+    return new Quantity(MAX_FLOAT_VALUE, val.unit || '1');
   } else {
     return null;
   }
@@ -310,14 +379,7 @@ export function maxValueForType(type: string, quantityInstance?: Quantity) {
       // Although the spec says max Quantity has unit '1', it doesn't make sense to change the unit,
       // especially if this is being used in the context of an interval or uncertainty since the
       // left and right sides need to be comparable in those cases.
-      const maxQuantity = MAX_QUANTITY_VALUE.clone();
-      if (quantityInstance == null) {
-        return maxQuantity;
-      }
-      if (quantityInstance.unit) {
-        maxQuantity.unit = quantityInstance.unit;
-      }
-      return maxQuantity;
+      return new Quantity(MAX_FLOAT_VALUE, quantityInstance?.unit || '1');
     }
   }
   return null;
@@ -342,11 +404,7 @@ export function minValueForInstance(val: any) {
     // Although the spec says max Quantity has unit '1', it doesn't make sense to change the unit,
     // especially if this is being used in the context of an interval or uncertainty since the
     // left and right sides need to be comparable in those cases.
-    const minQuantity = MIN_QUANTITY_VALUE.clone();
-    if (val.unit) {
-      minQuantity.unit = val.unit;
-    }
-    return minQuantity;
+    return new Quantity(MIN_FLOAT_VALUE, val.unit || '1');
   } else {
     return null;
   }
@@ -370,14 +428,7 @@ export function minValueForType(type: string, quantityInstance?: Quantity) {
       // Although the spec says max Quantity has unit '1', it doesn't make sense to change the unit,
       // especially if this is being used in the context of an interval or uncertainty since the
       // left and right sides need to be comparable in those cases.
-      const minQuantity = MIN_QUANTITY_VALUE.clone();
-      if (quantityInstance == null) {
-        return minQuantity;
-      }
-      if (quantityInstance.unit) {
-        minQuantity.unit = quantityInstance.unit;
-      }
-      return minQuantity;
+      return new Quantity(MIN_FLOAT_VALUE, quantityInstance?.unit || '1');
     }
   }
   return null;

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -1,5 +1,5 @@
 import { Exception } from '../datatypes/exception';
-import { Quantity } from '../datatypes/quantity';
+import { Quantity, MIN_QUANTITY_VALUE, MAX_QUANTITY_VALUE } from '../datatypes/quantity';
 import {
   MIN_DATETIME_VALUE as dtMinDateTimeValue,
   MAX_DATETIME_VALUE as dtMaxDateTimeValue,
@@ -279,9 +279,14 @@ export function maxValueForInstance(val: any) {
   } else if (val && val.isDate) {
     return MAX_DATE_VALUE?.copy();
   } else if (val && val.isQuantity) {
-    const val2 = val.clone();
-    val2.value = maxValueForInstance(val2.value);
-    return val2;
+    // Although the spec says max Quantity has unit '1', it doesn't make sense to change the unit,
+    // especially if this is being used in the context of an interval or uncertainty since the
+    // left and right sides need to be comparable in those cases.
+    const maxQuantity = MAX_QUANTITY_VALUE.clone();
+    if (val.unit) {
+      maxQuantity.unit = val.unit;
+    }
+    return maxQuantity;
   } else {
     return null;
   }
@@ -302,13 +307,17 @@ export function maxValueForType(type: string, quantityInstance?: Quantity) {
     case ELM_TIME_TYPE:
       return MAX_TIME_VALUE?.copy();
     case ELM_QUANTITY_TYPE: {
+      // Although the spec says max Quantity has unit '1', it doesn't make sense to change the unit,
+      // especially if this is being used in the context of an interval or uncertainty since the
+      // left and right sides need to be comparable in those cases.
+      const maxQuantity = MAX_QUANTITY_VALUE.clone();
       if (quantityInstance == null) {
-        // can't infer a quantity unit type from nothing]
-        return null;
+        return maxQuantity;
       }
-      const maxQty = quantityInstance.clone();
-      maxQty.value = MAX_FLOAT_VALUE;
-      return maxQty;
+      if (quantityInstance.unit) {
+        maxQuantity.unit = quantityInstance.unit;
+      }
+      return maxQuantity;
     }
   }
   return null;
@@ -330,9 +339,14 @@ export function minValueForInstance(val: any) {
   } else if (val && val.isDate) {
     return MIN_DATE_VALUE?.copy();
   } else if (val && val.isQuantity) {
-    const val2 = val.clone();
-    val2.value = minValueForInstance(val2.value);
-    return val2;
+    // Although the spec says max Quantity has unit '1', it doesn't make sense to change the unit,
+    // especially if this is being used in the context of an interval or uncertainty since the
+    // left and right sides need to be comparable in those cases.
+    const minQuantity = MIN_QUANTITY_VALUE.clone();
+    if (val.unit) {
+      minQuantity.unit = val.unit;
+    }
+    return minQuantity;
   } else {
     return null;
   }
@@ -353,13 +367,17 @@ export function minValueForType(type: string, quantityInstance?: Quantity) {
     case ELM_TIME_TYPE:
       return MIN_TIME_VALUE?.copy();
     case ELM_QUANTITY_TYPE: {
+      // Although the spec says max Quantity has unit '1', it doesn't make sense to change the unit,
+      // especially if this is being used in the context of an interval or uncertainty since the
+      // left and right sides need to be comparable in those cases.
+      const minQuantity = MIN_QUANTITY_VALUE.clone();
       if (quantityInstance == null) {
-        // can't infer a quantity unit type from nothing]
-        return null;
+        return minQuantity;
       }
-      const minQty = quantityInstance.clone();
-      minQty.value = MIN_FLOAT_VALUE;
-      return minQty;
+      if (quantityInstance.unit) {
+        minQuantity.unit = quantityInstance.unit;
+      }
+      return minQuantity;
     }
   }
   return null;

--- a/test-server/src/convert/convert.ts
+++ b/test-server/src/convert/convert.ts
@@ -25,6 +25,7 @@ import {
 import { guessSpecifierType, typeToCqlTypeSpecifier, typeToCqlTypeString } from './cqlTypes';
 import { emptyListParameter, nullValueParameter, emptyTupleParameter } from './specialParameters';
 import logger from '../logger';
+import { ELM_ANY_TYPE } from '../../../lib/util/elmTypes';
 
 const CQL_TO_UCUM_PRECISION = {
   year: 'a',
@@ -38,7 +39,7 @@ const CQL_TO_UCUM_PRECISION = {
 
 export function toParameters(result: any | null, type?: string | AnyTypeSpecifier): Parameters {
   // If the type is null or is Any, try to guess a more specific type to get better conversion results
-  if (type == null || type === '{urn:hl7-org:elm-types:r1}Any') {
+  if (type == null || type === ELM_ANY_TYPE) {
     const guessedType = guessSpecifierType(result);
     if (guessedType) {
       type = guessedType;

--- a/test-server/src/convert/cqlTypes.ts
+++ b/test-server/src/convert/cqlTypes.ts
@@ -8,9 +8,10 @@ import {
   AnyTypeSpecifier,
   Interval
 } from '../../..';
+import { ELM_ANY_TYPE } from '../../../lib/util/elmTypes';
 
 export function typeToCqlTypeSpecifier(
-  typeOrSpecifier: string | AnyTypeSpecifier = '{urn:hl7-org:elm-types:r1}Any'
+  typeOrSpecifier: string | AnyTypeSpecifier = ELM_ANY_TYPE
 ): AnyTypeSpecifier {
   if (typeof typeOrSpecifier === 'string') {
     return {
@@ -23,7 +24,7 @@ export function typeToCqlTypeSpecifier(
 
 // NOTE: Slightly modified from code in cql-execution: src/elm/type.ts
 export function typeToCqlTypeString(
-  typeOrSpecifier: string | AnyTypeSpecifier = '{urn:hl7-org:elm-types:r1}Any'
+  typeOrSpecifier: string | AnyTypeSpecifier = ELM_ANY_TYPE
 ): string {
   if (typeof typeOrSpecifier === 'string') {
     return typeOrSpecifier.replace('{urn:hl7-org:elm-types:r1}', 'System.');

--- a/test/datatypes/date-test.ts
+++ b/test/datatypes/date-test.ts
@@ -196,6 +196,36 @@ describe('Date.add', () => {
   });
 });
 
+describe('Date.successor', () => {
+  it('should use the specified precision', () => {
+    const date = Date.parse('2000-06-15');
+    date.successor(Date.Unit.YEAR).should.eql(Date.parse('2001-06-15'));
+    date.successor(Date.Unit.MONTH).should.eql(Date.parse('2000-07-15'));
+    date.successor(Date.Unit.DAY).should.eql(Date.parse('2000-06-16'));
+  });
+
+  it("should use the date's finest precision when precision is not specified", () => {
+    Date.parse('2000-06-15').successor().should.eql(Date.parse('2000-06-16'));
+    Date.parse('2000-06').successor().should.eql(Date.parse('2000-07'));
+    Date.parse('2000').successor().should.eql(Date.parse('2001'));
+  });
+});
+
+describe('Date.predecessor', () => {
+  it('should use the specified precision', () => {
+    const date = Date.parse('2000-06-15');
+    date.predecessor(Date.Unit.YEAR).should.eql(Date.parse('1999-06-15'));
+    date.predecessor(Date.Unit.MONTH).should.eql(Date.parse('2000-05-15'));
+    date.predecessor(Date.Unit.DAY).should.eql(Date.parse('2000-06-14'));
+  });
+
+  it("should use the date's finest precision when precision is not specified", () => {
+    Date.parse('2000-06-15').predecessor().should.eql(Date.parse('2000-06-14'));
+    Date.parse('2000-06').predecessor().should.eql(Date.parse('2000-05'));
+    Date.parse('2000').predecessor().should.eql(Date.parse('1999'));
+  });
+});
+
 describe('Date.differenceBetween', () => {
   it('should return null if passed a non-Date object', () => {
     const a = Date.parse('2018-01-23');

--- a/test/datatypes/interval-data.ts
+++ b/test/datatypes/interval-data.ts
@@ -1,5 +1,6 @@
 import { Interval } from '../../src/datatypes/interval';
-import { DateTime } from '../../src/datatypes/datetime';
+import { DateTime, Date } from '../../src/datatypes/datetime';
+import { Quantity } from '../../src/datatypes/quantity';
 
 class TestDateTime {
   static parse(string: string) {
@@ -43,23 +44,33 @@ class TestInterval {
   toMinute: Interval;
   toSecond: Interval;
   toMillisecond: Interval;
+  withNullStart: TestInterval;
+  withNullEnd: TestInterval;
 
-  constructor(low: any, high: any) {
-    const [thLow, thHigh] = Array.from([
-      TestDateTime.fromDateTime(low),
-      TestDateTime.fromDateTime(high)
-    ]);
+  constructor(low: any, high: any, createNullVariants = true) {
     this.closed = new Interval(low, high, true, true);
     this.open = new Interval(low, high, false, false);
     this.closedOpen = new Interval(low, high, true, false);
     this.openClosed = new Interval(low, high, false, true);
-    this.toYear = new Interval(thLow.toYear, thHigh.toYear);
-    this.toMonth = new Interval(thLow.toMonth, thHigh.toMonth);
-    this.toDay = new Interval(thLow.toDay, thHigh.toDay);
-    this.toHour = new Interval(thLow.toHour, thHigh.toHour);
-    this.toMinute = new Interval(thLow.toMinute, thHigh.toMinute);
-    this.toSecond = new Interval(thLow.toSecond, thHigh.toSecond);
-    this.toMillisecond = new Interval(thLow.toMillisecond, thHigh.toMillisecond);
+
+    if (low != null && high != null) {
+      const [thLow, thHigh] = Array.from([
+        TestDateTime.fromDateTime(low),
+        TestDateTime.fromDateTime(high)
+      ]);
+      this.toYear = new Interval(thLow.toYear, thHigh.toYear);
+      this.toMonth = new Interval(thLow.toMonth, thHigh.toMonth);
+      this.toDay = new Interval(thLow.toDay, thHigh.toDay);
+      this.toHour = new Interval(thLow.toHour, thHigh.toHour);
+      this.toMinute = new Interval(thLow.toMinute, thHigh.toMinute);
+      this.toSecond = new Interval(thLow.toSecond, thHigh.toSecond);
+      this.toMillisecond = new Interval(thLow.toMillisecond, thHigh.toMillisecond);
+    }
+
+    if (createNullVariants) {
+      this.withNullStart = new TestInterval(null, high, false);
+      this.withNullEnd = new TestInterval(low, null, false);
+    }
   }
 }
 
@@ -94,6 +105,11 @@ export default () => {
   data['mid2012'] = TestDateTime.parse('2012-06-01T00:00:00.0');
   data['end2012'] = TestDateTime.parse('2012-12-31T23:59:59.999');
   data['aft2012'] = TestDateTime.parse('2013-06-01T00:00:00.0');
+  data['all2012date'] = new TestInterval(Date.parse('2012-01-01'), Date.parse('2012-12-31'));
+  data['alldaytime'] = new TestInterval(
+    DateTime.parse('0001-01-01T00:00:00.0').getTime(),
+    DateTime.parse('0001-01-01T23:59:59.999').getTime()
+  );
   data['dIvl'] = {
     sameAs: {
       //    |----------X----------|
@@ -276,5 +292,7 @@ export default () => {
       y: new TestInterval(0n, 100n)
     }
   };
+  data['zeroPointFiveToNinePointFive'] = new TestInterval(0.5, 9.5);
+  data['zeroToHundredMg'] = new TestInterval(new Quantity(0, 'mg'), new Quantity(100, 'mg'));
   return data;
 };

--- a/test/datatypes/interval-test.ts
+++ b/test/datatypes/interval-test.ts
@@ -46,6 +46,20 @@ describe('Interval', () => {
     i.lowClosed.should.be.true();
     i.highClosed.should.be.true();
   });
+
+  it('should identify and copy boundless and unknown intervals', () => {
+    const all = boundlessInterval();
+    all.isBoundlessInterval.should.be.true();
+    all.isUnknownInterval.should.be.false();
+
+    const mystery = unknownInterval();
+    mystery.isBoundlessInterval.should.be.false();
+    mystery.isUnknownInterval.should.be.true();
+
+    const allCopy = all.copy();
+    allCopy.should.eql(all);
+    allCopy.should.not.equal(all);
+  });
 });
 
 describe('DateTimeInterval', () => {
@@ -91,6 +105,8 @@ describe('DateTimeInterval', () => {
       new Interval(date, null, true, false).contains(date).should.be.true();
       should(new Interval(date, null, true, false).contains(late)).be.null();
       new Interval(date, null, true, false).contains(early).should.be.false();
+      new Interval(null, null).contains(date).should.be.true();
+      should(new Interval(null, null, false, false).contains(date)).be.null();
     });
 
     it('should properly handle imprecision', () => {
@@ -350,6 +366,15 @@ describe('DateTimeInterval', () => {
       should.not.exist(x.toYear.includes(y.closed));
     });
 
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().includes(d.mid2012.full).should.be.true();
+      boundlessInterval().includes(d.all2012.closed).should.be.true();
+      boundlessInterval().includes(unknownInterval()).should.be.true();
+      d.all2012.closed.includes(boundlessInterval()).should.be.false();
+      should(unknownInterval().includes(d.all2012.closed)).be.null();
+      should(unknownInterval().includes(boundlessInterval())).be.null();
+    });
+
     it('should include a point date', () => {
       d.all2012.closed.includes(d.mid2012.full).should.be.true();
     });
@@ -477,8 +502,59 @@ describe('DateTimeInterval', () => {
       should.not.exist(x.toYear.includedIn(y.closed));
     });
 
+    it('should properly handle boundless and unknown intervals', () => {
+      d.all2012.closed.includedIn(boundlessInterval()).should.be.true();
+      boundlessInterval().includedIn(d.all2012.closed).should.be.false();
+      boundlessInterval().includedIn(boundlessInterval()).should.be.true();
+      unknownInterval().includedIn(boundlessInterval()).should.be.true();
+    });
+
     it('should include a point date', () => {
       d.all2012.closed.includedIn(d.mid2012.full).should.be.true();
+    });
+  });
+
+  describe('properlyIncludes', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().properlyIncludes(d.all2012.closed).should.be.true();
+      boundlessInterval().properlyIncludes(boundlessInterval()).should.be.false();
+      should(boundlessInterval().properlyIncludes(unknownInterval())).be.null();
+      should(unknownInterval().properlyIncludes(d.all2012.closed)).be.null();
+    });
+  });
+
+  describe('starts', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().starts(boundlessInterval()).should.be.true();
+      boundlessInterval().starts(d.all2012.closed).should.be.false();
+      d.all2012.closed.starts(boundlessInterval()).should.be.false();
+      should(boundlessInterval().starts(unknownInterval())).be.null();
+      should(unknownInterval().starts(boundlessInterval())).be.null();
+    });
+  });
+
+  describe('ends', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().ends(boundlessInterval()).should.be.true();
+      boundlessInterval().ends(d.all2012.closed).should.be.false();
+      d.all2012.closed.ends(boundlessInterval()).should.be.false();
+      should(boundlessInterval().ends(unknownInterval())).be.null();
+      should(unknownInterval().ends(boundlessInterval())).be.null();
     });
   });
 
@@ -572,6 +648,40 @@ describe('DateTimeInterval', () => {
       y.open.overlaps(x.open).should.be.true();
     });
 
+    it('should properly handle null endpoints', () => {
+      const date = DateTime.parse('2012-01-01T00:00:00.0');
+      const early = DateTime.parse('0001-01-01T00:00:00.0');
+      const late = DateTime.parse('2999-01-01T00:00:00.0');
+      const earlyInterval = new Interval(early, DateTime.parse('2011-01-01T00:00:00.0'));
+      const lateInterval = new Interval(DateTime.parse('2013-01-01T00:00:00.0'), late);
+      const startsAtDate = new Interval(date, late);
+      const endsAtDate = new Interval(early, date);
+
+      should(new Interval(null, date).overlaps(earlyInterval)).be.true();
+      should(new Interval(null, date).overlaps(lateInterval)).be.false();
+      should(new Interval(null, date, false, true).overlaps(startsAtDate)).be.true();
+      should(new Interval(null, date, false, true).overlaps(earlyInterval)).be.null();
+      should(new Interval(null, date, false, true).overlaps(lateInterval)).be.false();
+
+      should(new Interval(date, null).overlaps(lateInterval)).be.true();
+      should(new Interval(date, null).overlaps(earlyInterval)).be.false();
+      should(new Interval(date, null, true, false).overlaps(endsAtDate)).be.true();
+      should(new Interval(date, null, true, false).overlaps(lateInterval)).be.null();
+      should(new Interval(date, null, true, false).overlaps(earlyInterval)).be.false();
+
+      should(new Interval(null, null).overlaps(d.all2012.closed)).be.true();
+      should(new Interval(null, null, false, false).overlaps(d.all2012.closed)).be.null();
+      should(d.all2012.closed.overlaps(new Interval(null, null))).be.true();
+      should(d.all2012.closed.overlaps(new Interval(null, null, false, false))).be.null();
+      // TODO: These commented out edge cases with all null endpoints on both sides currently don't pass
+      //should(new Interval(null, null).overlaps(new Interval(null, null))).be.true();
+      //should(new Interval(null, null).overlaps(new Interval(null, null, false, false))).be.true();
+      //should(new Interval(null, null, false, false).overlaps(new Interval(null, null))).be.true();
+      should(
+        new Interval(null, null, false, false).overlaps(new Interval(null, null, false, false))
+      ).be.null();
+    });
+
     it('should properly handle boundless and unknown intervals', () => {
       boundlessInterval().overlaps(boundlessInterval()).should.be.true();
       boundlessInterval().overlaps(d.all2012.closed).should.be.true();
@@ -639,6 +749,24 @@ describe('DateTimeInterval', () => {
 
     it('should properly calculate dates after it', () => {
       d.all2012.closed.overlaps(d.aft2012.full).should.be.false();
+    });
+
+    it('should properly handle null endpoints', () => {
+      const date = DateTime.parse('2012-01-01T00:00:00.0');
+      const early = DateTime.parse('0001-01-01T00:00:00.0');
+      const late = DateTime.parse('2999-01-01T00:00:00.0');
+      should(new Interval(null, date).overlaps(early)).be.true();
+      should(new Interval(null, date).overlaps(late)).be.false();
+      should(new Interval(null, date, false, true).overlaps(date)).be.true();
+      should(new Interval(null, date, false, true).overlaps(early)).be.null();
+      should(new Interval(null, date, false, true).overlaps(late)).be.false();
+      should(new Interval(date, null).overlaps(late)).be.true();
+      should(new Interval(date, null).overlaps(early)).be.false();
+      should(new Interval(date, null, true, false).overlaps(date)).be.true();
+      should(new Interval(date, null, true, false).overlaps(late)).be.null();
+      should(new Interval(date, null, true, false).overlaps(early)).be.false();
+      should(new Interval(null, null).overlaps(date)).be.true();
+      should(new Interval(null, null, false, false).overlaps(date)).be.null();
     });
 
     it('should properly handle boundless and unknown intervals', () => {
@@ -852,6 +980,30 @@ describe('DateTimeInterval', () => {
 
       ivl.equals(point).should.be.false();
     });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().equals(boundlessInterval()).should.be.true();
+      boundlessInterval().equals(d.all2012.closed).should.be.false();
+      d.all2012.closed.equals(boundlessInterval()).should.be.false();
+      should(boundlessInterval().equals(unknownInterval())).be.null();
+      should(unknownInterval().equals(boundlessInterval())).be.null();
+      should(unknownInterval().equals(unknownInterval())).be.null();
+    });
+  });
+
+  describe('sameAs', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().sameAs(boundlessInterval()).should.be.true();
+      boundlessInterval().sameAs(d.all2012.closed).should.be.false();
+      d.all2012.closed.sameAs(boundlessInterval()).should.be.false();
+      should(boundlessInterval().sameAs(unknownInterval())).be.null();
+      should(unknownInterval().sameAs(boundlessInterval())).be.null();
+    });
   });
 
   describe('union', () => {
@@ -1031,6 +1183,13 @@ describe('DateTimeInterval', () => {
       x.toMonth.high.sameAs(j.high, DateTime.Unit.MONTH).should.be.true();
     });
 
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().union(d.all2012.closed).should.eql(boundlessInterval());
+      d.all2012.closed.union(boundlessInterval()).should.eql(boundlessInterval());
+      boundlessInterval().union(unknownInterval()).should.eql(boundlessInterval());
+      unknownInterval().union(boundlessInterval()).should.eql(boundlessInterval());
+    });
+
     it('should throw when the argument is a point', () => {
       should(() => d.all2012.closed.union(d.mid2012.closed)).throw(Error);
     });
@@ -1155,6 +1314,13 @@ describe('DateTimeInterval', () => {
       x.toDay.intersect(y.toDay).high.should.eql(x.toDay.high);
       y.toDay.intersect(x.toDay).low.should.eql(x.toDay.low);
       y.toDay.intersect(x.toDay).high.should.eql(x.toDay.high);
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().intersect(d.all2012.closed).should.eql(d.all2012.closed);
+      d.all2012.closed.intersect(boundlessInterval()).should.eql(d.all2012.closed);
+      boundlessInterval().intersect(unknownInterval()).should.eql(unknownInterval());
+      unknownInterval().intersect(boundlessInterval()).should.eql(unknownInterval());
     });
 
     it('should throw when the argument is a point', () => {
@@ -1425,6 +1591,25 @@ describe('DateTimeInterval', () => {
       should.not.exist(x.toYear.after(y.closed));
       should.not.exist(x.toYear.after(x.closed));
     });
+
+    it('should properly handle boundless intervals', () => {
+      boundlessInterval().after(d.all2012.closed).should.be.false();
+      d.all2012.closed.after(boundlessInterval()).should.be.false();
+    });
+  });
+
+  describe('sameOrAfter', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().sameOrAfter(boundlessInterval()).should.be.true();
+      boundlessInterval().sameOrAfter(d.all2012.closed).should.be.false();
+      d.all2012.closed.sameOrAfter(boundlessInterval()).should.be.false();
+      should(unknownInterval().sameOrAfter(boundlessInterval())).be.null();
+    });
   });
 
   describe('before', () => {
@@ -1557,6 +1742,25 @@ describe('DateTimeInterval', () => {
       should.not.exist(y.toYear.before(x.closed));
       should.not.exist(x.toYear.before(y.closed));
     });
+
+    it('should properly handle boundless intervals', () => {
+      boundlessInterval().before(d.all2012.closed).should.be.false();
+      d.all2012.closed.before(boundlessInterval()).should.be.false();
+    });
+  });
+
+  describe('sameOrBefore', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().sameOrBefore(boundlessInterval()).should.be.true();
+      boundlessInterval().sameOrBefore(d.all2012.closed).should.be.false();
+      d.all2012.closed.sameOrBefore(boundlessInterval()).should.be.false();
+      should(unknownInterval().sameOrBefore(boundlessInterval())).be.null();
+    });
   });
 
   // TODO Add tests that pass in precision parameters
@@ -1679,6 +1883,11 @@ describe('DateTimeInterval', () => {
       [x, y] = Array.from(xy(d.dIvl.ends));
       x.toMinute.meets(y.toMinute).should.be.false();
       x.toYear.meets(y.closed).should.be.false();
+    });
+
+    it('should properly handle boundless intervals', () => {
+      boundlessInterval().meets(d.all2012.closed).should.be.false();
+      d.all2012.closed.meets(boundlessInterval()).should.be.false();
     });
   });
 
@@ -1808,6 +2017,11 @@ describe('DateTimeInterval', () => {
       x.toMinute.meetsAfter(y.toMinute).should.be.false();
       x.toYear.meetsAfter(y.closed).should.be.false();
     });
+
+    it('should properly handle boundless intervals', () => {
+      boundlessInterval().meetsAfter(d.all2012.closed).should.be.false();
+      d.all2012.closed.meetsAfter(boundlessInterval()).should.be.false();
+    });
   });
 
   // TODO Add tests that pass in precision parameter
@@ -1932,6 +2146,11 @@ describe('DateTimeInterval', () => {
       x.toMinute.meetsBefore(y.toMinute).should.be.false();
       x.toYear.meetsBefore(y.closed).should.be.false();
     });
+
+    it('should properly handle boundless intervals', () => {
+      boundlessInterval().meetsBefore(d.all2012.closed).should.be.false();
+      d.all2012.closed.meetsBefore(boundlessInterval()).should.be.false();
+    });
   });
 });
 
@@ -1975,6 +2194,8 @@ describe('IntegerInterval', () => {
       new Interval(0, null, true, false).contains(0).should.be.true();
       should(new Interval(0, null, true, false).contains(123456789)).be.null();
       new Interval(0, null, true, false).contains(-1).should.be.false();
+      new Interval(null, null).contains(5).should.be.true();
+      should(new Interval(null, null, false, false).contains(5)).be.null();
     });
 
     it('should properly handle imprecision', () => {
@@ -2216,6 +2437,15 @@ describe('IntegerInterval', () => {
     it('should include a point Integer', () => {
       d.zeroToHundred.closed.includes(50).should.be.true();
     });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().includes(50).should.be.true();
+      boundlessInterval().includes(d.zeroToHundred.closed).should.be.true();
+      boundlessInterval().includes(unknownInterval()).should.be.true();
+      d.zeroToHundred.closed.includes(boundlessInterval()).should.be.false();
+      should(unknownInterval().includes(d.zeroToHundred.closed)).be.null();
+      should(unknownInterval().includes(boundlessInterval())).be.null();
+    });
   });
 
   describe('includedIn', () => {
@@ -2335,6 +2565,57 @@ describe('IntegerInterval', () => {
       d.zeroToHundred.closed.includedIn(50).should.be.true();
       d.zeroToHundred.closed.includedIn(500).should.be.false();
     });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      d.zeroToHundred.closed.includedIn(boundlessInterval()).should.be.true();
+      boundlessInterval().includedIn(d.zeroToHundred.closed).should.be.false();
+      boundlessInterval().includedIn(boundlessInterval()).should.be.true();
+      unknownInterval().includedIn(boundlessInterval()).should.be.true();
+    });
+  });
+
+  describe('properlyIncludes', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().properlyIncludes(d.zeroToHundred.closed).should.be.true();
+      boundlessInterval().properlyIncludes(boundlessInterval()).should.be.false();
+      should(boundlessInterval().properlyIncludes(unknownInterval())).be.null();
+      should(unknownInterval().properlyIncludes(d.zeroToHundred.closed)).be.null();
+    });
+  });
+
+  describe('starts', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().starts(boundlessInterval()).should.be.true();
+      boundlessInterval().starts(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.starts(boundlessInterval()).should.be.false();
+      should(boundlessInterval().starts(unknownInterval())).be.null();
+      should(unknownInterval().starts(boundlessInterval())).be.null();
+    });
+  });
+
+  describe('ends', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().ends(boundlessInterval()).should.be.true();
+      boundlessInterval().ends(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.ends(boundlessInterval()).should.be.false();
+      should(boundlessInterval().ends(unknownInterval())).be.null();
+      should(unknownInterval().ends(boundlessInterval())).be.null();
+    });
   });
 
   describe('overlaps(IntegerInterval)', () => {
@@ -2427,12 +2708,37 @@ describe('IntegerInterval', () => {
       y.open.overlaps(x.open).should.be.true();
     });
 
+    it('should properly handle null endpoints', () => {
+      const earlyInterval = new Interval(-123456789, -1);
+      const lateInterval = new Interval(1, 123456789);
+      const startsAtZero = new Interval(0, 123456789);
+      const endsAtZero = new Interval(-123456789, 0);
+
+      should(new Interval(null, 0).overlaps(earlyInterval)).be.true();
+      should(new Interval(null, 0).overlaps(lateInterval)).be.false();
+      should(new Interval(null, 0, false, true).overlaps(startsAtZero)).be.true();
+      should(new Interval(null, 0, false, true).overlaps(earlyInterval)).be.null();
+      should(new Interval(null, 0, false, true).overlaps(lateInterval)).be.false();
+
+      should(new Interval(0, null).overlaps(lateInterval)).be.true();
+      should(new Interval(0, null).overlaps(earlyInterval)).be.false();
+      should(new Interval(0, null, true, false).overlaps(endsAtZero)).be.true();
+      should(new Interval(0, null, true, false).overlaps(lateInterval)).be.null();
+      should(new Interval(0, null, true, false).overlaps(earlyInterval)).be.false();
+
+      should(new Interval(null, null).overlaps(d.zeroToHundred.closed)).be.true();
+      should(new Interval(null, null, false, false).overlaps(d.zeroToHundred.closed)).be.null();
+      should(d.zeroToHundred.closed.overlaps(new Interval(null, null))).be.true();
+      should(d.zeroToHundred.closed.overlaps(new Interval(null, null, false, false))).be.null();
+    });
+
     it('should properly handle boundless and unknown intervals', () => {
       boundlessInterval().overlaps(boundlessInterval()).should.be.true();
       boundlessInterval().overlaps(d.zeroToHundred.closed).should.be.true();
       d.zeroToHundred.closed.overlaps(boundlessInterval()).should.be.true();
-      should(boundlessInterval().overlaps(unknownInterval())).be.null();
-      should(unknownInterval().overlaps(boundlessInterval())).be.null();
+      // TODO: These commented out edge cases with all null endpoints on both sides currently don't pass
+      //boundlessInterval().overlaps(unknownInterval()).should.be.true();
+      //unknownInterval().overlaps(boundlessInterval()).should.be.true();
       should(unknownInterval().overlaps(d.zeroToHundred.closed)).be.null();
     });
 
@@ -2485,6 +2791,21 @@ describe('IntegerInterval', () => {
 
     it('should properly calculate integers greater than it', () => {
       d.zeroToHundred.closed.overlaps(105).should.be.false();
+    });
+
+    it('should properly handle null endpoints', () => {
+      should(new Interval(null, 0).overlaps(-123456789)).be.true();
+      should(new Interval(null, 0).overlaps(1)).be.false();
+      should(new Interval(null, 0, false, true).overlaps(0)).be.true();
+      should(new Interval(null, 0, false, true).overlaps(-123456789)).be.null();
+      should(new Interval(null, 0, false, true).overlaps(1)).be.false();
+      should(new Interval(0, null).overlaps(123456789)).be.true();
+      should(new Interval(0, null).overlaps(-1)).be.false();
+      should(new Interval(0, null, true, false).overlaps(0)).be.true();
+      should(new Interval(0, null, true, false).overlaps(123456789)).be.null();
+      should(new Interval(0, null, true, false).overlaps(-1)).be.false();
+      should(new Interval(null, null).overlaps(5)).be.true();
+      should(new Interval(null, null, false, false).overlaps(5)).be.null();
     });
 
     it('should properly handle boundless and unknown intervals', () => {
@@ -2693,6 +3014,30 @@ describe('IntegerInterval', () => {
 
       ivl.equals(point).should.be.false();
     });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().equals(boundlessInterval()).should.be.true();
+      boundlessInterval().equals(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.equals(boundlessInterval()).should.be.false();
+      should(boundlessInterval().equals(unknownInterval())).be.null();
+      should(unknownInterval().equals(boundlessInterval())).be.null();
+      should(unknownInterval().equals(unknownInterval())).be.null();
+    });
+  });
+
+  describe('sameAs', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().sameAs(boundlessInterval()).should.be.true();
+      boundlessInterval().sameAs(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.sameAs(boundlessInterval()).should.be.false();
+      should(boundlessInterval().sameAs(unknownInterval())).be.null();
+      should(unknownInterval().sameAs(boundlessInterval())).be.null();
+    });
   });
 
   describe('union', () => {
@@ -2837,6 +3182,13 @@ describe('IntegerInterval', () => {
     it('should throw when the argument is a point', () => {
       should(() => d.zeroToHundred.union(300)).throw(Error);
     });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().union(d.zeroToHundred.closed).should.eql(boundlessInterval());
+      d.zeroToHundred.closed.union(boundlessInterval()).should.eql(boundlessInterval());
+      boundlessInterval().union(unknownInterval()).should.eql(boundlessInterval());
+      unknownInterval().union(boundlessInterval()).should.eql(boundlessInterval());
+    });
   });
 
   describe('intersect', () => {
@@ -2972,6 +3324,13 @@ describe('IntegerInterval', () => {
 
     it('should throw when the argument is a point', () => {
       should(() => d.zeroToHundred.intersect(50)).throw(Error);
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().intersect(d.zeroToHundred.closed).should.eql(d.zeroToHundred.closed);
+      d.zeroToHundred.closed.intersect(boundlessInterval()).should.eql(d.zeroToHundred.closed);
+      boundlessInterval().intersect(unknownInterval()).should.eql(unknownInterval());
+      unknownInterval().intersect(boundlessInterval()).should.eql(unknownInterval());
     });
   });
 
@@ -3228,6 +3587,25 @@ describe('IntegerInterval', () => {
 
       uIvl.after(uIvl).should.be.false();
     });
+
+    it('should properly handle boundless intervals', () => {
+      boundlessInterval().after(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.after(boundlessInterval()).should.be.false();
+    });
+  });
+
+  describe('sameOrAfter', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().sameOrAfter(boundlessInterval()).should.be.true();
+      boundlessInterval().sameOrAfter(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.sameOrAfter(boundlessInterval()).should.be.false();
+      should(unknownInterval().sameOrAfter(boundlessInterval())).be.null();
+    });
   });
 
   describe('before', () => {
@@ -3348,6 +3726,25 @@ describe('IntegerInterval', () => {
       uIvl.before(ivl).should.be.false();
 
       uIvl.before(uIvl).should.be.false();
+    });
+
+    it('should properly handle boundless intervals', () => {
+      boundlessInterval().before(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.before(boundlessInterval()).should.be.false();
+    });
+  });
+
+  describe('sameOrBefore', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().sameOrBefore(boundlessInterval()).should.be.true();
+      boundlessInterval().sameOrBefore(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.sameOrBefore(boundlessInterval()).should.be.false();
+      should(unknownInterval().sameOrBefore(boundlessInterval())).be.null();
     });
   });
 
@@ -3470,6 +3867,11 @@ describe('IntegerInterval', () => {
 
       uIvl.meets(uIvl).should.be.false();
     });
+
+    it('should properly handle boundless intervals', () => {
+      boundlessInterval().meets(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.meets(boundlessInterval()).should.be.false();
+    });
   });
 
   describe('meetsAfter', () => {
@@ -3591,6 +3993,11 @@ describe('IntegerInterval', () => {
 
       uIvl.meetsAfter(uIvl).should.be.false();
     });
+
+    it('should properly handle boundless intervals', () => {
+      boundlessInterval().meetsAfter(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.meetsAfter(boundlessInterval()).should.be.false();
+    });
   });
 
   describe('meetsBefore', () => {
@@ -3711,6 +4118,11 @@ describe('IntegerInterval', () => {
       should.not.exist(uIvl.meetsBefore(ivl));
 
       uIvl.meetsBefore(uIvl).should.be.false();
+    });
+
+    it('should properly handle boundless intervals', () => {
+      boundlessInterval().meetsBefore(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.meetsBefore(boundlessInterval()).should.be.false();
     });
   });
 });
@@ -5496,6 +5908,11 @@ describe('LongInterval', () => {
 });
 
 describe('DecimalInterval', () => {
+  let d: any;
+  beforeEach(() => {
+    d = data();
+  });
+
   it('should close open decimal uncertainty endpoints using decimal point size', () => {
     const closed = new Interval(
       new Uncertainty(1, 2),
@@ -5525,5 +5942,140 @@ describe('DecimalInterval', () => {
     later.meetsAfter(earlier).should.be.true();
   });
 
-  // TODO: More decimal tests, similar to IntegerInterval and LongInterval test suites
+  it('should properly calculate meets intervals', () => {
+    const [x, y] = Array.from(xy(d.dIvl.meets));
+    x.closed.overlaps(y.closed).should.be.false();
+    x.closed.overlaps(y.open).should.be.false();
+    x.open.overlaps(y.closed).should.be.false();
+    x.open.overlaps(y.open).should.be.false();
+    y.closed.overlaps(x.closed).should.be.false();
+    y.closed.overlaps(x.open).should.be.false();
+    y.open.overlaps(x.closed).should.be.false();
+    y.open.overlaps(x.open).should.be.false();
+  });
+
+  it('should properly calculate left/right overlapping intervals', () => {
+    const [x, y] = Array.from(xy(d.dIvl.overlaps));
+    x.closed.overlaps(y.closed).should.be.true();
+    x.closed.overlaps(y.open).should.be.true();
+    x.open.overlaps(y.closed).should.be.true();
+    x.open.overlaps(y.open).should.be.true();
+    y.closed.overlaps(x.closed).should.be.true();
+    y.closed.overlaps(x.open).should.be.true();
+    y.open.overlaps(x.closed).should.be.true();
+    y.open.overlaps(x.open).should.be.true();
+  });
+
+  it('should properly calculate begins/begun by intervals', () => {
+    const [x, y] = Array.from(xy(d.dIvl.begins));
+    x.closed.overlaps(y.closed).should.be.true();
+    x.closed.overlaps(y.open).should.be.true();
+    x.open.overlaps(y.closed).should.be.true();
+    x.open.overlaps(y.open).should.be.true();
+    y.closed.overlaps(x.closed).should.be.true();
+    y.closed.overlaps(x.open).should.be.true();
+    y.open.overlaps(x.closed).should.be.true();
+    y.open.overlaps(x.open).should.be.true();
+  });
+
+  it('should properly calculate includes/included by intervals', () => {
+    const [x, y] = Array.from(xy(d.dIvl.during));
+    x.closed.overlaps(y.closed).should.be.true();
+    x.closed.overlaps(y.open).should.be.true();
+    x.open.overlaps(y.closed).should.be.true();
+    x.open.overlaps(y.open).should.be.true();
+    y.closed.overlaps(x.closed).should.be.true();
+    y.closed.overlaps(x.open).should.be.true();
+    y.open.overlaps(x.closed).should.be.true();
+    y.open.overlaps(x.open).should.be.true();
+  });
+
+  it('should properly calculate ends/ended by intervals', () => {
+    const [x, y] = Array.from(xy(d.dIvl.ends));
+    x.closed.overlaps(y.closed).should.be.true();
+    x.closed.overlaps(y.open).should.be.true();
+    x.open.overlaps(y.closed).should.be.true();
+    x.open.overlaps(y.open).should.be.true();
+    y.closed.overlaps(x.closed).should.be.true();
+    y.closed.overlaps(x.open).should.be.true();
+    y.open.overlaps(x.closed).should.be.true();
+    y.open.overlaps(x.open).should.be.true();
+  });
+
+  it('should properly handle null endpoints', () => {
+    const date = DateTime.parse('2012-01-01T00:00:00.0');
+    const early = DateTime.parse('0001-01-01T00:00:00.0');
+    const late = DateTime.parse('2999-01-01T00:00:00.0');
+    const earlyInterval = new Interval(early, DateTime.parse('2011-01-01T00:00:00.0'));
+    const lateInterval = new Interval(DateTime.parse('2013-01-01T00:00:00.0'), late);
+    const startsAtDate = new Interval(date, late);
+    const endsAtDate = new Interval(early, date);
+
+    should(new Interval(null, date).overlaps(earlyInterval)).be.true();
+    should(new Interval(null, date).overlaps(lateInterval)).be.false();
+    should(new Interval(null, date, false, true).overlaps(startsAtDate)).be.true();
+    should(new Interval(null, date, false, true).overlaps(earlyInterval)).be.null();
+    should(new Interval(null, date, false, true).overlaps(lateInterval)).be.false();
+
+    should(new Interval(date, null).overlaps(lateInterval)).be.true();
+    should(new Interval(date, null).overlaps(earlyInterval)).be.false();
+    should(new Interval(date, null, true, false).overlaps(endsAtDate)).be.true();
+    should(new Interval(date, null, true, false).overlaps(lateInterval)).be.null();
+    should(new Interval(date, null, true, false).overlaps(earlyInterval)).be.false();
+
+    should(new Interval(null, null).overlaps(d.all2012.closed)).be.true();
+    should(new Interval(null, null, false, false).overlaps(d.all2012.closed)).be.null();
+    should(d.all2012.closed.overlaps(new Interval(null, null))).be.true();
+    should(d.all2012.closed.overlaps(new Interval(null, null, false, false))).be.null();
+    // TODO: These commented out edge cases with all null endpoints on both sides currently don't pass
+    //should(new Interval(null, null).overlaps(new Interval(null, null))).be.true();
+    //should(new Interval(null, null).overlaps(new Interval(null, null, false, false))).be.true();
+    //should(new Interval(null, null, false, false).overlaps(new Interval(null, null))).be.true();
+    should(
+      new Interval(null, null, false, false).overlaps(new Interval(null, null, false, false))
+    ).be.null();
+  });
+
+  it('should properly handle boundless and unknown intervals', () => {
+    boundlessInterval().overlaps(boundlessInterval()).should.be.true();
+    boundlessInterval().overlaps(d.all2012.closed).should.be.true();
+    // TODO: These commented out edge cases with all null endpoints on both sides currently don't pass
+    //d.all2012.closed.overlaps(boundlessInterval()).should.be.true();
+    //boundlessInterval().overlaps(unknownInterval()).should.be.true();
+    //unknownInterval().overlaps(boundlessInterval()).should.be.true();
+    should(unknownInterval().overlaps(d.all2012.closed)).be.null();
+  });
+
+  it('should properly handle imprecision', () => {
+    let [x, y] = Array.from(xy(d.dIvl.sameAs));
+    x.closed.overlaps(y.toMinute).should.be.true();
+    x.toHour.overlaps(y.toMinute).should.be.true();
+
+    [x, y] = Array.from(xy(d.dIvl.before));
+    x.toMonth.overlaps(y.toMonth).should.be.false();
+    should.not.exist(x.toYear.overlaps(y.closed));
+
+    [x, y] = Array.from(xy(d.dIvl.meets));
+    x.toMonth.overlaps(y.toMonth).should.be.false();
+    should.not.exist(x.toYear.overlaps(y.closed));
+
+    [x, y] = Array.from(xy(d.dIvl.overlaps));
+    x.toMonth.overlaps(y.toMonth).should.be.true();
+    should.not.exist(x.toYear.overlaps(y.closed));
+
+    [x, y] = Array.from(xy(d.dIvl.begins));
+    x.toMinute.overlaps(y.toMinute).should.be.true();
+    should.not.exist(x.toYear.overlaps(y.closed));
+
+    [x, y] = Array.from(xy(d.dIvl.during));
+    x.toMonth.overlaps(y.toMonth).should.be.true();
+    y.toMonth.overlaps(x.toMonth).should.be.true();
+    should.not.exist(x.toYear.overlaps(y.closed));
+
+    [x, y] = Array.from(xy(d.dIvl.ends));
+    x.toMinute.overlaps(y.toMinute).should.be.true();
+    should.not.exist(x.toYear.overlaps(y.closed));
+  });
 });
+
+// TODO: Tests for real numbers (i.e., floats)

--- a/test/datatypes/interval-test.ts
+++ b/test/datatypes/interval-test.ts
@@ -1,13 +1,34 @@
 import should from 'should';
-import { DateTime, MIN_DATETIME_VALUE, MAX_DATETIME_VALUE } from '../../src/datatypes/datetime';
+import {
+  DateTime,
+  Date,
+  MIN_DATETIME_VALUE,
+  MAX_DATETIME_VALUE
+} from '../../src/datatypes/datetime';
 import { Interval } from '../../src/datatypes/interval';
+import { Quantity, MAX_QUANTITY_VALUE, MIN_QUANTITY_VALUE } from '../../src/datatypes/quantity';
 import { Uncertainty } from '../../src/datatypes/uncertainty';
 import {
+  ELM_DATE_TYPE,
   ELM_DATETIME_TYPE,
   ELM_DECIMAL_TYPE,
   ELM_INTEGER_TYPE,
-  ELM_LONG_TYPE
+  ELM_LONG_TYPE,
+  ELM_QUANTITY_TYPE,
+  ELM_TIME_TYPE
 } from '../../src/util/elmTypes';
+import {
+  MAX_DATE_VALUE,
+  MAX_FLOAT_VALUE,
+  MAX_INT_VALUE,
+  MAX_LONG_VALUE,
+  MAX_TIME_VALUE,
+  MIN_DATE_VALUE,
+  MIN_FLOAT_VALUE,
+  MIN_INT_VALUE,
+  MIN_LONG_VALUE,
+  MIN_TIME_VALUE
+} from '../../src/util/math';
 import data from './interval-data';
 
 const xy = (obj: any) => [obj.x, obj.y];
@@ -59,6 +80,270 @@ describe('Interval', () => {
     const allCopy = all.copy();
     allCopy.should.eql(all);
     allCopy.should.not.equal(all);
+  });
+
+  describe('start', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should return low for intervals with closed low', () => {
+      d.zeroToHundred.closed.start().should.equal(0);
+      d.zeroPointFiveToNinePointFive.closed.start().should.equal(0.5);
+      d.zeroToHundredLong.closed.start().should.equal(0n);
+      d.zeroToHundredMg.closed.start().should.eql(new Quantity(0, 'mg'));
+      d.all2012date.closed.start().should.eql(Date.parse('2012-01-01'));
+      d.all2012.closed.start().should.eql(DateTime.parse('2012-01-01T00:00:00.0'));
+      d.alldaytime.closed.start().should.eql(DateTime.parse('0001-01-01T00:00:00.0').getTime());
+    });
+
+    it('should return successor of low for intervals with open low', () => {
+      d.zeroToHundred.openClosed.start().should.equal(1);
+      d.zeroPointFiveToNinePointFive.openClosed.start().should.equal(0.50000001);
+      d.zeroToHundredLong.openClosed.start().should.equal(1n);
+      d.zeroToHundredMg.openClosed.start().should.eql(new Quantity(0.00000001, 'mg'));
+      d.all2012date.openClosed.start().should.eql(Date.parse('2012-01-02'));
+      d.all2012.openClosed.start().should.eql(DateTime.parse('2012-01-01T00:00:00.001'));
+      d.alldaytime.openClosed
+        .start()
+        .should.eql(DateTime.parse('0001-01-01T00:00:00.001').getTime());
+    });
+
+    it('should return type minimum for closed null low endpoints', () => {
+      d.zeroToHundred.withNullStart.closed.start().should.equal(MIN_INT_VALUE);
+      d.zeroToHundredLong.withNullStart.closed.start().should.equal(MIN_LONG_VALUE);
+      d.zeroPointFiveToNinePointFive.withNullStart.closed.start().should.equal(MIN_FLOAT_VALUE);
+      d.zeroToHundredMg.withNullStart.closed
+        .start()
+        .should.eql(new Quantity(MIN_FLOAT_VALUE, 'mg'));
+      d.all2012date.withNullStart.closed.start().should.eql(MIN_DATE_VALUE);
+      d.all2012.withNullStart.closed.start().should.eql(MIN_DATETIME_VALUE);
+      d.alldaytime.withNullStart.closed.start().should.eql(MIN_TIME_VALUE);
+    });
+
+    it('should return null for closed null low endpoints when no point type is available', () => {
+      should(new Interval(null, null, true, true).start()).be.null();
+      should(new Interval(null, null, true, true, 'Any').start()).be.null();
+    });
+
+    it('should return uncertainty for open null low endpoints', () => {
+      d.zeroToHundred.withNullStart.openClosed
+        .start()
+        .should.eql(new Uncertainty(MIN_INT_VALUE, 100));
+      d.zeroToHundredLong.withNullStart.openClosed
+        .start()
+        .should.eql(new Uncertainty(MIN_LONG_VALUE, 100n));
+      d.zeroPointFiveToNinePointFive.withNullStart.openClosed
+        .start()
+        .should.eql(new Uncertainty(MIN_FLOAT_VALUE, 9.5));
+      d.zeroToHundredMg.withNullStart.openClosed
+        .start()
+        .should.eql(new Uncertainty(new Quantity(MIN_FLOAT_VALUE, 'mg'), new Quantity(100, 'mg')));
+      d.all2012date.withNullStart.openClosed
+        .start()
+        .should.eql(new Uncertainty(MIN_DATE_VALUE, Date.parse('2012-12-31')));
+      d.all2012.withNullStart.openClosed
+        .start()
+        .should.eql(new Uncertainty(MIN_DATETIME_VALUE, DateTime.parse('2012-12-31T23:59:59.999')));
+      d.alldaytime.withNullStart.openClosed
+        .start()
+        .should.eql(
+          new Uncertainty(MIN_TIME_VALUE, DateTime.parse('0001-01-01T23:59:59.999').getTime())
+        );
+    });
+
+    it('should use the closed end as the high value for open null low endpoint uncertainty', () => {
+      d.zeroToHundred.withNullStart.open.start().should.eql(new Uncertainty(MIN_INT_VALUE, 99));
+      d.zeroToHundredLong.withNullStart.open
+        .start()
+        .should.eql(new Uncertainty(MIN_LONG_VALUE, 99n));
+      d.zeroPointFiveToNinePointFive.withNullStart.open
+        .start()
+        .should.eql(new Uncertainty(MIN_FLOAT_VALUE, 9.49999999));
+      d.zeroToHundredMg.withNullStart.open
+        .start()
+        .should.eql(
+          new Uncertainty(new Quantity(MIN_FLOAT_VALUE, 'mg'), new Quantity(99.99999999, 'mg'))
+        );
+      d.all2012date.withNullStart.open
+        .start()
+        .should.eql(new Uncertainty(MIN_DATE_VALUE, Date.parse('2012-12-30')));
+      d.all2012.withNullStart.open
+        .start()
+        .should.eql(new Uncertainty(MIN_DATETIME_VALUE, DateTime.parse('2012-12-31T23:59:59.998')));
+      d.alldaytime.withNullStart.open
+        .start()
+        .should.eql(
+          new Uncertainty(MIN_TIME_VALUE, DateTime.parse('0001-01-01T23:59:59.998').getTime())
+        );
+    });
+
+    it('should return null for open null low endpoints without a finite type minimum', () => {
+      should(new Interval(null, null, false, false).start()).be.null();
+      should(new Interval(null, null, false, false, 'Any').start()).be.null();
+    });
+
+    it('should use default point type when both endpoints are null', () => {
+      new Interval(null, null, true, true, ELM_INTEGER_TYPE).start().should.equal(MIN_INT_VALUE);
+      new Interval(null, null, true, true, ELM_LONG_TYPE).start().should.equal(MIN_LONG_VALUE);
+      new Interval(null, null, true, true, ELM_DECIMAL_TYPE).start().should.equal(MIN_FLOAT_VALUE);
+      new Interval(null, null, true, true, ELM_QUANTITY_TYPE)
+        .start()
+        .should.eql(MIN_QUANTITY_VALUE);
+      new Interval(null, null, true, true, ELM_DATETIME_TYPE)
+        .start()
+        .should.eql(MIN_DATETIME_VALUE);
+      new Interval(null, null, true, true, ELM_DATE_TYPE).start().should.eql(MIN_DATE_VALUE);
+      new Interval(null, null, true, true, ELM_TIME_TYPE).start().should.eql(MIN_TIME_VALUE);
+    });
+
+    it('should return full type uncertainty for open intervals with null endpoints and default point type', () => {
+      new Interval(null, null, false, false, ELM_INTEGER_TYPE)
+        .start()
+        .should.eql(new Uncertainty(MIN_INT_VALUE, MAX_INT_VALUE));
+      new Interval(null, null, false, false, ELM_LONG_TYPE)
+        .start()
+        .should.eql(new Uncertainty(MIN_LONG_VALUE, MAX_LONG_VALUE));
+      new Interval(null, null, false, false, ELM_DECIMAL_TYPE)
+        .start()
+        .should.eql(new Uncertainty(MIN_FLOAT_VALUE, MAX_FLOAT_VALUE));
+      new Interval(null, null, false, false, ELM_QUANTITY_TYPE)
+        .start()
+        .should.eql(new Uncertainty(MIN_QUANTITY_VALUE, MAX_QUANTITY_VALUE));
+      new Interval(null, null, false, false, ELM_DATETIME_TYPE)
+        .start()
+        .should.eql(new Uncertainty(MIN_DATETIME_VALUE, MAX_DATETIME_VALUE));
+      new Interval(null, null, false, false, ELM_TIME_TYPE)
+        .start()
+        .should.eql(new Uncertainty(MIN_TIME_VALUE, MAX_TIME_VALUE));
+    });
+  });
+
+  describe('end', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should return high for intervals with closed high', () => {
+      d.zeroToHundred.closed.end().should.equal(100);
+      d.zeroPointFiveToNinePointFive.closed.end().should.equal(9.5);
+      d.zeroToHundredLong.closed.end().should.equal(100n);
+      d.zeroToHundredMg.closed.end().should.eql(new Quantity(100, 'mg'));
+      d.all2012date.closed.end().should.eql(Date.parse('2012-12-31'));
+      d.all2012.closed.end().should.eql(DateTime.parse('2012-12-31T23:59:59.999'));
+      d.alldaytime.closed.end().should.eql(DateTime.parse('0001-01-01T23:59:59.999').getTime());
+    });
+
+    it('should return predecessor of high for intervals with open high', () => {
+      d.zeroToHundred.closedOpen.end().should.equal(99);
+      d.zeroPointFiveToNinePointFive.closedOpen.end().should.equal(9.49999999);
+      d.zeroToHundredLong.closedOpen.end().should.equal(99n);
+      d.zeroToHundredMg.closedOpen.end().should.eql(new Quantity(99.99999999, 'mg'));
+      d.all2012date.closedOpen.end().should.eql(Date.parse('2012-12-30'));
+      d.all2012.closedOpen.end().should.eql(DateTime.parse('2012-12-31T23:59:59.998'));
+      d.alldaytime.closedOpen.end().should.eql(DateTime.parse('0001-01-01T23:59:59.998').getTime());
+    });
+
+    it('should return type maximum for closed null high endpoints', () => {
+      d.zeroToHundred.withNullEnd.closed.end().should.equal(MAX_INT_VALUE);
+      d.zeroToHundredLong.withNullEnd.closed.end().should.equal(MAX_LONG_VALUE);
+      d.zeroPointFiveToNinePointFive.withNullEnd.closed.end().should.equal(MAX_FLOAT_VALUE);
+      d.zeroToHundredMg.withNullEnd.closed.end().should.eql(new Quantity(MAX_FLOAT_VALUE, 'mg'));
+      d.all2012date.withNullEnd.closed.end().should.eql(MAX_DATE_VALUE);
+      d.all2012.withNullEnd.closed.end().should.eql(MAX_DATETIME_VALUE);
+      d.alldaytime.withNullEnd.closed.end().should.eql(MAX_TIME_VALUE);
+    });
+
+    it('should return null for closed null high endpoints when no point type is available', () => {
+      should(new Interval(null, null, true, true).end()).be.null();
+      should(new Interval(null, null, true, true, 'Any').end()).be.null();
+    });
+
+    it('should return uncertainty for open null high endpoints with inferred finite point type', () => {
+      d.zeroToHundred.withNullEnd.closedOpen.end().should.eql(new Uncertainty(0, MAX_INT_VALUE));
+      d.zeroToHundredLong.withNullEnd.closedOpen
+        .end()
+        .should.eql(new Uncertainty(0n, MAX_LONG_VALUE));
+      d.zeroPointFiveToNinePointFive.withNullEnd.closedOpen
+        .end()
+        .should.eql(new Uncertainty(0.5, MAX_FLOAT_VALUE));
+      d.zeroToHundredMg.withNullEnd.closedOpen
+        .end()
+        .should.eql(new Uncertainty(new Quantity(0, 'mg'), new Quantity(MAX_FLOAT_VALUE, 'mg')));
+      d.all2012date.withNullEnd.closedOpen
+        .end()
+        .should.eql(new Uncertainty(Date.parse('2012-01-01'), MAX_DATE_VALUE));
+      d.all2012.withNullEnd.closedOpen
+        .end()
+        .should.eql(new Uncertainty(DateTime.parse('2012-01-01T00:00:00.0'), MAX_DATETIME_VALUE));
+      d.alldaytime.withNullEnd.closedOpen
+        .end()
+        .should.eql(
+          new Uncertainty(DateTime.parse('0001-01-01T00:00:00.0').getTime(), MAX_TIME_VALUE)
+        );
+    });
+
+    it('should use the closed start as the low value for open null high endpoint uncertainty', () => {
+      d.zeroToHundred.withNullEnd.open.end().should.eql(new Uncertainty(1, MAX_INT_VALUE));
+      d.zeroToHundredLong.withNullEnd.open.end().should.eql(new Uncertainty(1n, MAX_LONG_VALUE));
+      d.zeroPointFiveToNinePointFive.withNullEnd.open
+        .end()
+        .should.eql(new Uncertainty(0.50000001, MAX_FLOAT_VALUE));
+      d.zeroToHundredMg.withNullEnd.open
+        .end()
+        .should.eql(
+          new Uncertainty(new Quantity(0.00000001, 'mg'), new Quantity(MAX_FLOAT_VALUE, 'mg'))
+        );
+      d.all2012date.withNullEnd.open
+        .end()
+        .should.eql(new Uncertainty(Date.parse('2012-01-02'), MAX_DATE_VALUE));
+      d.all2012.withNullEnd.open
+        .end()
+        .should.eql(new Uncertainty(DateTime.parse('2012-01-01T00:00:00.001'), MAX_DATETIME_VALUE));
+      d.alldaytime.withNullEnd.open
+        .end()
+        .should.eql(
+          new Uncertainty(DateTime.parse('0001-01-01T00:00:00.001').getTime(), MAX_TIME_VALUE)
+        );
+    });
+
+    it('should return null for open null high endpoints without a finite type maximum', () => {
+      should(new Interval(null, null, false, false).end()).be.null();
+      should(new Interval(null, null, false, false, 'Any').end()).be.null();
+    });
+
+    it('should use default point type when both endpoints are null', () => {
+      new Interval(null, null, true, true, ELM_INTEGER_TYPE).end().should.equal(MAX_INT_VALUE);
+      new Interval(null, null, true, true, ELM_LONG_TYPE).end().should.equal(MAX_LONG_VALUE);
+      new Interval(null, null, true, true, ELM_DECIMAL_TYPE).end().should.equal(MAX_FLOAT_VALUE);
+      new Interval(null, null, true, true, ELM_QUANTITY_TYPE).end().should.eql(MAX_QUANTITY_VALUE);
+      new Interval(null, null, true, true, ELM_DATETIME_TYPE).end().should.eql(MAX_DATETIME_VALUE);
+      new Interval(null, null, true, true, ELM_DATE_TYPE).end().should.eql(MAX_DATE_VALUE);
+      new Interval(null, null, true, true, ELM_TIME_TYPE).end().should.eql(MAX_TIME_VALUE);
+    });
+
+    it('should return full type uncertainty for open intervals with null endpoints and default point type', () => {
+      new Interval(null, null, false, false, ELM_INTEGER_TYPE)
+        .end()
+        .should.eql(new Uncertainty(MIN_INT_VALUE, MAX_INT_VALUE));
+      new Interval(null, null, false, false, ELM_LONG_TYPE)
+        .end()
+        .should.eql(new Uncertainty(MIN_LONG_VALUE, MAX_LONG_VALUE));
+      new Interval(null, null, false, false, ELM_DECIMAL_TYPE)
+        .end()
+        .should.eql(new Uncertainty(MIN_FLOAT_VALUE, MAX_FLOAT_VALUE));
+      new Interval(null, null, false, false, ELM_QUANTITY_TYPE)
+        .end()
+        .should.eql(new Uncertainty(MIN_QUANTITY_VALUE, MAX_QUANTITY_VALUE));
+      new Interval(null, null, false, false, ELM_DATETIME_TYPE)
+        .end()
+        .should.eql(new Uncertainty(MIN_DATETIME_VALUE, MAX_DATETIME_VALUE));
+      new Interval(null, null, false, false, ELM_TIME_TYPE)
+        .end()
+        .should.eql(new Uncertainty(MIN_TIME_VALUE, MAX_TIME_VALUE));
+    });
   });
 });
 

--- a/test/datatypes/interval-test.ts
+++ b/test/datatypes/interval-test.ts
@@ -471,14 +471,14 @@ describe('DateTimeInterval', () => {
     });
 
     it('should properly calculate the left boundary date', () => {
-      d.all2012.closed.properContains(d.beg2012.full).should.be.false();
+      d.all2012.closed.properContains(d.beg2012.full).should.be.true();
       d.all2012.open.properContains(d.beg2012.full).should.be.false();
 
-      let next = d.beg2012.full.successor();
-      d.all2012.closed.properContains(next).should.be.true();
-      d.all2012.open.properContains(next).should.be.false();
+      const prev = d.beg2012.full.predecessor();
+      d.all2012.closed.properContains(prev).should.be.false();
+      d.all2012.open.properContains(prev).should.be.false();
 
-      next = next.successor();
+      const next = d.beg2012.full.successor();
       d.all2012.closed.properContains(next).should.be.true();
       d.all2012.open.properContains(next).should.be.true();
     });
@@ -488,16 +488,16 @@ describe('DateTimeInterval', () => {
     });
 
     it('should properly calculate the right boundary date', () => {
-      d.all2012.closed.properContains(d.end2012.full).should.be.false();
+      d.all2012.closed.properContains(d.end2012.full).should.be.true();
       d.all2012.open.properContains(d.end2012.full).should.be.false();
 
-      let prev = d.end2012.full.predecessor();
-      d.all2012.closed.properContains(prev).should.be.true();
-      d.all2012.open.properContains(prev).should.be.false();
-
-      prev = prev.predecessor();
+      const prev = d.end2012.full.predecessor();
       d.all2012.closed.properContains(prev).should.be.true();
       d.all2012.open.properContains(prev).should.be.true();
+
+      const next = d.end2012.full.successor();
+      d.all2012.closed.properContains(next).should.be.false();
+      d.all2012.open.properContains(next).should.be.false();
     });
 
     it('should properly calculate dates after it', () => {
@@ -510,16 +510,16 @@ describe('DateTimeInterval', () => {
       const early = DateTime.parse('2000-01-01T00:00:00.0');
       const late = DateTime.parse('2999-01-01T00:00:00.0');
       const maxDate = MAX_DATETIME_VALUE;
-      new Interval(null, date).properContains(minDate).should.be.false();
+      new Interval(null, date).properContains(minDate).should.be.true();
       new Interval(null, date).properContains(early).should.be.true();
       new Interval(null, date).properContains(late).should.be.false();
-      new Interval(null, date, false, true).properContains(date).should.be.false();
+      should(new Interval(null, date, false, true).properContains(date)).be.null();
       should(new Interval(null, date, false, true).properContains(early)).be.null();
       new Interval(null, date, false, true).properContains(late).should.be.false();
       new Interval(date, null).properContains(late).should.be.true();
       new Interval(date, null).properContains(early).should.be.false();
-      new Interval(date, null).properContains(maxDate).should.be.false();
-      new Interval(date, null, true, false).properContains(date).should.be.false();
+      new Interval(date, null).properContains(maxDate).should.be.true();
+      should(new Interval(date, null, true, false).properContains(date)).be.null();
       should(new Interval(date, null, true, false).properContains(late)).be.null();
       new Interval(date, null, true, false).properContains(early).should.be.false();
       new Interval(null, null, true, true, ELM_DATETIME_TYPE).properContains(date).should.be.true();
@@ -536,9 +536,9 @@ describe('DateTimeInterval', () => {
       d.all2012.closed.properContains(d.aft2012.toMonth).should.be.false();
 
       d.all2012.toMonth.properContains(d.bef2012.toMonth).should.be.false();
-      d.all2012.toMonth.properContains(d.beg2012.toMonth).should.be.false();
+      d.all2012.toMonth.properContains(d.beg2012.toMonth).should.be.true();
       d.all2012.toMonth.properContains(d.mid2012.toMonth).should.be.true();
-      d.all2012.toMonth.properContains(d.end2012.toMonth).should.be.false();
+      d.all2012.toMonth.properContains(d.end2012.toMonth).should.be.true();
       d.all2012.toMonth.properContains(d.aft2012.toMonth).should.be.false();
 
       d.all2012.toMonth.properContains(d.bef2012.full).should.be.false();
@@ -2678,10 +2678,10 @@ describe('IntegerInterval', () => {
     });
 
     it('should properly calculate the left boundary integer', () => {
-      d.zeroToHundred.closed.properContains(0).should.be.false();
+      d.zeroToHundred.closed.properContains(0).should.be.true();
       d.zeroToHundred.open.properContains(0).should.be.false();
       d.zeroToHundred.closed.properContains(1).should.be.true();
-      d.zeroToHundred.open.properContains(1).should.be.false();
+      d.zeroToHundred.open.properContains(1).should.be.true();
       d.zeroToHundred.closed.properContains(2).should.be.true();
       d.zeroToHundred.open.properContains(2).should.be.true();
     });
@@ -2691,10 +2691,10 @@ describe('IntegerInterval', () => {
     });
 
     it('should properly calculate the right boundary integer', () => {
-      d.zeroToHundred.closed.properContains(100).should.be.false();
+      d.zeroToHundred.closed.properContains(100).should.be.true();
       d.zeroToHundred.open.properContains(100).should.be.false();
       d.zeroToHundred.closed.properContains(99).should.be.true();
-      d.zeroToHundred.open.properContains(99).should.be.false();
+      d.zeroToHundred.open.properContains(99).should.be.true();
       d.zeroToHundred.closed.properContains(98).should.be.true();
       d.zeroToHundred.open.properContains(98).should.be.true();
     });
@@ -2706,12 +2706,12 @@ describe('IntegerInterval', () => {
     it('should properly handle null endpoints', () => {
       new Interval(null, 0).properContains(-123456789).should.be.true();
       new Interval(null, 0).properContains(1).should.be.false();
-      new Interval(null, 0, false, true).properContains(0).should.be.false();
+      should(new Interval(null, 0, false, true).properContains(0)).be.null();
       should(new Interval(null, 0, false, true).properContains(-123456789)).be.null();
       new Interval(null, 0, false, true).properContains(1).should.be.false();
       new Interval(0, null).properContains(123456789).should.be.true();
       new Interval(0, null).properContains(-1).should.be.false();
-      new Interval(0, null, true, false).properContains(0).should.be.false();
+      should(new Interval(0, null, true, false).properContains(0)).be.null();
       should(new Interval(0, null, true, false).properContains(123456789)).be.null();
       new Interval(0, null, true, false).properContains(-1).should.be.false();
       new Interval(null, null, true, true, ELM_INTEGER_TYPE).properContains(0).should.be.true();
@@ -2721,8 +2721,8 @@ describe('IntegerInterval', () => {
     it('should properly handle imprecision', () => {
       d.zeroToHundred.closed.properContains(new Uncertainty(-20, -10)).should.be.false();
       should.not.exist(d.zeroToHundred.closed.properContains(new Uncertainty(-20, 20)));
-      should.not.exist(d.zeroToHundred.closed.properContains(new Uncertainty(0, 100)));
-      d.zeroToHundred.closed.properContains(new Uncertainty(1, 99)).should.be.true();
+      should.not.exist(d.zeroToHundred.closed.properContains(new Uncertainty(0, 101)));
+      d.zeroToHundred.closed.properContains(new Uncertainty(0, 100)).should.be.true();
       should.not.exist(d.zeroToHundred.closed.properContains(new Uncertainty(80, 120)));
       d.zeroToHundred.closed.properContains(new Uncertainty(120, 140)).should.be.false();
       should.not.exist(d.zeroToHundred.closed.properContains(new Uncertainty(-20, 120)));
@@ -2730,22 +2730,22 @@ describe('IntegerInterval', () => {
       const uIvl = new Interval(new Uncertainty(5, 10), new Uncertainty(15, 20));
 
       uIvl.properContains(0).should.be.false();
-      uIvl.properContains(5).should.be.false();
+      should.not.exist(uIvl.properContains(5));
       should.not.exist(uIvl.properContains(6));
-      should.not.exist(uIvl.properContains(10));
+      uIvl.properContains(10).should.be.true();
       uIvl.properContains(12).should.be.true();
-      should.not.exist(uIvl.properContains(15));
+      uIvl.properContains(15).should.be.true();
       should.not.exist(uIvl.properContains(16));
-      uIvl.properContains(20).should.be.false();
+      should.not.exist(uIvl.properContains(20));
       uIvl.properContains(25).should.be.false();
 
       uIvl.properContains(new Uncertainty(0, 4)).should.be.false();
-      uIvl.properContains(new Uncertainty(0, 5)).should.be.false();
+      should.not.exist(uIvl.properContains(new Uncertainty(0, 5)));
       should.not.exist(uIvl.properContains(new Uncertainty(5, 10)));
-      should.not.exist(uIvl.properContains(new Uncertainty(10, 15)));
+      uIvl.properContains(new Uncertainty(10, 15)).should.be.true();
       uIvl.properContains(new Uncertainty(11, 14)).should.be.true();
       should.not.exist(uIvl.properContains(new Uncertainty(15, 20)));
-      uIvl.properContains(new Uncertainty(20, 25)).should.be.false();
+      should.not.exist(uIvl.properContains(new Uncertainty(20, 25)));
       uIvl.properContains(new Uncertainty(25, 30)).should.be.false();
     });
 
@@ -4643,10 +4643,10 @@ describe('LongInterval', () => {
     });
 
     it('should properly calculate the left boundary long', () => {
-      d.zeroToHundredLong.closed.properContains(0n).should.be.false();
+      d.zeroToHundredLong.closed.properContains(0n).should.be.true();
       d.zeroToHundredLong.open.properContains(0n).should.be.false();
       d.zeroToHundredLong.closed.properContains(1n).should.be.true();
-      d.zeroToHundredLong.open.properContains(1n).should.be.false();
+      d.zeroToHundredLong.open.properContains(1n).should.be.true();
       d.zeroToHundredLong.closed.properContains(2n).should.be.true();
       d.zeroToHundredLong.open.properContains(2n).should.be.true();
     });
@@ -4656,10 +4656,10 @@ describe('LongInterval', () => {
     });
 
     it('should properly calculate the right boundary long', () => {
-      d.zeroToHundredLong.closed.properContains(100n).should.be.false();
+      d.zeroToHundredLong.closed.properContains(100n).should.be.true();
       d.zeroToHundredLong.open.properContains(100n).should.be.false();
       d.zeroToHundredLong.closed.properContains(99n).should.be.true();
-      d.zeroToHundredLong.open.properContains(99n).should.be.false();
+      d.zeroToHundredLong.open.properContains(99n).should.be.true();
       d.zeroToHundredLong.closed.properContains(98n).should.be.true();
       d.zeroToHundredLong.open.properContains(98n).should.be.true();
     });
@@ -4671,12 +4671,12 @@ describe('LongInterval', () => {
     it('should properly handle null endpoints', () => {
       new Interval(null, 0n).properContains(-123456789n).should.be.true();
       new Interval(null, 0n).properContains(1n).should.be.false();
-      new Interval(null, 0n, false, true).properContains(0n).should.be.false();
+      should(new Interval(null, 0n, false, true).properContains(0n)).be.null();
       should(new Interval(null, 0n, false, true).properContains(-123456789n)).be.null();
       new Interval(null, 0n, false, true).properContains(1n).should.be.false();
       new Interval(0n, null).properContains(123456789n).should.be.true();
       new Interval(0n, null).properContains(-1n).should.be.false();
-      new Interval(0n, null, true, false).properContains(0n).should.be.false();
+      should(new Interval(0n, null, true, false).properContains(0n)).be.null();
       should(new Interval(0n, null, true, false).properContains(123456789n)).be.null();
       new Interval(0n, null, true, false).properContains(-1n).should.be.false();
       new Interval(null, null, true, true, ELM_LONG_TYPE).properContains(0n).should.be.true();
@@ -4686,8 +4686,8 @@ describe('LongInterval', () => {
     it('should properly handle imprecision', () => {
       d.zeroToHundredLong.closed.properContains(new Uncertainty(-20n, -10n)).should.be.false();
       should.not.exist(d.zeroToHundredLong.closed.properContains(new Uncertainty(-20n, 20n)));
-      should.not.exist(d.zeroToHundredLong.closed.properContains(new Uncertainty(0n, 100n)));
-      d.zeroToHundredLong.closed.properContains(new Uncertainty(1n, 99n)).should.be.true();
+      should.not.exist(d.zeroToHundredLong.closed.properContains(new Uncertainty(0n, 101n)));
+      d.zeroToHundredLong.closed.properContains(new Uncertainty(0n, 100n)).should.be.true();
       should.not.exist(d.zeroToHundredLong.closed.properContains(new Uncertainty(80n, 120n)));
       d.zeroToHundredLong.closed.properContains(new Uncertainty(120n, 140n)).should.be.false();
       should.not.exist(d.zeroToHundredLong.closed.properContains(new Uncertainty(-20n, 120n)));
@@ -4695,22 +4695,22 @@ describe('LongInterval', () => {
       const uIvl = new Interval(new Uncertainty(5n, 10n), new Uncertainty(15n, 20n));
 
       uIvl.properContains(0n).should.be.false();
-      uIvl.properContains(5n).should.be.false();
+      should.not.exist(uIvl.properContains(5n));
       should.not.exist(uIvl.properContains(6n));
-      should.not.exist(uIvl.properContains(10n));
+      uIvl.properContains(10n).should.be.true();
       uIvl.properContains(12n).should.be.true();
-      should.not.exist(uIvl.properContains(15n));
+      uIvl.properContains(15n).should.be.true();
       should.not.exist(uIvl.properContains(16n));
-      uIvl.properContains(20n).should.be.false();
+      should.not.exist(uIvl.properContains(20n));
       uIvl.properContains(25n).should.be.false();
 
       uIvl.properContains(new Uncertainty(0n, 4n)).should.be.false();
-      uIvl.properContains(new Uncertainty(0n, 5n)).should.be.false();
+      should.not.exist(uIvl.properContains(new Uncertainty(0n, 5n)));
       should.not.exist(uIvl.properContains(new Uncertainty(5n, 10n)));
-      should.not.exist(uIvl.properContains(new Uncertainty(10n, 15n)));
+      uIvl.properContains(new Uncertainty(10n, 15n)).should.be.true();
       uIvl.properContains(new Uncertainty(11n, 14n)).should.be.true();
       should.not.exist(uIvl.properContains(new Uncertainty(15n, 20n)));
-      uIvl.properContains(new Uncertainty(20n, 25n)).should.be.false();
+      should.not.exist(uIvl.properContains(new Uncertainty(20n, 25n)));
       uIvl.properContains(new Uncertainty(25n, 30n)).should.be.false();
     });
 

--- a/test/datatypes/interval-test.ts
+++ b/test/datatypes/interval-test.ts
@@ -2,11 +2,15 @@ import should from 'should';
 import {
   DateTime,
   Date,
+  MAX_DATE_VALUE,
+  MAX_DATETIME_VALUE,
+  MAX_TIME_VALUE,
+  MIN_DATE_VALUE,
   MIN_DATETIME_VALUE,
-  MAX_DATETIME_VALUE
+  MIN_TIME_VALUE
 } from '../../src/datatypes/datetime';
 import { Interval } from '../../src/datatypes/interval';
-import { Quantity, MAX_QUANTITY_VALUE, MIN_QUANTITY_VALUE } from '../../src/datatypes/quantity';
+import { Quantity } from '../../src/datatypes/quantity';
 import { Uncertainty } from '../../src/datatypes/uncertainty';
 import {
   ELM_DATE_TYPE,
@@ -18,24 +22,37 @@ import {
   ELM_TIME_TYPE
 } from '../../src/util/elmTypes';
 import {
-  MAX_DATE_VALUE,
   MAX_FLOAT_VALUE,
   MAX_INT_VALUE,
   MAX_LONG_VALUE,
-  MAX_TIME_VALUE,
-  MIN_DATE_VALUE,
   MIN_FLOAT_VALUE,
   MIN_INT_VALUE,
-  MIN_LONG_VALUE,
-  MIN_TIME_VALUE
-} from '../../src/util/math';
+  MIN_LONG_VALUE
+} from '../../src/util/limits';
 import data from './interval-data';
 
 const xy = (obj: any) => [obj.x, obj.y];
-const boundlessInterval = () => new Interval(null, null);
-const unknownInterval = () => new Interval(null, null, false, false);
+const boundlessInterval = (type?: string) => new Interval(null, null, true, true, type);
+const unknownInterval = (type?: string) => new Interval(null, null, false, false, type);
 
 describe('Interval', () => {
+  describe('equalInterval assertion', () => {
+    it('should compare intervals using interval equality', () => {
+      new Interval(1, 5).should.equalInterval(new Interval(0, 6, false, false));
+      new Interval(1, 5).should.not.equalInterval(new Interval(1, 4));
+    });
+
+    it('should require the object in context to be an interval', () => {
+      should(() => should({}).equalInterval(new Interval(1, 5))).throw(/to equal interval/);
+    });
+
+    it('should treat indeterminate interval equality as equal', () => {
+      // For test assertions we want to test that the intervals represent the same concept, so we
+      // consider uncertainties over the same range as equal
+      unknownInterval(ELM_INTEGER_TYPE).should.equalInterval(unknownInterval(ELM_INTEGER_TYPE));
+    });
+  });
+
   it('should properly set all properties when constructed as DateTime interval', () => {
     const i = new Interval(DateTime.parse('2012-01-01'), DateTime.parse('2013-01-01'), true, false);
     i.low.should.eql(DateTime.parse('2012-01-01'));
@@ -68,18 +85,18 @@ describe('Interval', () => {
     i.highClosed.should.be.true();
   });
 
-  it('should identify and copy boundless and unknown intervals', () => {
-    const all = boundlessInterval();
-    all.isBoundlessInterval.should.be.true();
-    all.isUnknownInterval.should.be.false();
+  it('should preserve null boundaries when closing an untyped interval', () => {
+    const all = boundlessInterval().toClosed();
+    should(all.low).be.null();
+    should(all.high).be.null();
+    all.lowClosed.should.be.true();
+    all.highClosed.should.be.true();
 
-    const mystery = unknownInterval();
-    mystery.isBoundlessInterval.should.be.false();
-    mystery.isUnknownInterval.should.be.true();
-
-    const allCopy = all.copy();
-    allCopy.should.eql(all);
-    allCopy.should.not.equal(all);
+    const mystery = unknownInterval().toClosed();
+    should(mystery.low).be.null();
+    should(mystery.high).be.null();
+    mystery.lowClosed.should.be.false();
+    mystery.highClosed.should.be.false();
   });
 
   describe('start', () => {
@@ -190,7 +207,7 @@ describe('Interval', () => {
       new Interval(null, null, true, true, ELM_DECIMAL_TYPE).start().should.equal(MIN_FLOAT_VALUE);
       new Interval(null, null, true, true, ELM_QUANTITY_TYPE)
         .start()
-        .should.eql(MIN_QUANTITY_VALUE);
+        .should.eql(new Quantity(MIN_FLOAT_VALUE, '1'));
       new Interval(null, null, true, true, ELM_DATETIME_TYPE)
         .start()
         .should.eql(MIN_DATETIME_VALUE);
@@ -210,7 +227,9 @@ describe('Interval', () => {
         .should.eql(new Uncertainty(MIN_FLOAT_VALUE, MAX_FLOAT_VALUE));
       new Interval(null, null, false, false, ELM_QUANTITY_TYPE)
         .start()
-        .should.eql(new Uncertainty(MIN_QUANTITY_VALUE, MAX_QUANTITY_VALUE));
+        .should.eql(
+          new Uncertainty(new Quantity(MIN_FLOAT_VALUE, '1'), new Quantity(MAX_FLOAT_VALUE, '1'))
+        );
       new Interval(null, null, false, false, ELM_DATETIME_TYPE)
         .start()
         .should.eql(new Uncertainty(MIN_DATETIME_VALUE, MAX_DATETIME_VALUE));
@@ -318,7 +337,9 @@ describe('Interval', () => {
       new Interval(null, null, true, true, ELM_INTEGER_TYPE).end().should.equal(MAX_INT_VALUE);
       new Interval(null, null, true, true, ELM_LONG_TYPE).end().should.equal(MAX_LONG_VALUE);
       new Interval(null, null, true, true, ELM_DECIMAL_TYPE).end().should.equal(MAX_FLOAT_VALUE);
-      new Interval(null, null, true, true, ELM_QUANTITY_TYPE).end().should.eql(MAX_QUANTITY_VALUE);
+      new Interval(null, null, true, true, ELM_QUANTITY_TYPE)
+        .end()
+        .should.eql(new Quantity(MAX_FLOAT_VALUE, '1'));
       new Interval(null, null, true, true, ELM_DATETIME_TYPE).end().should.eql(MAX_DATETIME_VALUE);
       new Interval(null, null, true, true, ELM_DATE_TYPE).end().should.eql(MAX_DATE_VALUE);
       new Interval(null, null, true, true, ELM_TIME_TYPE).end().should.eql(MAX_TIME_VALUE);
@@ -336,7 +357,9 @@ describe('Interval', () => {
         .should.eql(new Uncertainty(MIN_FLOAT_VALUE, MAX_FLOAT_VALUE));
       new Interval(null, null, false, false, ELM_QUANTITY_TYPE)
         .end()
-        .should.eql(new Uncertainty(MIN_QUANTITY_VALUE, MAX_QUANTITY_VALUE));
+        .should.eql(
+          new Uncertainty(new Quantity(MIN_FLOAT_VALUE, '1'), new Quantity(MAX_FLOAT_VALUE, '1'))
+        );
       new Interval(null, null, false, false, ELM_DATETIME_TYPE)
         .end()
         .should.eql(new Uncertainty(MIN_DATETIME_VALUE, MAX_DATETIME_VALUE));
@@ -344,6 +367,17 @@ describe('Interval', () => {
         .end()
         .should.eql(new Uncertainty(MIN_TIME_VALUE, MAX_TIME_VALUE));
     });
+  });
+});
+
+describe('DateInterval', () => {
+  it('should use the specified precision for meets comparisons', () => {
+    const january = new Interval(Date.parse('2020-01-01'), Date.parse('2020-01-15'));
+    const february = new Interval(Date.parse('2020-02-15'), Date.parse('2020-02-28'));
+
+    january.meets(february, Date.Unit.MONTH).should.be.true();
+    january.meetsBefore(february, Date.Unit.MONTH).should.be.true();
+    february.meetsAfter(january, Date.Unit.MONTH).should.be.true();
   });
 });
 
@@ -390,8 +424,8 @@ describe('DateTimeInterval', () => {
       new Interval(date, null, true, false).contains(date).should.be.true();
       should(new Interval(date, null, true, false).contains(late)).be.null();
       new Interval(date, null, true, false).contains(early).should.be.false();
-      new Interval(null, null).contains(date).should.be.true();
-      should(new Interval(null, null, false, false).contains(date)).be.null();
+      boundlessInterval(ELM_DATETIME_TYPE).contains(date).should.be.true();
+      should(unknownInterval(ELM_DATETIME_TYPE).contains(date)).be.null();
     });
 
     it('should properly handle imprecision', () => {
@@ -488,10 +522,6 @@ describe('DateTimeInterval', () => {
       new Interval(date, null, true, false).properContains(date).should.be.false();
       should(new Interval(date, null, true, false).properContains(late)).be.null();
       new Interval(date, null, true, false).properContains(early).should.be.false();
-    });
-
-    it.skip('should properly handle unbounded and unknown intervals', () => {
-      const date = DateTime.parse('2012-01-01T00:00:00.0');
       new Interval(null, null, true, true, ELM_DATETIME_TYPE).properContains(date).should.be.true();
       should(
         new Interval(null, null, false, false, ELM_DATETIME_TYPE).properContains(date)
@@ -652,12 +682,16 @@ describe('DateTimeInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().includes(d.mid2012.full).should.be.true();
-      boundlessInterval().includes(d.all2012.closed).should.be.true();
-      boundlessInterval().includes(unknownInterval()).should.be.true();
-      d.all2012.closed.includes(boundlessInterval()).should.be.false();
-      should(unknownInterval().includes(d.all2012.closed)).be.null();
-      should(unknownInterval().includes(boundlessInterval())).be.null();
+      boundlessInterval(ELM_DATETIME_TYPE).includes(d.mid2012.full).should.be.true();
+      boundlessInterval(ELM_DATETIME_TYPE).includes(d.all2012.closed).should.be.true();
+      boundlessInterval(ELM_DATETIME_TYPE)
+        .includes(unknownInterval(ELM_DATETIME_TYPE))
+        .should.be.true();
+      d.all2012.closed.includes(boundlessInterval(ELM_DATETIME_TYPE)).should.be.false();
+      should(unknownInterval(ELM_DATETIME_TYPE).includes(d.all2012.closed)).be.null();
+      should(
+        unknownInterval(ELM_DATETIME_TYPE).includes(boundlessInterval(ELM_DATETIME_TYPE))
+      ).be.null();
     });
 
     it('should include a point date', () => {
@@ -788,14 +822,14 @@ describe('DateTimeInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      d.all2012.closed.includedIn(boundlessInterval()).should.be.true();
-      boundlessInterval().includedIn(d.all2012.closed).should.be.false();
-      boundlessInterval().includedIn(boundlessInterval()).should.be.true();
-      unknownInterval().includedIn(boundlessInterval()).should.be.true();
-    });
-
-    it('should include a point date', () => {
-      d.all2012.closed.includedIn(d.mid2012.full).should.be.true();
+      d.all2012.closed.includedIn(boundlessInterval(ELM_DATETIME_TYPE)).should.be.true();
+      boundlessInterval(ELM_DATETIME_TYPE).includedIn(d.all2012.closed).should.be.false();
+      boundlessInterval(ELM_DATETIME_TYPE)
+        .includedIn(boundlessInterval(ELM_DATETIME_TYPE))
+        .should.be.true();
+      unknownInterval(ELM_DATETIME_TYPE)
+        .includedIn(boundlessInterval(ELM_DATETIME_TYPE))
+        .should.be.true();
     });
   });
 
@@ -806,10 +840,14 @@ describe('DateTimeInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().properlyIncludes(d.all2012.closed).should.be.true();
-      boundlessInterval().properlyIncludes(boundlessInterval()).should.be.false();
-      should(boundlessInterval().properlyIncludes(unknownInterval())).be.null();
-      should(unknownInterval().properlyIncludes(d.all2012.closed)).be.null();
+      boundlessInterval(ELM_DATETIME_TYPE).properlyIncludes(d.all2012.closed).should.be.true();
+      boundlessInterval(ELM_DATETIME_TYPE)
+        .properlyIncludes(boundlessInterval(ELM_DATETIME_TYPE))
+        .should.be.false();
+      should(
+        boundlessInterval(ELM_DATETIME_TYPE).properlyIncludes(unknownInterval(ELM_DATETIME_TYPE))
+      ).be.null();
+      should(unknownInterval(ELM_DATETIME_TYPE).properlyIncludes(d.all2012.closed)).be.null();
     });
   });
 
@@ -820,11 +858,17 @@ describe('DateTimeInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().starts(boundlessInterval()).should.be.true();
-      boundlessInterval().starts(d.all2012.closed).should.be.false();
-      d.all2012.closed.starts(boundlessInterval()).should.be.false();
-      should(boundlessInterval().starts(unknownInterval())).be.null();
-      should(unknownInterval().starts(boundlessInterval())).be.null();
+      boundlessInterval(ELM_DATETIME_TYPE)
+        .starts(boundlessInterval(ELM_DATETIME_TYPE))
+        .should.be.true();
+      boundlessInterval(ELM_DATETIME_TYPE).starts(d.all2012.closed).should.be.false();
+      d.all2012.closed.starts(boundlessInterval(ELM_DATETIME_TYPE)).should.be.false();
+      should(
+        boundlessInterval(ELM_DATETIME_TYPE).starts(unknownInterval(ELM_DATETIME_TYPE))
+      ).be.null();
+      should(
+        unknownInterval(ELM_DATETIME_TYPE).starts(boundlessInterval(ELM_DATETIME_TYPE))
+      ).be.null();
     });
   });
 
@@ -835,11 +879,17 @@ describe('DateTimeInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().ends(boundlessInterval()).should.be.true();
-      boundlessInterval().ends(d.all2012.closed).should.be.false();
-      d.all2012.closed.ends(boundlessInterval()).should.be.false();
-      should(boundlessInterval().ends(unknownInterval())).be.null();
-      should(unknownInterval().ends(boundlessInterval())).be.null();
+      boundlessInterval(ELM_DATETIME_TYPE)
+        .ends(boundlessInterval(ELM_DATETIME_TYPE))
+        .should.be.true();
+      boundlessInterval(ELM_DATETIME_TYPE).ends(d.all2012.closed).should.be.false();
+      d.all2012.closed.ends(boundlessInterval(ELM_DATETIME_TYPE)).should.be.false();
+      should(
+        boundlessInterval(ELM_DATETIME_TYPE).ends(unknownInterval(ELM_DATETIME_TYPE))
+      ).be.null();
+      should(
+        unknownInterval(ELM_DATETIME_TYPE).ends(boundlessInterval(ELM_DATETIME_TYPE))
+      ).be.null();
     });
   });
 
@@ -954,26 +1004,22 @@ describe('DateTimeInterval', () => {
       should(new Interval(date, null, true, false).overlaps(lateInterval)).be.null();
       should(new Interval(date, null, true, false).overlaps(earlyInterval)).be.false();
 
-      should(new Interval(null, null).overlaps(d.all2012.closed)).be.true();
-      should(new Interval(null, null, false, false).overlaps(d.all2012.closed)).be.null();
-      should(d.all2012.closed.overlaps(new Interval(null, null))).be.true();
-      should(d.all2012.closed.overlaps(new Interval(null, null, false, false))).be.null();
-      // TODO: These commented out edge cases with all null endpoints on both sides currently don't pass
-      //should(new Interval(null, null).overlaps(new Interval(null, null))).be.true();
-      //should(new Interval(null, null).overlaps(new Interval(null, null, false, false))).be.true();
-      //should(new Interval(null, null, false, false).overlaps(new Interval(null, null))).be.true();
+      should(boundlessInterval(ELM_DATETIME_TYPE).overlaps(d.all2012.closed)).be.true();
+      should(unknownInterval(ELM_DATETIME_TYPE).overlaps(d.all2012.closed)).be.null();
+      should(d.all2012.closed.overlaps(boundlessInterval(ELM_DATETIME_TYPE))).be.true();
+      should(d.all2012.closed.overlaps(unknownInterval(ELM_DATETIME_TYPE))).be.null();
       should(
-        new Interval(null, null, false, false).overlaps(new Interval(null, null, false, false))
+        boundlessInterval(ELM_DATETIME_TYPE).overlaps(boundlessInterval(ELM_DATETIME_TYPE))
+      ).be.true();
+      should(
+        boundlessInterval(ELM_DATETIME_TYPE).overlaps(unknownInterval(ELM_DATETIME_TYPE))
+      ).be.true();
+      should(
+        unknownInterval(ELM_DATETIME_TYPE).overlaps(boundlessInterval(ELM_DATETIME_TYPE))
+      ).be.true();
+      should(
+        unknownInterval(ELM_DATETIME_TYPE).overlaps(unknownInterval(ELM_DATETIME_TYPE))
       ).be.null();
-    });
-
-    it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().overlaps(boundlessInterval()).should.be.true();
-      boundlessInterval().overlaps(d.all2012.closed).should.be.true();
-      d.all2012.closed.overlaps(boundlessInterval()).should.be.true();
-      should(boundlessInterval().overlaps(unknownInterval())).be.null();
-      should(unknownInterval().overlaps(boundlessInterval())).be.null();
-      should(unknownInterval().overlaps(d.all2012.closed)).be.null();
     });
 
     it('should properly handle imprecision', () => {
@@ -1008,81 +1054,6 @@ describe('DateTimeInterval', () => {
     });
   });
 
-  describe('overlaps(DateTime)', () => {
-    let d: any;
-    beforeEach(() => {
-      d = data();
-    });
-
-    it('should properly calculate dates before it', () => {
-      d.all2012.closed.overlaps(d.bef2012.full).should.be.false();
-    });
-
-    it('should properly calculate the left boundary date', () => {
-      d.all2012.closed.overlaps(d.beg2012.full).should.be.true();
-      d.all2012.open.overlaps(d.beg2012.full).should.be.false();
-    });
-
-    it('should properly calculate dates in the middle of it', () => {
-      d.all2012.closed.overlaps(d.mid2012.full).should.be.true();
-    });
-
-    it('should properly calculate the right boundary date', () => {
-      d.all2012.closed.overlaps(d.end2012.full).should.be.true();
-      d.all2012.open.overlaps(d.end2012.full).should.be.false();
-    });
-
-    it('should properly calculate dates after it', () => {
-      d.all2012.closed.overlaps(d.aft2012.full).should.be.false();
-    });
-
-    it('should properly handle null endpoints', () => {
-      const date = DateTime.parse('2012-01-01T00:00:00.0');
-      const early = DateTime.parse('0001-01-01T00:00:00.0');
-      const late = DateTime.parse('2999-01-01T00:00:00.0');
-      should(new Interval(null, date).overlaps(early)).be.true();
-      should(new Interval(null, date).overlaps(late)).be.false();
-      should(new Interval(null, date, false, true).overlaps(date)).be.true();
-      should(new Interval(null, date, false, true).overlaps(early)).be.null();
-      should(new Interval(null, date, false, true).overlaps(late)).be.false();
-      should(new Interval(date, null).overlaps(late)).be.true();
-      should(new Interval(date, null).overlaps(early)).be.false();
-      should(new Interval(date, null, true, false).overlaps(date)).be.true();
-      should(new Interval(date, null, true, false).overlaps(late)).be.null();
-      should(new Interval(date, null, true, false).overlaps(early)).be.false();
-      should(new Interval(null, null).overlaps(date)).be.true();
-      should(new Interval(null, null, false, false).overlaps(date)).be.null();
-    });
-
-    it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().overlaps(d.mid2012.full).should.be.true();
-      should(boundlessInterval().overlaps(null)).be.null();
-      should(unknownInterval().overlaps(d.mid2012.full)).be.null();
-    });
-
-    it('should properly handle imprecision', () => {
-      d.all2012.closed.overlaps(d.bef2012.toMonth).should.be.false();
-      should.not.exist(d.all2012.closed.overlaps(d.beg2012.toMonth));
-      d.all2012.closed.overlaps(d.mid2012.toMonth).should.be.true();
-      should.not.exist(d.all2012.closed.overlaps(d.end2012.toMonth));
-      d.all2012.closed.overlaps(d.aft2012.toMonth).should.be.false();
-
-      d.all2012.toMonth.overlaps(d.bef2012.toMonth).should.be.false();
-      d.all2012.toMonth.overlaps(d.beg2012.toMonth).should.be.true();
-      d.all2012.toMonth.overlaps(d.mid2012.toMonth).should.be.true();
-      d.all2012.toMonth.overlaps(d.end2012.toMonth).should.be.true();
-      d.all2012.toMonth.overlaps(d.aft2012.toMonth).should.be.false();
-
-      d.all2012.toMonth.overlaps(d.bef2012.full).should.be.false();
-      should.not.exist(d.all2012.toMonth.overlaps(d.beg2012.full));
-      d.all2012.toMonth.overlaps(d.mid2012.full).should.be.true();
-      should.not.exist(d.all2012.toMonth.overlaps(d.end2012.full));
-      d.all2012.toMonth.overlaps(d.aft2012.full).should.be.false();
-
-      should.not.exist(d.all2012.closed.overlaps(d.mid2012.toYear));
-    });
-  });
-
   describe('overlapsBefore', () => {
     let d: any;
     beforeEach(() => {
@@ -1090,10 +1061,14 @@ describe('DateTimeInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().overlapsBefore(d.mid2012.full).should.be.true();
-      d.all2012.closed.overlapsBefore(boundlessInterval()).should.be.false();
-      should(boundlessInterval().overlapsBefore(unknownInterval())).be.null();
-      should(unknownInterval().overlapsBefore(boundlessInterval())).be.null();
+      boundlessInterval(ELM_DATETIME_TYPE).overlapsBefore(d.all2012.closed).should.be.true();
+      d.all2012.closed.overlapsBefore(boundlessInterval(ELM_DATETIME_TYPE)).should.be.false();
+      should(
+        boundlessInterval(ELM_DATETIME_TYPE).overlapsBefore(unknownInterval(ELM_DATETIME_TYPE))
+      ).be.null();
+      unknownInterval(ELM_DATETIME_TYPE)
+        .overlapsBefore(boundlessInterval(ELM_DATETIME_TYPE))
+        .should.be.false();
     });
   });
 
@@ -1104,10 +1079,14 @@ describe('DateTimeInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().overlapsAfter(d.mid2012.full).should.be.true();
-      d.all2012.closed.overlapsAfter(boundlessInterval()).should.be.false();
-      should(boundlessInterval().overlapsAfter(unknownInterval())).be.null();
-      should(unknownInterval().overlapsAfter(boundlessInterval())).be.null();
+      boundlessInterval(ELM_DATETIME_TYPE).overlapsAfter(d.all2012.closed).should.be.true();
+      d.all2012.closed.overlapsAfter(boundlessInterval(ELM_DATETIME_TYPE)).should.be.false();
+      should(
+        boundlessInterval(ELM_DATETIME_TYPE).overlapsAfter(unknownInterval(ELM_DATETIME_TYPE))
+      ).be.null();
+      unknownInterval(ELM_DATETIME_TYPE)
+        .overlapsAfter(boundlessInterval(ELM_DATETIME_TYPE))
+        .should.be.false();
     });
   });
 
@@ -1267,12 +1246,20 @@ describe('DateTimeInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().equals(boundlessInterval()).should.be.true();
-      boundlessInterval().equals(d.all2012.closed).should.be.false();
-      d.all2012.closed.equals(boundlessInterval()).should.be.false();
-      should(boundlessInterval().equals(unknownInterval())).be.null();
-      should(unknownInterval().equals(boundlessInterval())).be.null();
-      should(unknownInterval().equals(unknownInterval())).be.null();
+      boundlessInterval(ELM_DATETIME_TYPE)
+        .equals(boundlessInterval(ELM_DATETIME_TYPE))
+        .should.be.true();
+      boundlessInterval(ELM_DATETIME_TYPE).equals(d.all2012.closed).should.be.false();
+      d.all2012.closed.equals(boundlessInterval(ELM_DATETIME_TYPE)).should.be.false();
+      should(
+        boundlessInterval(ELM_DATETIME_TYPE).equals(unknownInterval(ELM_DATETIME_TYPE))
+      ).be.null();
+      should(
+        unknownInterval(ELM_DATETIME_TYPE).equals(boundlessInterval(ELM_DATETIME_TYPE))
+      ).be.null();
+      should(
+        unknownInterval(ELM_DATETIME_TYPE).equals(unknownInterval(ELM_DATETIME_TYPE))
+      ).be.null();
     });
   });
 
@@ -1282,12 +1269,69 @@ describe('DateTimeInterval', () => {
       d = data();
     });
 
+    it('should convert Date intervals to DateTime intervals before determining boundaries', () => {
+      const dateLow = Date.parse('2012-01-01');
+      const dateTimeLow = DateTime.parse('2012-01-01');
+      const dateTimeMinutesLow = DateTime.parse('2012-01-01T18:30');
+      const dateHigh = Date.parse('2012-12-31');
+      const dateTimeHigh = DateTime.parse('2012-12-31');
+      const dateTimeMinutesHigh = DateTime.parse('2012-12-31T22:00');
+      const dateInterval = new Interval(dateLow, dateHigh, true, true, ELM_DATE_TYPE);
+      const dateTimeInterval = new Interval(
+        dateTimeLow,
+        dateTimeHigh,
+        true,
+        true,
+        ELM_DATETIME_TYPE
+      );
+      const dateTimeMinutesInterval = new Interval(
+        dateTimeMinutesLow,
+        dateTimeMinutesHigh,
+        true,
+        true,
+        ELM_DATETIME_TYPE
+      );
+      const dateIntervalWithBoundlessHigh = new Interval(dateLow, null, true, true, ELM_DATE_TYPE);
+      const dateTimeIntervalWithBoundlessHigh = new Interval(
+        dateTimeLow,
+        null,
+        true,
+        true,
+        ELM_DATETIME_TYPE
+      );
+      const dateIntervalWithBoundlessLow = new Interval(null, dateHigh, true, true, ELM_DATE_TYPE);
+      const dateTimeIntervalWithBoundlessLow = new Interval(
+        null,
+        dateTimeHigh,
+        true,
+        true,
+        ELM_DATETIME_TYPE
+      );
+
+      dateInterval.sameAs(dateTimeInterval).should.be.true();
+      dateTimeInterval.sameAs(dateInterval).should.be.true();
+      should(dateInterval.sameAs(dateTimeMinutesInterval)).be.null();
+      should(dateTimeMinutesInterval.sameAs(dateInterval)).be.null();
+      dateInterval.sameAs(dateTimeIntervalWithBoundlessHigh).should.be.false();
+      dateTimeInterval.sameAs(dateIntervalWithBoundlessHigh).should.be.false();
+      dateIntervalWithBoundlessHigh.sameAs(dateTimeIntervalWithBoundlessHigh).should.be.true();
+      dateTimeIntervalWithBoundlessHigh.sameAs(dateIntervalWithBoundlessHigh).should.be.true();
+      dateIntervalWithBoundlessLow.sameAs(dateTimeIntervalWithBoundlessLow).should.be.true();
+      dateTimeIntervalWithBoundlessLow.sameAs(dateIntervalWithBoundlessLow).should.be.true();
+    });
+
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().sameAs(boundlessInterval()).should.be.true();
-      boundlessInterval().sameAs(d.all2012.closed).should.be.false();
-      d.all2012.closed.sameAs(boundlessInterval()).should.be.false();
-      should(boundlessInterval().sameAs(unknownInterval())).be.null();
-      should(unknownInterval().sameAs(boundlessInterval())).be.null();
+      boundlessInterval(ELM_DATETIME_TYPE)
+        .sameAs(boundlessInterval(ELM_DATETIME_TYPE))
+        .should.be.true();
+      boundlessInterval(ELM_DATETIME_TYPE).sameAs(d.all2012.closed).should.be.false();
+      d.all2012.closed.sameAs(boundlessInterval(ELM_DATETIME_TYPE)).should.be.false();
+      should(
+        boundlessInterval(ELM_DATETIME_TYPE).sameAs(unknownInterval(ELM_DATETIME_TYPE))
+      ).be.null();
+      should(
+        unknownInterval(ELM_DATETIME_TYPE).sameAs(boundlessInterval(ELM_DATETIME_TYPE))
+      ).be.null();
     });
   });
 
@@ -1299,14 +1343,14 @@ describe('DateTimeInterval', () => {
 
     it('should properly calculate sameAs unions', () => {
       const [x, y] = Array.from(xy(d.dIvl.sameAs));
-      x.closed.union(y.closed).equals(x.closed).should.be.true();
-      x.closed.union(y.open).equals(x.closed).should.be.true();
-      x.open.union(y.closed).equals(x.closed).should.be.true();
-      x.open.union(y.open).equals(x.open).should.be.true();
-      y.closed.union(x.closed).equals(y.closed).should.be.true();
-      y.closed.union(x.open).equals(y.closed).should.be.true();
-      y.open.union(x.closed).equals(y.closed).should.be.true();
-      y.open.union(x.open).equals(y.open).should.be.true();
+      x.closed.union(y.closed).should.equalInterval(x.closed);
+      x.closed.union(y.open).should.equalInterval(x.closed);
+      x.open.union(y.closed).should.equalInterval(x.closed);
+      x.open.union(y.open).should.equalInterval(x.open);
+      y.closed.union(x.closed).should.equalInterval(y.closed);
+      y.closed.union(x.open).should.equalInterval(y.closed);
+      y.open.union(x.closed).should.equalInterval(y.closed);
+      y.open.union(x.open).should.equalInterval(y.open);
     });
 
     it('should properly calculate before/after unions', () => {
@@ -1469,14 +1513,22 @@ describe('DateTimeInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().union(d.all2012.closed).should.eql(boundlessInterval());
-      d.all2012.closed.union(boundlessInterval()).should.eql(boundlessInterval());
-      boundlessInterval().union(unknownInterval()).should.eql(boundlessInterval());
-      unknownInterval().union(boundlessInterval()).should.eql(boundlessInterval());
+      boundlessInterval(ELM_DATETIME_TYPE)
+        .union(d.all2012.closed)
+        .should.equalInterval(boundlessInterval(ELM_DATETIME_TYPE));
+      d.all2012.closed
+        .union(boundlessInterval(ELM_DATETIME_TYPE))
+        .should.equalInterval(boundlessInterval(ELM_DATETIME_TYPE));
+      boundlessInterval(ELM_DATETIME_TYPE)
+        .union(unknownInterval(ELM_DATETIME_TYPE))
+        .should.equalInterval(boundlessInterval(ELM_DATETIME_TYPE));
+      unknownInterval(ELM_DATETIME_TYPE)
+        .union(boundlessInterval(ELM_DATETIME_TYPE))
+        .should.equalInterval(boundlessInterval(ELM_DATETIME_TYPE));
     });
 
     it('should throw when the argument is a point', () => {
-      should(() => d.all2012.closed.union(d.mid2012.closed)).throw(Error);
+      should(() => d.all2012.closed.union(d.mid2012)).throw(Error);
     });
   });
 
@@ -1602,10 +1654,18 @@ describe('DateTimeInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().intersect(d.all2012.closed).should.eql(d.all2012.closed);
-      d.all2012.closed.intersect(boundlessInterval()).should.eql(d.all2012.closed);
-      boundlessInterval().intersect(unknownInterval()).should.eql(unknownInterval());
-      unknownInterval().intersect(boundlessInterval()).should.eql(unknownInterval());
+      boundlessInterval(ELM_DATETIME_TYPE)
+        .intersect(d.all2012.closed)
+        .should.equalInterval(d.all2012.closed);
+      d.all2012.closed
+        .intersect(boundlessInterval(ELM_DATETIME_TYPE))
+        .should.equalInterval(d.all2012.closed);
+      boundlessInterval(ELM_DATETIME_TYPE)
+        .intersect(unknownInterval(ELM_DATETIME_TYPE))
+        .should.equalInterval(unknownInterval(ELM_DATETIME_TYPE));
+      unknownInterval(ELM_DATETIME_TYPE)
+        .intersect(boundlessInterval(ELM_DATETIME_TYPE))
+        .should.equalInterval(unknownInterval(ELM_DATETIME_TYPE));
     });
 
     it('should throw when the argument is a point', () => {
@@ -1633,26 +1693,26 @@ describe('DateTimeInterval', () => {
 
     it('should properly calculate before/after except', () => {
       const [x, y] = Array.from(xy(d.dIvl.before));
-      x.closed.except(y.closed).should.eql(x.closed);
-      x.closed.except(y.open).should.eql(x.closed);
-      x.open.except(y.closed).should.eql(x.open);
-      x.open.except(y.open).should.eql(x.open);
-      y.closed.except(x.closed).should.eql(y.closed);
-      y.closed.except(x.open).should.eql(y.closed);
-      y.open.except(x.closed).should.eql(y.open);
-      y.open.except(x.open).should.eql(y.open);
+      x.closed.except(y.closed).should.equalInterval(x.closed);
+      x.closed.except(y.open).should.equalInterval(x.closed);
+      x.open.except(y.closed).should.equalInterval(x.open);
+      x.open.except(y.open).should.equalInterval(x.open);
+      y.closed.except(x.closed).should.equalInterval(y.closed);
+      y.closed.except(x.open).should.equalInterval(y.closed);
+      y.open.except(x.closed).should.equalInterval(y.open);
+      y.open.except(x.open).should.equalInterval(y.open);
     });
 
     it('should properly calculate meets except', () => {
       const [x, y] = Array.from(xy(d.dIvl.meets));
-      x.closed.except(y.closed).should.eql(x.closed);
-      x.closed.except(y.open).should.eql(x.closed);
-      x.open.except(y.closed).should.eql(x.open);
-      x.open.except(y.open).should.eql(x.open);
-      y.closed.except(x.closed).should.eql(y.closed);
-      y.closed.except(x.open).should.eql(y.closed);
-      y.open.except(x.closed).should.eql(y.open);
-      y.open.except(x.open).should.eql(y.open);
+      x.closed.except(y.closed).should.equalInterval(x.closed);
+      x.closed.except(y.open).should.equalInterval(x.closed);
+      x.open.except(y.closed).should.equalInterval(x.open);
+      x.open.except(y.open).should.equalInterval(x.open);
+      y.closed.except(x.closed).should.equalInterval(y.closed);
+      y.closed.except(x.open).should.equalInterval(y.closed);
+      y.open.except(x.closed).should.equalInterval(y.open);
+      y.open.except(x.open).should.equalInterval(y.open);
     });
 
     it('should properly calculate left/right overlapping except', () => {
@@ -1673,7 +1733,7 @@ describe('DateTimeInterval', () => {
       const [x, y] = Array.from(xy(d.dIvl.begins));
       const b = d.julydec;
       should.not.exist(x.closed.except(y.closed));
-      x.closed.except(y.open).should.eql(new Interval(x.closed.low, x.closed.low));
+      x.closed.except(y.open).should.equalInterval(new Interval(x.closed.low, x.closed.low));
       should.not.exist(x.open.except(y.open));
       y.closed.except(x.closed).equals(b.openClosed).should.be.true();
       should.not.exist(y.closed.except(x.open));
@@ -1697,7 +1757,7 @@ describe('DateTimeInterval', () => {
       const [x, y] = Array.from(xy(d.dIvl.ends));
       const b = d.janjuly;
       should.not.exist(x.closed.except(y.closed));
-      x.closed.except(y.open).should.eql(new Interval(x.closed.high, x.closed.high));
+      x.closed.except(y.open).should.equalInterval(new Interval(x.closed.high, x.closed.high));
       should.not.exist(x.open.except(y.closed));
       should.not.exist(x.open.except(y.open));
       y.closed.except(x.closed).equals(b.closedOpen).should.be.true();
@@ -1715,9 +1775,9 @@ describe('DateTimeInterval', () => {
 
       [x, y] = Array.from(xy(d.dIvl.meets));
       // [a,b].except([b,c]) (where b is uncertain) should result in [a,b) but spec says we don't know if they overlap
-      x.toDay.except(y.toDay).should.eql(x.toDay);
+      x.toDay.except(y.toDay).should.equalInterval(x.toDay);
       // [b,c].except([a,b]) (where b is uncertain) should result in (b,c] but spec says we don't know if they overlap
-      y.toDay.except(x.toDay).should.eql(y.toDay);
+      y.toDay.except(x.toDay).should.equalInterval(y.toDay);
 
       [x, y] = Array.from(xy(d.dIvl.during));
       should.not.exist(x.toDay.except(y.toDay));
@@ -1728,16 +1788,24 @@ describe('DateTimeInterval', () => {
       should.not.exist(x.toDay.except(y.toDay));
       // x: ['2012-07-01', '2012-12-31']
       // y: ['2012-01-01', '2012-12-31']
-      y.toDay.except(x.toDay).should.eql(new Interval(y.toDay.low, x.toDay.low, true, false));
-      should.not.exist(y.toDay.except(x.toMinute));
+      y.toDay
+        .except(x.toDay)
+        .should.equalInterval(new Interval(y.toDay.low, x.toDay.low, true, false));
+      y.toDay
+        .except(x.toMinute)
+        .should.equalInterval(new Interval(y.toDay.low, x.toMinute.low, true, false));
 
       [x, y] = Array.from(xy(d.dIvl.begins));
       should.not.exist(x.toDay.except(y.toDay));
       should.not.exist(x.toDay.except(y.toDay));
       // x: ['2012-01-01', '2012-07-01']
       // y: ['2012-01-01', '2012-12-31']
-      y.toDay.except(x.toDay).should.eql(new Interval(x.toDay.high, y.toDay.high, false, true));
-      should.not.exist(y.toDay.except(x.toMinute));
+      y.toDay
+        .except(x.toDay)
+        .should.equalInterval(new Interval(x.toDay.high, y.toDay.high, false, true));
+      y.toDay
+        .except(x.toMinute)
+        .should.equalInterval(new Interval(x.toMinute.high, y.toDay.high, false, true));
     });
 
     it('should throw when the argument is a point', () => {
@@ -1773,6 +1841,36 @@ describe('DateTimeInterval', () => {
       y.closed.after(x.open).should.be.true();
       y.open.after(x.closed).should.be.true();
       y.open.after(x.open).should.be.true();
+    });
+
+    it('should compare an interval start to a point', () => {
+      const interval = new Interval(5, 10);
+      interval.after(4).should.be.true();
+      interval.after(5).should.be.false();
+      should(interval.after(null)).be.null();
+
+      const dateInterval = new Interval(
+        DateTime.parse('2012-03-01T00:00:00.000'),
+        DateTime.parse('2012-09-01T00:00:00.000')
+      );
+      dateInterval
+        .after(DateTime.parse('2012-02-29T23:59:59.999'), DateTime.Unit.DAY)
+        .should.be.true();
+      dateInterval
+        .after(DateTime.parse('2012-03-01T23:59:59.999'), DateTime.Unit.DAY)
+        .should.be.false();
+      dateInterval
+        .after(DateTime.parse('2012-02-29T23:59:59.999'), DateTime.Unit.MONTH)
+        .should.be.true();
+      dateInterval
+        .after(DateTime.parse('2012-03-01T23:59:59.999'), DateTime.Unit.MONTH)
+        .should.be.false();
+      dateInterval
+        .after(DateTime.parse('2012-02-29T23:59:59.999'), DateTime.Unit.YEAR)
+        .should.be.false();
+      dateInterval
+        .after(DateTime.parse('2012-03-01T23:59:59.999'), DateTime.Unit.YEAR)
+        .should.be.false();
     });
 
     it('should properly calculate meets intervals', () => {
@@ -1878,8 +1976,8 @@ describe('DateTimeInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().after(d.all2012.closed).should.be.false();
-      d.all2012.closed.after(boundlessInterval()).should.be.false();
+      boundlessInterval(ELM_DATETIME_TYPE).after(d.all2012.closed).should.be.false();
+      d.all2012.closed.after(boundlessInterval(ELM_DATETIME_TYPE)).should.be.false();
     });
   });
 
@@ -1889,11 +1987,22 @@ describe('DateTimeInterval', () => {
       d = data();
     });
 
+    it('should compare intervals to points as unit intervals', () => {
+      d.all2012.closed.sameOrAfter(DateTime.parse('2011-12-31T23:59:59.999')).should.be.true();
+      d.all2012.closed.sameOrAfter(DateTime.parse('2012-01-01T00:00:00.0')).should.be.true();
+      d.all2012.closed.sameOrAfter(DateTime.parse('2012-01-01T00:00:00.001')).should.be.false();
+      should(d.all2012.closed.sameOrAfter(null)).be.null();
+    });
+
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().sameOrAfter(boundlessInterval()).should.be.true();
-      boundlessInterval().sameOrAfter(d.all2012.closed).should.be.false();
-      d.all2012.closed.sameOrAfter(boundlessInterval()).should.be.false();
-      should(unknownInterval().sameOrAfter(boundlessInterval())).be.null();
+      boundlessInterval(ELM_DATETIME_TYPE)
+        .sameOrAfter(boundlessInterval(ELM_DATETIME_TYPE))
+        .should.be.false();
+      boundlessInterval(ELM_DATETIME_TYPE).sameOrAfter(d.all2012.closed).should.be.false();
+      d.all2012.closed.sameOrAfter(boundlessInterval(ELM_DATETIME_TYPE)).should.be.false();
+      should(
+        unknownInterval(ELM_DATETIME_TYPE).sameOrAfter(boundlessInterval(ELM_DATETIME_TYPE))
+      ).be.null();
     });
   });
 
@@ -1925,6 +2034,36 @@ describe('DateTimeInterval', () => {
       y.closed.before(x.open).should.be.false();
       y.open.before(x.closed).should.be.false();
       y.open.before(x.open).should.be.false();
+    });
+
+    it('should compare an interval end to a point', () => {
+      const interval = new Interval(5, 10);
+      interval.before(11).should.be.true();
+      interval.before(10).should.be.false();
+      should(interval.before(null)).be.null();
+
+      const dateInterval = new Interval(
+        DateTime.parse('2012-03-01T00:00:00.000'),
+        DateTime.parse('2012-09-01T00:00:00.000')
+      );
+      dateInterval
+        .before(DateTime.parse('2012-09-02T00:00:00.000'), DateTime.Unit.DAY)
+        .should.be.true();
+      dateInterval
+        .before(DateTime.parse('2012-09-01T23:59:59.999'), DateTime.Unit.DAY)
+        .should.be.false();
+      dateInterval
+        .before(DateTime.parse('2012-09-02T00:00:00.000'), DateTime.Unit.MONTH)
+        .should.be.false();
+      dateInterval
+        .before(DateTime.parse('2012-09-01T23:59:59.999'), DateTime.Unit.MONTH)
+        .should.be.false();
+      dateInterval
+        .before(DateTime.parse('2012-09-02T00:00:00.000'), DateTime.Unit.YEAR)
+        .should.be.false();
+      dateInterval
+        .before(DateTime.parse('2012-09-01T23:59:59.999'), DateTime.Unit.YEAR)
+        .should.be.false();
     });
 
     it('should properly calculate meets intervals', () => {
@@ -2029,8 +2168,8 @@ describe('DateTimeInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().before(d.all2012.closed).should.be.false();
-      d.all2012.closed.before(boundlessInterval()).should.be.false();
+      boundlessInterval(ELM_DATETIME_TYPE).before(d.all2012.closed).should.be.false();
+      d.all2012.closed.before(boundlessInterval(ELM_DATETIME_TYPE)).should.be.false();
     });
   });
 
@@ -2040,11 +2179,22 @@ describe('DateTimeInterval', () => {
       d = data();
     });
 
+    it('should compare intervals to points as unit intervals', () => {
+      d.all2012.closed.sameOrBefore(DateTime.parse('2013-01-01T00:00:00.0')).should.be.true();
+      d.all2012.closed.sameOrBefore(DateTime.parse('2012-12-31T23:59:59.999')).should.be.true();
+      d.all2012.closed.sameOrBefore(DateTime.parse('2012-12-31T00:00:00.0')).should.be.false();
+      should(d.all2012.closed.sameOrBefore(null)).be.null();
+    });
+
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().sameOrBefore(boundlessInterval()).should.be.true();
-      boundlessInterval().sameOrBefore(d.all2012.closed).should.be.false();
-      d.all2012.closed.sameOrBefore(boundlessInterval()).should.be.false();
-      should(unknownInterval().sameOrBefore(boundlessInterval())).be.null();
+      boundlessInterval(ELM_DATETIME_TYPE)
+        .sameOrBefore(boundlessInterval(ELM_DATETIME_TYPE))
+        .should.be.false();
+      boundlessInterval(ELM_DATETIME_TYPE).sameOrBefore(d.all2012.closed).should.be.false();
+      d.all2012.closed.sameOrBefore(boundlessInterval(ELM_DATETIME_TYPE)).should.be.false();
+      should(
+        unknownInterval(ELM_DATETIME_TYPE).sameOrBefore(boundlessInterval(ELM_DATETIME_TYPE))
+      ).be.null();
     });
   });
 
@@ -2171,8 +2321,8 @@ describe('DateTimeInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().meets(d.all2012.closed).should.be.false();
-      d.all2012.closed.meets(boundlessInterval()).should.be.false();
+      boundlessInterval(ELM_DATETIME_TYPE).meets(d.all2012.closed).should.be.false();
+      d.all2012.closed.meets(boundlessInterval(ELM_DATETIME_TYPE)).should.be.false();
     });
   });
 
@@ -2304,8 +2454,8 @@ describe('DateTimeInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().meetsAfter(d.all2012.closed).should.be.false();
-      d.all2012.closed.meetsAfter(boundlessInterval()).should.be.false();
+      boundlessInterval(ELM_DATETIME_TYPE).meetsAfter(d.all2012.closed).should.be.false();
+      d.all2012.closed.meetsAfter(boundlessInterval(ELM_DATETIME_TYPE)).should.be.false();
     });
   });
 
@@ -2433,8 +2583,8 @@ describe('DateTimeInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().meetsBefore(d.all2012.closed).should.be.false();
-      d.all2012.closed.meetsBefore(boundlessInterval()).should.be.false();
+      boundlessInterval(ELM_DATETIME_TYPE).meetsBefore(d.all2012.closed).should.be.false();
+      d.all2012.closed.meetsBefore(boundlessInterval(ELM_DATETIME_TYPE)).should.be.false();
     });
   });
 });
@@ -2479,8 +2629,8 @@ describe('IntegerInterval', () => {
       new Interval(0, null, true, false).contains(0).should.be.true();
       should(new Interval(0, null, true, false).contains(123456789)).be.null();
       new Interval(0, null, true, false).contains(-1).should.be.false();
-      new Interval(null, null).contains(5).should.be.true();
-      should(new Interval(null, null, false, false).contains(5)).be.null();
+      boundlessInterval(ELM_INTEGER_TYPE).contains(5).should.be.true();
+      should(unknownInterval(ELM_INTEGER_TYPE).contains(5)).be.null();
     });
 
     it('should properly handle imprecision', () => {
@@ -2564,9 +2714,6 @@ describe('IntegerInterval', () => {
       new Interval(0, null, true, false).properContains(0).should.be.false();
       should(new Interval(0, null, true, false).properContains(123456789)).be.null();
       new Interval(0, null, true, false).properContains(-1).should.be.false();
-    });
-
-    it.skip('should properly handle unbounded and unknown intervals', () => {
       new Interval(null, null, true, true, ELM_INTEGER_TYPE).properContains(0).should.be.true();
       should(new Interval(null, null, false, false, ELM_INTEGER_TYPE).properContains(0)).be.null();
     });
@@ -2724,12 +2871,16 @@ describe('IntegerInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().includes(50).should.be.true();
-      boundlessInterval().includes(d.zeroToHundred.closed).should.be.true();
-      boundlessInterval().includes(unknownInterval()).should.be.true();
-      d.zeroToHundred.closed.includes(boundlessInterval()).should.be.false();
-      should(unknownInterval().includes(d.zeroToHundred.closed)).be.null();
-      should(unknownInterval().includes(boundlessInterval())).be.null();
+      boundlessInterval(ELM_INTEGER_TYPE).includes(50).should.be.true();
+      boundlessInterval(ELM_INTEGER_TYPE).includes(d.zeroToHundred.closed).should.be.true();
+      boundlessInterval(ELM_INTEGER_TYPE)
+        .includes(unknownInterval(ELM_INTEGER_TYPE))
+        .should.be.true();
+      d.zeroToHundred.closed.includes(boundlessInterval(ELM_INTEGER_TYPE)).should.be.false();
+      should(unknownInterval(ELM_INTEGER_TYPE).includes(d.zeroToHundred.closed)).be.null();
+      should(
+        unknownInterval(ELM_INTEGER_TYPE).includes(boundlessInterval(ELM_INTEGER_TYPE))
+      ).be.null();
     });
   });
 
@@ -2846,16 +2997,15 @@ describe('IntegerInterval', () => {
       should.not.exist(uIvl.includedIn(uIvl));
     });
 
-    it('should include a point integer', () => {
-      d.zeroToHundred.closed.includedIn(50).should.be.true();
-      d.zeroToHundred.closed.includedIn(500).should.be.false();
-    });
-
     it('should properly handle boundless and unknown intervals', () => {
-      d.zeroToHundred.closed.includedIn(boundlessInterval()).should.be.true();
-      boundlessInterval().includedIn(d.zeroToHundred.closed).should.be.false();
-      boundlessInterval().includedIn(boundlessInterval()).should.be.true();
-      unknownInterval().includedIn(boundlessInterval()).should.be.true();
+      d.zeroToHundred.closed.includedIn(boundlessInterval(ELM_INTEGER_TYPE)).should.be.true();
+      boundlessInterval(ELM_INTEGER_TYPE).includedIn(d.zeroToHundred.closed).should.be.false();
+      boundlessInterval(ELM_INTEGER_TYPE)
+        .includedIn(boundlessInterval(ELM_INTEGER_TYPE))
+        .should.be.true();
+      unknownInterval(ELM_INTEGER_TYPE)
+        .includedIn(boundlessInterval(ELM_INTEGER_TYPE))
+        .should.be.true();
     });
   });
 
@@ -2866,10 +3016,14 @@ describe('IntegerInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().properlyIncludes(d.zeroToHundred.closed).should.be.true();
-      boundlessInterval().properlyIncludes(boundlessInterval()).should.be.false();
-      should(boundlessInterval().properlyIncludes(unknownInterval())).be.null();
-      should(unknownInterval().properlyIncludes(d.zeroToHundred.closed)).be.null();
+      boundlessInterval(ELM_INTEGER_TYPE).properlyIncludes(d.zeroToHundred.closed).should.be.true();
+      boundlessInterval(ELM_INTEGER_TYPE)
+        .properlyIncludes(boundlessInterval(ELM_INTEGER_TYPE))
+        .should.be.false();
+      should(
+        boundlessInterval(ELM_INTEGER_TYPE).properlyIncludes(unknownInterval(ELM_INTEGER_TYPE))
+      ).be.null();
+      should(unknownInterval(ELM_INTEGER_TYPE).properlyIncludes(d.zeroToHundred.closed)).be.null();
     });
   });
 
@@ -2880,11 +3034,17 @@ describe('IntegerInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().starts(boundlessInterval()).should.be.true();
-      boundlessInterval().starts(d.zeroToHundred.closed).should.be.false();
-      d.zeroToHundred.closed.starts(boundlessInterval()).should.be.false();
-      should(boundlessInterval().starts(unknownInterval())).be.null();
-      should(unknownInterval().starts(boundlessInterval())).be.null();
+      boundlessInterval(ELM_INTEGER_TYPE)
+        .starts(boundlessInterval(ELM_INTEGER_TYPE))
+        .should.be.true();
+      boundlessInterval(ELM_INTEGER_TYPE).starts(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.starts(boundlessInterval(ELM_INTEGER_TYPE)).should.be.false();
+      should(
+        boundlessInterval(ELM_INTEGER_TYPE).starts(unknownInterval(ELM_INTEGER_TYPE))
+      ).be.null();
+      should(
+        unknownInterval(ELM_INTEGER_TYPE).starts(boundlessInterval(ELM_INTEGER_TYPE))
+      ).be.null();
     });
   });
 
@@ -2895,11 +3055,13 @@ describe('IntegerInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().ends(boundlessInterval()).should.be.true();
-      boundlessInterval().ends(d.zeroToHundred.closed).should.be.false();
-      d.zeroToHundred.closed.ends(boundlessInterval()).should.be.false();
-      should(boundlessInterval().ends(unknownInterval())).be.null();
-      should(unknownInterval().ends(boundlessInterval())).be.null();
+      boundlessInterval(ELM_INTEGER_TYPE)
+        .ends(boundlessInterval(ELM_INTEGER_TYPE))
+        .should.be.true();
+      boundlessInterval(ELM_INTEGER_TYPE).ends(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.ends(boundlessInterval(ELM_INTEGER_TYPE)).should.be.false();
+      should(boundlessInterval(ELM_INTEGER_TYPE).ends(unknownInterval(ELM_INTEGER_TYPE))).be.null();
+      should(unknownInterval(ELM_INTEGER_TYPE).ends(boundlessInterval(ELM_INTEGER_TYPE))).be.null();
     });
   });
 
@@ -3011,20 +3173,19 @@ describe('IntegerInterval', () => {
       should(new Interval(0, null, true, false).overlaps(lateInterval)).be.null();
       should(new Interval(0, null, true, false).overlaps(earlyInterval)).be.false();
 
-      should(new Interval(null, null).overlaps(d.zeroToHundred.closed)).be.true();
-      should(new Interval(null, null, false, false).overlaps(d.zeroToHundred.closed)).be.null();
-      should(d.zeroToHundred.closed.overlaps(new Interval(null, null))).be.true();
-      should(d.zeroToHundred.closed.overlaps(new Interval(null, null, false, false))).be.null();
-    });
-
-    it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().overlaps(boundlessInterval()).should.be.true();
-      boundlessInterval().overlaps(d.zeroToHundred.closed).should.be.true();
-      d.zeroToHundred.closed.overlaps(boundlessInterval()).should.be.true();
-      // TODO: These commented out edge cases with all null endpoints on both sides currently don't pass
-      //boundlessInterval().overlaps(unknownInterval()).should.be.true();
-      //unknownInterval().overlaps(boundlessInterval()).should.be.true();
-      should(unknownInterval().overlaps(d.zeroToHundred.closed)).be.null();
+      should(boundlessInterval(ELM_INTEGER_TYPE).overlaps(d.zeroToHundred.closed)).be.true();
+      should(unknownInterval(ELM_INTEGER_TYPE).overlaps(d.zeroToHundred.closed)).be.null();
+      should(d.zeroToHundred.closed.overlaps(boundlessInterval(ELM_INTEGER_TYPE))).be.true();
+      should(d.zeroToHundred.closed.overlaps(unknownInterval(ELM_INTEGER_TYPE))).be.null();
+      boundlessInterval(ELM_INTEGER_TYPE)
+        .overlaps(boundlessInterval(ELM_INTEGER_TYPE))
+        .should.be.true();
+      boundlessInterval(ELM_INTEGER_TYPE)
+        .overlaps(unknownInterval(ELM_INTEGER_TYPE))
+        .should.be.true();
+      unknownInterval(ELM_INTEGER_TYPE)
+        .overlaps(boundlessInterval(ELM_INTEGER_TYPE))
+        .should.be.true();
     });
 
     it('should properly handle imprecision', () => {
@@ -3050,85 +3211,6 @@ describe('IntegerInterval', () => {
     });
   });
 
-  describe('overlaps(Integer)', () => {
-    let d: any;
-    beforeEach(() => {
-      d = data();
-    });
-
-    it('should properly calculate integers less than it', () => {
-      d.zeroToHundred.closed.overlaps(-5).should.be.false();
-    });
-
-    it('should properly calculate the left boundary integer', () => {
-      d.zeroToHundred.closed.overlaps(0).should.be.true();
-      d.zeroToHundred.open.overlaps(0).should.be.false();
-    });
-
-    it('should properly calculate integers in the middle of it', () => {
-      d.zeroToHundred.closed.overlaps(50).should.be.true();
-    });
-
-    it('should properly calculate the right boundary integer', () => {
-      d.zeroToHundred.closed.overlaps(100).should.be.true();
-      d.zeroToHundred.open.overlaps(100).should.be.false();
-    });
-
-    it('should properly calculate integers greater than it', () => {
-      d.zeroToHundred.closed.overlaps(105).should.be.false();
-    });
-
-    it('should properly handle null endpoints', () => {
-      should(new Interval(null, 0).overlaps(-123456789)).be.true();
-      should(new Interval(null, 0).overlaps(1)).be.false();
-      should(new Interval(null, 0, false, true).overlaps(0)).be.true();
-      should(new Interval(null, 0, false, true).overlaps(-123456789)).be.null();
-      should(new Interval(null, 0, false, true).overlaps(1)).be.false();
-      should(new Interval(0, null).overlaps(123456789)).be.true();
-      should(new Interval(0, null).overlaps(-1)).be.false();
-      should(new Interval(0, null, true, false).overlaps(0)).be.true();
-      should(new Interval(0, null, true, false).overlaps(123456789)).be.null();
-      should(new Interval(0, null, true, false).overlaps(-1)).be.false();
-      should(new Interval(null, null).overlaps(5)).be.true();
-      should(new Interval(null, null, false, false).overlaps(5)).be.null();
-    });
-
-    it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().overlaps(5).should.be.true();
-      should(boundlessInterval().overlaps(null)).be.null();
-      should(unknownInterval().overlaps(5)).be.null();
-    });
-
-    it('should properly handle imprecision', () => {
-      d.zeroToHundred.closed.overlaps(new Uncertainty(-20, -10)).should.be.false();
-      should.not.exist(d.zeroToHundred.closed.overlaps(new Uncertainty(-20, 20)));
-      d.zeroToHundred.closed.overlaps(new Uncertainty(0, 100)).should.be.true();
-      should.not.exist(d.zeroToHundred.closed.overlaps(new Uncertainty(80, 120)));
-      d.zeroToHundred.closed.overlaps(new Uncertainty(120, 140)).should.be.false();
-      should.not.exist(d.zeroToHundred.closed.overlaps(new Uncertainty(-20, 120)));
-
-      const uIvl = new Interval(new Uncertainty(5, 10), new Uncertainty(15, 20));
-
-      uIvl.overlaps(0).should.be.false();
-      should.not.exist(uIvl.overlaps(5));
-      should.not.exist(uIvl.overlaps(6));
-      uIvl.overlaps(10).should.be.true();
-      uIvl.overlaps(12).should.be.true();
-      uIvl.overlaps(15).should.be.true();
-      should.not.exist(uIvl.overlaps(16));
-      should.not.exist(uIvl.overlaps(20));
-      uIvl.overlaps(25).should.be.false();
-
-      uIvl.overlaps(new Uncertainty(0, 4)).should.be.false();
-      should.not.exist(uIvl.overlaps(new Uncertainty(0, 5)));
-      should.not.exist(uIvl.overlaps(new Uncertainty(5, 10)));
-      uIvl.overlaps(new Uncertainty(10, 15)).should.be.true();
-      should.not.exist(uIvl.overlaps(new Uncertainty(15, 20)));
-      should.not.exist(uIvl.overlaps(new Uncertainty(20, 25)));
-      uIvl.overlaps(new Uncertainty(25, 30)).should.be.false();
-    });
-  });
-
   describe('overlapsBefore', () => {
     let d: any;
     beforeEach(() => {
@@ -3136,11 +3218,14 @@ describe('IntegerInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().overlapsBefore(d.zeroToHundred.closed).should.be.true();
-      boundlessInterval().overlapsBefore(5).should.be.true();
-      d.zeroToHundred.closed.overlapsBefore(boundlessInterval()).should.be.false();
-      should(boundlessInterval().overlapsBefore(unknownInterval())).be.null();
-      should(unknownInterval().overlapsBefore(boundlessInterval())).be.null();
+      boundlessInterval(ELM_INTEGER_TYPE).overlapsBefore(d.zeroToHundred.closed).should.be.true();
+      d.zeroToHundred.closed.overlapsBefore(boundlessInterval(ELM_INTEGER_TYPE)).should.be.false();
+      should(
+        boundlessInterval(ELM_INTEGER_TYPE).overlapsBefore(unknownInterval(ELM_INTEGER_TYPE))
+      ).be.null();
+      unknownInterval(ELM_INTEGER_TYPE)
+        .overlapsBefore(boundlessInterval(ELM_INTEGER_TYPE))
+        .should.be.false();
     });
   });
 
@@ -3151,11 +3236,14 @@ describe('IntegerInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().overlapsAfter(d.zeroToHundred.closed).should.be.true();
-      boundlessInterval().overlapsAfter(5).should.be.true();
-      d.zeroToHundred.closed.overlapsAfter(boundlessInterval()).should.be.false();
-      should(boundlessInterval().overlapsAfter(unknownInterval())).be.null();
-      should(unknownInterval().overlapsAfter(boundlessInterval())).be.null();
+      boundlessInterval(ELM_INTEGER_TYPE).overlapsAfter(d.zeroToHundred.closed).should.be.true();
+      d.zeroToHundred.closed.overlapsAfter(boundlessInterval(ELM_INTEGER_TYPE)).should.be.false();
+      should(
+        boundlessInterval(ELM_INTEGER_TYPE).overlapsAfter(unknownInterval(ELM_INTEGER_TYPE))
+      ).be.null();
+      unknownInterval(ELM_INTEGER_TYPE)
+        .overlapsAfter(boundlessInterval(ELM_INTEGER_TYPE))
+        .should.be.false();
     });
   });
 
@@ -3301,12 +3389,18 @@ describe('IntegerInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().equals(boundlessInterval()).should.be.true();
-      boundlessInterval().equals(d.zeroToHundred.closed).should.be.false();
-      d.zeroToHundred.closed.equals(boundlessInterval()).should.be.false();
-      should(boundlessInterval().equals(unknownInterval())).be.null();
-      should(unknownInterval().equals(boundlessInterval())).be.null();
-      should(unknownInterval().equals(unknownInterval())).be.null();
+      boundlessInterval(ELM_INTEGER_TYPE)
+        .equals(boundlessInterval(ELM_INTEGER_TYPE))
+        .should.be.true();
+      boundlessInterval(ELM_INTEGER_TYPE).equals(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.equals(boundlessInterval(ELM_INTEGER_TYPE)).should.be.false();
+      should(
+        boundlessInterval(ELM_INTEGER_TYPE).equals(unknownInterval(ELM_INTEGER_TYPE))
+      ).be.null();
+      should(
+        unknownInterval(ELM_INTEGER_TYPE).equals(boundlessInterval(ELM_INTEGER_TYPE))
+      ).be.null();
+      should(unknownInterval(ELM_INTEGER_TYPE).equals(unknownInterval(ELM_INTEGER_TYPE))).be.null();
     });
   });
 
@@ -3317,11 +3411,17 @@ describe('IntegerInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().sameAs(boundlessInterval()).should.be.true();
-      boundlessInterval().sameAs(d.zeroToHundred.closed).should.be.false();
-      d.zeroToHundred.closed.sameAs(boundlessInterval()).should.be.false();
-      should(boundlessInterval().sameAs(unknownInterval())).be.null();
-      should(unknownInterval().sameAs(boundlessInterval())).be.null();
+      boundlessInterval(ELM_INTEGER_TYPE)
+        .sameAs(boundlessInterval(ELM_INTEGER_TYPE))
+        .should.be.true();
+      boundlessInterval(ELM_INTEGER_TYPE).sameAs(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.sameAs(boundlessInterval(ELM_INTEGER_TYPE)).should.be.false();
+      should(
+        boundlessInterval(ELM_INTEGER_TYPE).sameAs(unknownInterval(ELM_INTEGER_TYPE))
+      ).be.null();
+      should(
+        unknownInterval(ELM_INTEGER_TYPE).sameAs(boundlessInterval(ELM_INTEGER_TYPE))
+      ).be.null();
     });
   });
 
@@ -3443,10 +3543,10 @@ describe('IntegerInterval', () => {
 
       ivl = new Interval(10, 15);
       i = ivl.union(uIvl);
-      i.should.eql(uIvl);
+      i.should.equalInterval(uIvl);
 
       i = uIvl.union(ivl);
-      i.should.eql(uIvl);
+      i.should.equalInterval(uIvl);
 
       ivl = new Interval(15, 20);
       i = ivl.union(uIvl);
@@ -3469,10 +3569,18 @@ describe('IntegerInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().union(d.zeroToHundred.closed).should.eql(boundlessInterval());
-      d.zeroToHundred.closed.union(boundlessInterval()).should.eql(boundlessInterval());
-      boundlessInterval().union(unknownInterval()).should.eql(boundlessInterval());
-      unknownInterval().union(boundlessInterval()).should.eql(boundlessInterval());
+      boundlessInterval(ELM_INTEGER_TYPE)
+        .union(d.zeroToHundred.closed)
+        .should.equalInterval(boundlessInterval(ELM_INTEGER_TYPE));
+      d.zeroToHundred.closed
+        .union(boundlessInterval(ELM_INTEGER_TYPE))
+        .should.equalInterval(boundlessInterval(ELM_INTEGER_TYPE));
+      boundlessInterval(ELM_INTEGER_TYPE)
+        .union(unknownInterval(ELM_INTEGER_TYPE))
+        .should.equalInterval(boundlessInterval(ELM_INTEGER_TYPE));
+      unknownInterval(ELM_INTEGER_TYPE)
+        .union(boundlessInterval(ELM_INTEGER_TYPE))
+        .should.equalInterval(boundlessInterval(ELM_INTEGER_TYPE));
     });
   });
 
@@ -3576,8 +3684,8 @@ describe('IntegerInterval', () => {
 
       let x = new Interval(b, e);
       let y = new Interval(a, c);
-      x.intersect(y).should.eql(new Interval(b, c));
-      y.intersect(x).should.eql(new Interval(b, c));
+      x.intersect(y).should.equalInterval(new Interval(b, c));
+      y.intersect(x).should.equalInterval(new Interval(b, c));
 
       x = new Interval(a, b);
       y = new Interval(b, d);
@@ -3588,13 +3696,13 @@ describe('IntegerInterval', () => {
 
       x = new Interval(a, e);
       y = new Interval(b, d);
-      x.intersect(y).should.eql(y);
-      y.intersect(x).should.eql(y);
+      x.intersect(y).should.equalInterval(y);
+      y.intersect(x).should.equalInterval(y);
 
       x = new Interval(a, d);
       y = new Interval(b, e);
-      x.intersect(y).should.eql(new Interval(b, d));
-      y.intersect(x).should.eql(new Interval(b, d));
+      x.intersect(y).should.equalInterval(new Interval(b, d));
+      y.intersect(x).should.equalInterval(new Interval(b, d));
 
       x = new Interval(a, b);
       y = new Interval(d, e);
@@ -3603,8 +3711,12 @@ describe('IntegerInterval', () => {
 
       x = new Interval(new Uncertainty(5, 10), new Uncertainty(15, 20));
       y = new Interval(8, 17);
-      x.intersect(y).should.eql(new Interval(new Uncertainty(8, 10), new Uncertainty(15, 17)));
-      y.intersect(x).should.eql(new Interval(new Uncertainty(8, 10), new Uncertainty(15, 17)));
+      x.intersect(y).should.equalInterval(
+        new Interval(new Uncertainty(8, 10), new Uncertainty(15, 17))
+      );
+      y.intersect(x).should.equalInterval(
+        new Interval(new Uncertainty(8, 10), new Uncertainty(15, 17))
+      );
     });
 
     it('should throw when the argument is a point', () => {
@@ -3612,10 +3724,18 @@ describe('IntegerInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().intersect(d.zeroToHundred.closed).should.eql(d.zeroToHundred.closed);
-      d.zeroToHundred.closed.intersect(boundlessInterval()).should.eql(d.zeroToHundred.closed);
-      boundlessInterval().intersect(unknownInterval()).should.eql(unknownInterval());
-      unknownInterval().intersect(boundlessInterval()).should.eql(unknownInterval());
+      boundlessInterval(ELM_INTEGER_TYPE)
+        .intersect(d.zeroToHundred.closed)
+        .should.equalInterval(d.zeroToHundred.closed);
+      d.zeroToHundred.closed
+        .intersect(boundlessInterval(ELM_INTEGER_TYPE))
+        .should.equalInterval(d.zeroToHundred.closed);
+      boundlessInterval(ELM_INTEGER_TYPE)
+        .intersect(unknownInterval(ELM_INTEGER_TYPE))
+        .should.equalInterval(unknownInterval(ELM_INTEGER_TYPE));
+      unknownInterval(ELM_INTEGER_TYPE)
+        .intersect(boundlessInterval(ELM_INTEGER_TYPE))
+        .should.equalInterval(unknownInterval(ELM_INTEGER_TYPE));
     });
   });
 
@@ -3639,26 +3759,26 @@ describe('IntegerInterval', () => {
 
     it('should properly calculate before/after except', () => {
       const [x, y] = Array.from(xy(d.iIvl.before));
-      x.closed.except(y.closed).should.eql(x.closed);
-      x.closed.except(y.open).should.eql(x.closed);
-      x.open.except(y.closed).should.eql(x.open);
-      x.open.except(y.open).should.eql(x.open);
-      y.closed.except(x.closed).should.eql(y.closed);
-      y.closed.except(x.open).should.eql(y.closed);
-      y.open.except(x.closed).should.eql(y.open);
-      y.open.except(x.open).should.eql(y.open);
+      x.closed.except(y.closed).should.equalInterval(x.closed);
+      x.closed.except(y.open).should.equalInterval(x.closed);
+      x.open.except(y.closed).should.equalInterval(x.open);
+      x.open.except(y.open).should.equalInterval(x.open);
+      y.closed.except(x.closed).should.equalInterval(y.closed);
+      y.closed.except(x.open).should.equalInterval(y.closed);
+      y.open.except(x.closed).should.equalInterval(y.open);
+      y.open.except(x.open).should.equalInterval(y.open);
     });
 
     it('should properly calculate meets except', () => {
       const [x, y] = Array.from(xy(d.iIvl.meets));
-      x.closed.except(y.closed).should.eql(x.closed);
-      x.closed.except(y.open).should.eql(x.closed);
-      x.open.except(y.closed).should.eql(x.open);
-      x.open.except(y.open).should.eql(x.open);
-      y.closed.except(x.closed).should.eql(y.closed);
-      y.closed.except(x.open).should.eql(y.closed);
-      y.open.except(x.closed).should.eql(y.open);
-      y.open.except(x.open).should.eql(y.open);
+      x.closed.except(y.closed).should.equalInterval(x.closed);
+      x.closed.except(y.open).should.equalInterval(x.closed);
+      x.open.except(y.closed).should.equalInterval(x.open);
+      x.open.except(y.open).should.equalInterval(x.open);
+      y.closed.except(x.closed).should.equalInterval(y.closed);
+      y.closed.except(x.open).should.equalInterval(y.closed);
+      y.open.except(x.closed).should.equalInterval(y.open);
+      y.open.except(x.open).should.equalInterval(y.open);
     });
 
     it('should properly calculate left/right overlapping except', () => {
@@ -3679,7 +3799,7 @@ describe('IntegerInterval', () => {
       const [x, y] = Array.from(xy(d.iIvl.begins));
       const b = d.sixtyToHundred;
       should.not.exist(x.closed.except(y.closed));
-      x.closed.except(y.open).should.eql(new Interval(x.closed.low, x.closed.low));
+      x.closed.except(y.open).should.equalInterval(new Interval(x.closed.low, x.closed.low));
       should.not.exist(x.open.except(y.closed));
       should.not.exist(x.open.except(y.open));
       y.closed.except(x.closed).equals(b.openClosed).should.be.true();
@@ -3704,7 +3824,7 @@ describe('IntegerInterval', () => {
       const [x, y] = Array.from(xy(d.iIvl.ends));
       const b = d.zeroToForty;
       should.not.exist(x.closed.except(y.closed));
-      x.closed.except(y.open).should.eql(new Interval(x.closed.high, x.closed.high));
+      x.closed.except(y.open).should.equalInterval(new Interval(x.closed.high, x.closed.high));
       should.not.exist(x.open.except(y.closed));
       should.not.exist(x.open.except(y.open));
       y.closed.except(x.closed).equals(b.closedOpen).should.be.true();
@@ -3722,8 +3842,8 @@ describe('IntegerInterval', () => {
 
       let x = new Interval(b, e); //([10,20] , 100)
       let y = new Interval(a, c); //(   0    ,  50)
-      x.except(y).should.eql(new Interval(c, e, false, true));
-      y.except(x).should.eql(new Interval(a, b, true, false));
+      x.except(y).should.equalInterval(new Interval(c, e, false, true));
+      y.except(x).should.equalInterval(new Interval(a, b, true, false));
 
       x = new Interval(a, b);
       y = new Interval(b, d);
@@ -3739,13 +3859,13 @@ describe('IntegerInterval', () => {
 
       x = new Interval(a, d);
       y = new Interval(b, e);
-      x.except(y).should.eql(new Interval(a, b, true, false));
-      y.except(x).should.eql(new Interval(d, e, false, true));
+      x.except(y).should.equalInterval(new Interval(a, b, true, false));
+      y.except(x).should.equalInterval(new Interval(d, e, false, true));
 
       x = new Interval(a, b);
       y = new Interval(d, e);
-      x.except(y).should.eql(x);
-      y.except(x).should.eql(y);
+      x.except(y).should.equalInterval(x);
+      y.except(x).should.equalInterval(y);
     });
 
     it('should throw when the argument is a point', () => {
@@ -3874,8 +3994,8 @@ describe('IntegerInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().after(d.zeroToHundred.closed).should.be.false();
-      d.zeroToHundred.closed.after(boundlessInterval()).should.be.false();
+      boundlessInterval(ELM_INTEGER_TYPE).after(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.after(boundlessInterval(ELM_INTEGER_TYPE)).should.be.false();
     });
   });
 
@@ -3885,11 +4005,22 @@ describe('IntegerInterval', () => {
       d = data();
     });
 
+    it('should compare intervals to points as unit intervals', () => {
+      d.zeroToHundred.closed.sameOrAfter(0).should.be.true();
+      d.zeroToHundred.closed.sameOrAfter(-1).should.be.true();
+      d.zeroToHundred.closed.sameOrAfter(1).should.be.false();
+      should(d.zeroToHundred.closed.sameOrAfter(null)).be.null();
+    });
+
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().sameOrAfter(boundlessInterval()).should.be.true();
-      boundlessInterval().sameOrAfter(d.zeroToHundred.closed).should.be.false();
-      d.zeroToHundred.closed.sameOrAfter(boundlessInterval()).should.be.false();
-      should(unknownInterval().sameOrAfter(boundlessInterval())).be.null();
+      boundlessInterval(ELM_INTEGER_TYPE)
+        .sameOrAfter(boundlessInterval(ELM_INTEGER_TYPE))
+        .should.be.false();
+      boundlessInterval(ELM_INTEGER_TYPE).sameOrAfter(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.sameOrAfter(boundlessInterval(ELM_INTEGER_TYPE)).should.be.false();
+      should(
+        unknownInterval(ELM_INTEGER_TYPE).sameOrAfter(boundlessInterval(ELM_INTEGER_TYPE))
+      ).be.null();
     });
   });
 
@@ -4014,8 +4145,8 @@ describe('IntegerInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().before(d.zeroToHundred.closed).should.be.false();
-      d.zeroToHundred.closed.before(boundlessInterval()).should.be.false();
+      boundlessInterval(ELM_INTEGER_TYPE).before(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.before(boundlessInterval(ELM_INTEGER_TYPE)).should.be.false();
     });
   });
 
@@ -4025,11 +4156,22 @@ describe('IntegerInterval', () => {
       d = data();
     });
 
+    it('should compare intervals to points as unit intervals', () => {
+      d.zeroToHundred.closed.sameOrBefore(100).should.be.true();
+      d.zeroToHundred.closed.sameOrBefore(99).should.be.false();
+      d.zeroToHundred.closed.sameOrBefore(101).should.be.true();
+      should(d.zeroToHundred.closed.sameOrBefore(null)).be.null();
+    });
+
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().sameOrBefore(boundlessInterval()).should.be.true();
-      boundlessInterval().sameOrBefore(d.zeroToHundred.closed).should.be.false();
-      d.zeroToHundred.closed.sameOrBefore(boundlessInterval()).should.be.false();
-      should(unknownInterval().sameOrBefore(boundlessInterval())).be.null();
+      boundlessInterval(ELM_INTEGER_TYPE)
+        .sameOrBefore(boundlessInterval(ELM_INTEGER_TYPE))
+        .should.be.false();
+      boundlessInterval(ELM_INTEGER_TYPE).sameOrBefore(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.sameOrBefore(boundlessInterval(ELM_INTEGER_TYPE)).should.be.false();
+      should(
+        unknownInterval(ELM_INTEGER_TYPE).sameOrBefore(boundlessInterval(ELM_INTEGER_TYPE))
+      ).be.null();
     });
   });
 
@@ -4154,8 +4296,8 @@ describe('IntegerInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().meets(d.zeroToHundred.closed).should.be.false();
-      d.zeroToHundred.closed.meets(boundlessInterval()).should.be.false();
+      boundlessInterval(ELM_INTEGER_TYPE).meets(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.meets(boundlessInterval(ELM_INTEGER_TYPE)).should.be.false();
     });
   });
 
@@ -4280,8 +4422,8 @@ describe('IntegerInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().meetsAfter(d.zeroToHundred.closed).should.be.false();
-      d.zeroToHundred.closed.meetsAfter(boundlessInterval()).should.be.false();
+      boundlessInterval(ELM_INTEGER_TYPE).meetsAfter(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.meetsAfter(boundlessInterval(ELM_INTEGER_TYPE)).should.be.false();
     });
   });
 
@@ -4406,8 +4548,8 @@ describe('IntegerInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().meetsBefore(d.zeroToHundred.closed).should.be.false();
-      d.zeroToHundred.closed.meetsBefore(boundlessInterval()).should.be.false();
+      boundlessInterval(ELM_INTEGER_TYPE).meetsBefore(d.zeroToHundred.closed).should.be.false();
+      d.zeroToHundred.closed.meetsBefore(boundlessInterval(ELM_INTEGER_TYPE)).should.be.false();
     });
   });
 });
@@ -4452,8 +4594,8 @@ describe('LongInterval', () => {
       new Interval(0n, null, true, false).contains(0n).should.be.true();
       should(new Interval(0n, null, true, false).contains(123456789n)).be.null();
       new Interval(0n, null, true, false).contains(-1n).should.be.false();
-      new Interval(null, null).contains(5n).should.be.true();
-      should(new Interval(null, null, false, false).contains(5n)).be.null();
+      boundlessInterval(ELM_LONG_TYPE).contains(5n).should.be.true();
+      should(unknownInterval(ELM_LONG_TYPE).contains(5n)).be.null();
     });
 
     it('should properly handle imprecision', () => {
@@ -4537,11 +4679,8 @@ describe('LongInterval', () => {
       new Interval(0n, null, true, false).properContains(0n).should.be.false();
       should(new Interval(0n, null, true, false).properContains(123456789n)).be.null();
       new Interval(0n, null, true, false).properContains(-1n).should.be.false();
-    });
-
-    it.skip('should properly handle unbounded and unknown intervals', () => {
-      new Interval(null, null, true, true, ELM_LONG_TYPE).properContains(0).should.be.true();
-      should(new Interval(null, null, false, false, ELM_LONG_TYPE).properContains(0)).be.null();
+      new Interval(null, null, true, true, ELM_LONG_TYPE).properContains(0n).should.be.true();
+      should(new Interval(null, null, false, false, ELM_LONG_TYPE).properContains(0n)).be.null();
     });
 
     it('should properly handle imprecision', () => {
@@ -4697,12 +4836,12 @@ describe('LongInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().includes(50n).should.be.true();
-      boundlessInterval().includes(d.zeroToHundredLong.closed).should.be.true();
-      boundlessInterval().includes(unknownInterval()).should.be.true();
-      d.zeroToHundredLong.closed.includes(boundlessInterval()).should.be.false();
-      should(unknownInterval().includes(d.zeroToHundredLong.closed)).be.null();
-      should(unknownInterval().includes(boundlessInterval())).be.null();
+      boundlessInterval(ELM_LONG_TYPE).includes(50n).should.be.true();
+      boundlessInterval(ELM_LONG_TYPE).includes(d.zeroToHundredLong.closed).should.be.true();
+      boundlessInterval(ELM_LONG_TYPE).includes(unknownInterval(ELM_LONG_TYPE)).should.be.true();
+      d.zeroToHundredLong.closed.includes(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      should(unknownInterval(ELM_LONG_TYPE).includes(d.zeroToHundredLong.closed)).be.null();
+      should(unknownInterval(ELM_LONG_TYPE).includes(boundlessInterval(ELM_LONG_TYPE))).be.null();
     });
   });
 
@@ -4819,16 +4958,13 @@ describe('LongInterval', () => {
       should.not.exist(uIvl.includedIn(uIvl));
     });
 
-    it('should include a point long', () => {
-      d.zeroToHundredLong.closed.includedIn(50n).should.be.true();
-      d.zeroToHundredLong.closed.includedIn(500n).should.be.false();
-    });
-
     it('should properly handle boundless and unknown intervals', () => {
-      d.zeroToHundredLong.closed.includedIn(boundlessInterval()).should.be.true();
-      boundlessInterval().includedIn(d.zeroToHundredLong.closed).should.be.false();
-      boundlessInterval().includedIn(boundlessInterval()).should.be.true();
-      unknownInterval().includedIn(boundlessInterval()).should.be.true();
+      d.zeroToHundredLong.closed.includedIn(boundlessInterval(ELM_LONG_TYPE)).should.be.true();
+      boundlessInterval(ELM_LONG_TYPE).includedIn(d.zeroToHundredLong.closed).should.be.false();
+      boundlessInterval(ELM_LONG_TYPE)
+        .includedIn(boundlessInterval(ELM_LONG_TYPE))
+        .should.be.true();
+      unknownInterval(ELM_LONG_TYPE).includedIn(boundlessInterval(ELM_LONG_TYPE)).should.be.true();
     });
   });
 
@@ -4839,10 +4975,16 @@ describe('LongInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().properlyIncludes(d.zeroToHundredLong.closed).should.be.true();
-      boundlessInterval().properlyIncludes(boundlessInterval()).should.be.false();
-      should(boundlessInterval().properlyIncludes(unknownInterval())).be.null();
-      should(unknownInterval().properlyIncludes(d.zeroToHundredLong.closed)).be.null();
+      boundlessInterval(ELM_LONG_TYPE)
+        .properlyIncludes(d.zeroToHundredLong.closed)
+        .should.be.true();
+      boundlessInterval(ELM_LONG_TYPE)
+        .properlyIncludes(boundlessInterval(ELM_LONG_TYPE))
+        .should.be.false();
+      should(
+        boundlessInterval(ELM_LONG_TYPE).properlyIncludes(unknownInterval(ELM_LONG_TYPE))
+      ).be.null();
+      should(unknownInterval(ELM_LONG_TYPE).properlyIncludes(d.zeroToHundredLong.closed)).be.null();
     });
   });
 
@@ -4853,11 +4995,11 @@ describe('LongInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().starts(boundlessInterval()).should.be.true();
-      boundlessInterval().starts(d.zeroToHundredLong.closed).should.be.false();
-      d.zeroToHundredLong.closed.starts(boundlessInterval()).should.be.false();
-      should(boundlessInterval().starts(unknownInterval())).be.null();
-      should(unknownInterval().starts(boundlessInterval())).be.null();
+      boundlessInterval(ELM_LONG_TYPE).starts(boundlessInterval(ELM_LONG_TYPE)).should.be.true();
+      boundlessInterval(ELM_LONG_TYPE).starts(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.starts(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      should(boundlessInterval(ELM_LONG_TYPE).starts(unknownInterval(ELM_INTEGER_TYPE))).be.null();
+      should(unknownInterval(ELM_LONG_TYPE).starts(boundlessInterval(ELM_LONG_TYPE))).be.null();
     });
   });
 
@@ -4868,11 +5010,11 @@ describe('LongInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().ends(boundlessInterval()).should.be.true();
-      boundlessInterval().ends(d.zeroToHundredLong.closed).should.be.false();
-      d.zeroToHundredLong.closed.ends(boundlessInterval()).should.be.false();
-      should(boundlessInterval().ends(unknownInterval())).be.null();
-      should(unknownInterval().ends(boundlessInterval())).be.null();
+      boundlessInterval(ELM_LONG_TYPE).ends(boundlessInterval(ELM_LONG_TYPE)).should.be.true();
+      boundlessInterval(ELM_LONG_TYPE).ends(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.ends(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      should(boundlessInterval(ELM_LONG_TYPE).ends(unknownInterval(ELM_LONG_TYPE))).be.null();
+      should(unknownInterval(ELM_LONG_TYPE).ends(boundlessInterval(ELM_LONG_TYPE))).be.null();
     });
   });
 
@@ -4984,19 +5126,13 @@ describe('LongInterval', () => {
       should(new Interval(0n, null, true, false).overlaps(positiveInterval)).be.null();
       should(new Interval(0n, null, true, false).overlaps(negativeInterval)).be.false();
 
-      should(new Interval(null, null).overlaps(d.zeroToHundredLong.closed)).be.true();
-      should(new Interval(null, null, false, false).overlaps(d.zeroToHundredLong.closed)).be.null();
-      should(d.zeroToHundredLong.closed.overlaps(new Interval(null, null))).be.true();
-      should(d.zeroToHundredLong.closed.overlaps(new Interval(null, null, false, false))).be.null();
-    });
-
-    it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().overlaps(boundlessInterval()).should.be.true();
-      boundlessInterval().overlaps(d.zeroToHundredLong.closed).should.be.true();
-      d.zeroToHundredLong.closed.overlaps(boundlessInterval()).should.be.true();
-      should(boundlessInterval().overlaps(unknownInterval())).be.null();
-      should(unknownInterval().overlaps(boundlessInterval())).be.null();
-      should(unknownInterval().overlaps(d.zeroToHundredLong.closed)).be.null();
+      should(boundlessInterval(ELM_LONG_TYPE).overlaps(d.zeroToHundredLong.closed)).be.true();
+      should(unknownInterval(ELM_LONG_TYPE).overlaps(d.zeroToHundredLong.closed)).be.null();
+      should(d.zeroToHundredLong.closed.overlaps(boundlessInterval(ELM_LONG_TYPE))).be.true();
+      should(d.zeroToHundredLong.closed.overlaps(unknownInterval(ELM_LONG_TYPE))).be.null();
+      boundlessInterval(ELM_LONG_TYPE).overlaps(boundlessInterval(ELM_LONG_TYPE)).should.be.true();
+      boundlessInterval(ELM_LONG_TYPE).overlaps(unknownInterval(ELM_LONG_TYPE)).should.be.true();
+      unknownInterval(ELM_LONG_TYPE).overlaps(boundlessInterval(ELM_LONG_TYPE)).should.be.true();
     });
 
     it('should properly handle imprecision', () => {
@@ -5022,85 +5158,6 @@ describe('LongInterval', () => {
     });
   });
 
-  describe('overlaps(Long)', () => {
-    let d: any;
-    beforeEach(() => {
-      d = data();
-    });
-
-    it('should properly calculate longs less than it', () => {
-      d.zeroToHundredLong.closed.overlaps(-5n).should.be.false();
-    });
-
-    it('should properly calculate the left boundary long', () => {
-      d.zeroToHundredLong.closed.overlaps(0n).should.be.true();
-      d.zeroToHundredLong.open.overlaps(0n).should.be.false();
-    });
-
-    it('should properly calculate longs in the middle of it', () => {
-      d.zeroToHundredLong.closed.overlaps(50n).should.be.true();
-    });
-
-    it('should properly calculate the right boundary long', () => {
-      d.zeroToHundredLong.closed.overlaps(100n).should.be.true();
-      d.zeroToHundredLong.open.overlaps(100n).should.be.false();
-    });
-
-    it('should properly calculate longs greater than it', () => {
-      d.zeroToHundredLong.closed.overlaps(105n).should.be.false();
-    });
-
-    it('should properly handle null endpoints', () => {
-      should(new Interval(null, 0n).overlaps(-123456789n)).be.true();
-      should(new Interval(null, 0n).overlaps(1n)).be.false();
-      should(new Interval(null, 0n, false, true).overlaps(0n)).be.true();
-      should(new Interval(null, 0n, false, true).overlaps(-123456789n)).be.null();
-      should(new Interval(null, 0n, false, true).overlaps(1n)).be.false();
-      should(new Interval(0n, null).overlaps(123456789n)).be.true();
-      should(new Interval(0n, null).overlaps(-1n)).be.false();
-      should(new Interval(0n, null, true, false).overlaps(0n)).be.true();
-      should(new Interval(0n, null, true, false).overlaps(123456789n)).be.null();
-      should(new Interval(0n, null, true, false).overlaps(-1n)).be.false();
-      should(new Interval(null, null).overlaps(5n)).be.true();
-      should(new Interval(null, null, false, false).overlaps(5n)).be.null();
-    });
-
-    it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().overlaps(5n).should.be.true();
-      should(boundlessInterval().overlaps(null)).be.null();
-      should(unknownInterval().overlaps(5n)).be.null();
-    });
-
-    it('should properly handle imprecision', () => {
-      d.zeroToHundredLong.closed.overlaps(new Uncertainty(-20n, -10n)).should.be.false();
-      should.not.exist(d.zeroToHundredLong.closed.overlaps(new Uncertainty(-20n, 20n)));
-      d.zeroToHundredLong.closed.overlaps(new Uncertainty(0n, 100n)).should.be.true();
-      should.not.exist(d.zeroToHundredLong.closed.overlaps(new Uncertainty(80n, 120n)));
-      d.zeroToHundredLong.closed.overlaps(new Uncertainty(120n, 140n)).should.be.false();
-      should.not.exist(d.zeroToHundredLong.closed.overlaps(new Uncertainty(-20n, 120n)));
-
-      const uIvl = new Interval(new Uncertainty(5n, 10n), new Uncertainty(15n, 20n));
-
-      uIvl.overlaps(0n).should.be.false();
-      should.not.exist(uIvl.overlaps(5n));
-      should.not.exist(uIvl.overlaps(6n));
-      uIvl.overlaps(10n).should.be.true();
-      uIvl.overlaps(12n).should.be.true();
-      uIvl.overlaps(15n).should.be.true();
-      should.not.exist(uIvl.overlaps(16n));
-      should.not.exist(uIvl.overlaps(20n));
-      uIvl.overlaps(25n).should.be.false();
-
-      uIvl.overlaps(new Uncertainty(0n, 4n)).should.be.false();
-      should.not.exist(uIvl.overlaps(new Uncertainty(0n, 5n)));
-      should.not.exist(uIvl.overlaps(new Uncertainty(5n, 10n)));
-      uIvl.overlaps(new Uncertainty(10n, 15n)).should.be.true();
-      should.not.exist(uIvl.overlaps(new Uncertainty(15n, 20n)));
-      should.not.exist(uIvl.overlaps(new Uncertainty(20n, 25n)));
-      uIvl.overlaps(new Uncertainty(25n, 30n)).should.be.false();
-    });
-  });
-
   describe('overlapsBefore', () => {
     let d: any;
     beforeEach(() => {
@@ -5108,11 +5165,14 @@ describe('LongInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().overlapsBefore(d.zeroToHundredLong.closed).should.be.true();
-      boundlessInterval().overlapsBefore(5n).should.be.true();
-      d.zeroToHundredLong.closed.overlapsBefore(boundlessInterval()).should.be.false();
-      should(boundlessInterval().overlapsBefore(unknownInterval())).be.null();
-      should(unknownInterval().overlapsBefore(boundlessInterval())).be.null();
+      boundlessInterval(ELM_LONG_TYPE).overlapsBefore(d.zeroToHundredLong.closed).should.be.true();
+      d.zeroToHundredLong.closed.overlapsBefore(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      should(
+        boundlessInterval(ELM_LONG_TYPE).overlapsBefore(unknownInterval(ELM_LONG_TYPE))
+      ).be.null();
+      unknownInterval(ELM_LONG_TYPE)
+        .overlapsBefore(boundlessInterval(ELM_LONG_TYPE))
+        .should.be.false();
     });
   });
 
@@ -5123,11 +5183,14 @@ describe('LongInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().overlapsAfter(d.zeroToHundredLong.closed).should.be.true();
-      boundlessInterval().overlapsAfter(5n).should.be.true();
-      d.zeroToHundredLong.closed.overlapsAfter(boundlessInterval()).should.be.false();
-      should(boundlessInterval().overlapsAfter(unknownInterval())).be.null();
-      should(unknownInterval().overlapsAfter(boundlessInterval())).be.null();
+      boundlessInterval(ELM_LONG_TYPE).overlapsAfter(d.zeroToHundredLong.closed).should.be.true();
+      d.zeroToHundredLong.closed.overlapsAfter(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      should(
+        boundlessInterval(ELM_LONG_TYPE).overlapsAfter(unknownInterval(ELM_LONG_TYPE))
+      ).be.null();
+      unknownInterval(ELM_LONG_TYPE)
+        .overlapsAfter(boundlessInterval(ELM_LONG_TYPE))
+        .should.be.false();
     });
   });
 
@@ -5273,12 +5336,12 @@ describe('LongInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().equals(boundlessInterval()).should.be.true();
-      boundlessInterval().equals(d.zeroToHundredLong.closed).should.be.false();
-      d.zeroToHundredLong.closed.equals(boundlessInterval()).should.be.false();
-      should(boundlessInterval().equals(unknownInterval())).be.null();
-      should(unknownInterval().equals(boundlessInterval())).be.null();
-      should(unknownInterval().equals(unknownInterval())).be.null();
+      boundlessInterval(ELM_LONG_TYPE).equals(boundlessInterval(ELM_LONG_TYPE)).should.be.true();
+      boundlessInterval(ELM_LONG_TYPE).equals(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.equals(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      should(boundlessInterval(ELM_LONG_TYPE).equals(unknownInterval(ELM_LONG_TYPE))).be.null();
+      should(unknownInterval(ELM_LONG_TYPE).equals(boundlessInterval(ELM_LONG_TYPE))).be.null();
+      should(unknownInterval(ELM_LONG_TYPE).equals(unknownInterval(ELM_LONG_TYPE))).be.null();
     });
   });
 
@@ -5289,12 +5352,12 @@ describe('LongInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().sameAs(boundlessInterval()).should.be.true();
-      boundlessInterval().sameAs(d.zeroToHundredLong.closed).should.be.false();
-      d.zeroToHundredLong.closed.sameAs(boundlessInterval()).should.be.false();
-      should(boundlessInterval().sameAs(unknownInterval())).be.null();
-      should(unknownInterval().sameAs(boundlessInterval())).be.null();
-      should(unknownInterval().sameAs(unknownInterval())).be.null();
+      boundlessInterval(ELM_LONG_TYPE).sameAs(boundlessInterval(ELM_LONG_TYPE)).should.be.true();
+      boundlessInterval(ELM_LONG_TYPE).sameAs(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.sameAs(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      should(boundlessInterval(ELM_LONG_TYPE).sameAs(unknownInterval(ELM_LONG_TYPE))).be.null();
+      should(unknownInterval(ELM_LONG_TYPE).sameAs(boundlessInterval(ELM_LONG_TYPE))).be.null();
+      should(unknownInterval(ELM_LONG_TYPE).sameAs(unknownInterval(ELM_LONG_TYPE))).be.null();
     });
   });
 
@@ -5416,10 +5479,10 @@ describe('LongInterval', () => {
 
       ivl = new Interval(10n, 15n);
       i = ivl.union(uIvl);
-      i.should.eql(uIvl);
+      i.should.equalInterval(uIvl);
 
       i = uIvl.union(ivl);
-      i.should.eql(uIvl);
+      i.should.equalInterval(uIvl);
 
       ivl = new Interval(15n, 20n);
       i = ivl.union(uIvl);
@@ -5442,11 +5505,19 @@ describe('LongInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().union(d.zeroToHundredLong.closed).should.eql(boundlessInterval());
-      d.zeroToHundredLong.closed.union(boundlessInterval()).should.eql(boundlessInterval());
-      boundlessInterval().union(unknownInterval()).should.eql(boundlessInterval());
-      unknownInterval().union(boundlessInterval()).should.eql(boundlessInterval());
-      should(unknownInterval().union(unknownInterval())).be.null();
+      boundlessInterval(ELM_LONG_TYPE)
+        .union(d.zeroToHundredLong.closed)
+        .should.equalInterval(boundlessInterval(ELM_LONG_TYPE));
+      d.zeroToHundredLong.closed
+        .union(boundlessInterval(ELM_LONG_TYPE))
+        .should.equalInterval(boundlessInterval(ELM_LONG_TYPE));
+      boundlessInterval(ELM_LONG_TYPE)
+        .union(unknownInterval(ELM_LONG_TYPE))
+        .should.equalInterval(boundlessInterval(ELM_LONG_TYPE));
+      unknownInterval(ELM_LONG_TYPE)
+        .union(boundlessInterval(ELM_LONG_TYPE))
+        .should.equalInterval(boundlessInterval(ELM_LONG_TYPE));
+      should(unknownInterval(ELM_LONG_TYPE).union(unknownInterval(ELM_LONG_TYPE))).be.null();
     });
   });
 
@@ -5550,8 +5621,8 @@ describe('LongInterval', () => {
 
       let x = new Interval(b, e);
       let y = new Interval(a, c);
-      x.intersect(y).should.eql(new Interval(b, c));
-      y.intersect(x).should.eql(new Interval(b, c));
+      x.intersect(y).should.equalInterval(new Interval(b, c));
+      y.intersect(x).should.equalInterval(new Interval(b, c));
 
       x = new Interval(a, b);
       y = new Interval(b, d);
@@ -5562,13 +5633,13 @@ describe('LongInterval', () => {
 
       x = new Interval(a, e);
       y = new Interval(b, d);
-      x.intersect(y).should.eql(y);
-      y.intersect(x).should.eql(y);
+      x.intersect(y).should.equalInterval(y);
+      y.intersect(x).should.equalInterval(y);
 
       x = new Interval(a, d);
       y = new Interval(b, e);
-      x.intersect(y).should.eql(new Interval(b, d));
-      y.intersect(x).should.eql(new Interval(b, d));
+      x.intersect(y).should.equalInterval(new Interval(b, d));
+      y.intersect(x).should.equalInterval(new Interval(b, d));
 
       x = new Interval(a, b);
       y = new Interval(d, e);
@@ -5577,8 +5648,12 @@ describe('LongInterval', () => {
 
       x = new Interval(new Uncertainty(5n, 10n), new Uncertainty(15n, 20n));
       y = new Interval(8n, 17n);
-      x.intersect(y).should.eql(new Interval(new Uncertainty(8n, 10n), new Uncertainty(15n, 17n)));
-      y.intersect(x).should.eql(new Interval(new Uncertainty(8n, 10n), new Uncertainty(15n, 17n)));
+      x.intersect(y).should.equalInterval(
+        new Interval(new Uncertainty(8n, 10n), new Uncertainty(15n, 17n))
+      );
+      y.intersect(x).should.equalInterval(
+        new Interval(new Uncertainty(8n, 10n), new Uncertainty(15n, 17n))
+      );
     });
 
     it('should throw when the argument is a point', () => {
@@ -5586,15 +5661,19 @@ describe('LongInterval', () => {
     });
 
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval()
+      boundlessInterval(ELM_LONG_TYPE)
         .intersect(d.zeroToHundredLong.closed)
-        .should.eql(d.zeroToHundredLong.closed);
+        .should.equalInterval(d.zeroToHundredLong.closed);
       d.zeroToHundredLong.closed
-        .intersect(boundlessInterval())
-        .should.eql(d.zeroToHundredLong.closed);
-      boundlessInterval().intersect(unknownInterval()).should.eql(unknownInterval());
-      unknownInterval().intersect(boundlessInterval()).should.eql(unknownInterval());
-      should(unknownInterval().intersect(unknownInterval())).be.null();
+        .intersect(boundlessInterval(ELM_LONG_TYPE))
+        .should.equalInterval(d.zeroToHundredLong.closed);
+      boundlessInterval(ELM_LONG_TYPE)
+        .intersect(unknownInterval(ELM_LONG_TYPE))
+        .should.equalInterval(unknownInterval(ELM_LONG_TYPE));
+      unknownInterval(ELM_LONG_TYPE)
+        .intersect(boundlessInterval(ELM_LONG_TYPE))
+        .should.equalInterval(unknownInterval(ELM_LONG_TYPE));
+      should(unknownInterval(ELM_LONG_TYPE).intersect(unknownInterval(ELM_LONG_TYPE))).be.null();
     });
   });
 
@@ -5618,26 +5697,26 @@ describe('LongInterval', () => {
 
     it('should properly calculate before/after except', () => {
       const [x, y] = Array.from(xy(d.lIvl.before));
-      x.closed.except(y.closed).should.eql(x.closed);
-      x.closed.except(y.open).should.eql(x.closed);
-      x.open.except(y.closed).should.eql(x.open);
-      x.open.except(y.open).should.eql(x.open);
-      y.closed.except(x.closed).should.eql(y.closed);
-      y.closed.except(x.open).should.eql(y.closed);
-      y.open.except(x.closed).should.eql(y.open);
-      y.open.except(x.open).should.eql(y.open);
+      x.closed.except(y.closed).should.equalInterval(x.closed);
+      x.closed.except(y.open).should.equalInterval(x.closed);
+      x.open.except(y.closed).should.equalInterval(x.open);
+      x.open.except(y.open).should.equalInterval(x.open);
+      y.closed.except(x.closed).should.equalInterval(y.closed);
+      y.closed.except(x.open).should.equalInterval(y.closed);
+      y.open.except(x.closed).should.equalInterval(y.open);
+      y.open.except(x.open).should.equalInterval(y.open);
     });
 
     it('should properly calculate meets except', () => {
       const [x, y] = Array.from(xy(d.lIvl.meets));
-      x.closed.except(y.closed).should.eql(x.closed);
-      x.closed.except(y.open).should.eql(x.closed);
-      x.open.except(y.closed).should.eql(x.open);
-      x.open.except(y.open).should.eql(x.open);
-      y.closed.except(x.closed).should.eql(y.closed);
-      y.closed.except(x.open).should.eql(y.closed);
-      y.open.except(x.closed).should.eql(y.open);
-      y.open.except(x.open).should.eql(y.open);
+      x.closed.except(y.closed).should.equalInterval(x.closed);
+      x.closed.except(y.open).should.equalInterval(x.closed);
+      x.open.except(y.closed).should.equalInterval(x.open);
+      x.open.except(y.open).should.equalInterval(x.open);
+      y.closed.except(x.closed).should.equalInterval(y.closed);
+      y.closed.except(x.open).should.equalInterval(y.closed);
+      y.open.except(x.closed).should.equalInterval(y.open);
+      y.open.except(x.open).should.equalInterval(y.open);
     });
 
     it('should properly calculate left/right overlapping except', () => {
@@ -5658,7 +5737,7 @@ describe('LongInterval', () => {
       const [x, y] = Array.from(xy(d.lIvl.begins));
       const b = d.sixtyToHundredLong;
       should.not.exist(x.closed.except(y.closed));
-      x.closed.except(y.open).should.eql(new Interval(x.closed.low, x.closed.low));
+      x.closed.except(y.open).should.equalInterval(new Interval(x.closed.low, x.closed.low));
       should.not.exist(x.open.except(y.closed));
       should.not.exist(x.open.except(y.open));
       y.closed.except(x.closed).equals(b.openClosed).should.be.true();
@@ -5683,7 +5762,7 @@ describe('LongInterval', () => {
       const [x, y] = Array.from(xy(d.lIvl.ends));
       const b = d.zeroToFortyLong;
       should.not.exist(x.closed.except(y.closed));
-      x.closed.except(y.open).should.eql(new Interval(x.closed.high, x.closed.high));
+      x.closed.except(y.open).should.equalInterval(new Interval(x.closed.high, x.closed.high));
       should.not.exist(x.open.except(y.closed));
       should.not.exist(x.open.except(y.open));
       y.closed.except(x.closed).equals(b.closedOpen).should.be.true();
@@ -5701,8 +5780,8 @@ describe('LongInterval', () => {
 
       let x = new Interval(b, e); //([10n,20n] , 100n)
       let y = new Interval(a, c); //(   0n    ,  50n)
-      x.except(y).should.eql(new Interval(c, e, false, true));
-      y.except(x).should.eql(new Interval(a, b, true, false));
+      x.except(y).should.equalInterval(new Interval(c, e, false, true));
+      y.except(x).should.equalInterval(new Interval(a, b, true, false));
 
       x = new Interval(a, b);
       y = new Interval(b, d);
@@ -5718,13 +5797,13 @@ describe('LongInterval', () => {
 
       x = new Interval(a, d);
       y = new Interval(b, e);
-      x.except(y).should.eql(new Interval(a, b, true, false));
-      y.except(x).should.eql(new Interval(d, e, false, true));
+      x.except(y).should.equalInterval(new Interval(a, b, true, false));
+      y.except(x).should.equalInterval(new Interval(d, e, false, true));
 
       x = new Interval(a, b);
       y = new Interval(d, e);
-      x.except(y).should.eql(x);
-      y.except(x).should.eql(y);
+      x.except(y).should.equalInterval(x);
+      y.except(x).should.equalInterval(y);
     });
 
     it('should throw when the argument is a point', () => {
@@ -5853,11 +5932,11 @@ describe('LongInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().after(boundlessInterval()).should.be.false();
-      boundlessInterval().after(d.zeroToHundredLong.closed).should.be.false();
-      d.zeroToHundredLong.closed.after(boundlessInterval()).should.be.false();
-      unknownInterval().after(boundlessInterval()).should.be.false();
-      should(unknownInterval().after(unknownInterval())).be.null();
+      boundlessInterval(ELM_LONG_TYPE).after(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      boundlessInterval(ELM_LONG_TYPE).after(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.after(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      unknownInterval(ELM_LONG_TYPE).after(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      should(unknownInterval(ELM_LONG_TYPE).after(unknownInterval(ELM_LONG_TYPE))).be.null();
     });
   });
 
@@ -5867,12 +5946,23 @@ describe('LongInterval', () => {
       d = data();
     });
 
+    it('should compare intervals to points as unit intervals', () => {
+      d.zeroToHundredLong.closed.sameOrAfter(0n).should.be.true();
+      d.zeroToHundredLong.closed.sameOrAfter(-1n).should.be.true();
+      d.zeroToHundredLong.closed.sameOrAfter(1n).should.be.false();
+      should(d.zeroToHundredLong.closed.sameOrAfter(null)).be.null();
+    });
+
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().sameOrAfter(boundlessInterval()).should.be.true();
-      boundlessInterval().sameOrAfter(d.zeroToHundredLong.closed).should.be.false();
-      d.zeroToHundredLong.closed.sameOrAfter(boundlessInterval()).should.be.false();
-      should(unknownInterval().sameOrAfter(boundlessInterval())).be.null();
-      should(unknownInterval().sameOrAfter(unknownInterval())).be.null();
+      boundlessInterval(ELM_LONG_TYPE)
+        .sameOrAfter(boundlessInterval(ELM_LONG_TYPE))
+        .should.be.false();
+      boundlessInterval(ELM_LONG_TYPE).sameOrAfter(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.sameOrAfter(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      should(
+        unknownInterval(ELM_LONG_TYPE).sameOrAfter(boundlessInterval(ELM_LONG_TYPE))
+      ).be.null();
+      should(unknownInterval(ELM_LONG_TYPE).sameOrAfter(unknownInterval(ELM_LONG_TYPE))).be.null();
     });
   });
 
@@ -5997,11 +6087,11 @@ describe('LongInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().before(boundlessInterval()).should.be.false();
-      boundlessInterval().before(d.zeroToHundredLong.closed).should.be.false();
-      d.zeroToHundredLong.closed.before(boundlessInterval()).should.be.false();
-      unknownInterval().before(boundlessInterval()).should.be.false();
-      should(unknownInterval().before(unknownInterval())).be.null();
+      boundlessInterval(ELM_LONG_TYPE).before(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      boundlessInterval(ELM_LONG_TYPE).before(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.before(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      unknownInterval(ELM_LONG_TYPE).before(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      should(unknownInterval(ELM_LONG_TYPE).before(unknownInterval(ELM_LONG_TYPE))).be.null();
     });
   });
 
@@ -6011,12 +6101,23 @@ describe('LongInterval', () => {
       d = data();
     });
 
+    it('should compare intervals to points as unit intervals', () => {
+      d.zeroToHundredLong.closed.sameOrBefore(100n).should.be.true();
+      d.zeroToHundredLong.closed.sameOrBefore(99n).should.be.false();
+      d.zeroToHundredLong.closed.sameOrBefore(101n).should.be.true();
+      should(d.zeroToHundredLong.closed.sameOrBefore(null)).be.null();
+    });
+
     it('should properly handle boundless and unknown intervals', () => {
-      boundlessInterval().sameOrBefore(boundlessInterval()).should.be.true();
-      boundlessInterval().sameOrBefore(d.zeroToHundredLong.closed).should.be.false();
-      d.zeroToHundredLong.closed.sameOrBefore(boundlessInterval()).should.be.false();
-      should(unknownInterval().sameOrBefore(boundlessInterval())).be.null();
-      should(unknownInterval().sameOrBefore(unknownInterval())).be.null();
+      boundlessInterval(ELM_LONG_TYPE)
+        .sameOrBefore(boundlessInterval(ELM_LONG_TYPE))
+        .should.be.false();
+      boundlessInterval(ELM_LONG_TYPE).sameOrBefore(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.sameOrBefore(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      should(
+        unknownInterval(ELM_LONG_TYPE).sameOrBefore(boundlessInterval(ELM_LONG_TYPE))
+      ).be.null();
+      should(unknownInterval(ELM_LONG_TYPE).sameOrBefore(unknownInterval(ELM_LONG_TYPE))).be.null();
     });
   });
 
@@ -6141,11 +6242,11 @@ describe('LongInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().meets(boundlessInterval()).should.be.false();
-      boundlessInterval().meets(d.zeroToHundredLong.closed).should.be.false();
-      d.zeroToHundredLong.closed.meets(boundlessInterval()).should.be.false();
-      unknownInterval().meets(boundlessInterval()).should.be.false();
-      should(unknownInterval().meets(unknownInterval())).be.null();
+      boundlessInterval(ELM_LONG_TYPE).meets(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      boundlessInterval(ELM_LONG_TYPE).meets(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.meets(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      unknownInterval(ELM_LONG_TYPE).meets(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      should(unknownInterval(ELM_LONG_TYPE).meets(unknownInterval(ELM_LONG_TYPE))).be.null();
     });
   });
 
@@ -6270,11 +6371,13 @@ describe('LongInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().meetsAfter(boundlessInterval()).should.be.false();
-      boundlessInterval().meetsAfter(d.zeroToHundredLong.closed).should.be.false();
-      d.zeroToHundredLong.closed.meetsAfter(boundlessInterval()).should.be.false();
-      unknownInterval().meetsAfter(boundlessInterval()).should.be.false();
-      should(unknownInterval().meetsAfter(unknownInterval())).be.null();
+      boundlessInterval(ELM_LONG_TYPE)
+        .meetsAfter(boundlessInterval(ELM_LONG_TYPE))
+        .should.be.false();
+      boundlessInterval(ELM_LONG_TYPE).meetsAfter(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.meetsAfter(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      unknownInterval(ELM_LONG_TYPE).meetsAfter(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      should(unknownInterval(ELM_LONG_TYPE).meetsAfter(unknownInterval(ELM_LONG_TYPE))).be.null();
     });
   });
 
@@ -6399,11 +6502,15 @@ describe('LongInterval', () => {
     });
 
     it('should properly handle boundless intervals', () => {
-      boundlessInterval().meetsBefore(boundlessInterval()).should.be.false();
-      boundlessInterval().meetsBefore(d.zeroToHundredLong.closed).should.be.false();
-      d.zeroToHundredLong.closed.meetsBefore(boundlessInterval()).should.be.false();
-      unknownInterval().meetsBefore(boundlessInterval()).should.be.false();
-      should(unknownInterval().meetsBefore(unknownInterval())).be.null();
+      boundlessInterval(ELM_LONG_TYPE)
+        .meetsBefore(boundlessInterval(ELM_LONG_TYPE))
+        .should.be.false();
+      boundlessInterval(ELM_LONG_TYPE).meetsBefore(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.meetsBefore(boundlessInterval(ELM_LONG_TYPE)).should.be.false();
+      unknownInterval(ELM_LONG_TYPE)
+        .meetsBefore(boundlessInterval(ELM_LONG_TYPE))
+        .should.be.false();
+      should(unknownInterval(ELM_LONG_TYPE).meetsBefore(unknownInterval(ELM_LONG_TYPE))).be.null();
     });
   });
 });
@@ -6412,6 +6519,13 @@ describe('DecimalInterval', () => {
   let d: any;
   beforeEach(() => {
     d = data();
+  });
+
+  it('should calculate width and size outside the Integer range', () => {
+    const interval = new Interval(0.0, 3000000000.0, true, true, ELM_DECIMAL_TYPE);
+
+    interval.width().should.equal(3000000000.0);
+    interval.size().should.equal(3000000000.0);
   });
 
   it('should close open decimal uncertainty endpoints using decimal point size', () => {
@@ -6504,47 +6618,41 @@ describe('DecimalInterval', () => {
   });
 
   it('should properly handle null endpoints', () => {
-    const date = DateTime.parse('2012-01-01T00:00:00.0');
-    const early = DateTime.parse('0001-01-01T00:00:00.0');
-    const late = DateTime.parse('2999-01-01T00:00:00.0');
-    const earlyInterval = new Interval(early, DateTime.parse('2011-01-01T00:00:00.0'));
-    const lateInterval = new Interval(DateTime.parse('2013-01-01T00:00:00.0'), late);
-    const startsAtDate = new Interval(date, late);
-    const endsAtDate = new Interval(early, date);
+    const decimal = 1.5;
+    const early = -1.5;
+    const late = 3.5;
+    const decimalInterval = new Interval(0.5, 1.5);
+    const earlyInterval = new Interval(early, -0.5);
+    const lateInterval = new Interval(3.5, late);
+    const startsAtDecimal = new Interval(decimal, late);
+    const endsAtDecimal = new Interval(early, decimal);
 
-    should(new Interval(null, date).overlaps(earlyInterval)).be.true();
-    should(new Interval(null, date).overlaps(lateInterval)).be.false();
-    should(new Interval(null, date, false, true).overlaps(startsAtDate)).be.true();
-    should(new Interval(null, date, false, true).overlaps(earlyInterval)).be.null();
-    should(new Interval(null, date, false, true).overlaps(lateInterval)).be.false();
+    should(new Interval(null, decimal).overlaps(earlyInterval)).be.true();
+    should(new Interval(null, decimal).overlaps(lateInterval)).be.false();
+    should(new Interval(null, decimal, false, true).overlaps(startsAtDecimal)).be.true();
+    should(new Interval(null, decimal, false, true).overlaps(earlyInterval)).be.null();
+    should(new Interval(null, decimal, false, true).overlaps(lateInterval)).be.false();
 
-    should(new Interval(date, null).overlaps(lateInterval)).be.true();
-    should(new Interval(date, null).overlaps(earlyInterval)).be.false();
-    should(new Interval(date, null, true, false).overlaps(endsAtDate)).be.true();
-    should(new Interval(date, null, true, false).overlaps(lateInterval)).be.null();
-    should(new Interval(date, null, true, false).overlaps(earlyInterval)).be.false();
+    should(new Interval(decimal, null).overlaps(lateInterval)).be.true();
+    should(new Interval(decimal, null).overlaps(earlyInterval)).be.false();
+    should(new Interval(decimal, null, true, false).overlaps(endsAtDecimal)).be.true();
+    should(new Interval(decimal, null, true, false).overlaps(lateInterval)).be.null();
+    should(new Interval(decimal, null, true, false).overlaps(earlyInterval)).be.false();
 
-    should(new Interval(null, null).overlaps(d.all2012.closed)).be.true();
-    should(new Interval(null, null, false, false).overlaps(d.all2012.closed)).be.null();
-    should(d.all2012.closed.overlaps(new Interval(null, null))).be.true();
-    should(d.all2012.closed.overlaps(new Interval(null, null, false, false))).be.null();
-    // TODO: These commented out edge cases with all null endpoints on both sides currently don't pass
-    //should(new Interval(null, null).overlaps(new Interval(null, null))).be.true();
-    //should(new Interval(null, null).overlaps(new Interval(null, null, false, false))).be.true();
-    //should(new Interval(null, null, false, false).overlaps(new Interval(null, null))).be.true();
+    should(boundlessInterval(ELM_DECIMAL_TYPE).overlaps(decimalInterval)).be.true();
+    should(unknownInterval(ELM_DECIMAL_TYPE).overlaps(decimalInterval)).be.null();
+    should(decimalInterval.overlaps(boundlessInterval(ELM_DECIMAL_TYPE))).be.true();
+    should(decimalInterval.overlaps(unknownInterval(ELM_DECIMAL_TYPE))).be.null();
     should(
-      new Interval(null, null, false, false).overlaps(new Interval(null, null, false, false))
-    ).be.null();
-  });
-
-  it('should properly handle boundless and unknown intervals', () => {
-    boundlessInterval().overlaps(boundlessInterval()).should.be.true();
-    boundlessInterval().overlaps(d.all2012.closed).should.be.true();
-    // TODO: These commented out edge cases with all null endpoints on both sides currently don't pass
-    //d.all2012.closed.overlaps(boundlessInterval()).should.be.true();
-    //boundlessInterval().overlaps(unknownInterval()).should.be.true();
-    //unknownInterval().overlaps(boundlessInterval()).should.be.true();
-    should(unknownInterval().overlaps(d.all2012.closed)).be.null();
+      boundlessInterval(ELM_DECIMAL_TYPE).overlaps(boundlessInterval(ELM_DECIMAL_TYPE))
+    ).be.true();
+    should(
+      boundlessInterval(ELM_DECIMAL_TYPE).overlaps(unknownInterval(ELM_DECIMAL_TYPE))
+    ).be.true();
+    should(
+      unknownInterval(ELM_DECIMAL_TYPE).overlaps(boundlessInterval(ELM_DECIMAL_TYPE))
+    ).be.true();
+    should(unknownInterval(ELM_DECIMAL_TYPE).overlaps(unknownInterval(ELM_DECIMAL_TYPE))).be.null();
   });
 
   it('should properly handle imprecision', () => {

--- a/test/datatypes/interval-test.ts
+++ b/test/datatypes/interval-test.ts
@@ -4167,6 +4167,8 @@ describe('LongInterval', () => {
       new Interval(0n, null, true, false).contains(0n).should.be.true();
       should(new Interval(0n, null, true, false).contains(123456789n)).be.null();
       new Interval(0n, null, true, false).contains(-1n).should.be.false();
+      new Interval(null, null).contains(5n).should.be.true();
+      should(new Interval(null, null, false, false).contains(5n)).be.null();
     });
 
     it('should properly handle imprecision', () => {
@@ -4408,6 +4410,15 @@ describe('LongInterval', () => {
     it('should include a point Long', () => {
       d.zeroToHundredLong.closed.includes(50n).should.be.true();
     });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().includes(50n).should.be.true();
+      boundlessInterval().includes(d.zeroToHundredLong.closed).should.be.true();
+      boundlessInterval().includes(unknownInterval()).should.be.true();
+      d.zeroToHundredLong.closed.includes(boundlessInterval()).should.be.false();
+      should(unknownInterval().includes(d.zeroToHundredLong.closed)).be.null();
+      should(unknownInterval().includes(boundlessInterval())).be.null();
+    });
   });
 
   describe('includedIn', () => {
@@ -4527,6 +4538,57 @@ describe('LongInterval', () => {
       d.zeroToHundredLong.closed.includedIn(50n).should.be.true();
       d.zeroToHundredLong.closed.includedIn(500n).should.be.false();
     });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      d.zeroToHundredLong.closed.includedIn(boundlessInterval()).should.be.true();
+      boundlessInterval().includedIn(d.zeroToHundredLong.closed).should.be.false();
+      boundlessInterval().includedIn(boundlessInterval()).should.be.true();
+      unknownInterval().includedIn(boundlessInterval()).should.be.true();
+    });
+  });
+
+  describe('properlyIncludes', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().properlyIncludes(d.zeroToHundredLong.closed).should.be.true();
+      boundlessInterval().properlyIncludes(boundlessInterval()).should.be.false();
+      should(boundlessInterval().properlyIncludes(unknownInterval())).be.null();
+      should(unknownInterval().properlyIncludes(d.zeroToHundredLong.closed)).be.null();
+    });
+  });
+
+  describe('starts', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().starts(boundlessInterval()).should.be.true();
+      boundlessInterval().starts(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.starts(boundlessInterval()).should.be.false();
+      should(boundlessInterval().starts(unknownInterval())).be.null();
+      should(unknownInterval().starts(boundlessInterval())).be.null();
+    });
+  });
+
+  describe('ends', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().ends(boundlessInterval()).should.be.true();
+      boundlessInterval().ends(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.ends(boundlessInterval()).should.be.false();
+      should(boundlessInterval().ends(unknownInterval())).be.null();
+      should(unknownInterval().ends(boundlessInterval())).be.null();
+    });
   });
 
   describe('overlaps(LongInterval)', () => {
@@ -4619,6 +4681,30 @@ describe('LongInterval', () => {
       y.open.overlaps(x.open).should.be.true();
     });
 
+    it('should properly handle null endpoints', () => {
+      const negativeInterval = new Interval(-123456789n, -1n);
+      const positiveInterval = new Interval(1n, 123456789n);
+      const startsAtZero = new Interval(0n, 123456789n);
+      const endsAtZero = new Interval(-123456789n, 0n);
+
+      should(new Interval(null, 0n).overlaps(negativeInterval)).be.true();
+      should(new Interval(null, 0n).overlaps(positiveInterval)).be.false();
+      should(new Interval(null, 0n, false, true).overlaps(startsAtZero)).be.true();
+      should(new Interval(null, 0n, false, true).overlaps(negativeInterval)).be.null();
+      should(new Interval(null, 0n, false, true).overlaps(positiveInterval)).be.false();
+
+      should(new Interval(0n, null).overlaps(positiveInterval)).be.true();
+      should(new Interval(0n, null).overlaps(negativeInterval)).be.false();
+      should(new Interval(0n, null, true, false).overlaps(endsAtZero)).be.true();
+      should(new Interval(0n, null, true, false).overlaps(positiveInterval)).be.null();
+      should(new Interval(0n, null, true, false).overlaps(negativeInterval)).be.false();
+
+      should(new Interval(null, null).overlaps(d.zeroToHundredLong.closed)).be.true();
+      should(new Interval(null, null, false, false).overlaps(d.zeroToHundredLong.closed)).be.null();
+      should(d.zeroToHundredLong.closed.overlaps(new Interval(null, null))).be.true();
+      should(d.zeroToHundredLong.closed.overlaps(new Interval(null, null, false, false))).be.null();
+    });
+
     it('should properly handle boundless and unknown intervals', () => {
       boundlessInterval().overlaps(boundlessInterval()).should.be.true();
       boundlessInterval().overlaps(d.zeroToHundredLong.closed).should.be.true();
@@ -4677,6 +4763,21 @@ describe('LongInterval', () => {
 
     it('should properly calculate longs greater than it', () => {
       d.zeroToHundredLong.closed.overlaps(105n).should.be.false();
+    });
+
+    it('should properly handle null endpoints', () => {
+      should(new Interval(null, 0n).overlaps(-123456789n)).be.true();
+      should(new Interval(null, 0n).overlaps(1n)).be.false();
+      should(new Interval(null, 0n, false, true).overlaps(0n)).be.true();
+      should(new Interval(null, 0n, false, true).overlaps(-123456789n)).be.null();
+      should(new Interval(null, 0n, false, true).overlaps(1n)).be.false();
+      should(new Interval(0n, null).overlaps(123456789n)).be.true();
+      should(new Interval(0n, null).overlaps(-1n)).be.false();
+      should(new Interval(0n, null, true, false).overlaps(0n)).be.true();
+      should(new Interval(0n, null, true, false).overlaps(123456789n)).be.null();
+      should(new Interval(0n, null, true, false).overlaps(-1n)).be.false();
+      should(new Interval(null, null).overlaps(5n)).be.true();
+      should(new Interval(null, null, false, false).overlaps(5n)).be.null();
     });
 
     it('should properly handle boundless and unknown intervals', () => {
@@ -4885,6 +4986,31 @@ describe('LongInterval', () => {
 
       ivl.equals(point).should.be.false();
     });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().equals(boundlessInterval()).should.be.true();
+      boundlessInterval().equals(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.equals(boundlessInterval()).should.be.false();
+      should(boundlessInterval().equals(unknownInterval())).be.null();
+      should(unknownInterval().equals(boundlessInterval())).be.null();
+      should(unknownInterval().equals(unknownInterval())).be.null();
+    });
+  });
+
+  describe('sameAs', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().sameAs(boundlessInterval()).should.be.true();
+      boundlessInterval().sameAs(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.sameAs(boundlessInterval()).should.be.false();
+      should(boundlessInterval().sameAs(unknownInterval())).be.null();
+      should(unknownInterval().sameAs(boundlessInterval())).be.null();
+      should(unknownInterval().sameAs(unknownInterval())).be.null();
+    });
   });
 
   describe('union', () => {
@@ -5029,6 +5155,14 @@ describe('LongInterval', () => {
     it('should throw when the argument is a point', () => {
       should(() => d.zeroToHundredLong.union(300n)).throw(Error);
     });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().union(d.zeroToHundredLong.closed).should.eql(boundlessInterval());
+      d.zeroToHundredLong.closed.union(boundlessInterval()).should.eql(boundlessInterval());
+      boundlessInterval().union(unknownInterval()).should.eql(boundlessInterval());
+      unknownInterval().union(boundlessInterval()).should.eql(boundlessInterval());
+      should(unknownInterval().union(unknownInterval())).be.null();
+    });
   });
 
   describe('intersect', () => {
@@ -5164,6 +5298,18 @@ describe('LongInterval', () => {
 
     it('should throw when the argument is a point', () => {
       should(() => d.zeroToHundredLong.intersect(50n)).throw(Error);
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval()
+        .intersect(d.zeroToHundredLong.closed)
+        .should.eql(d.zeroToHundredLong.closed);
+      d.zeroToHundredLong.closed
+        .intersect(boundlessInterval())
+        .should.eql(d.zeroToHundredLong.closed);
+      boundlessInterval().intersect(unknownInterval()).should.eql(unknownInterval());
+      unknownInterval().intersect(boundlessInterval()).should.eql(unknownInterval());
+      should(unknownInterval().intersect(unknownInterval())).be.null();
     });
   });
 
@@ -5420,6 +5566,29 @@ describe('LongInterval', () => {
 
       uIvl.after(uIvl).should.be.false();
     });
+
+    it('should properly handle boundless intervals', () => {
+      boundlessInterval().after(boundlessInterval()).should.be.false();
+      boundlessInterval().after(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.after(boundlessInterval()).should.be.false();
+      unknownInterval().after(boundlessInterval()).should.be.false();
+      should(unknownInterval().after(unknownInterval())).be.null();
+    });
+  });
+
+  describe('sameOrAfter', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().sameOrAfter(boundlessInterval()).should.be.true();
+      boundlessInterval().sameOrAfter(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.sameOrAfter(boundlessInterval()).should.be.false();
+      should(unknownInterval().sameOrAfter(boundlessInterval())).be.null();
+      should(unknownInterval().sameOrAfter(unknownInterval())).be.null();
+    });
   });
 
   describe('before', () => {
@@ -5540,6 +5709,29 @@ describe('LongInterval', () => {
       uIvl.before(ivl).should.be.false();
 
       uIvl.before(uIvl).should.be.false();
+    });
+
+    it('should properly handle boundless intervals', () => {
+      boundlessInterval().before(boundlessInterval()).should.be.false();
+      boundlessInterval().before(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.before(boundlessInterval()).should.be.false();
+      unknownInterval().before(boundlessInterval()).should.be.false();
+      should(unknownInterval().before(unknownInterval())).be.null();
+    });
+  });
+
+  describe('sameOrBefore', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly handle boundless and unknown intervals', () => {
+      boundlessInterval().sameOrBefore(boundlessInterval()).should.be.true();
+      boundlessInterval().sameOrBefore(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.sameOrBefore(boundlessInterval()).should.be.false();
+      should(unknownInterval().sameOrBefore(boundlessInterval())).be.null();
+      should(unknownInterval().sameOrBefore(unknownInterval())).be.null();
     });
   });
 
@@ -5662,6 +5854,14 @@ describe('LongInterval', () => {
 
       uIvl.meets(uIvl).should.be.false();
     });
+
+    it('should properly handle boundless intervals', () => {
+      boundlessInterval().meets(boundlessInterval()).should.be.false();
+      boundlessInterval().meets(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.meets(boundlessInterval()).should.be.false();
+      unknownInterval().meets(boundlessInterval()).should.be.false();
+      should(unknownInterval().meets(unknownInterval())).be.null();
+    });
   });
 
   describe('meetsAfter', () => {
@@ -5783,6 +5983,14 @@ describe('LongInterval', () => {
 
       uIvl.meetsAfter(uIvl).should.be.false();
     });
+
+    it('should properly handle boundless intervals', () => {
+      boundlessInterval().meetsAfter(boundlessInterval()).should.be.false();
+      boundlessInterval().meetsAfter(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.meetsAfter(boundlessInterval()).should.be.false();
+      unknownInterval().meetsAfter(boundlessInterval()).should.be.false();
+      should(unknownInterval().meetsAfter(unknownInterval())).be.null();
+    });
   });
 
   describe('meetsBefore', () => {
@@ -5903,6 +6111,14 @@ describe('LongInterval', () => {
       should.not.exist(uIvl.meetsBefore(ivl));
 
       uIvl.meetsBefore(uIvl).should.be.false();
+    });
+
+    it('should properly handle boundless intervals', () => {
+      boundlessInterval().meetsBefore(boundlessInterval()).should.be.false();
+      boundlessInterval().meetsBefore(d.zeroToHundredLong.closed).should.be.false();
+      d.zeroToHundredLong.closed.meetsBefore(boundlessInterval()).should.be.false();
+      unknownInterval().meetsBefore(boundlessInterval()).should.be.false();
+      should(unknownInterval().meetsBefore(unknownInterval())).be.null();
     });
   });
 });

--- a/test/datatypes/uncertainty-test.ts
+++ b/test/datatypes/uncertainty-test.ts
@@ -164,6 +164,82 @@ describe('Uncertainty', () => {
       .should.be.false();
   });
 
+  it('should properly calculate sameness for point uncertainties', () => {
+    new Uncertainty(1).sameAs(1).should.be.true();
+    new Uncertainty(1).sameAs(new Uncertainty(1)).should.be.true();
+    new Uncertainty(1).sameAs(2).should.be.false();
+    new Uncertainty(1).sameAs('1').should.be.false();
+
+    const first = DateTime.parse('2022-01-01T12:30:15.123');
+    const second = DateTime.parse('2022-01-01T12:30:15.456');
+    new Uncertainty(first).sameAs(second, DateTime.Unit.MILLISECOND).should.be.false();
+    new Uncertainty(first).sameAs(second, DateTime.Unit.SECOND).should.be.true();
+    new Uncertainty(first)
+      .sameAs(new Uncertainty(second), DateTime.Unit.MILLISECOND)
+      .should.be.false();
+    new Uncertainty(first).sameAs(new Uncertainty(second), DateTime.Unit.SECOND).should.be.true();
+
+    new Uncertainty(new Date(2022, 1, 1)).sameAs(new DateTime(2022, 1, 1)).should.be.false();
+    new Uncertainty(new DateTime(2022, 1, 1)).sameAs(new Date(2022, 1, 1)).should.be.false();
+  });
+
+  it('should handle imprecise DateTimes', () => {
+    const precise = new Uncertainty(DateTime.parse('2022-01-01T12:30:15.123'));
+    const imprecise = new Uncertainty(DateTime.parse('2022-01-01T12:30'));
+    const sameImprecise = new Uncertainty(DateTime.parse('2022-01-01T12:30'));
+    const laterImprecise = new Uncertainty(DateTime.parse('2022-01-01T12:31'));
+
+    should.not.exist(precise.sameAs(imprecise));
+    should.not.exist(precise.sameAs(imprecise, DateTime.Unit.SECOND));
+    precise.sameAs(imprecise, DateTime.Unit.MINUTE).should.be.true();
+    imprecise.sameAs(sameImprecise).should.be.true();
+    should.not.exist(imprecise.sameAs(sameImprecise, DateTime.Unit.SECOND));
+    imprecise.sameAs(sameImprecise, DateTime.Unit.MINUTE).should.be.true();
+
+    imprecise.lessThan(laterImprecise, DateTime.Unit.SECOND).should.be.true();
+    laterImprecise.greaterThan(imprecise, DateTime.Unit.SECOND).should.be.true();
+    imprecise.lessThanOrEquals(laterImprecise, DateTime.Unit.SECOND).should.be.true();
+    imprecise.greaterThanOrEquals(laterImprecise, DateTime.Unit.SECOND).should.be.false();
+  });
+
+  it('should properly calculate sameness for non-point uncertainties', () => {
+    new Uncertainty(1, 2).sameAs(new Uncertainty(3, 4)).should.be.false();
+    should.not.exist(new Uncertainty(1, 3).sameAs(new Uncertainty(2, 4)));
+    new Uncertainty(1, 2).sameAs(3).should.be.false();
+    should.not.exist(new Uncertainty(1, 3).sameAs(2));
+
+    const first = new Uncertainty(
+      DateTime.parse('2022-01-01T12:30:15.123'),
+      DateTime.parse('2022-01-01T12:30:15.124')
+    );
+    const second = new Uncertainty(
+      DateTime.parse('2022-01-01T12:30:15.125'),
+      DateTime.parse('2022-01-01T12:30:15.126')
+    );
+    first.sameAs(second, DateTime.Unit.MILLISECOND).should.be.false();
+    first.sameAs(second, DateTime.Unit.SECOND).should.be.true();
+  });
+
+  it('should use precision when calculating inequalities', () => {
+    const first = new Uncertainty(
+      DateTime.parse('2022-01-01T12:30:15.123'),
+      DateTime.parse('2022-01-01T12:30:15.124')
+    );
+    const second = new Uncertainty(
+      DateTime.parse('2022-01-01T12:30:15.125'),
+      DateTime.parse('2022-01-01T12:30:15.126')
+    );
+
+    first.lessThan(second, DateTime.Unit.MILLISECOND).should.be.true();
+    first.lessThan(second, DateTime.Unit.SECOND).should.be.false();
+    second.greaterThan(first, DateTime.Unit.MILLISECOND).should.be.true();
+    second.greaterThan(first, DateTime.Unit.SECOND).should.be.false();
+    first.lessThanOrEquals(second, DateTime.Unit.MILLISECOND).should.be.true();
+    first.lessThanOrEquals(second, DateTime.Unit.SECOND).should.be.true();
+    first.greaterThanOrEquals(second, DateTime.Unit.MILLISECOND).should.be.false();
+    first.greaterThanOrEquals(second, DateTime.Unit.SECOND).should.be.true();
+  });
+
   it('should properly calculate "less than" inequality', () => {
     // Equality
     new Uncertainty(1, 1).lessThan(new Uncertainty(1, 1)).should.be.false();

--- a/test/elm/arithmetic/arithmetic-test.ts
+++ b/test/elm/arithmetic/arithmetic-test.ts
@@ -15,7 +15,7 @@ import {
   MIN_FLOAT_VALUE,
   MIN_INT_VALUE,
   MIN_LONG_VALUE
-} from '../../../src/util/math';
+} from '../../../src/util/limits';
 import {
   MAX_DATE_VALUE,
   MAX_DATETIME_VALUE,

--- a/test/elm/interval/data.cql
+++ b/test/elm/interval/data.cql
@@ -832,8 +832,8 @@ define OverlapsBeforeRealIvl: Interval[1.234, 1.567] overlaps Interval[1.345, 1.
 define OverlapsAfterRealIvl: Interval[1.345, 1.678] overlaps Interval[1.234, 1.567]
 define OverlapsBoundaryRealIvl: Interval[1.0, 1.234] overlaps Interval[1.234, 2.0]
 define NoOverlapsRealIvl: Interval[1.0, 1.23456789) overlaps Interval[1.23456789, 2.0]
-define OverlapsClosedNullIntervalLHS: Interval[null, null] overlaps Interval[6, 10]
-define OverlapsClosedNullIntervalRHS: Interval[6, 10] overlaps Interval[null, null]
+define OverlapsClosedNullIntervalLHS: (Interval[null, null] as Interval<Integer>) overlaps Interval[6, 10]
+define OverlapsClosedNullIntervalRHS: Interval[6, 10] overlaps (Interval[null, null] as Interval<Integer>)
 define OverlapsIsNull: Interval[6, 10] overlaps (null as Interval<Integer>)
 
 // @Test: OverlapsDateTime
@@ -854,8 +854,8 @@ define NoOverlap: ivlC overlaps ivlD
 define NoImpreciseOverlap: ivlE overlaps ivlG
 define UnknownOverlap: ivlE overlaps ivlH
 define MatchingPrecisionOverlap: ivlF overlaps ivlG
-define OverlapsClosedNullIntervalLHS: Interval[null, null] overlaps ivlA
-define OverlapsClosedNullIntervalRHS: ivlA overlaps Interval[null, null]
+define OverlapsClosedNullIntervalLHS: (Interval[null, null] as Interval<DateTime>) overlaps ivlA
+define OverlapsClosedNullIntervalRHS: ivlA overlaps (Interval[null, null] as Interval<DateTime>)
 define PrecisionDateIvl: Interval[DateTime(2012, 3, 2, 12, 34, 56, 789), DateTime(2012, 9, 2, 1, 23, 45, 678))
 // NOTE: There appears to be a bug in cql-to-elm that translates these 'overlaps' to 'OverlapsAfter'!
 define OverlapsBeforeDayOfIvlEdge: PrecisionDateIvl overlaps day of Interval[DateTime(2012, 9, 2, 23, 59, 59, 999), DateTime(2012, 10, 1, 0, 0, 0, 0)]

--- a/test/elm/interval/data.cql
+++ b/test/elm/interval/data.cql
@@ -77,12 +77,12 @@ define MayContainImpreciseDate: DateIvlHighOpen contains DateTime(2012)
 define PrecisionDateIvlHighOpen: Interval[DateTime(2012, 3, 2, 12, 34, 56, 789), DateTime(2012, 9, 2, 1, 23, 45, 678))
 define PrecisionDateIvlHighClosed: Interval[DateTime(2012, 3, 2, 12, 34, 56, 789), DateTime(2012, 9, 2, 1, 23, 45, 678)]
 define ContainsDayOfDateLowEdge: PrecisionDateIvlHighOpen contains day of DateTime(2012, 3, 2, 0, 0, 0, 0)
-define NotContainsDayOfDateHighEdgeOpen: PrecisionDateIvlHighOpen contains day of DateTime(2012, 9, 2, 23, 59, 59, 999)
+define ContainsDayOfDateHighEdgeOpen: PrecisionDateIvlHighOpen contains day of DateTime(2012, 9, 2, 23, 59, 59, 999)
 define ContainsDayOfDateHighEdgeClosed: PrecisionDateIvlHighClosed contains day of DateTime(2012, 9, 2, 23, 59, 59, 999)
 define NotContainsDayOfDateLowEdge: PrecisionDateIvlHighOpen contains day of DateTime(2012, 3, 1, 23, 59, 59, 999)
 define NotContainsDayOfDateBeyondHighEdge: PrecisionDateIvlHighOpen contains day of DateTime(2012, 9, 3, 0, 0, 0, 0)
 define ContainsDayOfDateImpreciseLowEdge: PrecisionDateIvlHighOpen contains day of DateTime(2012, 3, 2)
-define NotContainsDayOfDateImpreciseHighEdgeOpen: PrecisionDateIvlHighOpen contains day of DateTime(2012, 9, 2)
+define ContainsDayOfDateImpreciseHighEdgeOpen: PrecisionDateIvlHighOpen contains day of DateTime(2012, 9, 2)
 define ContainsDayOfDateImpreciseHighEdgeClosed: PrecisionDateIvlHighClosed contains day of DateTime(2012, 9, 2)
 define ContainsDayOfDateVeryImpreciseMiddle: PrecisionDateIvlHighOpen contains day of DateTime(2012, 6)
 define NotContainsDayOfDateVeryImpreciseLow: PrecisionDateIvlHighOpen contains day of DateTime(2012, 2)
@@ -146,12 +146,12 @@ define MayContainImpreciseDate: DateTime(2012) in DateIvlHighClosed
 define PrecisionDateIvlHighOpen: Interval[DateTime(2012, 3, 2, 12, 34, 56, 789), DateTime(2012, 9, 2, 1, 23, 45, 678))
 define PrecisionDateIvlHighClosed: Interval[DateTime(2012, 3, 2, 12, 34, 56, 789), DateTime(2012, 9, 2, 1, 23, 45, 678)]
 define ContainsDayOfDateLowEdge: DateTime(2012, 3, 2, 0, 0, 0, 0) in day of PrecisionDateIvlHighOpen
-define NotContainsDayOfDateHighEdgeOpen: DateTime(2012, 9, 2, 23, 59, 59, 999) in day of PrecisionDateIvlHighOpen
+define ContainsDayOfDateHighEdgeOpen: DateTime(2012, 9, 2, 23, 59, 59, 999) in day of PrecisionDateIvlHighOpen
 define ContainsDayOfDateHighEdgeClosed: DateTime(2012, 9, 2, 23, 59, 59, 999) in day of PrecisionDateIvlHighClosed
 define NotContainsDayOfDateLowEdge: DateTime(2012, 3, 1, 23, 59, 59, 999) in day of PrecisionDateIvlHighOpen
 define NotContainsDayOfDateBeyondHighEdge: DateTime(2012, 9, 3, 0, 0, 0, 0) in day of PrecisionDateIvlHighOpen
 define ContainsDayOfDateImpreciseLowEdge: DateTime(2012, 3, 2) in day of PrecisionDateIvlHighOpen
-define NotContainsDayOfDateImpreciseHighEdgeOpen: DateTime(2012, 9, 2) in day of PrecisionDateIvlHighOpen
+define ContainsDayOfDateImpreciseHighEdgeOpen: DateTime(2012, 9, 2) in day of PrecisionDateIvlHighOpen
 define ContainsDayOfDateImpreciseHighEdgeClosed: DateTime(2012, 9, 2) in day of PrecisionDateIvlHighClosed
 define ContainsDayOfDateVeryImpreciseMiddle: DateTime(2012, 6) in day of PrecisionDateIvlHighOpen
 define NotContainsDayOfDateVeryImpreciseLow: DateTime(2012, 2) in day of PrecisionDateIvlHighOpen
@@ -439,9 +439,19 @@ define AfterLongIvl: Interval[5L, 10L] after Interval[2L, 4L]
 define NotAfterLongIvl: Interval[5L, 10L] after Interval[2L, 5L]
 define AfterRealIvl: Interval[1.234, 2.345] after Interval[0.0, 1.23]
 define NotAfterRealIvl: Interval[1.234, 2.345] after Interval[0.0, 1.234]
+define AfterIntPoint: Interval[5, 10] after 4
+define NotAfterIntPoint: Interval[5, 10] after 5
+define AfterLongPoint: Interval[5L, 10L] after 4L
+define NotAfterLongPoint: Interval[5L, 10L] after 5L
+define AfterRealPoint: Interval[1.234, 2.345] after 1.23
+define NotAfterRealPoint: Interval[1.234, 2.345] after 1.234
 define DateIvl: Interval[DateTime(2012, 3, 1, 0, 0, 0, 0), DateTime(2012, 9, 1, 0, 0, 0, 0))
 define AfterDateIvl: DateIvl after Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2012, 3, 1, 0, 0, 0, 0))
 define NotAfterDateIvl: DateIvl after Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2012, 3, 1, 0, 0, 0, 0)]
+define AfterDatePoint: DateIvl after DateTime(2012, 2, 29, 23, 59, 59, 999)
+define NotAfterDatePoint: DateIvl after DateTime(2012, 3, 1, 0, 0, 0, 0)
+define AfterDayOfDatePoint: DateIvl after day of DateTime(2012, 2, 29, 23, 59, 59, 999)
+define NotAfterDayOfDatePoint: DateIvl after day of DateTime(2012, 3, 1, 23, 59, 59, 999)
 define AfterImpreciseDateIvl: DateIvl after Interval[DateTime(2012, 1), DateTime(2012, 2)]
 define NotAfterImpreciseDateIvl: DateIvl after Interval[DateTime(2012, 1), DateTime(2012, 3)]
 define MayBeAfterImpreciseDateIvl: DateIvl after Interval[DateTime(2012), DateTime(2012)]
@@ -477,6 +487,10 @@ define PosInfEndAfterDateIvl: Interval[DateTime(2013, 1, 1, 0, 0, 0, 0), null] a
 define PosInfEndNotAfterDateIvl: Interval[DateTime(2013, 1, 1, 0, 0, 0, 0), null] after Interval[DateTime(2000, 1, 1, 0, 0, 0, 0), DateTime(2020, 1, 1, 0, 0, 0, 0)]
 define UnknownEndAfterDateIvl: Interval[DateTime(2013, 1, 1, 0, 0, 0, 0), null) after Interval[DateTime(2000, 1, 1, 0, 0, 0, 0), DateTime(2010, 1, 1, 0, 0, 0, 0)]
 define UnknownEndNotAfterDateIvl: Interval[DateTime(2013, 1, 1, 0, 0, 0, 0), null) after Interval[DateTime(2020, 1, 1, 0, 0, 0, 0), DateTime(2040, 1, 1, 0, 0, 0, 0)]
+define AfterBoundlessInterval: Interval[5, 10] after Interval[null as Integer, null as Integer]
+define AfterUnknownInterval: Interval[5, 10] after Interval(null as Integer, 4]
+define NotAfterUnknownInterval: Interval[5, 10] after Interval(null as Integer, 5]
+define MayBeAfterUnknownEndInterval: Interval[5, 10] after Interval[1, null as Integer)
 
 // @Test: Before
 define BeforeIntIvl: Interval[2, 4] before Interval[5, 10]
@@ -485,9 +499,19 @@ define BeforeLongIvl: Interval[2L, 4L] before Interval[5L, 10L]
 define NotBeforeLongIvl: Interval[2L, 5L] before Interval[5L, 10L]
 define BeforeRealIvl: Interval[0.0, 1.23] before Interval[1.234, 2.345]
 define NotBeforeRealIvl: Interval[1.234, 2.345] before Interval[0.0, 1.234]
+define BeforeIntPoint: Interval[5, 10] before 11
+define NotBeforeIntPoint: Interval[5, 10] before 10
+define BeforeLongPoint: Interval[5L, 10L] before 11L
+define NotBeforeLongPoint: Interval[5L, 10L] before 10L
+define BeforeRealPoint: Interval[1.234, 2.345] before 2.346
+define NotBeforeRealPoint: Interval[1.234, 2.345] before 2.345
 define DateIvl: Interval[DateTime(2012, 3, 1, 0, 0, 0, 0), DateTime(2012, 9, 1, 0, 0, 0, 0))
 define BeforeDateIvl: Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2012, 3, 1, 0, 0, 0, 0)) before DateIvl
 define NotBeforeDateIvl: Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2012, 3, 1, 0, 0, 0, 0)] before DateIvl
+define BeforeDatePoint: DateIvl before DateTime(2012, 9, 1, 0, 0, 0, 1)
+define NotBeforeDatePoint: DateIvl before DateTime(2012, 8, 31, 23, 59, 59, 999)
+define BeforeDayOfDatePoint: DateIvl before day of DateTime(2012, 9, 2, 0, 0, 0, 0)
+define NotBeforeDayOfDatePoint: DateIvl before day of DateTime(2012, 8, 31, 23, 59, 59, 999)
 define BeforeImpreciseDateIvl: DateIvl before Interval[DateTime(2012, 9), DateTime(2012, 12)]
 define NotBeforeImpreciseDateIvl: DateIvl before Interval[DateTime(2012, 8), DateTime(2012, 12)]
 define MayBeBeforeImpreciseDateIvl: DateIvl before Interval[DateTime(2012), DateTime(2012)]
@@ -523,6 +547,10 @@ define UnknownBegNotBeforeDateIvl: Interval(null, DateTime(2013, 1, 1, 0, 0, 0, 
 define PosInfEndNotBeforeDateIvl: Interval[DateTime(2013, 1, 1, 0, 0, 0, 0), null] before Interval[DateTime(2000, 1, 1, 0, 0, 0, 0), DateTime(2020, 1, 1, 0, 0, 0, 0)]
 define UnknownEndMayBeBeforeDateIvl: Interval[DateTime(2013, 1, 1, 0, 0, 0, 0), null) before Interval[DateTime(2020, 1, 1, 0, 0, 0, 0), DateTime(2040, 1, 1, 0, 0, 0, 0)]
 define UnknownEndNotBeforeDateIvl: Interval[DateTime(2013, 1, 1, 0, 0, 0, 0), null) before Interval[DateTime(2000, 1, 1, 0, 0, 0, 0), DateTime(2013, 1, 1, 0, 0, 0, 0)]
+define BeforeBoundlessInterval: Interval[5, 10] before Interval[null as Integer, null as Integer]
+define BeforeUnknownInterval: Interval[5, 10] before Interval[11, null as Integer)
+define NotBeforeUnknownInterval: Interval[5, 10] before Interval[10, null as Integer)
+define MayBeBeforeUnknownStartInterval: Interval[5, 10] before Interval(null as Integer, 15]
 
 // @Test: BeforeOrOn
 define DateIvl: Interval[DateTime(2012, 3, 1, 0, 0, 0, 0), DateTime(2012, 9, 1, 0, 0, 0, 0)]
@@ -564,6 +592,10 @@ define DateOnlyIvl: Interval[Date(2012, 1, 1), Date(2012, 2, 20)]
 define DateOnlyIvlBeforeDateIvl: DateOnlyIvl before or on DateIvl
 define DateIvlAfterDateOnlyIvl: DateIvl before or on DateOnlyIvl
 define DateOnlyMeetsBeforeDateIvl: Interval[Date(2012, 1, 1), Date(2012, 3, 1)] before or on DateIvl
+define IntegerIvlBeforeOrOnPoint: Interval[1, 5] before or on 5
+define IntegerIvlNotBeforeOrOnPoint: Interval[1, 5] before or on 4
+define LongIvlBeforeOrOnPoint: Interval[1L, 5L] before or on 5L
+define LongIvlNotBeforeOrOnPoint: Interval[1L, 5L] before or on 4L
 
 // @Test: AfterOrOn
 define DateIvl: Interval[DateTime(2012, 3, 1, 0, 0, 0, 0), DateTime(2012, 9, 1, 0, 0, 0, 0)]
@@ -605,6 +637,10 @@ define DateOnlyIvl: Interval[Date(2012, 1, 1), Date(2012, 2, 20)]
 define DateOnlyIvlBeforeDateIvl: DateOnlyIvl after or on DateIvl
 define DateIvlAfterDateOnlyIvl: DateIvl after or on DateOnlyIvl
 define DateOnlyMeetsAfterDateIvl: Interval[Date(2012, 9, 1), Date(2012, 10, 1)] after or on DateIvl
+define IntegerIvlAfterOrOnPoint: Interval[1, 5] after or on 1
+define IntegerIvlNotAfterOrOnPoint: Interval[1, 5] after or on 2
+define LongIvlAfterOrOnPoint: Interval[1L, 5L] after or on 1L
+define LongIvlNotAfterOrOnPoint: Interval[1L, 5L] after or on 2L
 
 // @Test: Meets
 define MeetsAfterIntIvl: Interval[11, 15] meets Interval[5, 10]
@@ -832,8 +868,8 @@ define OverlapsBeforeRealIvl: Interval[1.234, 1.567] overlaps Interval[1.345, 1.
 define OverlapsAfterRealIvl: Interval[1.345, 1.678] overlaps Interval[1.234, 1.567]
 define OverlapsBoundaryRealIvl: Interval[1.0, 1.234] overlaps Interval[1.234, 2.0]
 define NoOverlapsRealIvl: Interval[1.0, 1.23456789) overlaps Interval[1.23456789, 2.0]
-define OverlapsClosedNullIntervalLHS: (Interval[null, null] as Interval<Integer>) overlaps Interval[6, 10]
-define OverlapsClosedNullIntervalRHS: Interval[6, 10] overlaps (Interval[null, null] as Interval<Integer>)
+define OverlapsClosedNullIntervalLHS: Interval[null as Integer, null as Integer] overlaps Interval[6, 10]
+define OverlapsClosedNullIntervalRHS: Interval[6, 10] overlaps (Interval[null as Integer, null as Integer])
 define OverlapsIsNull: Interval[6, 10] overlaps (null as Interval<Integer>)
 
 // @Test: OverlapsDateTime
@@ -854,8 +890,8 @@ define NoOverlap: ivlC overlaps ivlD
 define NoImpreciseOverlap: ivlE overlaps ivlG
 define UnknownOverlap: ivlE overlaps ivlH
 define MatchingPrecisionOverlap: ivlF overlaps ivlG
-define OverlapsClosedNullIntervalLHS: (Interval[null, null] as Interval<DateTime>) overlaps ivlA
-define OverlapsClosedNullIntervalRHS: ivlA overlaps (Interval[null, null] as Interval<DateTime>)
+define OverlapsClosedNullIntervalLHS: Interval[null as DateTime, null as DateTime] overlaps ivlA
+define OverlapsClosedNullIntervalRHS: ivlA overlaps Interval[null as DateTime, null as DateTime]
 define PrecisionDateIvl: Interval[DateTime(2012, 3, 2, 12, 34, 56, 789), DateTime(2012, 9, 2, 1, 23, 45, 678))
 // NOTE: There appears to be a bug in cql-to-elm that translates these 'overlaps' to 'OverlapsAfter'!
 define OverlapsBeforeDayOfIvlEdge: PrecisionDateIvl overlaps day of Interval[DateTime(2012, 9, 2, 23, 59, 59, 999), DateTime(2012, 10, 1, 0, 0, 0, 0)]
@@ -1009,7 +1045,7 @@ define OpenLongNotNull: end of Interval(1L, 3L)
 define OpenNull: end of Interval(DateTime(2013, 1, 1), null)
 
 // @Test: Starts
-define TestStartsNull: Interval[null, null] starts Interval[1, 10]
+define TestStartsNull: Interval[null as Integer, null as Integer] starts Interval[1, 10]
 define IntegerIntervalStartsTrue: Interval[4,10] starts Interval[4, 15]
 define IntegerIntervalStartsFalse: Interval[1, 10] starts Interval[4, 10]
 define IntegerIntervalStartEndsFalse: Interval[4, 10] starts Interval[4, 9]
@@ -1028,7 +1064,7 @@ define DateTimeIntervalStartsDayOfTrue: Interval[DateTime(2012, 1, 5), DateTime(
 define DateTimeIntervalStartsEndsFalse: Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)] starts day of Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 24)]
 
 // @Test: Ends
-define TestEndsNull: Interval[1, 10] ends Interval[null, null]
+define TestEndsNull: Interval[1, 10] ends Interval[null as Integer, null as Integer]
 define IntegerIntervalEndsTrue: Interval[4,10] ends Interval[1,10]
 define IntegerIntervalEndsFalse: Interval[4, 9] ends Interval[1,10]
 define IntegerIntervalEndsStartsFalse: Interval[0, 10] ends Interval[1,10]
@@ -1336,7 +1372,7 @@ define DateTimeNullStartCollapseNoOverlap: collapse { DateTime9_10Interval, Date
 define DateTimeNullStartCollapseNoOverlapExpected: { DateTimeNull_5Interval, DateTime9_10Interval }
 define DateTimeNullEndCollapseExpected: { Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), null] }
 define DateTimeNullStartEndCollapse: collapse { DateTimeNull_5Interval, DateTime1_10Interval, DateTime5_NullInterval }
-define DateTimeNullStartEndCollapseExpected: { Interval[null, null] }
+define DateTimeNullStartEndCollapseExpected: { Interval[null as DateTime, null as DateTime] }
 define QuantityMeterNullLowIntervalList: { Interval[null, ToQuantity('1.995 \'m\'')], Interval[ToQuantity('2 \'m\''), ToQuantity('3 \'m\'')] }
 define CollapseQuantityNullLowUnitsWithinPer: collapse QuantityMeterNullLowIntervalList per ToQuantity('1 \'cm\'')
 define CollapseQuantityNullLowUnitsWithinPerExpected : { Interval[null, ToQuantity('3 \'m\'')] }
@@ -1345,7 +1381,7 @@ define CollapseQuantityNullHighUnitsWithinPer: collapse QuantityMeterNullHighInt
 define CollapseQuantityNullHighUnitsWithinPerExpected : { Interval[ToQuantity('1 \'m\''), null] }
 define QuantityIntervalListWithNulls: { Interval[ToQuantity(4), ToQuantity(8)], Interval[null, ToQuantity(2)], Interval[ToQuantity(1), ToQuantity(4)], Interval[ToQuantity(7), null] }
 define CollapseQuantityIntervalListWithNulls: collapse QuantityIntervalListWithNulls
-define CollapseQuantityIntervalListWithNullsExpected: { Interval[null, null] }
+define CollapseQuantityIntervalListWithNullsExpected: { Interval[null as Quantity, null as Quantity] }
 define QuantityIntervalListWithNullLowNoOverlap: { Interval[ToQuantity(4), ToQuantity(8)], Interval[null, ToQuantity(2)] }
 define CollapseQuantityIntervalListWithNullLowNoOverlap: collapse QuantityIntervalListWithNullLowNoOverlap
 define CollapseQuantityIntervalListWithNullLowNoOverlapExpected: { Interval[null, ToQuantity(2)], Interval[ToQuantity(4), ToQuantity(8)]}
@@ -1608,8 +1644,8 @@ define NullBoth: expand { Interval[null, null] } per 1.5 '1'
 define BadPerMinute: expand { Interval(2.1, 4.1] } per 0.5 minute
 
 // @Test: SameAs
-define NullBoth: Interval[null,null] same as Interval[null,null]
-define NullOne: Interval[DateTime(2018,01,01), DateTime(2018,02,02)] same as Interval[null,null]
+define NullBoth: Interval[null as DateTime, null as DateTime] same as Interval[null as DateTime, null as DateTime]
+define NullOne: Interval[DateTime(2018,01,01), DateTime(2018,02,02)] same as Interval[null as DateTime, null as DateTime]
 define Equal: Interval[DateTime(2018,01,01), DateTime(2018,01,01)] same as Interval[DateTime(2018,01,01), DateTime(2018,01,01)]
 define NotEqual: Interval[DateTime(2018,01,01), DateTime(2018,01,01)] same as Interval[DateTime(2018,02,01), DateTime(2018,05,01)]
 define DateTimeAndDateComparisonEqual: Interval[DateTime(2018,01,01), DateTime(2018,01,01)] same as Interval[Date(2018,01,01), Date(2018,01,01)]

--- a/test/elm/interval/data.cql
+++ b/test/elm/interval/data.cql
@@ -395,17 +395,19 @@ define NotProperContainsIntHighEdge: Interval[1, 5] properly includes 5
 define ProperContainsReal: Interval[1.234, 3.456] properly includes 2.345
 define NotProperContainsReal: Interval[1.234, 3.456] properly includes 4.567
 define ProperContainsQuantity: Interval[1 'mg', 5 'mg'] properly includes 3 'mg'
-define NotProperContainsQuantityEdge: Interval[1 'mg', 5 'mg'] properly includes 5 'mg'
+define ProperContainsQuantityEdge: Interval[1 'mg', 5 'mg'] properly includes 5 'mg'
+define NotProperContainsQuantity: Interval[1 'mg', 5 'mg'] properly includes 5.00000001 'mg'
 define DateIvlHighOpen: Interval[DateTime(2012, 3, 1, 0, 0, 0, 0), DateTime(2012, 9, 1, 0, 0, 0, 0))
 define DateIvlHighClosed: Interval[DateTime(2012, 3, 1, 0, 0, 0, 0), DateTime(2012, 9, 1, 0, 0, 0, 0)]
 define ProperContainsDate: DateIvlHighOpen properly includes DateTime(2012, 6, 1, 0, 0, 0, 0)
 define NotProperContainsDateHighEdgeOpen: DateIvlHighOpen properly includes DateTime(2012, 9, 1, 0, 0, 0, 0)
-define NotProperContainsDateHighEdgeClosed: DateIvlHighClosed properly includes DateTime(2012, 9, 1, 0, 0, 0, 0)
+define ProperContainsDateHighEdgeClosed: DateIvlHighClosed properly includes DateTime(2012, 9, 1, 0, 0, 0, 0)
 define ProperContainsTime: Interval[@T12:00:00.000, @T21:59:59.999] properly includes @T12:00:00.001
-define NotProperContainsTimeLowEdge: Interval[@T12:00:00.000, @T21:59:59.999] properly includes @T12:00:00.000
+define ProperContainsTimeLowEdge: Interval[@T12:00:00.000, @T21:59:59.999] properly includes @T12:00:00.000
+define NotProperContainsTime: Interval[@T12:00:00.000, @T21:59:59.999] properly includes @T22:00:00.000
 define MayProperContainsTime: Interval[@T12:00:00.001, @T21:59:59.999] properly includes @T12:00:00
 define ProperContainsSecondOfTime: Interval[@T12:00:00.000, @T21:59:59.999] properly includes second of @T12:00:01
-define NotProperContainsSecondOfTime: Interval[@T12:00:00.001, @T21:59:59.999] properly includes second of @T12:00:00
+define NotProperContainsSecondOfTime: Interval[@T12:00:00.001, @T12:00:00.001] properly includes second of @T12:00:00
 define MayProperContainsMillisecondOfTime: Interval[@T12:00:00.001, @T21:59:59.999] properly includes millisecond of @T12:00:00
 define ProperContainsNull: Interval[1, 5] properly includes null
 
@@ -413,22 +415,24 @@ define ProperContainsNull: Interval[1, 5] properly includes null
 // @Test: ProperIn
 define ProperInInt: 3 properly included in Interval[1, 5]
 define NotProperInInt: 7 properly included in Interval[1, 5]
-define NotProperInIntLowEdge: 1 properly included in Interval[1, 5]
-define NotProperInIntHighEdge: 5 properly included in Interval[1, 5]
+define ProperInIntLowEdge: 1 properly included in Interval[1, 5]
+define ProperInIntHighEdge: 5 properly included in Interval[1, 5]
 define ProperInReal: 2.345 properly included in Interval[1.234, 3.456]
 define NotProperInReal: 4.567 properly included in Interval[1.234, 3.456]
 define ProperInQuantity: 3 'mg' properly included in Interval[1 'mg', 5 'mg']
-define NotProperInQuantityEdge: 5 'mg' properly included in Interval[1 'mg', 5 'mg']
+define ProperInQuantityEdge: 5 'mg' properly included in Interval[1 'mg', 5 'mg']
+define NotProperInQuantity: 0.99999999 'mg' properly included in Interval[1 'mg', 5 'mg']
 define DateIvlHighOpen: Interval[DateTime(2012, 3, 1, 0, 0, 0, 0), DateTime(2012, 9, 1, 0, 0, 0, 0))
 define DateIvlHighClosed: Interval[DateTime(2012, 3, 1, 0, 0, 0, 0), DateTime(2012, 9, 1, 0, 0, 0, 0)]
 define ProperInDate: DateTime(2012, 6, 1, 0, 0, 0, 0) properly included in DateIvlHighOpen
 define NotProperInDateHighEdgeOpen: DateTime(2012, 9, 1, 0, 0, 0, 0) properly included in DateIvlHighOpen
-define NotProperInDateHighEdgeClosed: DateTime(2012, 9, 1, 0, 0, 0, 0) properly included in DateIvlHighClosed
+define ProperInDateHighEdgeClosed: DateTime(2012, 9, 1, 0, 0, 0, 0) properly included in DateIvlHighClosed
 define ProperInTime: @T12:00:00.001 properly included in Interval[@T12:00:00.000, @T21:59:59.999]
-define NotProperInTimeLowEdge: @T12:00:00.000 properly included in Interval[@T12:00:00.000, @T21:59:59.999]
+define ProperInTimeLowEdge: @T12:00:00.000 properly included in Interval[@T12:00:00.000, @T21:59:59.999]
+define NotProperInTime: @T22:00:00.000 properly included in Interval[@T12:00:00.000, @T21:59:59.999]
 define MayProperInTime: @T12:00:00 properly included in Interval[@T12:00:00.001, @T21:59:59.999]
 define ProperInSecondOfTime: @T12:00:01 properly included in second of Interval[@T12:00:00.000, @T21:59:59.999]
-define NotProperInSecondOfTime: @T12:00:00 properly included in second of Interval[@T12:00:00.001, @T21:59:59.999]
+define NotProperInSecondOfTime: @T12:00:00 properly included in second of Interval[@T12:00:00.000, @T12:00:00.000]
 define MayProperInMillisecondOfTime: @T12:00:00 properly included in millisecond of Interval[@T12:00:00.001, @T21:59:59.999]
 define ProperInNull: null properly included in Interval[1, 5]
 

--- a/test/elm/interval/interval-test.ts
+++ b/test/elm/interval/interval-test.ts
@@ -2,7 +2,7 @@ import should from 'should';
 import setup from '../../setup';
 const data = require('./data');
 import { Interval } from '../../../src/datatypes/interval';
-import { DateTime } from '../../../src/datatypes/datetime';
+import { DateTime, MIN_DATETIME_VALUE, MAX_DATETIME_VALUE } from '../../../src/datatypes/datetime';
 import { Uncertainty } from '../../../src/datatypes/uncertainty';
 import {
   MIN_INT_VALUE,
@@ -11,10 +11,8 @@ import {
   MAX_LONG_VALUE,
   MIN_FLOAT_VALUE,
   MIN_FLOAT_PRECISION_VALUE,
-  MAX_FLOAT_VALUE,
-  MIN_DATETIME_VALUE,
-  MAX_DATETIME_VALUE
-} from '../../../src/util/math';
+  MAX_FLOAT_VALUE
+} from '../../../src/util/limits';
 
 describe('Interval', () => {
   beforeEach(function () {
@@ -250,12 +248,12 @@ describe('Contains', () => {
 
   it('should correctly compare using the requested precision', async function () {
     (await this.containsDayOfDateLowEdge.exec(this.ctx)).should.be.true();
-    (await this.notContainsDayOfDateHighEdgeOpen.exec(this.ctx)).should.be.false();
+    (await this.containsDayOfDateHighEdgeOpen.exec(this.ctx)).should.be.true();
     (await this.containsDayOfDateHighEdgeClosed.exec(this.ctx)).should.be.true();
     (await this.notContainsDayOfDateLowEdge.exec(this.ctx)).should.be.false();
     (await this.notContainsDayOfDateBeyondHighEdge.exec(this.ctx)).should.be.false();
     (await this.containsDayOfDateImpreciseLowEdge.exec(this.ctx)).should.be.true();
-    (await this.notContainsDayOfDateImpreciseHighEdgeOpen.exec(this.ctx)).should.be.false();
+    (await this.containsDayOfDateImpreciseHighEdgeOpen.exec(this.ctx)).should.be.true();
     (await this.containsDayOfDateImpreciseHighEdgeClosed.exec(this.ctx)).should.be.true();
     (await this.containsDayOfDateVeryImpreciseMiddle.exec(this.ctx)).should.be.true();
     (await this.notContainsDayOfDateVeryImpreciseLow.exec(this.ctx)).should.be.false();
@@ -339,12 +337,12 @@ describe('In', () => {
 
   it('should correctly compare using the requested precision', async function () {
     (await this.containsDayOfDateLowEdge.exec(this.ctx)).should.be.true();
-    (await this.notContainsDayOfDateHighEdgeOpen.exec(this.ctx)).should.be.false();
+    (await this.containsDayOfDateHighEdgeOpen.exec(this.ctx)).should.be.true();
     (await this.containsDayOfDateHighEdgeClosed.exec(this.ctx)).should.be.true();
     (await this.notContainsDayOfDateLowEdge.exec(this.ctx)).should.be.false();
     (await this.notContainsDayOfDateBeyondHighEdge.exec(this.ctx)).should.be.false();
     (await this.containsDayOfDateImpreciseLowEdge.exec(this.ctx)).should.be.true();
-    (await this.notContainsDayOfDateImpreciseHighEdgeOpen.exec(this.ctx)).should.be.false();
+    (await this.containsDayOfDateImpreciseHighEdgeOpen.exec(this.ctx)).should.be.true();
     (await this.containsDayOfDateImpreciseHighEdgeClosed.exec(this.ctx)).should.be.true();
     (await this.containsDayOfDateVeryImpreciseMiddle.exec(this.ctx)).should.be.true();
     (await this.notContainsDayOfDateVeryImpreciseLow.exec(this.ctx)).should.be.false();
@@ -714,6 +712,19 @@ describe('After', () => {
     (await this.notAfterDateIvl.exec(this.ctx)).should.be.false();
   });
 
+  it('should compare interval starts to points', async function () {
+    (await this.afterIntPoint.exec(this.ctx)).should.be.true();
+    (await this.notAfterIntPoint.exec(this.ctx)).should.be.false();
+    (await this.afterLongPoint.exec(this.ctx)).should.be.true();
+    (await this.notAfterLongPoint.exec(this.ctx)).should.be.false();
+    (await this.afterRealPoint.exec(this.ctx)).should.be.true();
+    (await this.notAfterRealPoint.exec(this.ctx)).should.be.false();
+    (await this.afterDatePoint.exec(this.ctx)).should.be.true();
+    (await this.notAfterDatePoint.exec(this.ctx)).should.be.false();
+    (await this.afterDayOfDatePoint.exec(this.ctx)).should.be.true();
+    (await this.notAfterDayOfDatePoint.exec(this.ctx)).should.be.false();
+  });
+
   it('should correctly handle null endpoints (int)', async function () {
     (await this.negInfBegNotAfterIntIvl.exec(this.ctx)).should.be.false();
     should(await this.unknownBegMayBeAfterIntIvl.exec(this.ctx)).be.null();
@@ -742,6 +753,13 @@ describe('After', () => {
     (await this.posInfEndNotAfterDateIvl.exec(this.ctx)).should.be.false();
     (await this.unknownEndAfterDateIvl.exec(this.ctx)).should.be.true();
     (await this.unknownEndNotAfterDateIvl.exec(this.ctx)).should.be.false();
+  });
+
+  it('should compare boundless and unknown intervals', async function () {
+    (await this.afterBoundlessInterval.exec(this.ctx)).should.be.false();
+    (await this.afterUnknownInterval.exec(this.ctx)).should.be.true();
+    (await this.notAfterUnknownInterval.exec(this.ctx)).should.be.false();
+    should(await this.mayBeAfterUnknownEndInterval.exec(this.ctx)).be.null();
   });
 
   it('should correctly handle imprecision', async function () {
@@ -783,6 +801,19 @@ describe('Before', () => {
     (await this.notBeforeDateIvl.exec(this.ctx)).should.be.false();
   });
 
+  it('should compare interval ends to points', async function () {
+    (await this.beforeIntPoint.exec(this.ctx)).should.be.true();
+    (await this.notBeforeIntPoint.exec(this.ctx)).should.be.false();
+    (await this.beforeLongPoint.exec(this.ctx)).should.be.true();
+    (await this.notBeforeLongPoint.exec(this.ctx)).should.be.false();
+    (await this.beforeRealPoint.exec(this.ctx)).should.be.true();
+    (await this.notBeforeRealPoint.exec(this.ctx)).should.be.false();
+    (await this.beforeDatePoint.exec(this.ctx)).should.be.true();
+    (await this.notBeforeDatePoint.exec(this.ctx)).should.be.false();
+    (await this.beforeDayOfDatePoint.exec(this.ctx)).should.be.true();
+    (await this.notBeforeDayOfDatePoint.exec(this.ctx)).should.be.false();
+  });
+
   it('should correctly handle null endpoints (int)', async function () {
     (await this.negInfBegBeforeIntIvl.exec(this.ctx)).should.be.true();
     (await this.negInfBegNotBeforeIntIvl.exec(this.ctx)).should.be.false();
@@ -813,6 +844,13 @@ describe('Before', () => {
     (await this.unknownEndNotBeforeDateIvl.exec(this.ctx)).should.be.false();
   });
 
+  it('should compare boundless and unknown intervals', async function () {
+    (await this.beforeBoundlessInterval.exec(this.ctx)).should.be.false();
+    (await this.beforeUnknownInterval.exec(this.ctx)).should.be.true();
+    (await this.notBeforeUnknownInterval.exec(this.ctx)).should.be.false();
+    should(await this.mayBeBeforeUnknownStartInterval.exec(this.ctx)).be.null();
+  });
+
   it('should correctly handle imprecision', async function () {
     (await this.beforeImpreciseDateIvl.exec(this.ctx)).should.be.true();
     // meets with uncertaintity due to toClose
@@ -835,7 +873,6 @@ describe('Before', () => {
 
 describe('BeforeOrOn', () => {
   // NOTE: BeforeOrOn is synonym for SameOrBefore.
-  // NOTE: SameOrBefore for numeric intervals is tests in spec tests
 
   beforeEach(function () {
     setup(this, data);
@@ -897,6 +934,13 @@ describe('BeforeOrOn', () => {
     (await this.dateIvlAfterDateOnlyIvl.exec(this.ctx)).should.be.false();
   });
 
+  it('should compare integer and long intervals to points', async function () {
+    (await this.integerIvlBeforeOrOnPoint.exec(this.ctx)).should.be.true();
+    (await this.integerIvlNotBeforeOrOnPoint.exec(this.ctx)).should.be.false();
+    (await this.longIvlBeforeOrOnPoint.exec(this.ctx)).should.be.true();
+    (await this.longIvlNotBeforeOrOnPoint.exec(this.ctx)).should.be.false();
+  });
+
   it('should handle null Interval<Date> on boundary of Interval<DateTime>', async function () {
     should(await this.dateOnlyMeetsBeforeDateIvl.exec(this.ctx)).be.null();
   });
@@ -904,7 +948,6 @@ describe('BeforeOrOn', () => {
 
 describe('AfterOrOn', () => {
   // NOTE: AfterOrOn is synonym for SameOrAfter.
-  // NOTE: SameOrAfter for numeric intervals is tests in spec tests
 
   beforeEach(function () {
     setup(this, data);
@@ -964,6 +1007,13 @@ describe('AfterOrOn', () => {
   it('should handle Interval<Date> and Interval<DateTime> on either side', async function () {
     (await this.dateOnlyIvlBeforeDateIvl.exec(this.ctx)).should.be.false();
     (await this.dateIvlAfterDateOnlyIvl.exec(this.ctx)).should.be.true();
+  });
+
+  it('should compare integer and long intervals to points', async function () {
+    (await this.integerIvlAfterOrOnPoint.exec(this.ctx)).should.be.true();
+    (await this.integerIvlNotAfterOrOnPoint.exec(this.ctx)).should.be.false();
+    (await this.longIvlAfterOrOnPoint.exec(this.ctx)).should.be.true();
+    (await this.longIvlNotAfterOrOnPoint.exec(this.ctx)).should.be.false();
   });
 
   it('should handle null Interval<Date> on boundary of Interval<DateTime>', async function () {
@@ -1575,13 +1625,17 @@ describe('Width', () => {
     // define IntWidthThreeToMax: width of Interval[3, null]
     (await this.intWidthThreeToMax.exec(this.ctx)).should.equal(Math.pow(2, 31) - 4);
     // define IntWidthMinToThree: width of Interval[null, 3]
-    (await this.intWidthMinToThree.exec(this.ctx)).should.equal(Math.pow(2, 31) + 3);
+    // returns null because width overflows max integer
+    should(await this.intWidthMinToThree.exec(this.ctx)).be.null();
   });
 
   it('should calculate the width of infinite intervals that result in null', async function () {
     // define IntWidthThreeToUnknown: width of Interval[3, null)
-    should(await this.intWidthThreeToUnknown.exec(this.ctx)).be.null();
+    (await this.intWidthThreeToUnknown.exec(this.ctx)).should.eql(
+      new Uncertainty(0, MAX_INT_VALUE - 3)
+    );
     // define IntWidthUnknownToThree: width of Interval(null, 3]
+    // returns null because width overflows max integer
     should(await this.intWidthUnknownToThree.exec(this.ctx)).be.null();
   });
 
@@ -1638,13 +1692,17 @@ describe('Size', () => {
     // define IntSizeThreeToMax: Size(Interval[3, null])
     (await this.intSizeThreeToMax.exec(this.ctx)).should.equal(Math.pow(2, 31) - 4 + 1);
     // define IntSizeMinToThree: Size(Interval[null, 3])
-    (await this.intSizeMinToThree.exec(this.ctx)).should.equal(Math.pow(2, 31) + 3 + 1);
+    // returns null because width overflows max integer
+    should(await this.intSizeMinToThree.exec(this.ctx)).be.null();
   });
 
   it('should calculate the size of infinite intervals that result in null', async function () {
     // define IntSizeThreeToUnknown: Size(Interval[3, null))
-    should(await this.intSizeThreeToUnknown.exec(this.ctx)).be.null();
+    (await this.intSizeThreeToUnknown.exec(this.ctx)).should.eql(
+      new Uncertainty(1, MAX_INT_VALUE - 2)
+    );
     // define IntSizeUnknownToThree: Size(Interval(null, 3])
+    // returns null because width overflows max integer
     should(await this.intSizeUnknownToThree.exec(this.ctx)).be.null();
   });
 
@@ -3670,12 +3728,12 @@ describe('SameAs', () => {
   });
 
   it('returns true when both intervals values are null and closed', async function () {
-    // define NullBoth: Interval[null,null] same as Interval[null,null]
+    // define NullBoth: Interval[null as DateTime, null as DateTime] same as Interval[null as DateTime, null as DateTime]
     (await this.nullBoth.exec(this.ctx)).should.be.true();
   });
 
   it('returns false when one intervals low and high are null', async function () {
-    // define NullOne: Interval[DateTime(2018,01,01), DateTime(2018,02,02)] same as Interval[null,null]
+    // define NullOne: Interval[DateTime(2018,01,01), DateTime(2018,02,02)] same as Interval[null as DateTime, null as DateTime]
     (await this.nullOne.exec(this.ctx)).should.be.false();
   });
 

--- a/test/elm/interval/interval-test.ts
+++ b/test/elm/interval/interval-test.ts
@@ -628,21 +628,23 @@ describe('ProperContains', () => {
 
   it('should accept properly contained items', async function () {
     (await this.properContainsInt.exec(this.ctx)).should.be.true();
+    (await this.notProperContainsIntLowEdge.exec(this.ctx)).should.be.true();
+    (await this.notProperContainsIntHighEdge.exec(this.ctx)).should.be.true();
     (await this.properContainsReal.exec(this.ctx)).should.be.true();
     (await this.properContainsQuantity.exec(this.ctx)).should.be.true();
+    (await this.properContainsQuantityEdge.exec(this.ctx)).should.be.true();
     (await this.properContainsDate.exec(this.ctx)).should.be.true();
+    (await this.properContainsDateHighEdgeClosed.exec(this.ctx)).should.be.true();
     (await this.properContainsTime.exec(this.ctx)).should.be.true();
+    (await this.properContainsTimeLowEdge.exec(this.ctx)).should.be.true();
   });
 
   it('should reject items outside the interval or on an edge', async function () {
     (await this.notProperContainsInt.exec(this.ctx)).should.be.false();
-    (await this.notProperContainsIntLowEdge.exec(this.ctx)).should.be.false();
-    (await this.notProperContainsIntHighEdge.exec(this.ctx)).should.be.false();
     (await this.notProperContainsReal.exec(this.ctx)).should.be.false();
-    (await this.notProperContainsQuantityEdge.exec(this.ctx)).should.be.false();
+    (await this.notProperContainsQuantity.exec(this.ctx)).should.be.false();
     (await this.notProperContainsDateHighEdgeOpen.exec(this.ctx)).should.be.false();
-    (await this.notProperContainsDateHighEdgeClosed.exec(this.ctx)).should.be.false();
-    (await this.notProperContainsTimeLowEdge.exec(this.ctx)).should.be.false();
+    (await this.notProperContainsTime.exec(this.ctx)).should.be.false();
   });
 
   it('should correctly compare using the requested precision', async function () {
@@ -664,21 +666,23 @@ describe('ProperIn', () => {
 
   it('should accept properly contained items', async function () {
     (await this.properInInt.exec(this.ctx)).should.be.true();
+    (await this.properInIntLowEdge.exec(this.ctx)).should.be.true();
+    (await this.properInIntHighEdge.exec(this.ctx)).should.be.true();
     (await this.properInReal.exec(this.ctx)).should.be.true();
     (await this.properInQuantity.exec(this.ctx)).should.be.true();
+    (await this.properInQuantityEdge.exec(this.ctx)).should.be.true();
     (await this.properInDate.exec(this.ctx)).should.be.true();
+    (await this.properInDateHighEdgeClosed.exec(this.ctx)).should.be.true();
     (await this.properInTime.exec(this.ctx)).should.be.true();
+    (await this.properInTimeLowEdge.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject items outside the interval or on an edge', async function () {
+  it('should reject items outside the interval', async function () {
     (await this.notProperInInt.exec(this.ctx)).should.be.false();
-    (await this.notProperInIntLowEdge.exec(this.ctx)).should.be.false();
-    (await this.notProperInIntHighEdge.exec(this.ctx)).should.be.false();
     (await this.notProperInReal.exec(this.ctx)).should.be.false();
-    (await this.notProperInQuantityEdge.exec(this.ctx)).should.be.false();
+    (await this.notProperInQuantity.exec(this.ctx)).should.be.false();
     (await this.notProperInDateHighEdgeOpen.exec(this.ctx)).should.be.false();
-    (await this.notProperInDateHighEdgeClosed.exec(this.ctx)).should.be.false();
-    (await this.notProperInTimeLowEdge.exec(this.ctx)).should.be.false();
+    (await this.notProperInTime.exec(this.ctx)).should.be.false();
   });
 
   it('should correctly compare using the requested precision', async function () {

--- a/test/elm/interval/interval-test.ts
+++ b/test/elm/interval/interval-test.ts
@@ -1781,8 +1781,8 @@ describe('Starts', () => {
     setup(this, data);
   });
 
-  it('should calculate to null', async function () {
-    should(await this.testStartsNull.exec(this.ctx)).be.null();
+  it('should calculate to false for boundless interval starts bounded interval', async function () {
+    should(await this.testStartsNull.exec(this.ctx)).be.false();
   });
 
   it('should calculate integer intervals properly', async function () {
@@ -1822,8 +1822,8 @@ describe('Ends', () => {
     setup(this, data);
   });
 
-  it('should calculate to null', async function () {
-    should(await this.testEndsNull.exec(this.ctx)).be.null();
+  it('should calculate to false for boundless interval ends bounded interval', async function () {
+    should(await this.testEndsNull.exec(this.ctx)).be.false();
   });
 
   it('should calculate integer intervals properly', async function () {

--- a/test/elm/interval/interval-test.ts
+++ b/test/elm/interval/interval-test.ts
@@ -3,6 +3,7 @@ import setup from '../../setup';
 const data = require('./data');
 import { Interval } from '../../../src/datatypes/interval';
 import { DateTime } from '../../../src/datatypes/datetime';
+import { Uncertainty } from '../../../src/datatypes/uncertainty';
 import {
   MIN_INT_VALUE,
   MAX_INT_VALUE,
@@ -869,12 +870,12 @@ describe('BeforeOrOn', () => {
     (await this.beforeNullEndIvl.exec(this.ctx)).should.be.true();
     (await this.afterStartNullEndIvl.exec(this.ctx)).should.be.false();
     should(await this.nullEndStartBeforeIvl.exec(this.ctx)).be.null();
-    should(await this.nullEndStartAfterIvl.exec(this.ctx)).be.null();
+    (await this.nullEndStartAfterIvl.exec(this.ctx)).should.be.false();
   });
 
   it('should handle intervals with null start', async function () {
     should(await this.endsBeforeNullStartIvlEnds.exec(this.ctx)).be.null();
-    should(await this.afterEndOfNullStartIvl.exec(this.ctx)).be.null();
+    (await this.afterEndOfNullStartIvl.exec(this.ctx)).should.be.false();
     (await this.nullStartStartBeforeIvl.exec(this.ctx)).should.be.true();
     (await this.nullStartStartAfterIvl.exec(this.ctx)).should.be.false();
   });
@@ -935,7 +936,7 @@ describe('AfterOrOn', () => {
   });
 
   it('should handle intervals with null end', async function () {
-    should(await this.beforeNullEndIvl.exec(this.ctx)).be.null();
+    (await this.beforeNullEndIvl.exec(this.ctx)).should.be.false();
     should(await this.afterStartNullEndIvl.exec(this.ctx)).be.null();
     (await this.nullEndStartBeforeIvl.exec(this.ctx)).should.be.false();
     (await this.nullEndStartAfterIvl.exec(this.ctx)).should.be.true();
@@ -944,7 +945,7 @@ describe('AfterOrOn', () => {
   it('should handle intervals with null start', async function () {
     (await this.endsBeforeNullStartIvlEnds.exec(this.ctx)).should.be.false();
     (await this.afterEndOfNullStartIvl.exec(this.ctx)).should.be.true();
-    should(await this.nullStartStartBeforeIvl.exec(this.ctx)).be.null();
+    (await this.nullStartStartBeforeIvl.exec(this.ctx)).should.be.false();
     should(await this.nullStartStartAfterIvl.exec(this.ctx)).be.null();
   });
 
@@ -1723,8 +1724,10 @@ describe('Start', () => {
     (await this.openLongNotNull.exec(this.ctx)).should.eql(2n);
   });
 
-  it('should return null for open interval with null high value', async function () {
-    should(await this.openNull.exec(this.ctx)).be.null();
+  it('should return uncertainty for open interval with null low value', async function () {
+    (await this.openNull.exec(this.ctx)).should.eql(
+      new Uncertainty(MIN_DATETIME_VALUE, new DateTime(2012, 12, 31))
+    );
   });
 });
 
@@ -1771,8 +1774,10 @@ describe('End', () => {
     (await this.openLongNotNull.exec(this.ctx)).should.eql(2n);
   });
 
-  it('should return null for open interval with null low value', async function () {
-    should(await this.openNull.exec(this.ctx)).be.null();
+  it('should return uncertainty for open interval with null high value', async function () {
+    (await this.openNull.exec(this.ctx)).should.eql(
+      new Uncertainty(new DateTime(2013, 1, 2), MAX_DATETIME_VALUE)
+    );
   });
 });
 

--- a/test/elm/type/data.cql
+++ b/test/elm/type/data.cql
@@ -61,11 +61,13 @@ define CastTupleAsListOfIntegers: cast Echo(Tuple{A: 5}) as List<Integer>
 // @Test: AsIntervalType
 define function Echo(Val Any): Val // fool CQL-to-ELM into letting the casts compile
 define IntervalOfIntegersAsIntervalOfIntegers: Echo(Interval[1, 5]) as Interval<Integer>
+define UnboundedIntervalAsIntervalOfIntegers: Echo(Interval[null, null]) as Interval<Integer>
 define IntervalOfDatesAsIntervalOfIntegers: Echo(Interval[@2000-01-01, @2000-12-31]) as Interval<Integer>
 define IntegerAsIntervalOfIntegers: Echo(5) as Interval<Integer>
 define ListAsIntervalOfIntegers: Echo({1, 2, 3, 4, 5}) as Interval<Integer>
 define TupleAsIntervalOfIntegers: Echo(Tuple{A: 5}) as Interval<Integer>
 define CastIntervalOfIntegersAsIntervalOfIntegers: cast Echo(Interval[1, 5]) as Interval<Integer>
+define CastUnboundedIntervalAsIntervalOfIntegers: cast Echo(Interval[null, null]) as Interval<Integer>
 define CastIntervalOfDatesAsIntervalOfIntegers: cast Echo(Interval[@2000-01-01, @2000-12-31]) as Interval<Integer>
 define CastIntegerAsIntervalOfIntegers: cast Echo(5) as Interval<Integer>
 define CastListAsIntervalOfIntegers: cast Echo({1, 2, 3, 4, 5}) as Interval<Integer>

--- a/test/elm/type/data.js
+++ b/test/elm/type/data.js
@@ -5326,11 +5326,13 @@ using Simple version '1.0.0'
 context Patient
 define function Echo(Val Any): Val // fool CQL-to-ELM into letting the casts compile
 define IntervalOfIntegersAsIntervalOfIntegers: Echo(Interval[1, 5]) as Interval<Integer>
+define UnboundedIntervalAsIntervalOfIntegers: Echo(Interval[null, null]) as Interval<Integer>
 define IntervalOfDatesAsIntervalOfIntegers: Echo(Interval[@2000-01-01, @2000-12-31]) as Interval<Integer>
 define IntegerAsIntervalOfIntegers: Echo(5) as Interval<Integer>
 define ListAsIntervalOfIntegers: Echo({1, 2, 3, 4, 5}) as Interval<Integer>
 define TupleAsIntervalOfIntegers: Echo(Tuple{A: 5}) as Interval<Integer>
 define CastIntervalOfIntegersAsIntervalOfIntegers: cast Echo(Interval[1, 5]) as Interval<Integer>
+define CastUnboundedIntervalAsIntervalOfIntegers: cast Echo(Interval[null, null]) as Interval<Integer>
 define CastIntervalOfDatesAsIntervalOfIntegers: cast Echo(Interval[@2000-01-01, @2000-12-31]) as Interval<Integer>
 define CastIntegerAsIntervalOfIntegers: cast Echo(5) as Interval<Integer>
 define CastListAsIntervalOfIntegers: cast Echo({1, 2, 3, 4, 5}) as Interval<Integer>
@@ -5349,7 +5351,7 @@ module.exports['AsIntervalType'] = {
       "type" : "Annotation",
       "t" : [ ],
       "s" : {
-        "r" : "405",
+        "r" : "443",
         "s" : [ {
           "value" : [ "", "library TestSnippet version '1'" ]
         } ]
@@ -5611,7 +5613,7 @@ module.exports['AsIntervalType'] = {
         }
       }, {
         "localId" : "239",
-        "name" : "IntervalOfDatesAsIntervalOfIntegers",
+        "name" : "UnboundedIntervalAsIntervalOfIntegers",
         "context" : "Patient",
         "accessLevel" : "Public",
         "annotation" : [ {
@@ -5620,18 +5622,18 @@ module.exports['AsIntervalType'] = {
           "s" : {
             "r" : "239",
             "s" : [ {
-              "value" : [ "", "define ", "IntervalOfDatesAsIntervalOfIntegers", ": " ]
+              "value" : [ "", "define ", "UnboundedIntervalAsIntervalOfIntegers", ": " ]
             }, {
               "r" : "240",
               "s" : [ {
-                "r" : "254",
+                "r" : "246",
                 "s" : [ {
                   "value" : [ "Echo", "(" ]
                 }, {
-                  "r" : "251",
+                  "r" : "243",
                   "s" : [ {
-                    "r" : "245",
-                    "value" : [ "Interval[", "@2000-01-01", ", ", "@2000-12-31", "]" ]
+                    "r" : "241",
+                    "value" : [ "Interval[", "null", ", ", "null", "]" ]
                   } ]
                 }, {
                   "value" : [ ")" ]
@@ -5639,11 +5641,11 @@ module.exports['AsIntervalType'] = {
               }, {
                 "value" : [ " as " ]
               }, {
-                "r" : "256",
+                "r" : "248",
                 "s" : [ {
                   "value" : [ "Interval<" ]
                 }, {
-                  "r" : "257",
+                  "r" : "249",
                   "s" : [ {
                     "value" : [ "Integer" ]
                   } ]
@@ -5656,11 +5658,11 @@ module.exports['AsIntervalType'] = {
         } ],
         "resultTypeSpecifier" : {
           "type" : "IntervalTypeSpecifier",
-          "localId" : "262",
+          "localId" : "254",
           "annotation" : [ ],
           "pointType" : {
             "type" : "NamedTypeSpecifier",
-            "localId" : "263",
+            "localId" : "255",
             "name" : "{urn:hl7-org:elm-types:r1}Integer",
             "annotation" : [ ]
           }
@@ -5672,11 +5674,11 @@ module.exports['AsIntervalType'] = {
           "annotation" : [ ],
           "resultTypeSpecifier" : {
             "type" : "IntervalTypeSpecifier",
-            "localId" : "260",
+            "localId" : "252",
             "annotation" : [ ],
             "pointType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "261",
+              "localId" : "253",
               "name" : "{urn:hl7-org:elm-types:r1}Integer",
               "annotation" : [ ]
             }
@@ -5684,56 +5686,196 @@ module.exports['AsIntervalType'] = {
           "signature" : [ ],
           "operand" : {
             "type" : "FunctionRef",
-            "localId" : "254",
+            "localId" : "246",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
             "name" : "Echo",
             "annotation" : [ ],
             "signature" : [ {
               "type" : "NamedTypeSpecifier",
-              "localId" : "255",
+              "localId" : "247",
               "name" : "{urn:hl7-org:elm-types:r1}Any",
               "annotation" : [ ]
             } ],
             "operand" : [ {
               "type" : "Interval",
-              "localId" : "251",
+              "localId" : "243",
               "lowClosed" : true,
               "highClosed" : true,
               "annotation" : [ ],
               "resultTypeSpecifier" : {
                 "type" : "IntervalTypeSpecifier",
-                "localId" : "252",
+                "localId" : "244",
                 "annotation" : [ ],
                 "pointType" : {
                   "type" : "NamedTypeSpecifier",
-                  "localId" : "253",
+                  "localId" : "245",
+                  "name" : "{urn:hl7-org:elm-types:r1}Any",
+                  "annotation" : [ ]
+                }
+              },
+              "low" : {
+                "type" : "Null",
+                "localId" : "241",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                "annotation" : [ ]
+              },
+              "high" : {
+                "type" : "Null",
+                "localId" : "242",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                "annotation" : [ ]
+              }
+            } ]
+          },
+          "asTypeSpecifier" : {
+            "type" : "IntervalTypeSpecifier",
+            "localId" : "248",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "IntervalTypeSpecifier",
+              "localId" : "250",
+              "annotation" : [ ],
+              "pointType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "251",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "pointType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "249",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          }
+        }
+      }, {
+        "localId" : "258",
+        "name" : "IntervalOfDatesAsIntervalOfIntegers",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "258",
+            "s" : [ {
+              "value" : [ "", "define ", "IntervalOfDatesAsIntervalOfIntegers", ": " ]
+            }, {
+              "r" : "259",
+              "s" : [ {
+                "r" : "273",
+                "s" : [ {
+                  "value" : [ "Echo", "(" ]
+                }, {
+                  "r" : "270",
+                  "s" : [ {
+                    "r" : "264",
+                    "value" : [ "Interval[", "@2000-01-01", ", ", "@2000-12-31", "]" ]
+                  } ]
+                }, {
+                  "value" : [ ")" ]
+                } ]
+              }, {
+                "value" : [ " as " ]
+              }, {
+                "r" : "275",
+                "s" : [ {
+                  "value" : [ "Interval<" ]
+                }, {
+                  "r" : "276",
+                  "s" : [ {
+                    "value" : [ "Integer" ]
+                  } ]
+                }, {
+                  "value" : [ ">" ]
+                } ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "IntervalTypeSpecifier",
+          "localId" : "281",
+          "annotation" : [ ],
+          "pointType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "282",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "As",
+          "localId" : "259",
+          "strict" : false,
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "IntervalTypeSpecifier",
+            "localId" : "279",
+            "annotation" : [ ],
+            "pointType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "280",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          },
+          "signature" : [ ],
+          "operand" : {
+            "type" : "FunctionRef",
+            "localId" : "273",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+            "name" : "Echo",
+            "annotation" : [ ],
+            "signature" : [ {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "274",
+              "name" : "{urn:hl7-org:elm-types:r1}Any",
+              "annotation" : [ ]
+            } ],
+            "operand" : [ {
+              "type" : "Interval",
+              "localId" : "270",
+              "lowClosed" : true,
+              "highClosed" : true,
+              "annotation" : [ ],
+              "resultTypeSpecifier" : {
+                "type" : "IntervalTypeSpecifier",
+                "localId" : "271",
+                "annotation" : [ ],
+                "pointType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "272",
                   "name" : "{urn:hl7-org:elm-types:r1}Date",
                   "annotation" : [ ]
                 }
               },
               "low" : {
                 "type" : "Date",
-                "localId" : "245",
+                "localId" : "264",
                 "resultTypeName" : "{urn:hl7-org:elm-types:r1}Date",
                 "annotation" : [ ],
                 "signature" : [ ],
                 "year" : {
                   "type" : "Literal",
-                  "localId" : "242",
+                  "localId" : "261",
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "2000",
                   "annotation" : [ ]
                 },
                 "month" : {
                   "type" : "Literal",
-                  "localId" : "243",
+                  "localId" : "262",
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "1",
                   "annotation" : [ ]
                 },
                 "day" : {
                   "type" : "Literal",
-                  "localId" : "244",
+                  "localId" : "263",
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "1",
                   "annotation" : [ ]
@@ -5741,27 +5883,27 @@ module.exports['AsIntervalType'] = {
               },
               "high" : {
                 "type" : "Date",
-                "localId" : "250",
+                "localId" : "269",
                 "resultTypeName" : "{urn:hl7-org:elm-types:r1}Date",
                 "annotation" : [ ],
                 "signature" : [ ],
                 "year" : {
                   "type" : "Literal",
-                  "localId" : "247",
+                  "localId" : "266",
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "2000",
                   "annotation" : [ ]
                 },
                 "month" : {
                   "type" : "Literal",
-                  "localId" : "248",
+                  "localId" : "267",
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "12",
                   "annotation" : [ ]
                 },
                 "day" : {
                   "type" : "Literal",
-                  "localId" : "249",
+                  "localId" : "268",
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "31",
                   "annotation" : [ ]
@@ -5771,22 +5913,22 @@ module.exports['AsIntervalType'] = {
           },
           "asTypeSpecifier" : {
             "type" : "IntervalTypeSpecifier",
-            "localId" : "256",
+            "localId" : "275",
             "annotation" : [ ],
             "resultTypeSpecifier" : {
               "type" : "IntervalTypeSpecifier",
-              "localId" : "258",
+              "localId" : "277",
               "annotation" : [ ],
               "pointType" : {
                 "type" : "NamedTypeSpecifier",
-                "localId" : "259",
+                "localId" : "278",
                 "name" : "{urn:hl7-org:elm-types:r1}Integer",
                 "annotation" : [ ]
               }
             },
             "pointType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "257",
+              "localId" : "276",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
               "name" : "{urn:hl7-org:elm-types:r1}Integer",
               "annotation" : [ ]
@@ -5794,7 +5936,7 @@ module.exports['AsIntervalType'] = {
           }
         }
       }, {
-        "localId" : "266",
+        "localId" : "285",
         "name" : "IntegerAsIntervalOfIntegers",
         "context" : "Patient",
         "accessLevel" : "Public",
@@ -5802,25 +5944,25 @@ module.exports['AsIntervalType'] = {
           "type" : "Annotation",
           "t" : [ ],
           "s" : {
-            "r" : "266",
+            "r" : "285",
             "s" : [ {
               "value" : [ "", "define ", "IntegerAsIntervalOfIntegers", ": " ]
             }, {
-              "r" : "267",
+              "r" : "286",
               "s" : [ {
-                "r" : "269",
+                "r" : "288",
                 "s" : [ {
-                  "r" : "268",
+                  "r" : "287",
                   "value" : [ "Echo", "(", "5", ")" ]
                 } ]
               }, {
                 "value" : [ " as " ]
               }, {
-                "r" : "271",
+                "r" : "290",
                 "s" : [ {
                   "value" : [ "Interval<" ]
                 }, {
-                  "r" : "272",
+                  "r" : "291",
                   "s" : [ {
                     "value" : [ "Integer" ]
                   } ]
@@ -5833,27 +5975,27 @@ module.exports['AsIntervalType'] = {
         } ],
         "resultTypeSpecifier" : {
           "type" : "IntervalTypeSpecifier",
-          "localId" : "277",
+          "localId" : "296",
           "annotation" : [ ],
           "pointType" : {
             "type" : "NamedTypeSpecifier",
-            "localId" : "278",
+            "localId" : "297",
             "name" : "{urn:hl7-org:elm-types:r1}Integer",
             "annotation" : [ ]
           }
         },
         "expression" : {
           "type" : "As",
-          "localId" : "267",
+          "localId" : "286",
           "strict" : false,
           "annotation" : [ ],
           "resultTypeSpecifier" : {
             "type" : "IntervalTypeSpecifier",
-            "localId" : "275",
+            "localId" : "294",
             "annotation" : [ ],
             "pointType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "276",
+              "localId" : "295",
               "name" : "{urn:hl7-org:elm-types:r1}Integer",
               "annotation" : [ ]
             }
@@ -5861,19 +6003,19 @@ module.exports['AsIntervalType'] = {
           "signature" : [ ],
           "operand" : {
             "type" : "FunctionRef",
-            "localId" : "269",
+            "localId" : "288",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
             "name" : "Echo",
             "annotation" : [ ],
             "signature" : [ {
               "type" : "NamedTypeSpecifier",
-              "localId" : "270",
+              "localId" : "289",
               "name" : "{urn:hl7-org:elm-types:r1}Any",
               "annotation" : [ ]
             } ],
             "operand" : [ {
               "type" : "Literal",
-              "localId" : "268",
+              "localId" : "287",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
               "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
               "value" : "5",
@@ -5882,22 +6024,22 @@ module.exports['AsIntervalType'] = {
           },
           "asTypeSpecifier" : {
             "type" : "IntervalTypeSpecifier",
-            "localId" : "271",
+            "localId" : "290",
             "annotation" : [ ],
             "resultTypeSpecifier" : {
               "type" : "IntervalTypeSpecifier",
-              "localId" : "273",
+              "localId" : "292",
               "annotation" : [ ],
               "pointType" : {
                 "type" : "NamedTypeSpecifier",
-                "localId" : "274",
+                "localId" : "293",
                 "name" : "{urn:hl7-org:elm-types:r1}Integer",
                 "annotation" : [ ]
               }
             },
             "pointType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "272",
+              "localId" : "291",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
               "name" : "{urn:hl7-org:elm-types:r1}Integer",
               "annotation" : [ ]
@@ -5905,7 +6047,7 @@ module.exports['AsIntervalType'] = {
           }
         }
       }, {
-        "localId" : "281",
+        "localId" : "300",
         "name" : "ListAsIntervalOfIntegers",
         "context" : "Patient",
         "accessLevel" : "Public",
@@ -5913,188 +6055,20 @@ module.exports['AsIntervalType'] = {
           "type" : "Annotation",
           "t" : [ ],
           "s" : {
-            "r" : "281",
+            "r" : "300",
             "s" : [ {
               "value" : [ "", "define ", "ListAsIntervalOfIntegers", ": " ]
             }, {
-              "r" : "282",
-              "s" : [ {
-                "r" : "291",
-                "s" : [ {
-                  "value" : [ "Echo", "(" ]
-                }, {
-                  "r" : "283",
-                  "s" : [ {
-                    "r" : "284",
-                    "value" : [ "{", "1", ", ", "2", ", ", "3", ", ", "4", ", ", "5", "}" ]
-                  } ]
-                }, {
-                  "value" : [ ")" ]
-                } ]
-              }, {
-                "value" : [ " as " ]
-              }, {
-                "r" : "293",
-                "s" : [ {
-                  "value" : [ "Interval<" ]
-                }, {
-                  "r" : "294",
-                  "s" : [ {
-                    "value" : [ "Integer" ]
-                  } ]
-                }, {
-                  "value" : [ ">" ]
-                } ]
-              } ]
-            } ]
-          }
-        } ],
-        "resultTypeSpecifier" : {
-          "type" : "IntervalTypeSpecifier",
-          "localId" : "299",
-          "annotation" : [ ],
-          "pointType" : {
-            "type" : "NamedTypeSpecifier",
-            "localId" : "300",
-            "name" : "{urn:hl7-org:elm-types:r1}Integer",
-            "annotation" : [ ]
-          }
-        },
-        "expression" : {
-          "type" : "As",
-          "localId" : "282",
-          "strict" : false,
-          "annotation" : [ ],
-          "resultTypeSpecifier" : {
-            "type" : "IntervalTypeSpecifier",
-            "localId" : "297",
-            "annotation" : [ ],
-            "pointType" : {
-              "type" : "NamedTypeSpecifier",
-              "localId" : "298",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer",
-              "annotation" : [ ]
-            }
-          },
-          "signature" : [ ],
-          "operand" : {
-            "type" : "FunctionRef",
-            "localId" : "291",
-            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
-            "name" : "Echo",
-            "annotation" : [ ],
-            "signature" : [ {
-              "type" : "NamedTypeSpecifier",
-              "localId" : "292",
-              "name" : "{urn:hl7-org:elm-types:r1}Any",
-              "annotation" : [ ]
-            } ],
-            "operand" : [ {
-              "type" : "List",
-              "localId" : "283",
-              "annotation" : [ ],
-              "resultTypeSpecifier" : {
-                "type" : "ListTypeSpecifier",
-                "localId" : "289",
-                "annotation" : [ ],
-                "elementType" : {
-                  "type" : "NamedTypeSpecifier",
-                  "localId" : "290",
-                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                  "annotation" : [ ]
-                }
-              },
-              "element" : [ {
-                "type" : "Literal",
-                "localId" : "284",
-                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                "value" : "1",
-                "annotation" : [ ]
-              }, {
-                "type" : "Literal",
-                "localId" : "285",
-                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                "value" : "2",
-                "annotation" : [ ]
-              }, {
-                "type" : "Literal",
-                "localId" : "286",
-                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                "value" : "3",
-                "annotation" : [ ]
-              }, {
-                "type" : "Literal",
-                "localId" : "287",
-                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                "value" : "4",
-                "annotation" : [ ]
-              }, {
-                "type" : "Literal",
-                "localId" : "288",
-                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                "value" : "5",
-                "annotation" : [ ]
-              } ]
-            } ]
-          },
-          "asTypeSpecifier" : {
-            "type" : "IntervalTypeSpecifier",
-            "localId" : "293",
-            "annotation" : [ ],
-            "resultTypeSpecifier" : {
-              "type" : "IntervalTypeSpecifier",
-              "localId" : "295",
-              "annotation" : [ ],
-              "pointType" : {
-                "type" : "NamedTypeSpecifier",
-                "localId" : "296",
-                "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                "annotation" : [ ]
-              }
-            },
-            "pointType" : {
-              "type" : "NamedTypeSpecifier",
-              "localId" : "294",
-              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer",
-              "annotation" : [ ]
-            }
-          }
-        }
-      }, {
-        "localId" : "303",
-        "name" : "TupleAsIntervalOfIntegers",
-        "context" : "Patient",
-        "accessLevel" : "Public",
-        "annotation" : [ {
-          "type" : "Annotation",
-          "t" : [ ],
-          "s" : {
-            "r" : "303",
-            "s" : [ {
-              "value" : [ "", "define ", "TupleAsIntervalOfIntegers", ": " ]
-            }, {
-              "r" : "304",
+              "r" : "301",
               "s" : [ {
                 "r" : "310",
                 "s" : [ {
                   "value" : [ "Echo", "(" ]
                 }, {
-                  "r" : "305",
+                  "r" : "302",
                   "s" : [ {
-                    "value" : [ "Tuple{" ]
-                  }, {
-                    "s" : [ {
-                      "r" : "306",
-                      "value" : [ "A", ": ", "5" ]
-                    } ]
-                  }, {
-                    "value" : [ "}" ]
+                    "r" : "303",
+                    "value" : [ "{", "1", ", ", "2", ", ", "3", ", ", "4", ", ", "5", "}" ]
                   } ]
                 }, {
                   "value" : [ ")" ]
@@ -6130,7 +6104,7 @@ module.exports['AsIntervalType'] = {
         },
         "expression" : {
           "type" : "As",
-          "localId" : "304",
+          "localId" : "301",
           "strict" : false,
           "annotation" : [ ],
           "resultTypeSpecifier" : {
@@ -6158,35 +6132,55 @@ module.exports['AsIntervalType'] = {
               "annotation" : [ ]
             } ],
             "operand" : [ {
-              "type" : "Tuple",
-              "localId" : "305",
+              "type" : "List",
+              "localId" : "302",
               "annotation" : [ ],
               "resultTypeSpecifier" : {
-                "type" : "TupleTypeSpecifier",
-                "localId" : "307",
+                "type" : "ListTypeSpecifier",
+                "localId" : "308",
                 "annotation" : [ ],
-                "element" : [ {
-                  "localId" : "308",
-                  "name" : "A",
-                  "annotation" : [ ],
-                  "elementType" : {
-                    "type" : "NamedTypeSpecifier",
-                    "localId" : "309",
-                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                    "annotation" : [ ]
-                  }
-                } ]
-              },
-              "element" : [ {
-                "name" : "A",
-                "value" : {
-                  "type" : "Literal",
-                  "localId" : "306",
-                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                  "value" : "5",
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "309",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
                   "annotation" : [ ]
                 }
+              },
+              "element" : [ {
+                "type" : "Literal",
+                "localId" : "303",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                "value" : "1",
+                "annotation" : [ ]
+              }, {
+                "type" : "Literal",
+                "localId" : "304",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                "value" : "2",
+                "annotation" : [ ]
+              }, {
+                "type" : "Literal",
+                "localId" : "305",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                "value" : "3",
+                "annotation" : [ ]
+              }, {
+                "type" : "Literal",
+                "localId" : "306",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                "value" : "4",
+                "annotation" : [ ]
+              }, {
+                "type" : "Literal",
+                "localId" : "307",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                "value" : "5",
+                "annotation" : [ ]
               } ]
             } ]
           },
@@ -6216,7 +6210,7 @@ module.exports['AsIntervalType'] = {
         }
       }, {
         "localId" : "322",
-        "name" : "CastIntervalOfIntegersAsIntervalOfIntegers",
+        "name" : "TupleAsIntervalOfIntegers",
         "context" : "Patient",
         "accessLevel" : "Public",
         "annotation" : [ {
@@ -6225,20 +6219,24 @@ module.exports['AsIntervalType'] = {
           "s" : {
             "r" : "322",
             "s" : [ {
-              "value" : [ "", "define ", "CastIntervalOfIntegersAsIntervalOfIntegers", ": " ]
+              "value" : [ "", "define ", "TupleAsIntervalOfIntegers", ": " ]
             }, {
               "r" : "323",
               "s" : [ {
-                "value" : [ "cast " ]
-              }, {
                 "r" : "329",
                 "s" : [ {
                   "value" : [ "Echo", "(" ]
                 }, {
-                  "r" : "326",
+                  "r" : "324",
                   "s" : [ {
-                    "r" : "324",
-                    "value" : [ "Interval[", "1", ", ", "5", "]" ]
+                    "value" : [ "Tuple{" ]
+                  }, {
+                    "s" : [ {
+                      "r" : "325",
+                      "value" : [ "A", ": ", "5" ]
+                    } ]
+                  }, {
+                    "value" : [ "}" ]
                   } ]
                 }, {
                   "value" : [ ")" ]
@@ -6275,7 +6273,7 @@ module.exports['AsIntervalType'] = {
         "expression" : {
           "type" : "As",
           "localId" : "323",
-          "strict" : true,
+          "strict" : false,
           "annotation" : [ ],
           "resultTypeSpecifier" : {
             "type" : "IntervalTypeSpecifier",
@@ -6302,38 +6300,36 @@ module.exports['AsIntervalType'] = {
               "annotation" : [ ]
             } ],
             "operand" : [ {
-              "type" : "Interval",
-              "localId" : "326",
-              "lowClosed" : true,
-              "highClosed" : true,
+              "type" : "Tuple",
+              "localId" : "324",
               "annotation" : [ ],
               "resultTypeSpecifier" : {
-                "type" : "IntervalTypeSpecifier",
-                "localId" : "327",
+                "type" : "TupleTypeSpecifier",
+                "localId" : "326",
                 "annotation" : [ ],
-                "pointType" : {
-                  "type" : "NamedTypeSpecifier",
-                  "localId" : "328",
-                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "element" : [ {
+                  "localId" : "327",
+                  "name" : "A",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "328",
+                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                    "annotation" : [ ]
+                  }
+                } ]
+              },
+              "element" : [ {
+                "name" : "A",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "325",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "5",
                   "annotation" : [ ]
                 }
-              },
-              "low" : {
-                "type" : "Literal",
-                "localId" : "324",
-                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                "value" : "1",
-                "annotation" : [ ]
-              },
-              "high" : {
-                "type" : "Literal",
-                "localId" : "325",
-                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
-                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                "value" : "5",
-                "annotation" : [ ]
-              }
+              } ]
             } ]
           },
           "asTypeSpecifier" : {
@@ -6362,7 +6358,7 @@ module.exports['AsIntervalType'] = {
         }
       }, {
         "localId" : "341",
-        "name" : "CastIntervalOfDatesAsIntervalOfIntegers",
+        "name" : "CastIntervalOfIntegersAsIntervalOfIntegers",
         "context" : "Patient",
         "accessLevel" : "Public",
         "annotation" : [ {
@@ -6371,20 +6367,20 @@ module.exports['AsIntervalType'] = {
           "s" : {
             "r" : "341",
             "s" : [ {
-              "value" : [ "", "define ", "CastIntervalOfDatesAsIntervalOfIntegers", ": " ]
+              "value" : [ "", "define ", "CastIntervalOfIntegersAsIntervalOfIntegers", ": " ]
             }, {
               "r" : "342",
               "s" : [ {
                 "value" : [ "cast " ]
               }, {
-                "r" : "356",
+                "r" : "348",
                 "s" : [ {
                   "value" : [ "Echo", "(" ]
                 }, {
-                  "r" : "353",
+                  "r" : "345",
                   "s" : [ {
-                    "r" : "347",
-                    "value" : [ "Interval[", "@2000-01-01", ", ", "@2000-12-31", "]" ]
+                    "r" : "343",
+                    "value" : [ "Interval[", "1", ", ", "5", "]" ]
                   } ]
                 }, {
                   "value" : [ ")" ]
@@ -6392,11 +6388,11 @@ module.exports['AsIntervalType'] = {
               }, {
                 "value" : [ " as " ]
               }, {
-                "r" : "358",
+                "r" : "350",
                 "s" : [ {
                   "value" : [ "Interval<" ]
                 }, {
-                  "r" : "359",
+                  "r" : "351",
                   "s" : [ {
                     "value" : [ "Integer" ]
                   } ]
@@ -6409,11 +6405,11 @@ module.exports['AsIntervalType'] = {
         } ],
         "resultTypeSpecifier" : {
           "type" : "IntervalTypeSpecifier",
-          "localId" : "364",
+          "localId" : "356",
           "annotation" : [ ],
           "pointType" : {
             "type" : "NamedTypeSpecifier",
-            "localId" : "365",
+            "localId" : "357",
             "name" : "{urn:hl7-org:elm-types:r1}Integer",
             "annotation" : [ ]
           }
@@ -6425,11 +6421,11 @@ module.exports['AsIntervalType'] = {
           "annotation" : [ ],
           "resultTypeSpecifier" : {
             "type" : "IntervalTypeSpecifier",
-            "localId" : "362",
+            "localId" : "354",
             "annotation" : [ ],
             "pointType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "363",
+              "localId" : "355",
               "name" : "{urn:hl7-org:elm-types:r1}Integer",
               "annotation" : [ ]
             }
@@ -6437,56 +6433,344 @@ module.exports['AsIntervalType'] = {
           "signature" : [ ],
           "operand" : {
             "type" : "FunctionRef",
-            "localId" : "356",
+            "localId" : "348",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
             "name" : "Echo",
             "annotation" : [ ],
             "signature" : [ {
               "type" : "NamedTypeSpecifier",
-              "localId" : "357",
+              "localId" : "349",
               "name" : "{urn:hl7-org:elm-types:r1}Any",
               "annotation" : [ ]
             } ],
             "operand" : [ {
               "type" : "Interval",
-              "localId" : "353",
+              "localId" : "345",
               "lowClosed" : true,
               "highClosed" : true,
               "annotation" : [ ],
               "resultTypeSpecifier" : {
                 "type" : "IntervalTypeSpecifier",
-                "localId" : "354",
+                "localId" : "346",
                 "annotation" : [ ],
                 "pointType" : {
                   "type" : "NamedTypeSpecifier",
-                  "localId" : "355",
+                  "localId" : "347",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "annotation" : [ ]
+                }
+              },
+              "low" : {
+                "type" : "Literal",
+                "localId" : "343",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                "value" : "1",
+                "annotation" : [ ]
+              },
+              "high" : {
+                "type" : "Literal",
+                "localId" : "344",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                "value" : "5",
+                "annotation" : [ ]
+              }
+            } ]
+          },
+          "asTypeSpecifier" : {
+            "type" : "IntervalTypeSpecifier",
+            "localId" : "350",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "IntervalTypeSpecifier",
+              "localId" : "352",
+              "annotation" : [ ],
+              "pointType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "353",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "pointType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "351",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          }
+        }
+      }, {
+        "localId" : "360",
+        "name" : "CastUnboundedIntervalAsIntervalOfIntegers",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "360",
+            "s" : [ {
+              "value" : [ "", "define ", "CastUnboundedIntervalAsIntervalOfIntegers", ": " ]
+            }, {
+              "r" : "361",
+              "s" : [ {
+                "value" : [ "cast " ]
+              }, {
+                "r" : "367",
+                "s" : [ {
+                  "value" : [ "Echo", "(" ]
+                }, {
+                  "r" : "364",
+                  "s" : [ {
+                    "r" : "362",
+                    "value" : [ "Interval[", "null", ", ", "null", "]" ]
+                  } ]
+                }, {
+                  "value" : [ ")" ]
+                } ]
+              }, {
+                "value" : [ " as " ]
+              }, {
+                "r" : "369",
+                "s" : [ {
+                  "value" : [ "Interval<" ]
+                }, {
+                  "r" : "370",
+                  "s" : [ {
+                    "value" : [ "Integer" ]
+                  } ]
+                }, {
+                  "value" : [ ">" ]
+                } ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "IntervalTypeSpecifier",
+          "localId" : "375",
+          "annotation" : [ ],
+          "pointType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "376",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "As",
+          "localId" : "361",
+          "strict" : true,
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "IntervalTypeSpecifier",
+            "localId" : "373",
+            "annotation" : [ ],
+            "pointType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "374",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          },
+          "signature" : [ ],
+          "operand" : {
+            "type" : "FunctionRef",
+            "localId" : "367",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+            "name" : "Echo",
+            "annotation" : [ ],
+            "signature" : [ {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "368",
+              "name" : "{urn:hl7-org:elm-types:r1}Any",
+              "annotation" : [ ]
+            } ],
+            "operand" : [ {
+              "type" : "Interval",
+              "localId" : "364",
+              "lowClosed" : true,
+              "highClosed" : true,
+              "annotation" : [ ],
+              "resultTypeSpecifier" : {
+                "type" : "IntervalTypeSpecifier",
+                "localId" : "365",
+                "annotation" : [ ],
+                "pointType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "366",
+                  "name" : "{urn:hl7-org:elm-types:r1}Any",
+                  "annotation" : [ ]
+                }
+              },
+              "low" : {
+                "type" : "Null",
+                "localId" : "362",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                "annotation" : [ ]
+              },
+              "high" : {
+                "type" : "Null",
+                "localId" : "363",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                "annotation" : [ ]
+              }
+            } ]
+          },
+          "asTypeSpecifier" : {
+            "type" : "IntervalTypeSpecifier",
+            "localId" : "369",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "IntervalTypeSpecifier",
+              "localId" : "371",
+              "annotation" : [ ],
+              "pointType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "372",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "pointType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "370",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          }
+        }
+      }, {
+        "localId" : "379",
+        "name" : "CastIntervalOfDatesAsIntervalOfIntegers",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "379",
+            "s" : [ {
+              "value" : [ "", "define ", "CastIntervalOfDatesAsIntervalOfIntegers", ": " ]
+            }, {
+              "r" : "380",
+              "s" : [ {
+                "value" : [ "cast " ]
+              }, {
+                "r" : "394",
+                "s" : [ {
+                  "value" : [ "Echo", "(" ]
+                }, {
+                  "r" : "391",
+                  "s" : [ {
+                    "r" : "385",
+                    "value" : [ "Interval[", "@2000-01-01", ", ", "@2000-12-31", "]" ]
+                  } ]
+                }, {
+                  "value" : [ ")" ]
+                } ]
+              }, {
+                "value" : [ " as " ]
+              }, {
+                "r" : "396",
+                "s" : [ {
+                  "value" : [ "Interval<" ]
+                }, {
+                  "r" : "397",
+                  "s" : [ {
+                    "value" : [ "Integer" ]
+                  } ]
+                }, {
+                  "value" : [ ">" ]
+                } ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "IntervalTypeSpecifier",
+          "localId" : "402",
+          "annotation" : [ ],
+          "pointType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "403",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "As",
+          "localId" : "380",
+          "strict" : true,
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "IntervalTypeSpecifier",
+            "localId" : "400",
+            "annotation" : [ ],
+            "pointType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "401",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          },
+          "signature" : [ ],
+          "operand" : {
+            "type" : "FunctionRef",
+            "localId" : "394",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+            "name" : "Echo",
+            "annotation" : [ ],
+            "signature" : [ {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "395",
+              "name" : "{urn:hl7-org:elm-types:r1}Any",
+              "annotation" : [ ]
+            } ],
+            "operand" : [ {
+              "type" : "Interval",
+              "localId" : "391",
+              "lowClosed" : true,
+              "highClosed" : true,
+              "annotation" : [ ],
+              "resultTypeSpecifier" : {
+                "type" : "IntervalTypeSpecifier",
+                "localId" : "392",
+                "annotation" : [ ],
+                "pointType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "393",
                   "name" : "{urn:hl7-org:elm-types:r1}Date",
                   "annotation" : [ ]
                 }
               },
               "low" : {
                 "type" : "Date",
-                "localId" : "347",
+                "localId" : "385",
                 "resultTypeName" : "{urn:hl7-org:elm-types:r1}Date",
                 "annotation" : [ ],
                 "signature" : [ ],
                 "year" : {
                   "type" : "Literal",
-                  "localId" : "344",
+                  "localId" : "382",
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "2000",
                   "annotation" : [ ]
                 },
                 "month" : {
                   "type" : "Literal",
-                  "localId" : "345",
+                  "localId" : "383",
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "1",
                   "annotation" : [ ]
                 },
                 "day" : {
                   "type" : "Literal",
-                  "localId" : "346",
+                  "localId" : "384",
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "1",
                   "annotation" : [ ]
@@ -6494,27 +6778,27 @@ module.exports['AsIntervalType'] = {
               },
               "high" : {
                 "type" : "Date",
-                "localId" : "352",
+                "localId" : "390",
                 "resultTypeName" : "{urn:hl7-org:elm-types:r1}Date",
                 "annotation" : [ ],
                 "signature" : [ ],
                 "year" : {
                   "type" : "Literal",
-                  "localId" : "349",
+                  "localId" : "387",
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "2000",
                   "annotation" : [ ]
                 },
                 "month" : {
                   "type" : "Literal",
-                  "localId" : "350",
+                  "localId" : "388",
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "12",
                   "annotation" : [ ]
                 },
                 "day" : {
                   "type" : "Literal",
-                  "localId" : "351",
+                  "localId" : "389",
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "31",
                   "annotation" : [ ]
@@ -6524,22 +6808,22 @@ module.exports['AsIntervalType'] = {
           },
           "asTypeSpecifier" : {
             "type" : "IntervalTypeSpecifier",
-            "localId" : "358",
+            "localId" : "396",
             "annotation" : [ ],
             "resultTypeSpecifier" : {
               "type" : "IntervalTypeSpecifier",
-              "localId" : "360",
+              "localId" : "398",
               "annotation" : [ ],
               "pointType" : {
                 "type" : "NamedTypeSpecifier",
-                "localId" : "361",
+                "localId" : "399",
                 "name" : "{urn:hl7-org:elm-types:r1}Integer",
                 "annotation" : [ ]
               }
             },
             "pointType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "359",
+              "localId" : "397",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
               "name" : "{urn:hl7-org:elm-types:r1}Integer",
               "annotation" : [ ]
@@ -6547,7 +6831,7 @@ module.exports['AsIntervalType'] = {
           }
         }
       }, {
-        "localId" : "368",
+        "localId" : "406",
         "name" : "CastIntegerAsIntervalOfIntegers",
         "context" : "Patient",
         "accessLevel" : "Public",
@@ -6555,27 +6839,27 @@ module.exports['AsIntervalType'] = {
           "type" : "Annotation",
           "t" : [ ],
           "s" : {
-            "r" : "368",
+            "r" : "406",
             "s" : [ {
               "value" : [ "", "define ", "CastIntegerAsIntervalOfIntegers", ": " ]
             }, {
-              "r" : "369",
+              "r" : "407",
               "s" : [ {
                 "value" : [ "cast " ]
               }, {
-                "r" : "371",
+                "r" : "409",
                 "s" : [ {
-                  "r" : "370",
+                  "r" : "408",
                   "value" : [ "Echo", "(", "5", ")" ]
                 } ]
               }, {
                 "value" : [ " as " ]
               }, {
-                "r" : "373",
+                "r" : "411",
                 "s" : [ {
                   "value" : [ "Interval<" ]
                 }, {
-                  "r" : "374",
+                  "r" : "412",
                   "s" : [ {
                     "value" : [ "Integer" ]
                   } ]
@@ -6588,27 +6872,27 @@ module.exports['AsIntervalType'] = {
         } ],
         "resultTypeSpecifier" : {
           "type" : "IntervalTypeSpecifier",
-          "localId" : "379",
+          "localId" : "417",
           "annotation" : [ ],
           "pointType" : {
             "type" : "NamedTypeSpecifier",
-            "localId" : "380",
+            "localId" : "418",
             "name" : "{urn:hl7-org:elm-types:r1}Integer",
             "annotation" : [ ]
           }
         },
         "expression" : {
           "type" : "As",
-          "localId" : "369",
+          "localId" : "407",
           "strict" : true,
           "annotation" : [ ],
           "resultTypeSpecifier" : {
             "type" : "IntervalTypeSpecifier",
-            "localId" : "377",
+            "localId" : "415",
             "annotation" : [ ],
             "pointType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "378",
+              "localId" : "416",
               "name" : "{urn:hl7-org:elm-types:r1}Integer",
               "annotation" : [ ]
             }
@@ -6616,19 +6900,19 @@ module.exports['AsIntervalType'] = {
           "signature" : [ ],
           "operand" : {
             "type" : "FunctionRef",
-            "localId" : "371",
+            "localId" : "409",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
             "name" : "Echo",
             "annotation" : [ ],
             "signature" : [ {
               "type" : "NamedTypeSpecifier",
-              "localId" : "372",
+              "localId" : "410",
               "name" : "{urn:hl7-org:elm-types:r1}Any",
               "annotation" : [ ]
             } ],
             "operand" : [ {
               "type" : "Literal",
-              "localId" : "370",
+              "localId" : "408",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
               "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
               "value" : "5",
@@ -6637,22 +6921,22 @@ module.exports['AsIntervalType'] = {
           },
           "asTypeSpecifier" : {
             "type" : "IntervalTypeSpecifier",
-            "localId" : "373",
+            "localId" : "411",
             "annotation" : [ ],
             "resultTypeSpecifier" : {
               "type" : "IntervalTypeSpecifier",
-              "localId" : "375",
+              "localId" : "413",
               "annotation" : [ ],
               "pointType" : {
                 "type" : "NamedTypeSpecifier",
-                "localId" : "376",
+                "localId" : "414",
                 "name" : "{urn:hl7-org:elm-types:r1}Integer",
                 "annotation" : [ ]
               }
             },
             "pointType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "374",
+              "localId" : "412",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
               "name" : "{urn:hl7-org:elm-types:r1}Integer",
               "annotation" : [ ]
@@ -6660,7 +6944,7 @@ module.exports['AsIntervalType'] = {
           }
         }
       }, {
-        "localId" : "383",
+        "localId" : "421",
         "name" : "CastListAsIntervalOfIntegers",
         "context" : "Patient",
         "accessLevel" : "Public",
@@ -6668,21 +6952,21 @@ module.exports['AsIntervalType'] = {
           "type" : "Annotation",
           "t" : [ ],
           "s" : {
-            "r" : "383",
+            "r" : "421",
             "s" : [ {
               "value" : [ "", "define ", "CastListAsIntervalOfIntegers", ": " ]
             }, {
-              "r" : "384",
+              "r" : "422",
               "s" : [ {
                 "value" : [ "cast " ]
               }, {
-                "r" : "393",
+                "r" : "431",
                 "s" : [ {
                   "value" : [ "Echo", "(" ]
                 }, {
-                  "r" : "385",
+                  "r" : "423",
                   "s" : [ {
-                    "r" : "386",
+                    "r" : "424",
                     "value" : [ "{", "1", ", ", "2", ", ", "3", ", ", "4", ", ", "5", "}" ]
                   } ]
                 }, {
@@ -6691,11 +6975,11 @@ module.exports['AsIntervalType'] = {
               }, {
                 "value" : [ " as " ]
               }, {
-                "r" : "395",
+                "r" : "433",
                 "s" : [ {
                   "value" : [ "Interval<" ]
                 }, {
-                  "r" : "396",
+                  "r" : "434",
                   "s" : [ {
                     "value" : [ "Integer" ]
                   } ]
@@ -6708,27 +6992,27 @@ module.exports['AsIntervalType'] = {
         } ],
         "resultTypeSpecifier" : {
           "type" : "IntervalTypeSpecifier",
-          "localId" : "401",
+          "localId" : "439",
           "annotation" : [ ],
           "pointType" : {
             "type" : "NamedTypeSpecifier",
-            "localId" : "402",
+            "localId" : "440",
             "name" : "{urn:hl7-org:elm-types:r1}Integer",
             "annotation" : [ ]
           }
         },
         "expression" : {
           "type" : "As",
-          "localId" : "384",
+          "localId" : "422",
           "strict" : true,
           "annotation" : [ ],
           "resultTypeSpecifier" : {
             "type" : "IntervalTypeSpecifier",
-            "localId" : "399",
+            "localId" : "437",
             "annotation" : [ ],
             "pointType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "400",
+              "localId" : "438",
               "name" : "{urn:hl7-org:elm-types:r1}Integer",
               "annotation" : [ ]
             }
@@ -6736,62 +7020,62 @@ module.exports['AsIntervalType'] = {
           "signature" : [ ],
           "operand" : {
             "type" : "FunctionRef",
-            "localId" : "393",
+            "localId" : "431",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
             "name" : "Echo",
             "annotation" : [ ],
             "signature" : [ {
               "type" : "NamedTypeSpecifier",
-              "localId" : "394",
+              "localId" : "432",
               "name" : "{urn:hl7-org:elm-types:r1}Any",
               "annotation" : [ ]
             } ],
             "operand" : [ {
               "type" : "List",
-              "localId" : "385",
+              "localId" : "423",
               "annotation" : [ ],
               "resultTypeSpecifier" : {
                 "type" : "ListTypeSpecifier",
-                "localId" : "391",
+                "localId" : "429",
                 "annotation" : [ ],
                 "elementType" : {
                   "type" : "NamedTypeSpecifier",
-                  "localId" : "392",
+                  "localId" : "430",
                   "name" : "{urn:hl7-org:elm-types:r1}Integer",
                   "annotation" : [ ]
                 }
               },
               "element" : [ {
                 "type" : "Literal",
-                "localId" : "386",
+                "localId" : "424",
                 "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                 "value" : "1",
                 "annotation" : [ ]
               }, {
                 "type" : "Literal",
-                "localId" : "387",
+                "localId" : "425",
                 "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                 "value" : "2",
                 "annotation" : [ ]
               }, {
                 "type" : "Literal",
-                "localId" : "388",
+                "localId" : "426",
                 "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                 "value" : "3",
                 "annotation" : [ ]
               }, {
                 "type" : "Literal",
-                "localId" : "389",
+                "localId" : "427",
                 "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                 "value" : "4",
                 "annotation" : [ ]
               }, {
                 "type" : "Literal",
-                "localId" : "390",
+                "localId" : "428",
                 "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                 "value" : "5",
@@ -6801,22 +7085,22 @@ module.exports['AsIntervalType'] = {
           },
           "asTypeSpecifier" : {
             "type" : "IntervalTypeSpecifier",
-            "localId" : "395",
+            "localId" : "433",
             "annotation" : [ ],
             "resultTypeSpecifier" : {
               "type" : "IntervalTypeSpecifier",
-              "localId" : "397",
+              "localId" : "435",
               "annotation" : [ ],
               "pointType" : {
                 "type" : "NamedTypeSpecifier",
-                "localId" : "398",
+                "localId" : "436",
                 "name" : "{urn:hl7-org:elm-types:r1}Integer",
                 "annotation" : [ ]
               }
             },
             "pointType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "396",
+              "localId" : "434",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
               "name" : "{urn:hl7-org:elm-types:r1}Integer",
               "annotation" : [ ]
@@ -6824,7 +7108,7 @@ module.exports['AsIntervalType'] = {
           }
         }
       }, {
-        "localId" : "405",
+        "localId" : "443",
         "name" : "CastTupleAsIntervalOfIntegers",
         "context" : "Patient",
         "accessLevel" : "Public",
@@ -6832,24 +7116,24 @@ module.exports['AsIntervalType'] = {
           "type" : "Annotation",
           "t" : [ ],
           "s" : {
-            "r" : "405",
+            "r" : "443",
             "s" : [ {
               "value" : [ "", "define ", "CastTupleAsIntervalOfIntegers", ": " ]
             }, {
-              "r" : "406",
+              "r" : "444",
               "s" : [ {
                 "value" : [ "cast " ]
               }, {
-                "r" : "412",
+                "r" : "450",
                 "s" : [ {
                   "value" : [ "Echo", "(" ]
                 }, {
-                  "r" : "407",
+                  "r" : "445",
                   "s" : [ {
                     "value" : [ "Tuple{" ]
                   }, {
                     "s" : [ {
-                      "r" : "408",
+                      "r" : "446",
                       "value" : [ "A", ": ", "5" ]
                     } ]
                   }, {
@@ -6861,11 +7145,11 @@ module.exports['AsIntervalType'] = {
               }, {
                 "value" : [ " as " ]
               }, {
-                "r" : "414",
+                "r" : "452",
                 "s" : [ {
                   "value" : [ "Interval<" ]
                 }, {
-                  "r" : "415",
+                  "r" : "453",
                   "s" : [ {
                     "value" : [ "Integer" ]
                   } ]
@@ -6878,27 +7162,27 @@ module.exports['AsIntervalType'] = {
         } ],
         "resultTypeSpecifier" : {
           "type" : "IntervalTypeSpecifier",
-          "localId" : "420",
+          "localId" : "458",
           "annotation" : [ ],
           "pointType" : {
             "type" : "NamedTypeSpecifier",
-            "localId" : "421",
+            "localId" : "459",
             "name" : "{urn:hl7-org:elm-types:r1}Integer",
             "annotation" : [ ]
           }
         },
         "expression" : {
           "type" : "As",
-          "localId" : "406",
+          "localId" : "444",
           "strict" : true,
           "annotation" : [ ],
           "resultTypeSpecifier" : {
             "type" : "IntervalTypeSpecifier",
-            "localId" : "418",
+            "localId" : "456",
             "annotation" : [ ],
             "pointType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "419",
+              "localId" : "457",
               "name" : "{urn:hl7-org:elm-types:r1}Integer",
               "annotation" : [ ]
             }
@@ -6906,31 +7190,31 @@ module.exports['AsIntervalType'] = {
           "signature" : [ ],
           "operand" : {
             "type" : "FunctionRef",
-            "localId" : "412",
+            "localId" : "450",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
             "name" : "Echo",
             "annotation" : [ ],
             "signature" : [ {
               "type" : "NamedTypeSpecifier",
-              "localId" : "413",
+              "localId" : "451",
               "name" : "{urn:hl7-org:elm-types:r1}Any",
               "annotation" : [ ]
             } ],
             "operand" : [ {
               "type" : "Tuple",
-              "localId" : "407",
+              "localId" : "445",
               "annotation" : [ ],
               "resultTypeSpecifier" : {
                 "type" : "TupleTypeSpecifier",
-                "localId" : "409",
+                "localId" : "447",
                 "annotation" : [ ],
                 "element" : [ {
-                  "localId" : "410",
+                  "localId" : "448",
                   "name" : "A",
                   "annotation" : [ ],
                   "elementType" : {
                     "type" : "NamedTypeSpecifier",
-                    "localId" : "411",
+                    "localId" : "449",
                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
                     "annotation" : [ ]
                   }
@@ -6940,7 +7224,7 @@ module.exports['AsIntervalType'] = {
                 "name" : "A",
                 "value" : {
                   "type" : "Literal",
-                  "localId" : "408",
+                  "localId" : "446",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "5",
@@ -6951,22 +7235,22 @@ module.exports['AsIntervalType'] = {
           },
           "asTypeSpecifier" : {
             "type" : "IntervalTypeSpecifier",
-            "localId" : "414",
+            "localId" : "452",
             "annotation" : [ ],
             "resultTypeSpecifier" : {
               "type" : "IntervalTypeSpecifier",
-              "localId" : "416",
+              "localId" : "454",
               "annotation" : [ ],
               "pointType" : {
                 "type" : "NamedTypeSpecifier",
-                "localId" : "417",
+                "localId" : "455",
                 "name" : "{urn:hl7-org:elm-types:r1}Integer",
                 "annotation" : [ ]
               }
             },
             "pointType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "415",
+              "localId" : "453",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
               "name" : "{urn:hl7-org:elm-types:r1}Integer",
               "annotation" : [ ]

--- a/test/elm/type/type-test.ts
+++ b/test/elm/type/type-test.ts
@@ -200,6 +200,13 @@ describe('AsIntervalType', () => {
     );
   });
 
+  it('should apply the cast point type to unbounded intervals', async function () {
+    const expected = new Interval(null, null, true, true, '{urn:hl7-org:elm-types:r1}Integer');
+
+    (await this.unboundedIntervalAsIntervalOfIntegers.exec(this.ctx)).should.eql(expected);
+    (await this.castUnboundedIntervalAsIntervalOfIntegers.exec(this.ctx)).should.eql(expected);
+  });
+
   it('should return null on non-matching types for non-strict cast', async function () {
     should(await this.intervalOfDatesAsIntervalOfIntegers.exec(this.ctx)).be.null();
     should(await this.integerAsIntervalOfIntegers.exec(this.ctx)).be.null();

--- a/test/should-extensions.ts
+++ b/test/should-extensions.ts
@@ -1,0 +1,16 @@
+import should from 'should';
+import { Interval } from '../src/datatypes/interval';
+
+declare module 'should' {
+  interface Assertion {
+    equalInterval(expected: Interval): this;
+  }
+}
+
+(should as any).Assertion.add('equalInterval', function (this: any, expected: Interval) {
+  this.params = { operator: 'to equal interval', expected };
+
+  should(this.obj?.isInterval).be.ok();
+  should(expected?.isInterval).be.ok();
+  this.obj.toClosed().should.eql(expected.toClosed());
+});

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
@@ -1426,9 +1426,11 @@ define "ProperContains": Tuple{
     output: true
   },
   "TimeProperContainsFalse": Tuple{
+    skipped: 'Wrong output: According to spec, a contained point is properly contained as long as the interval is not a unit interval'
+    /*
     expression: Interval[@T12:00:00.000, @T21:59:59.999] properly includes @T12:00:00.000,
     output: false
-  },
+    */  },
   "TimeProperContainsNull": Tuple{
     expression: Interval[@T12:00:00.001, @T21:59:59.999] properly includes @T12:00:00,
     output: null
@@ -1438,9 +1440,11 @@ define "ProperContains": Tuple{
     output: true
   },
   "TimeProperContainsPrecisionFalse": Tuple{
+    skipped: 'Wrong output: According to spec, a contained point is properly contained as long as the interval is not a unit interval'
+    /*
     expression: Interval[@T12:00:00.001, @T21:59:59.999] properly includes second of @T12:00:00,
     output: false
-  },
+    */  },
   "TimeProperContainsPrecisionNull": Tuple{
     expression: Interval[@T12:00:00.001, @T21:59:59.999] properly includes millisecond of @T12:00:00,
     output: null
@@ -1453,9 +1457,11 @@ define "ProperIn": Tuple{
     output: true
   },
   "TimeProperInFalse": Tuple{
+    skipped: 'Wrong output: According to spec, a contained point is properly in as long as the interval is not a unit interval'
+    /*
     expression: @T12:00:00.000 properly included in  Interval[@T12:00:00.000, @T21:59:59.999],
     output: false
-  },
+    */  },
   "TimeProperInNull": Tuple{
     expression: @T12:00:00 properly included in Interval[@T12:00:00.001, @T21:59:59.999],
     output: null
@@ -1465,9 +1471,11 @@ define "ProperIn": Tuple{
     output: true
   },
   "TimeProperInPrecisionFalse": Tuple{
+    skipped: 'Wrong output: According to spec, a contained point is properly in as long as the interval is not a unit interval'
+    /*
     expression: @T12:00:00 properly included in second of Interval[@T12:00:00.001, @T21:59:59.999],
     output: false
-  },
+    */  },
   "TimeProperInPrecisionNull": Tuple{
     expression: @T12:00:00 properly included in millisecond of Interval[@T12:00:00.001, @T21:59:59.999],
     output: null

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
@@ -1601,9 +1601,11 @@ define "Start": Tuple{
 
 define "Starts": Tuple{
   "TestStartsNull": Tuple{
+    skipped: 'Wrong answer (Interval[null, null] can only start Interval[null, null])'
+    /*
     expression: Interval[null, null] starts Interval[1, 10],
     output: null
-  },
+    */  },
   "IntegerIntervalStartsTrue": Tuple{
     expression: Interval[4, 10] starts Interval[4, 15],
     output: true

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
@@ -327,7 +327,7 @@ define "Expand": Tuple{
     output: { }
   },
   "ExpandPer0D1": Tuple{
-    skipped: 'Translation Error: Could not resolve call to operator Expand with signature (list<interval<System.Integer>>,System.Decimal).'
+    skipped: 'Wrong answer (interval elements\'s decimals do not match expected output)'
     /*
     expression: expand { Interval[10, 10] } per 0.1,
     output: { Interval[10.0, 10.0], Interval[10.1, 10.1], Interval[10.2, 10.2], Interval[10.3, 10.3], Interval[10.4, 10.4], Interval[10.5, 10.5], Interval[10.6, 10.6], Interval[10.7, 10.7], Interval[10.8, 10.8], Interval[10.9, 10.9] }
@@ -572,11 +572,9 @@ define "Except": Tuple{
     output: null
   },
   "DecimalIntervalExcept1to3": Tuple{
-    skipped: 'Expected Interval[1.0, 3.99999999] but got Interval[1.0, 4) (closed boundary vs equivalent open boundary)'
-    /*
     expression: Interval[1.0, 10.0] except Interval[4.0, 10.0],
     output: Interval [ 1.0, 3.99999999 ]
-    */  },
+  },
   "DecimalIntervalExceptNull": Tuple{
     expression: Interval[1.0, 10.0] except Interval[3.0, 7.0],
     output: null
@@ -1140,11 +1138,9 @@ define "OnOrBefore": Tuple{
 
 define "Overlaps": Tuple{
   "TestOverlapsNull": Tuple{
-    skipped: 'Wrong answer (Interval[null, null] should overlap everything)'
-    /*
     expression: Interval[null, null] overlaps Interval[1, 10],
     output: null
-    */  },
+  },
   "IntegerIntervalOverlapsTrue": Tuple{
     expression: Interval[1, 10] overlaps Interval[4, 10],
     output: true
@@ -1249,11 +1245,9 @@ define "Overlaps": Tuple{
 
 define "OverlapsBefore": Tuple{
   "TestOverlapsBeforeNull": Tuple{
-    skipped: 'Wrong answer (Interval[null, null] should overlap before anything but another interval w/ null low closed boundary)'
-    /*
     expression: Interval[null, null] overlaps before Interval[1, 10],
     output: null
-    */  },
+  },
   "IntegerIntervalOverlapsBeforeTrue": Tuple{
     expression: Interval[1, 10] overlaps before Interval[4, 10],
     output: true
@@ -1326,11 +1320,9 @@ define "OverlapsBefore": Tuple{
 
 define "OverlapsAfter": Tuple{
   "TestOverlapsAfterNull": Tuple{
-    skipped: 'Wrong answer (Interval[null, null] should overlap after anything but another interval w/ null high closed boundary)'
-    /*
     expression: Interval[null, null] overlaps after Interval[1, 10],
     output: null
-    */  },
+  },
   "IntegerIntervalOverlapsAfterTrue": Tuple{
     expression: Interval[4, 15] overlaps after Interval[1, 10],
     output: true
@@ -1601,11 +1593,9 @@ define "Start": Tuple{
 
 define "Starts": Tuple{
   "TestStartsNull": Tuple{
-    skipped: 'Wrong answer (Interval[null, null] can only start Interval[null, null])'
-    /*
     expression: Interval[null, null] starts Interval[1, 10],
     output: null
-    */  },
+  },
   "IntegerIntervalStartsTrue": Tuple{
     expression: Interval[4, 10] starts Interval[4, 15],
     output: true
@@ -1650,11 +1640,9 @@ define "Starts": Tuple{
 
 define "Union": Tuple{
   "TestUnionNull": Tuple{
-    skipped: 'Wrong answer (Interval[null, null] union any valid interval of the same point type is Interval[null, null])'
-    /*
     expression: Interval[null, null] union Interval[1, 10],
     output: null
-    */  },
+  },
   "IntegerIntervalUnion1To15": Tuple{
     expression: Interval[1, 10] union Interval[4, 15],
     output: Interval [ 1, 15 ]

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.json
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.json
@@ -17808,7 +17808,7 @@
                         "type": "Literal",
                         "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
                         "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "Translation Error: Could not resolve call to operator Expand with signature (list<interval<System.Integer>>,System.Decimal).",
+                        "value": "Wrong answer (interval elements's decimals do not match expected output)",
                         "annotation": []
                       }
                     }
@@ -27469,12 +27469,29 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
-                        "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
-                        "annotation": []
+                        "type": "IntervalTypeSpecifier",
+                        "annotation": [],
+                        "pointType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Decimal",
+                          "annotation": []
+                        }
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "IntervalTypeSpecifier",
+                        "annotation": [],
+                        "pointType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Decimal",
+                          "annotation": []
+                        }
                       }
                     }
                   ]
@@ -27864,12 +27881,29 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
-                          "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
-                          "annotation": []
+                          "type": "IntervalTypeSpecifier",
+                          "annotation": [],
+                          "pointType": {
+                            "type": "NamedTypeSpecifier",
+                            "name": "{urn:hl7-org:elm-types:r1}Decimal",
+                            "annotation": []
+                          }
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "IntervalTypeSpecifier",
+                          "annotation": [],
+                          "pointType": {
+                            "type": "NamedTypeSpecifier",
+                            "name": "{urn:hl7-org:elm-types:r1}Decimal",
+                            "annotation": []
+                          }
                         }
                       }
                     ]
@@ -28556,25 +28590,141 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
-                          "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
-                          "annotation": []
+                          "type": "IntervalTypeSpecifier",
+                          "annotation": [],
+                          "pointType": {
+                            "type": "NamedTypeSpecifier",
+                            "name": "{urn:hl7-org:elm-types:r1}Decimal",
+                            "annotation": []
+                          }
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "IntervalTypeSpecifier",
+                          "annotation": [],
+                          "pointType": {
+                            "type": "NamedTypeSpecifier",
+                            "name": "{urn:hl7-org:elm-types:r1}Decimal",
+                            "annotation": []
+                          }
                         }
                       }
                     ]
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "value": {
-                        "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "Expected Interval[1.0, 3.99999999] but got Interval[1.0, 4) (closed boundary vs equivalent open boundary)",
-                        "annotation": []
+                        "type": "Except",
+                        "annotation": [],
+                        "resultTypeSpecifier": {
+                          "type": "IntervalTypeSpecifier",
+                          "annotation": [],
+                          "pointType": {
+                            "type": "NamedTypeSpecifier",
+                            "name": "{urn:hl7-org:elm-types:r1}Decimal",
+                            "annotation": []
+                          }
+                        },
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Decimal",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Literal",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Decimal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Decimal",
+                              "value": "1.0",
+                              "annotation": []
+                            },
+                            "high": {
+                              "type": "Literal",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Decimal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Decimal",
+                              "value": "10.0",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Decimal",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Literal",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Decimal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Decimal",
+                              "value": "4.0",
+                              "annotation": []
+                            },
+                            "high": {
+                              "type": "Literal",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Decimal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Decimal",
+                              "value": "10.0",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Interval",
+                        "lowClosed": true,
+                        "highClosed": true,
+                        "annotation": [],
+                        "resultTypeSpecifier": {
+                          "type": "IntervalTypeSpecifier",
+                          "annotation": [],
+                          "pointType": {
+                            "type": "NamedTypeSpecifier",
+                            "name": "{urn:hl7-org:elm-types:r1}Decimal",
+                            "annotation": []
+                          }
+                        },
+                        "low": {
+                          "type": "Literal",
+                          "resultTypeName": "{urn:hl7-org:elm-types:r1}Decimal",
+                          "valueType": "{urn:hl7-org:elm-types:r1}Decimal",
+                          "value": "1.0",
+                          "annotation": []
+                        },
+                        "high": {
+                          "type": "Literal",
+                          "resultTypeName": "{urn:hl7-org:elm-types:r1}Decimal",
+                          "valueType": "{urn:hl7-org:elm-types:r1}Decimal",
+                          "value": "3.99999999",
+                          "annotation": []
+                        }
                       }
                     }
                   ]
@@ -53335,11 +53485,11 @@
                               "annotation": [],
                               "resultTypeSpecifier": {
                                 "type": "IntervalTypeSpecifier",
-                                "localId": "9884",
+                                "localId": "9912",
                                 "annotation": [],
                                 "pointType": {
                                   "type": "NamedTypeSpecifier",
-                                  "localId": "9885",
+                                  "localId": "9913",
                                   "name": "{urn:hl7-org:elm-types:r1}Date",
                                   "annotation": []
                                 }
@@ -55205,11 +55355,11 @@
                               "annotation": [],
                               "resultTypeSpecifier": {
                                 "type": "IntervalTypeSpecifier",
-                                "localId": "10209",
+                                "localId": "10237",
                                 "annotation": [],
                                 "pointType": {
                                   "type": "NamedTypeSpecifier",
-                                  "localId": "10210",
+                                  "localId": "10238",
                                   "name": "{urn:hl7-org:elm-types:r1}Date",
                                   "annotation": []
                                 }
@@ -56498,11 +56648,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -57226,11 +57385,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -57950,11 +58118,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -57962,12 +58139,75 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "value": {
-                        "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "Wrong answer (Interval[null, null] should overlap everything)",
+                        "type": "Overlaps",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "high": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Literal",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "1",
+                              "annotation": []
+                            },
+                            "high": {
+                              "type": "Literal",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "10",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Null",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -61420,11 +61660,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -61924,11 +62173,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -62424,11 +62682,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -62436,12 +62703,75 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "value": {
-                        "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "Wrong answer (Interval[null, null] should overlap before anything but another interval w/ null low closed boundary)",
+                        "type": "OverlapsBefore",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "high": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Literal",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "1",
+                              "annotation": []
+                            },
+                            "high": {
+                              "type": "Literal",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "10",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Null",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -64716,11 +65046,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -65220,11 +65559,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -65720,11 +66068,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -65732,12 +66089,75 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "value": {
-                        "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "Wrong answer (Interval[null, null] should overlap after anything but another interval w/ null high closed boundary)",
+                        "type": "OverlapsAfter",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "high": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Literal",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "1",
+                              "annotation": []
+                            },
+                            "high": {
+                              "type": "Literal",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "10",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Null",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -76364,11 +76784,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -76672,11 +77101,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -76976,11 +77414,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -76988,12 +77435,75 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "value": {
-                        "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "Wrong answer (Interval[null, null] can only start Interval[null, null])",
+                        "type": "Starts",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "high": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Literal",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "1",
+                              "annotation": []
+                            },
+                            "high": {
+                              "type": "Literal",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "10",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Null",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -78484,11 +78994,24 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "IntervalTypeSpecifier",
+                        "annotation": [],
+                        "pointType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
+                          "annotation": []
+                        }
+                      }
+                    },
+                    {
+                      "name": "output",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -78852,11 +79375,24 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "IntervalTypeSpecifier",
+                          "annotation": [],
+                          "pointType": {
+                            "type": "NamedTypeSpecifier",
+                            "name": "{urn:hl7-org:elm-types:r1}Any",
+                            "annotation": []
+                          }
+                        }
+                      },
+                      {
+                        "name": "output",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -79216,11 +79752,24 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "IntervalTypeSpecifier",
+                          "annotation": [],
+                          "pointType": {
+                            "type": "NamedTypeSpecifier",
+                            "name": "{urn:hl7-org:elm-types:r1}Any",
+                            "annotation": []
+                          }
+                        }
+                      },
+                      {
+                        "name": "output",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -79228,12 +79777,83 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "value": {
-                        "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "Wrong answer (Interval[null, null] union any valid interval of the same point type is Interval[null, null])",
+                        "type": "Union",
+                        "annotation": [],
+                        "resultTypeSpecifier": {
+                          "type": "IntervalTypeSpecifier",
+                          "annotation": [],
+                          "pointType": {
+                            "type": "NamedTypeSpecifier",
+                            "name": "{urn:hl7-org:elm-types:r1}Any",
+                            "annotation": []
+                          }
+                        },
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "high": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Literal",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "1",
+                              "annotation": []
+                            },
+                            "high": {
+                              "type": "Literal",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "10",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Null",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -81526,11 +82146,11 @@
                             "annotation": [],
                             "resultTypeSpecifier": {
                               "type": "IntervalTypeSpecifier",
-                              "localId": "15127",
+                              "localId": "15240",
                               "annotation": [],
                               "pointType": {
                                 "type": "NamedTypeSpecifier",
-                                "localId": "15128",
+                                "localId": "15241",
                                 "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.json
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.json
@@ -68772,20 +68772,11 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "expression",
+                      "name": "skipped",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "annotation": []
-                      }
-                    },
-                    {
-                      "name": "output",
-                      "annotation": [],
-                      "elementType": {
-                        "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "name": "{urn:hl7-org:elm-types:r1}String",
                         "annotation": []
                       }
                     }
@@ -68856,20 +68847,11 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "expression",
+                      "name": "skipped",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "annotation": []
-                      }
-                    },
-                    {
-                      "name": "output",
-                      "annotation": [],
-                      "elementType": {
-                        "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "name": "{urn:hl7-org:elm-types:r1}String",
                         "annotation": []
                       }
                     }
@@ -68949,20 +68931,11 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "expression",
+                        "name": "skipped",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
-                          "annotation": []
-                        }
-                      },
-                      {
-                        "name": "output",
-                        "annotation": [],
-                        "elementType": {
-                          "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
                           "annotation": []
                         }
                       }
@@ -69033,20 +69006,11 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "expression",
+                        "name": "skipped",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
-                          "annotation": []
-                        }
-                      },
-                      {
-                        "name": "output",
-                        "annotation": [],
-                        "elementType": {
-                          "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
                           "annotation": []
                         }
                       }
@@ -69253,20 +69217,11 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "expression",
+                        "name": "skipped",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
-                          "annotation": []
-                        }
-                      },
-                      {
-                        "name": "output",
-                        "annotation": [],
-                        "elementType": {
-                          "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
                           "annotation": []
                         }
                       }
@@ -69274,128 +69229,12 @@
                   },
                   "element": [
                     {
-                      "name": "expression",
-                      "value": {
-                        "type": "ProperContains",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "annotation": [],
-                        "signature": [],
-                        "operand": [
-                          {
-                            "type": "Interval",
-                            "lowClosed": true,
-                            "highClosed": true,
-                            "annotation": [],
-                            "resultTypeSpecifier": {
-                              "type": "IntervalTypeSpecifier",
-                              "annotation": [],
-                              "pointType": {
-                                "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}Time",
-                                "annotation": []
-                              }
-                            },
-                            "low": {
-                              "type": "Time",
-                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
-                              "annotation": [],
-                              "signature": [],
-                              "hour": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "12",
-                                "annotation": []
-                              },
-                              "minute": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "0",
-                                "annotation": []
-                              },
-                              "second": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "0",
-                                "annotation": []
-                              },
-                              "millisecond": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "0",
-                                "annotation": []
-                              }
-                            },
-                            "high": {
-                              "type": "Time",
-                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
-                              "annotation": [],
-                              "signature": [],
-                              "hour": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "21",
-                                "annotation": []
-                              },
-                              "minute": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "59",
-                                "annotation": []
-                              },
-                              "second": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "59",
-                                "annotation": []
-                              },
-                              "millisecond": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "999",
-                                "annotation": []
-                              }
-                            }
-                          },
-                          {
-                            "type": "Time",
-                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
-                            "annotation": [],
-                            "signature": [],
-                            "hour": {
-                              "type": "Literal",
-                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                              "value": "12",
-                              "annotation": []
-                            },
-                            "minute": {
-                              "type": "Literal",
-                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                              "value": "0",
-                              "annotation": []
-                            },
-                            "second": {
-                              "type": "Literal",
-                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                              "value": "0",
-                              "annotation": []
-                            },
-                            "millisecond": {
-                              "type": "Literal",
-                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                              "value": "0",
-                              "annotation": []
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "name": "output",
+                      "name": "skipped",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "value": "false",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "Wrong output: According to spec, a contained point is properly contained as long as the interval is not a unit interval",
                         "annotation": []
                       }
                     }
@@ -69717,20 +69556,11 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "expression",
+                        "name": "skipped",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
-                          "annotation": []
-                        }
-                      },
-                      {
-                        "name": "output",
-                        "annotation": [],
-                        "elementType": {
-                          "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
                           "annotation": []
                         }
                       }
@@ -69738,123 +69568,12 @@
                   },
                   "element": [
                     {
-                      "name": "expression",
-                      "value": {
-                        "type": "ProperContains",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "precision": "Second",
-                        "annotation": [],
-                        "signature": [],
-                        "operand": [
-                          {
-                            "type": "Interval",
-                            "lowClosed": true,
-                            "highClosed": true,
-                            "annotation": [],
-                            "resultTypeSpecifier": {
-                              "type": "IntervalTypeSpecifier",
-                              "annotation": [],
-                              "pointType": {
-                                "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}Time",
-                                "annotation": []
-                              }
-                            },
-                            "low": {
-                              "type": "Time",
-                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
-                              "annotation": [],
-                              "signature": [],
-                              "hour": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "12",
-                                "annotation": []
-                              },
-                              "minute": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "0",
-                                "annotation": []
-                              },
-                              "second": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "0",
-                                "annotation": []
-                              },
-                              "millisecond": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "1",
-                                "annotation": []
-                              }
-                            },
-                            "high": {
-                              "type": "Time",
-                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
-                              "annotation": [],
-                              "signature": [],
-                              "hour": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "21",
-                                "annotation": []
-                              },
-                              "minute": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "59",
-                                "annotation": []
-                              },
-                              "second": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "59",
-                                "annotation": []
-                              },
-                              "millisecond": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "999",
-                                "annotation": []
-                              }
-                            }
-                          },
-                          {
-                            "type": "Time",
-                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
-                            "annotation": [],
-                            "signature": [],
-                            "hour": {
-                              "type": "Literal",
-                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                              "value": "12",
-                              "annotation": []
-                            },
-                            "minute": {
-                              "type": "Literal",
-                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                              "value": "0",
-                              "annotation": []
-                            },
-                            "second": {
-                              "type": "Literal",
-                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                              "value": "0",
-                              "annotation": []
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "name": "output",
+                      "name": "skipped",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "value": "false",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "Wrong output: According to spec, a contained point is properly contained as long as the interval is not a unit interval",
                         "annotation": []
                       }
                     }
@@ -70061,20 +69780,11 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "expression",
+                      "name": "skipped",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "annotation": []
-                      }
-                    },
-                    {
-                      "name": "output",
-                      "annotation": [],
-                      "elementType": {
-                        "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "name": "{urn:hl7-org:elm-types:r1}String",
                         "annotation": []
                       }
                     }
@@ -70145,20 +69855,11 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "expression",
+                      "name": "skipped",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "annotation": []
-                      }
-                    },
-                    {
-                      "name": "output",
-                      "annotation": [],
-                      "elementType": {
-                        "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "name": "{urn:hl7-org:elm-types:r1}String",
                         "annotation": []
                       }
                     }
@@ -70238,20 +69939,11 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "expression",
+                        "name": "skipped",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
-                          "annotation": []
-                        }
-                      },
-                      {
-                        "name": "output",
-                        "annotation": [],
-                        "elementType": {
-                          "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
                           "annotation": []
                         }
                       }
@@ -70322,20 +70014,11 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "expression",
+                        "name": "skipped",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
-                          "annotation": []
-                        }
-                      },
-                      {
-                        "name": "output",
-                        "annotation": [],
-                        "elementType": {
-                          "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
                           "annotation": []
                         }
                       }
@@ -70542,20 +70225,11 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "expression",
+                        "name": "skipped",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
-                          "annotation": []
-                        }
-                      },
-                      {
-                        "name": "output",
-                        "annotation": [],
-                        "elementType": {
-                          "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
                           "annotation": []
                         }
                       }
@@ -70563,128 +70237,12 @@
                   },
                   "element": [
                     {
-                      "name": "expression",
-                      "value": {
-                        "type": "ProperIn",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "annotation": [],
-                        "signature": [],
-                        "operand": [
-                          {
-                            "type": "Time",
-                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
-                            "annotation": [],
-                            "signature": [],
-                            "hour": {
-                              "type": "Literal",
-                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                              "value": "12",
-                              "annotation": []
-                            },
-                            "minute": {
-                              "type": "Literal",
-                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                              "value": "0",
-                              "annotation": []
-                            },
-                            "second": {
-                              "type": "Literal",
-                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                              "value": "0",
-                              "annotation": []
-                            },
-                            "millisecond": {
-                              "type": "Literal",
-                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                              "value": "0",
-                              "annotation": []
-                            }
-                          },
-                          {
-                            "type": "Interval",
-                            "lowClosed": true,
-                            "highClosed": true,
-                            "annotation": [],
-                            "resultTypeSpecifier": {
-                              "type": "IntervalTypeSpecifier",
-                              "annotation": [],
-                              "pointType": {
-                                "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}Time",
-                                "annotation": []
-                              }
-                            },
-                            "low": {
-                              "type": "Time",
-                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
-                              "annotation": [],
-                              "signature": [],
-                              "hour": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "12",
-                                "annotation": []
-                              },
-                              "minute": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "0",
-                                "annotation": []
-                              },
-                              "second": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "0",
-                                "annotation": []
-                              },
-                              "millisecond": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "0",
-                                "annotation": []
-                              }
-                            },
-                            "high": {
-                              "type": "Time",
-                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
-                              "annotation": [],
-                              "signature": [],
-                              "hour": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "21",
-                                "annotation": []
-                              },
-                              "minute": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "59",
-                                "annotation": []
-                              },
-                              "second": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "59",
-                                "annotation": []
-                              },
-                              "millisecond": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "999",
-                                "annotation": []
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "name": "output",
+                      "name": "skipped",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "value": "false",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "Wrong output: According to spec, a contained point is properly in as long as the interval is not a unit interval",
                         "annotation": []
                       }
                     }
@@ -71006,20 +70564,11 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "expression",
+                        "name": "skipped",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
-                          "annotation": []
-                        }
-                      },
-                      {
-                        "name": "output",
-                        "annotation": [],
-                        "elementType": {
-                          "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
                           "annotation": []
                         }
                       }
@@ -71027,123 +70576,12 @@
                   },
                   "element": [
                     {
-                      "name": "expression",
-                      "value": {
-                        "type": "ProperIn",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "precision": "Second",
-                        "annotation": [],
-                        "signature": [],
-                        "operand": [
-                          {
-                            "type": "Time",
-                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
-                            "annotation": [],
-                            "signature": [],
-                            "hour": {
-                              "type": "Literal",
-                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                              "value": "12",
-                              "annotation": []
-                            },
-                            "minute": {
-                              "type": "Literal",
-                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                              "value": "0",
-                              "annotation": []
-                            },
-                            "second": {
-                              "type": "Literal",
-                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                              "value": "0",
-                              "annotation": []
-                            }
-                          },
-                          {
-                            "type": "Interval",
-                            "lowClosed": true,
-                            "highClosed": true,
-                            "annotation": [],
-                            "resultTypeSpecifier": {
-                              "type": "IntervalTypeSpecifier",
-                              "annotation": [],
-                              "pointType": {
-                                "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}Time",
-                                "annotation": []
-                              }
-                            },
-                            "low": {
-                              "type": "Time",
-                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
-                              "annotation": [],
-                              "signature": [],
-                              "hour": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "12",
-                                "annotation": []
-                              },
-                              "minute": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "0",
-                                "annotation": []
-                              },
-                              "second": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "0",
-                                "annotation": []
-                              },
-                              "millisecond": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "1",
-                                "annotation": []
-                              }
-                            },
-                            "high": {
-                              "type": "Time",
-                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
-                              "annotation": [],
-                              "signature": [],
-                              "hour": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "21",
-                                "annotation": []
-                              },
-                              "minute": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "59",
-                                "annotation": []
-                              },
-                              "second": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "59",
-                                "annotation": []
-                              },
-                              "millisecond": {
-                                "type": "Literal",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "999",
-                                "annotation": []
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "name": "output",
+                      "name": "skipped",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "value": "false",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "Wrong output: According to spec, a contained point is properly in as long as the interval is not a unit interval",
                         "annotation": []
                       }
                     }
@@ -82146,11 +81584,11 @@
                             "annotation": [],
                             "resultTypeSpecifier": {
                               "type": "IntervalTypeSpecifier",
-                              "localId": "15240",
+                              "localId": "15142",
                               "annotation": [],
                               "pointType": {
                                 "type": "NamedTypeSpecifier",
-                                "localId": "15241",
+                                "localId": "15143",
                                 "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.json
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.json
@@ -76364,20 +76364,11 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "expression",
+                      "name": "skipped",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "annotation": []
-                      }
-                    },
-                    {
-                      "name": "output",
-                      "annotation": [],
-                      "elementType": {
-                        "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}Any",
+                        "name": "{urn:hl7-org:elm-types:r1}String",
                         "annotation": []
                       }
                     }
@@ -76681,20 +76672,11 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "expression",
+                        "name": "skipped",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
-                          "annotation": []
-                        }
-                      },
-                      {
-                        "name": "output",
-                        "annotation": [],
-                        "elementType": {
-                          "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Any",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
                           "annotation": []
                         }
                       }
@@ -76994,20 +76976,11 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "expression",
+                        "name": "skipped",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
-                          "annotation": []
-                        }
-                      },
-                      {
-                        "name": "output",
-                        "annotation": [],
-                        "elementType": {
-                          "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}Any",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
                           "annotation": []
                         }
                       }
@@ -77015,75 +76988,12 @@
                   },
                   "element": [
                     {
-                      "name": "expression",
+                      "name": "skipped",
                       "value": {
-                        "type": "Starts",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
-                        "annotation": [],
-                        "signature": [],
-                        "operand": [
-                          {
-                            "type": "Interval",
-                            "lowClosed": true,
-                            "highClosed": true,
-                            "annotation": [],
-                            "resultTypeSpecifier": {
-                              "type": "IntervalTypeSpecifier",
-                              "annotation": [],
-                              "pointType": {
-                                "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}Any",
-                                "annotation": []
-                              }
-                            },
-                            "low": {
-                              "type": "Null",
-                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
-                              "annotation": []
-                            },
-                            "high": {
-                              "type": "Null",
-                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
-                              "annotation": []
-                            }
-                          },
-                          {
-                            "type": "Interval",
-                            "lowClosed": true,
-                            "highClosed": true,
-                            "annotation": [],
-                            "resultTypeSpecifier": {
-                              "type": "IntervalTypeSpecifier",
-                              "annotation": [],
-                              "pointType": {
-                                "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}Integer",
-                                "annotation": []
-                              }
-                            },
-                            "low": {
-                              "type": "Literal",
-                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                              "value": "1",
-                              "annotation": []
-                            },
-                            "high": {
-                              "type": "Literal",
-                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                              "value": "10",
-                              "annotation": []
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "name": "output",
-                      "value": {
-                        "type": "Null",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "Wrong answer (Interval[null, null] can only start Interval[null, null])",
                         "annotation": []
                       }
                     }
@@ -81616,11 +81526,11 @@
                             "annotation": [],
                             "resultTypeSpecifier": {
                               "type": "IntervalTypeSpecifier",
-                              "localId": "15143",
+                              "localId": "15127",
                               "annotation": [],
                               "pointType": {
                                 "type": "NamedTypeSpecifier",
-                                "localId": "15144",
+                                "localId": "15128",
                                 "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }

--- a/test/spec-tests/cql/CqlListOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlListOperatorsTest.cql
@@ -943,65 +943,45 @@ define "Skip": Tuple{
 
 define "Slice": Tuple{
   "SliceAll": Tuple{
-    skipped: 'Slice not implemented'
-    /*
     expression: Slice({ 1, 2, 3, 4, 5 }),
     output: { 1, 2, 3, 4, 5 }
-    */  },
+  },
   "SliceEmpty": Tuple{
-    skipped: 'Slice not implemented'
-    /*
     expression: Slice({ }),
     output: { }
-    */  },
+  },
   "SliceNull": Tuple{
-    skipped: 'Slice not implemented'
-    /*
     expression: Slice(null),
     output: null
-    */  },
+  },
   "SliceStart": Tuple{
-    skipped: 'Slice not implemented'
-    /*
     expression: Slice({ 1, 2, 3, 4, 5 }, 1),
     output: { 2, 3, 4, 5 }
-    */  },
+  },
   "SliceStartNull": Tuple{
-    skipped: 'Slice not implemented'
-    /*
     expression: Slice({ 1, 2, 3, 4, 5 }, null),
     output: { 1, 2, 3, 4, 5 }
-    */  },
+  },
   "SliceEnd": Tuple{
-    skipped: 'Slice not implemented'
-    /*
     expression: Slice({ 1, 2, 3, 4, 5 }, 1, 3),
     output: { 2, 3 }
-    */  },
+  },
   "SliceEndNull": Tuple{
-    skipped: 'Slice not implemented'
-    /*
     expression: Slice({ 1, 2, 3, 4, 5 }, 1, null),
     output: { 2, 3, 4, 5 }
-    */  },
+  },
   "SliceNegative": Tuple{
-    skipped: 'Slice not implemented'
-    /*
     expression: Slice({ 1, 2, 3, 4, 5 }, -2),
     output: { 4, 5 }
-    */  },
+  },
   "SliceStartAndNegative": Tuple{
-    skipped: 'Slice not implemented'
-    /*
     expression: Slice({ 1, 2, 3, 4, 5 }, 1, -1),
     output: { 2, 3, 4 }
-    */  },
+  },
   "SlicePast": Tuple{
-    skipped: 'Slice not implemented'
-    /*
     expression: Slice({ 1, 2, 3, 4, 5 }, 5),
     output: { }
-    */  }
+  }
 }
 
 define "Tail": Tuple{

--- a/test/spec-tests/cql/ValueLiteralsAndSelectors.cql
+++ b/test/spec-tests/cql/ValueLiteralsAndSelectors.cql
@@ -265,11 +265,9 @@ define "Decimal": Tuple{
     output: 9999999999999999999999999999.99999999
     */  },
   "DecimalNeg10Pow28ToZeroOneStepDecimalMinValue": Tuple{
-    skipped: 'Wrong answer (null vs big number)'
-    /*
     expression: -10*1000000000000000000000000000.00000000+0.00000001,
     output: -9999999999999999999999999999.99999999
-    */  },
+  },
   "Decimal10Pow28": Tuple{
     expression: 10000000000000000000000000000.00000000,
     invalid: true

--- a/test/spec-tests/cql/ValueLiteralsAndSelectors.json
+++ b/test/spec-tests/cql/ValueLiteralsAndSelectors.json
@@ -4150,11 +4150,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Decimal",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Decimal",
                         "annotation": []
                       }
                     }
@@ -5308,11 +5317,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Decimal",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Decimal",
                           "annotation": []
                         }
                       }
@@ -8317,11 +8335,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Decimal",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Decimal",
                           "annotation": []
                         }
                       }
@@ -8329,13 +8356,70 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "value": {
-                        "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "Wrong answer (null vs big number)",
-                        "annotation": []
+                        "type": "Add",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Decimal",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Multiply",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Decimal",
+                            "annotation": [],
+                            "signature": [],
+                            "operand": [
+                              {
+                                "type": "ToDecimal",
+                                "annotation": [],
+                                "signature": [],
+                                "operand": {
+                                  "type": "Negate",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "annotation": [],
+                                  "signature": [],
+                                  "operand": {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value": "10",
+                                    "annotation": []
+                                  }
+                                }
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Decimal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Decimal",
+                                "value": "1000000000000000000000000000.00000000",
+                                "annotation": []
+                              }
+                            ]
+                          },
+                          {
+                            "type": "Literal",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Decimal",
+                            "valueType": "{urn:hl7-org:elm-types:r1}Decimal",
+                            "value": "0.00000001",
+                            "annotation": []
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Negate",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Decimal",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": {
+                          "type": "Literal",
+                          "resultTypeName": "{urn:hl7-org:elm-types:r1}Decimal",
+                          "valueType": "{urn:hl7-org:elm-types:r1}Decimal",
+                          "value": "9999999999999999999999999999.99999999",
+                          "annotation": []
+                        }
                       }
                     }
                   ]

--- a/test/spec-tests/skip-list.txt
+++ b/test/spec-tests/skip-list.txt
@@ -1,5 +1,4 @@
 # Invalid CQL (does not translate)
-CqlIntervalOperatorsTest.Expand.ExpandPer0D1        Translation Error: Could not resolve call to operator Expand with signature (list<interval<System.Integer>>,System.Decimal).
 
 # Invalid Translation (translates, but translates wrong)
 CqlAggregateTest.AggregateTests.RolledOutIntervals  CQL adds an integer to a date ("S + duration in days of X"). Should be "S + Quantity{ value: duration in days of X, unit: 'days' }". Translator translates it, but probably shouldn't.
@@ -16,7 +15,6 @@ CqlListOperatorsTest.Sort.simpleSortDesc                        Wrong output: Qu
 "CqlStringOperatorsTest.toString tests.DateTimeToString2"         Answer does not include timezone offset, but default offset depends on test environment
 
 # Equivalent answer but represented differently than expected output
-CqlIntervalOperatorsTest.Except.DecimalIntervalExcept1to3       Expected Interval[1.0, 3.99999999] but got Interval[1.0, 4) (closed boundary vs equivalent open boundary)
 
 # Incorrect answer
 CqlComparisonOperatorsTest.Equal.DateTimeEqNull                 Wrong answer (true vs null - due to not evaluating DateTime(null) as null)
@@ -31,23 +29,18 @@ CqlIntervalOperatorsTest.Expand.ExpandListWithNull                        Wrong 
 CqlIntervalOperatorsTest.Expand.ExpandPerDayIntervalOverload              Wrong answer (single interval overload should return list of points)
 CqlIntervalOperatorsTest.Expand.ExpandPerHourIntervalOverload             Wrong answer (single interval overload should return list of points)
 CqlIntervalOperatorsTest.Expand.ExpandPerHourOpenIntervalOverload         Wrong answer (single interval overload should return list of points)
+CqlIntervalOperatorsTest.Expand.ExpandPer0D1                              Wrong answer (interval elements's decimals do not match expected output)
 CqlIntervalOperatorsTest.Expand.ExpandPer0D1IntervalOverload              Wrong answer (single interval overload should return list of points)
 CqlIntervalOperatorsTest.Expand.ExpandPer1IntervalOverload                Wrong answer (single interval overload should return list of points)
 CqlIntervalOperatorsTest.Expand.ExpandPer1OpenIntervalOverload            Wrong answer (single interval overload should return list of points)
 CqlIntervalOperatorsTest.Expand.ExpandPer2DaysIntervalOverload            Wrong answer (single interval overload should return list of points)
 CqlIntervalOperatorsTest.Intersect.TestIntersectNull            Wrong answer (Interval[5, 10] vs Interval[5, null))
-CqlIntervalOperatorsTest.Overlaps.TestOverlapsNull              Wrong answer (Interval[null, null] should overlap everything)
-CqlIntervalOperatorsTest.OverlapsBefore.TestOverlapsBeforeNull  Wrong answer (Interval[null, null] should overlap before anything but another interval w/ null low closed boundary)
-CqlIntervalOperatorsTest.OverlapsAfter.TestOverlapsAfterNull    Wrong answer (Interval[null, null] should overlap after anything but another interval w/ null high closed boundary)
-CqlIntervalOperatorsTest.Starts.TestStartsNull                  Wrong answer (Interval[null, null] can only start Interval[null, null])
-CqlIntervalOperatorsTest.Union.TestUnionNull                    Wrong answer (Interval[null, null] union any valid interval of the same point type is Interval[null, null])
 CqlTypeOperatorsTest.Convert.StringToDateTime                   Wrong answer (different offsets)
 CqlTypeOperatorsTest.ToDateTime.ToDateTime1                     Wrong answer (different offsets)
 CqlTypeOperatorsTest.ToDateTime.ToDateTime2                     Wrong answer (different offsets)
 CqlTypeOperatorsTest.ToDateTime.ToDateTime3                     Wrong answer (different offsets)
 ValueLiteralsAndSelectors.Decimal.Decimal10Pow28ToZeroOneStepDecimalMaxValue    Wrong answer (null vs big number)
 ValueLiteralsAndSelectors.Decimal.DecimalPos10Pow28ToZeroOneStepDecimalMaxValue Wrong answer (null vs big number)
-ValueLiteralsAndSelectors.Decimal.DecimalNeg10Pow28ToZeroOneStepDecimalMinValue Wrong answer (null vs big number)
 
 # Unimplemented
 CqlArithmeticFunctionsTest.HighBoundary                 HighBoundary not implemented
@@ -64,4 +57,3 @@ CqlArithmeticFunctionsTest.Modulo.Modulo10By3Quantity                 Modulo not
 "CqlArithmeticFunctionsTest.Truncated Divide.TruncatedDivide414By206DQuantity"        Truncated divide not implemented for Quantity
 
 # Unimplemented (New in CQL 2.0)
-CqlListOperatorsTest.Slice                              Slice not implemented

--- a/test/spec-tests/skip-list.txt
+++ b/test/spec-tests/skip-list.txt
@@ -39,6 +39,7 @@ CqlIntervalOperatorsTest.Intersect.TestIntersectNull            Wrong answer (In
 CqlIntervalOperatorsTest.Overlaps.TestOverlapsNull              Wrong answer (Interval[null, null] should overlap everything)
 CqlIntervalOperatorsTest.OverlapsBefore.TestOverlapsBeforeNull  Wrong answer (Interval[null, null] should overlap before anything but another interval w/ null low closed boundary)
 CqlIntervalOperatorsTest.OverlapsAfter.TestOverlapsAfterNull    Wrong answer (Interval[null, null] should overlap after anything but another interval w/ null high closed boundary)
+CqlIntervalOperatorsTest.Starts.TestStartsNull                  Wrong answer (Interval[null, null] can only start Interval[null, null])
 CqlIntervalOperatorsTest.Union.TestUnionNull                    Wrong answer (Interval[null, null] union any valid interval of the same point type is Interval[null, null])
 CqlTypeOperatorsTest.Convert.StringToDateTime                   Wrong answer (different offsets)
 CqlTypeOperatorsTest.ToDateTime.ToDateTime1                     Wrong answer (different offsets)

--- a/test/spec-tests/skip-list.txt
+++ b/test/spec-tests/skip-list.txt
@@ -3,10 +3,12 @@
 # Invalid Translation (translates, but translates wrong)
 CqlAggregateTest.AggregateTests.RolledOutIntervals  CQL adds an integer to a date ("S + duration in days of X"). Should be "S + Quantity{ value: duration in days of X, unit: 'days' }". Translator translates it, but probably shouldn't.
 
-# Potentially Invalid Translation (translates, but potentially translates wrong)
-
 # Incorrect Expected Output
 CqlIntervalOperatorsTest.In.TestInNullBoundaries                Wrong output: According to spec, comparison against null closed boundaries should result in true
+CqlIntervalOperatorsTest.ProperContains.TimeProperContainsPrecisionFalse  Wrong output: According to spec, a contained point is properly contained as long as the interval is not a unit interval
+CqlIntervalOperatorsTest.ProperContains.TimeProperContainsFalse Wrong output: According to spec, a contained point is properly contained as long as the interval is not a unit interval
+CqlIntervalOperatorsTest.ProperIn.TimeProperInPrecisionFalse    Wrong output: According to spec, a contained point is properly in as long as the interval is not a unit interval
+CqlIntervalOperatorsTest.ProperIn.TimeProperInFalse             Wrong output: According to spec, a contained point is properly in as long as the interval is not a unit interval
 CqlListOperatorsTest.Equal.EqualNullNull                        Wrong output: According to spec, if either list contains a null, the result is null
 CqlListOperatorsTest.Sort.simpleSortAsc                         Wrong output: Queries return distinct lists by default; need to use "all" to retain duplicates
 CqlListOperatorsTest.Sort.simpleSortDesc                        Wrong output: Queries return distinct lists by default; need to use "all" to retain duplicates

--- a/test/spec-tests/spec-test.ts
+++ b/test/spec-tests/spec-test.ts
@@ -52,42 +52,59 @@ describe('CQL Spec Tests (from XML)', () => {
                 const ctx = new PatientContext(library);
                 ctx.getExecutionDateTime().timezoneOffset = 0;
                 const actualExp = build(testCaseMap.get('expression')) as any;
-                let actual = await actualExp.execute(ctx);
+                const actual = await actualExp.execute(ctx);
                 const expectedExp = build(testCaseMap.get('output')) as any;
-                let expected = await expectedExp.execute(ctx);
-                if (expectedExp.json && expectedExp.json.type === 'Null') {
-                  should(actual).be.null();
-                } else if (actual && actual.isInterval && expected && expected.isInterval) {
-                  // Since intervals can be semantically equal w/ different representations, fall back on Interval.equal function.
-                  // E.g., Interval[1,3] == Interval[1,4)
-                  if (!actual.equals(expected)) {
-                    should.fail(actual, expected, 'Intervals are not equal');
-                  }
-                } else if (
-                  actual &&
-                  actual.isUncertainty &&
-                  expected &&
-                  expected.isInterval &&
-                  expected.highClosed &&
-                  expected.lowClosed
-                ) {
-                  // Since there is no literal representation of Uncertainty, the test framework used Interval.
-                  // Switch it back to an uncertainty.
-                  expected = new Uncertainty(expected.low, expected.high);
-                  actual.should.eql(expected);
-                } else {
-                  // The tests are somewhat inconsistent w/ number of decimal places used.
-                  // To get consistency (and avoid false negatives), always round to 8 places.
-                  actual = roundDecimalsWhenApplicable(actual);
-                  expected = roundDecimalsWhenApplicable(expected);
-                  if (actual == null) {
-                    should.deepEqual(actual, expected);
-                  } else {
-                    actual.should.eql(expected);
-                  }
-                }
+                const expected = await expectedExp.execute(ctx);
+                assertEqual(actual, expected, expectedExp);
               }
             });
+
+            function assertEqual(actual: any, expected: any, expectedExp?: any) {
+              if (expectedExp?.json?.type === 'Null') {
+                should(actual).be.null();
+              } else if (actual && actual.isInterval && expected && expected.isInterval) {
+                // Since intervals can be semantically equal w/ different representations, fall back on Interval.equal function.
+                // E.g., Interval[1,3] == Interval[1,4)
+                if (!actual.equals(expected)) {
+                  should.fail(actual, expected, 'Intervals are not equal');
+                }
+              } else if (
+                actual &&
+                actual.isUncertainty &&
+                expected &&
+                expected.isInterval &&
+                expected.highClosed &&
+                expected.lowClosed
+              ) {
+                // Since there is no literal representation of Uncertainty, the test framework used Interval.
+                // Switch it back to an uncertainty.
+                expected = new Uncertainty(expected.low, expected.high);
+                actual.should.eql(expected);
+              } else if (
+                Array.isArray(actual) &&
+                Array.isArray(expected) &&
+                actual.length === expected.length
+              ) {
+                try {
+                  for (let i = 0; i < actual.length; i++) {
+                    assertEqual(actual[i], expected[i]);
+                  }
+                } catch {
+                  should.fail(actual, expected, 'Lists are not equal');
+                }
+              } else {
+                // The tests are somewhat inconsistent w/ number of decimal places used.
+                // To get consistency (and avoid false negatives), always round to 8 places.
+                actual = roundDecimalsWhenApplicable(actual);
+                expected = roundDecimalsWhenApplicable(expected);
+                if (actual == null) {
+                  should.deepEqual(actual, expected);
+                } else {
+                  actual.should.eql(expected);
+                }
+              }
+              return { actual, expected };
+            }
           });
         });
       });

--- a/test/util/comparison-test.ts
+++ b/test/util/comparison-test.ts
@@ -1,6 +1,7 @@
 import should from 'should';
 import { Date as CQLDate, DateTime as CQLDateTime } from '../../src/datatypes/datetime';
 import { Quantity } from '../../src/datatypes/quantity';
+import { Uncertainty } from '../../src/datatypes/uncertainty';
 import {
   equals,
   equivalent,
@@ -400,5 +401,47 @@ describe('comparison helpers', () => {
         should(greaterThanOrEquals(low, high)).be.false();
       });
     });
+  });
+
+  it('should use precision when comparing uncertainties', () => {
+    const first = new Uncertainty(
+      CQLDateTime.parse('2022-01-01T12:30:15.123'),
+      CQLDateTime.parse('2022-01-01T12:30:15.124')
+    );
+    const second = new Uncertainty(
+      CQLDateTime.parse('2022-01-01T12:30:15.125'),
+      CQLDateTime.parse('2022-01-01T12:30:15.126')
+    );
+
+    lessThan(first, second, CQLDateTime.Unit.MILLISECOND).should.be.true();
+    lessThan(first, second, CQLDateTime.Unit.SECOND).should.be.false();
+    greaterThan(second, first, CQLDateTime.Unit.MILLISECOND).should.be.true();
+    greaterThan(second, first, CQLDateTime.Unit.SECOND).should.be.false();
+    lessThanOrEquals(second, first, CQLDateTime.Unit.MILLISECOND).should.be.false();
+    lessThanOrEquals(second, first, CQLDateTime.Unit.SECOND).should.be.true();
+    greaterThanOrEquals(first, second, CQLDateTime.Unit.MILLISECOND).should.be.false();
+    greaterThanOrEquals(first, second, CQLDateTime.Unit.SECOND).should.be.true();
+  });
+
+  it('should use precision when the second argument is an uncertainty', () => {
+    const firstPoint = CQLDateTime.parse('2022-01-01T12:30:15.123');
+    const first = new Uncertainty(
+      CQLDateTime.parse('2022-01-01T12:30:15.123'),
+      CQLDateTime.parse('2022-01-01T12:30:15.124')
+    );
+    const second = new Uncertainty(
+      CQLDateTime.parse('2022-01-01T12:30:15.125'),
+      CQLDateTime.parse('2022-01-01T12:30:15.126')
+    );
+    const secondPoint = CQLDateTime.parse('2022-01-01T12:30:15.127');
+
+    lessThan(firstPoint, second, CQLDateTime.Unit.MILLISECOND).should.be.true();
+    lessThan(firstPoint, second, CQLDateTime.Unit.SECOND).should.be.false();
+    greaterThan(secondPoint, first, CQLDateTime.Unit.MILLISECOND).should.be.true();
+    greaterThan(secondPoint, first, CQLDateTime.Unit.SECOND).should.be.false();
+    lessThanOrEquals(secondPoint, first, CQLDateTime.Unit.MILLISECOND).should.be.false();
+    lessThanOrEquals(secondPoint, first, CQLDateTime.Unit.SECOND).should.be.true();
+    greaterThanOrEquals(firstPoint, second, CQLDateTime.Unit.MILLISECOND).should.be.false();
+    greaterThanOrEquals(firstPoint, second, CQLDateTime.Unit.SECOND).should.be.true();
   });
 });

--- a/test/util/math-test.ts
+++ b/test/util/math-test.ts
@@ -1,5 +1,6 @@
 import { Uncertainty } from '../../src/datatypes/uncertainty';
-import { MAX_FLOAT_VALUE, MIN_FLOAT_VALUE, predecessor, successor } from '../../src/util/math';
+import { MAX_FLOAT_VALUE, MIN_FLOAT_VALUE } from '../../src/util/limits';
+import { predecessor, successor } from '../../src/util/math';
 import { ELM_DECIMAL_TYPE, ELM_INTEGER_TYPE } from '../../src/util/elmTypes';
 
 describe('successor', () => {


### PR DESCRIPTION
Add special case logic for boundless intervals (e.g., `Interval[null, null]`) and  unknown intervals (e.g., `Interval(null, null)`).

When we process an Interval that has both boundaries null, we can't infer the point type since we have no value to infer it from. This caused problems in the existing logic that needs to know the point type for some calculations. To address this, I've added special-case logic for these edge cases since we often don't really need to know the point type to arrive at the correct answer.

I initially tried implementing this by using the point type of the _other_ argument in each operation, but this turned out to be kind of messy and still was not perfect (in particular, it failed tests like `Interval[null, null] overlaps Interval[null, null]`).

My [CQL Long PR](https://github.com/cqframework/cql-execution/pull/363) introduces the approach of using the `resultType` from the ELM when we can't easily infer types from the data. We should extend that to also work in these cases, but since we want to get this fix out ASAP, I decided to implement this approach first. We need this approach regardless since ELM does not always carry the `resultType`.

_NOTE: The CI that runs `npm audit` currently fails, but the reported audit issues are currently not resolvable, so there's not much we can do._

Fixes #364.

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

**Submitter:**

- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name:

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
