### PR TITLE
Safe import for immutable

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -5715,9 +5715,6 @@ exports.Library = Library;
 
 },{"./expressions":23}],28:[function(require,module,exports){
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Slice = exports.Last = exports.First = exports.Current = exports.toDistinctList = exports.Distinct = exports.Flatten = exports.ForEach = exports.IndexOf = exports.ToList = exports.SingletonFrom = exports.Filter = exports.Times = exports.Exists = exports.List = void 0;
 exports.doUnion = doUnion;
@@ -5726,7 +5723,7 @@ exports.doIntersect = doIntersect;
 exports.doContains = doContains;
 exports.doIncludes = doIncludes;
 exports.doProperIncludes = doProperIncludes;
-const immutable_1 = __importDefault(require("immutable"));
+const immutable_1 = require("immutable");
 const comparison_1 = require("../util/comparison");
 const immutableUtil_1 = require("../util/immutableUtil");
 const util_1 = require("../util/util");
@@ -5898,7 +5895,7 @@ class Distinct extends expression_1.Expression {
 exports.Distinct = Distinct;
 const toDistinctList = (list) => {
     const list_keys = list.map(immutableUtil_1.toNormalizedKey);
-    const set = immutable_1.default.Set().asMutable();
+    const set = (0, immutable_1.Set)().asMutable();
     const distinct = [];
     set.withMutations(y => {
         list_keys.forEach((key, i) => {
@@ -9183,13 +9180,10 @@ var __importStar = (this && this.__importStar) || (function () {
         return result;
     };
 })();
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.toNormalizedKey = void 0;
 const ucum = __importStar(require("@lhncbc/ucum-lhc"));
-const immutable_1 = __importDefault(require("immutable"));
+const immutable_1 = require("immutable");
 const datatypes_1 = require("../datatypes/datatypes");
 const math_1 = require("./math");
 const units_1 = require("./units");
@@ -9207,7 +9201,7 @@ const toNormalizedKey = (js) => {
     }
     // Handle the edge case of functions
     if (typeof js === 'function') {
-        return immutable_1.default.Map({
+        return (0, immutable_1.Map)({
             name: js.toString(),
             __instance: 'JS.Function'
         });
@@ -9219,11 +9213,11 @@ const toNormalizedKey = (js) => {
     // Handle objects - normalize as necessary to generate unique keys
     switch (js.constructor) {
         case Array:
-            return immutable_1.default.Seq(js)
+            return (0, immutable_1.Seq)(js)
                 .map((x) => (0, exports.toNormalizedKey)(x))
                 .toList();
         case datatypes_1.Code:
-            return immutable_1.default.Map({
+            return (0, immutable_1.Map)({
                 code: (0, exports.toNormalizedKey)(js.code),
                 system: (0, exports.toNormalizedKey)(js.system),
                 version: (0, exports.toNormalizedKey)(js.version),
@@ -9231,31 +9225,31 @@ const toNormalizedKey = (js) => {
                 __instance: js.constructor
             });
         case Date:
-            return immutable_1.default.Map({
+            return (0, immutable_1.Map)({
                 epochMs: js.getTime(),
                 __instance: js.constructor
             });
         case datatypes_1.DateTime:
             if (typeof js.timezoneOffset === 'number' && js.timezoneOffset !== 0) {
-                return immutable_1.default.Seq(js.convertToTimezoneOffset(0))
+                return (0, immutable_1.Seq)(js.convertToTimezoneOffset(0))
                     .map((x) => (0, exports.toNormalizedKey)(x))
                     .toMap()
                     .set('__instance', js.constructor);
             }
             else {
-                return immutable_1.default.Seq(js)
+                return (0, immutable_1.Seq)(js)
                     .map((x) => (0, exports.toNormalizedKey)(x))
                     .toMap()
                     .set('__instance', js.constructor);
             }
         case datatypes_1.Interval:
-            return immutable_1.default.Seq(js.toClosed())
+            return (0, immutable_1.Seq)(js.toClosed())
                 .map((x) => (0, exports.toNormalizedKey)(x))
                 .toMap()
                 .set('__instance', js.constructor);
         case datatypes_1.Quantity:
             if (!js.unit) {
-                return immutable_1.default.Map({
+                return (0, immutable_1.Map)({
                     value: (_a = js.value) !== null && _a !== void 0 ? _a : null,
                     unit: null,
                     __instance: js.constructor
@@ -9265,7 +9259,7 @@ const toNormalizedKey = (js) => {
             const baseUnitKey = ucumUtilInstance.commensurablesList(js.unit)[0];
             if (!baseUnitKey) {
                 // No units found - normalization not possible and use provided values
-                return immutable_1.default.Map({
+                return (0, immutable_1.Map)({
                     value: (_b = js.value) !== null && _b !== void 0 ? _b : null,
                     unit: (_c = js.unit) !== null && _c !== void 0 ? _c : null,
                     __instance: js.constructor
@@ -9276,20 +9270,20 @@ const toNormalizedKey = (js) => {
                 const baseUnitKeyCode = baseUnitKey[0].csCode_;
                 const conversionValue = (0, units_1.convertUnit)(js.value, js.unit, baseUnitKeyCode);
                 const finalValue = conversionValue ? (0, math_1.decimalAdjust)('round', conversionValue, -8) : null;
-                return immutable_1.default.Map({
+                return (0, immutable_1.Map)({
                     value: finalValue !== null && finalValue !== void 0 ? finalValue : null,
                     unit: baseUnitKeyCode !== null && baseUnitKeyCode !== void 0 ? baseUnitKeyCode : null,
                     __instance: js.constructor
                 });
             }
         case datatypes_1.Ratio:
-            return immutable_1.default.Map({
+            return (0, immutable_1.Map)({
                 numerator: (0, exports.toNormalizedKey)(js.numerator),
                 denominator: (0, exports.toNormalizedKey)(js.denominator),
                 __instance: js.constructor
             });
         case RegExp:
-            return immutable_1.default.Map({
+            return (0, immutable_1.Map)({
                 source: (0, exports.toNormalizedKey)(js.source),
                 global: (0, exports.toNormalizedKey)(js.global),
                 ignoreCase: (0, exports.toNormalizedKey)(js.ignoreCase),
@@ -9301,7 +9295,7 @@ const toNormalizedKey = (js) => {
                 return (0, exports.toNormalizedKey)(js.low);
             }
             else {
-                return immutable_1.default.Seq(js)
+                return (0, immutable_1.Seq)(js)
                     .map((x) => (0, exports.toNormalizedKey)(x))
                     .toMap()
                     .set('__instance', js.constructor);
@@ -9310,7 +9304,7 @@ const toNormalizedKey = (js) => {
             // If the object is a model object (e.g. FHIRObject) with a _typeHierarchy function,
             // then use the typeHierarchy information for the __instance value.
             // Otherwise, use the constructor for the __instance value.
-            return immutable_1.default.Seq(js)
+            return (0, immutable_1.Seq)(js)
                 .map((x) => (0, exports.toNormalizedKey)(x))
                 .toMap()
                 .set('__instance', (_e = (0, exports.toNormalizedKey)((_d = js._typeHierarchy) === null || _d === void 0 ? void 0 : _d.call(js))) !== null && _e !== void 0 ? _e : js.constructor);

--- a/src/elm/list.ts
+++ b/src/elm/list.ts
@@ -1,4 +1,4 @@
-import Immutable from 'immutable';
+import { Set as ImmutableSet } from 'immutable';
 import { Context } from '../runtime/context';
 import { equals } from '../util/comparison';
 import { NormalizedKey, toNormalizedKey } from '../util/immutableUtil';
@@ -188,7 +188,7 @@ export class Distinct extends Expression {
 
 export const toDistinctList = (list: unknown[]): unknown[] => {
   const list_keys = list.map(toNormalizedKey);
-  const set = Immutable.Set<NormalizedKey>().asMutable();
+  const set = ImmutableSet<NormalizedKey>().asMutable();
   const distinct: unknown[] = [];
 
   set.withMutations(y => {

--- a/src/util/immutableUtil.ts
+++ b/src/util/immutableUtil.ts
@@ -1,5 +1,5 @@
 import * as ucum from '@lhncbc/ucum-lhc';
-import { Map as ImmutableMap, Seq as ImmutableSeq } from 'immutable';
+import { type Collection, Map as ImmutableMap, Seq as ImmutableSeq } from 'immutable';
 import { Code, DateTime, Interval, Quantity, Ratio, Uncertainty } from '../datatypes/datatypes';
 import { decimalAdjust } from './math';
 import { convertUnit } from './units';
@@ -7,7 +7,7 @@ import { convertUnit } from './units';
 const ucumUtilInstance = ucum.UcumLhcUtils.getInstance();
 
 type Primitive = string | number | boolean | bigint | symbol | undefined | null;
-export type NormalizedKey = Primitive | Immutable.Collection<NormalizedKey, unknown>;
+export type NormalizedKey = Primitive | Collection<NormalizedKey, unknown>;
 
 /**
  * Provide a unique key for an object to be used for value equality

--- a/src/util/immutableUtil.ts
+++ b/src/util/immutableUtil.ts
@@ -1,5 +1,5 @@
 import * as ucum from '@lhncbc/ucum-lhc';
-import Immutable from 'immutable';
+import { Map as ImmutableMap, Seq as ImmutableSeq } from 'immutable';
 import { Code, DateTime, Interval, Quantity, Ratio, Uncertainty } from '../datatypes/datatypes';
 import { decimalAdjust } from './math';
 import { convertUnit } from './units';
@@ -22,7 +22,7 @@ export const toNormalizedKey = (js: any): NormalizedKey => {
 
   // Handle the edge case of functions
   if (typeof js === 'function') {
-    return Immutable.Map({
+    return ImmutableMap({
       name: js.toString(),
       __instance: 'JS.Function'
     });
@@ -36,12 +36,12 @@ export const toNormalizedKey = (js: any): NormalizedKey => {
   // Handle objects - normalize as necessary to generate unique keys
   switch (js.constructor) {
     case Array:
-      return Immutable.Seq(js)
+      return ImmutableSeq(js)
         .map((x: any) => toNormalizedKey(x))
         .toList();
 
     case Code:
-      return Immutable.Map({
+      return ImmutableMap({
         code: toNormalizedKey(js.code),
         system: toNormalizedKey(js.system),
         version: toNormalizedKey(js.version),
@@ -50,33 +50,33 @@ export const toNormalizedKey = (js: any): NormalizedKey => {
       });
 
     case Date:
-      return Immutable.Map({
+      return ImmutableMap({
         epochMs: js.getTime(),
         __instance: js.constructor
       });
 
     case DateTime:
       if (typeof js.timezoneOffset === 'number' && js.timezoneOffset !== 0) {
-        return Immutable.Seq(js.convertToTimezoneOffset(0))
+        return ImmutableSeq(js.convertToTimezoneOffset(0))
           .map((x: any) => toNormalizedKey(x))
           .toMap()
           .set('__instance', js.constructor);
       } else {
-        return Immutable.Seq(js)
+        return ImmutableSeq(js)
           .map((x: any) => toNormalizedKey(x))
           .toMap()
           .set('__instance', js.constructor);
       }
 
     case Interval:
-      return Immutable.Seq(js.toClosed())
+      return ImmutableSeq(js.toClosed())
         .map((x: any) => toNormalizedKey(x))
         .toMap()
         .set('__instance', js.constructor);
 
     case Quantity:
       if (!js.unit) {
-        return Immutable.Map({
+        return ImmutableMap({
           value: js.value ?? null,
           unit: null,
           __instance: js.constructor
@@ -88,7 +88,7 @@ export const toNormalizedKey = (js: any): NormalizedKey => {
 
       if (!baseUnitKey) {
         // No units found - normalization not possible and use provided values
-        return Immutable.Map({
+        return ImmutableMap({
           value: js.value ?? null,
           unit: js.unit ?? null,
           __instance: js.constructor
@@ -98,7 +98,7 @@ export const toNormalizedKey = (js: any): NormalizedKey => {
         const baseUnitKeyCode = baseUnitKey[0].csCode_;
         const conversionValue = convertUnit(js.value, js.unit, baseUnitKeyCode);
         const finalValue = conversionValue ? decimalAdjust('round', conversionValue, -8) : null;
-        return Immutable.Map({
+        return ImmutableMap({
           value: finalValue ?? null,
           unit: baseUnitKeyCode ?? null,
           __instance: js.constructor
@@ -106,14 +106,14 @@ export const toNormalizedKey = (js: any): NormalizedKey => {
       }
 
     case Ratio:
-      return Immutable.Map({
+      return ImmutableMap({
         numerator: toNormalizedKey(js.numerator),
         denominator: toNormalizedKey(js.denominator),
         __instance: js.constructor
       });
 
     case RegExp:
-      return Immutable.Map({
+      return ImmutableMap({
         source: toNormalizedKey(js.source),
         global: toNormalizedKey(js.global),
         ignoreCase: toNormalizedKey(js.ignoreCase),
@@ -125,7 +125,7 @@ export const toNormalizedKey = (js: any): NormalizedKey => {
       if (js.isPoint()) {
         return toNormalizedKey(js.low);
       } else {
-        return Immutable.Seq(js)
+        return ImmutableSeq(js)
           .map((x: any) => toNormalizedKey(x))
           .toMap()
           .set('__instance', js.constructor);
@@ -135,7 +135,7 @@ export const toNormalizedKey = (js: any): NormalizedKey => {
       // If the object is a model object (e.g. FHIRObject) with a _typeHierarchy function,
       // then use the typeHierarchy information for the __instance value.
       // Otherwise, use the constructor for the __instance value.
-      return Immutable.Seq(js)
+      return ImmutableSeq(js)
         .map((x: any) => toNormalizedKey(x))
         .toMap()
         .set('__instance', toNormalizedKey(js._typeHierarchy?.()) ?? js.constructor);

--- a/test/util/immutableUtil-test.ts
+++ b/test/util/immutableUtil-test.ts
@@ -1,4 +1,4 @@
-import Immutable from 'immutable';
+import { is as immutableIs } from 'immutable';
 import should from 'should';
 import { Code, CodeSystem, Concept, DateTime, Quantity, Ratio, CQLValueSet } from '../../src/cql';
 import { Uncertainty } from '../../src/datatypes/uncertainty';
@@ -15,8 +15,8 @@ describe('ImmutableUtil Tests', () => {
 
     equals(c1, c2).should.be.true();
     equals(c2, c1).should.be.true();
-    Immutable.is(ic1, ic2).should.be.true();
-    Immutable.is(ic2, ic1).should.be.true();
+    immutableIs(ic1, ic2).should.be.true();
+    immutableIs(ic2, ic1).should.be.true();
   });
 
   it('should properly match quantities', () => {
@@ -32,9 +32,9 @@ describe('ImmutableUtil Tests', () => {
     equals(q1, q3).should.be.false();
     equals(q2, q3).should.be.false();
 
-    Immutable.is(iq1, iq2).should.be.true();
-    Immutable.is(iq1, iq3).should.be.false();
-    Immutable.is(iq2, iq3).should.be.false();
+    immutableIs(iq1, iq2).should.be.true();
+    immutableIs(iq1, iq3).should.be.false();
+    immutableIs(iq2, iq3).should.be.false();
   });
 
   it('should properly match ratios', () => {
@@ -49,8 +49,8 @@ describe('ImmutableUtil Tests', () => {
     equals(r2, r1).should.be.true();
 
     // Immutable
-    Immutable.is(ir1, ir2).should.be.true();
-    Immutable.is(ir2, ir1).should.be.true();
+    immutableIs(ir1, ir2).should.be.true();
+    immutableIs(ir2, ir1).should.be.true();
   });
 
   it('should properly match uncertainties', () => {
@@ -66,7 +66,7 @@ describe('ImmutableUtil Tests', () => {
     const id1 = toNormalizedKey(d1);
     const iu1 = toNormalizedKey(u1);
 
-    Immutable.is(id1, iu1).should.be.true();
+    immutableIs(id1, iu1).should.be.true();
 
     // Dates and Datetimes
     const d2 = new Date(2000, 1, 1);
@@ -138,42 +138,42 @@ describe('ImmutableUtil Tests', () => {
     equals(u9, u10).should.be.true();
 
     // Immutable
-    Immutable.is(id2, id3).should.be.false();
-    Immutable.is(id3, id2).should.be.false();
-    Immutable.is(id2, iu2).should.be.true();
-    Immutable.is(id2, iu3).should.be.false();
-    Immutable.is(id3, iu2).should.be.false();
-    Immutable.is(id3, iu3).should.be.true();
-    Immutable.is(iu2, iu3).should.be.false();
-    Immutable.is(iu3, iu2).should.be.false();
+    immutableIs(id2, id3).should.be.false();
+    immutableIs(id3, id2).should.be.false();
+    immutableIs(id2, iu2).should.be.true();
+    immutableIs(id2, iu3).should.be.false();
+    immutableIs(id3, iu2).should.be.false();
+    immutableIs(id3, iu3).should.be.true();
+    immutableIs(iu2, iu3).should.be.false();
+    immutableIs(iu3, iu2).should.be.false();
 
-    Immutable.is(iu2, iu4).should.be.true();
-    Immutable.is(iu3, iu5).should.be.true();
-    Immutable.is(iu2, iu5).should.be.false();
-    Immutable.is(iu3, iu4).should.be.false();
-    Immutable.is(iu4, iu5).should.be.false();
+    immutableIs(iu2, iu4).should.be.true();
+    immutableIs(iu3, iu5).should.be.true();
+    immutableIs(iu2, iu5).should.be.false();
+    immutableIs(iu3, iu4).should.be.false();
+    immutableIs(iu4, iu5).should.be.false();
 
-    Immutable.is(iu2, iu6).should.be.false();
-    Immutable.is(iu2, iu7).should.be.false();
-    Immutable.is(iu3, iu7).should.be.false();
-    Immutable.is(iu4, iu6).should.be.false();
-    Immutable.is(iu4, iu7).should.be.false();
-    Immutable.is(iu5, iu6).should.be.false();
-    Immutable.is(iu5, iu7).should.be.false();
-    Immutable.is(iu6, iu7).should.be.false();
-    Immutable.is(iu7, iu6).should.be.false();
+    immutableIs(iu2, iu6).should.be.false();
+    immutableIs(iu2, iu7).should.be.false();
+    immutableIs(iu3, iu7).should.be.false();
+    immutableIs(iu4, iu6).should.be.false();
+    immutableIs(iu4, iu7).should.be.false();
+    immutableIs(iu5, iu6).should.be.false();
+    immutableIs(iu5, iu7).should.be.false();
+    immutableIs(iu6, iu7).should.be.false();
+    immutableIs(iu7, iu6).should.be.false();
 
-    Immutable.is(iu4, iu8).should.be.false();
-    Immutable.is(iu5, iu8).should.be.false();
-    Immutable.is(iu6, iu8).should.be.false();
-    Immutable.is(iu7, iu8).should.be.false();
-    Immutable.is(iu8, iu4).should.be.false();
-    Immutable.is(iu8, iu5).should.be.false();
-    Immutable.is(iu8, iu6).should.be.false();
-    Immutable.is(iu8, iu7).should.be.false();
+    immutableIs(iu4, iu8).should.be.false();
+    immutableIs(iu5, iu8).should.be.false();
+    immutableIs(iu6, iu8).should.be.false();
+    immutableIs(iu7, iu8).should.be.false();
+    immutableIs(iu8, iu4).should.be.false();
+    immutableIs(iu8, iu5).should.be.false();
+    immutableIs(iu8, iu6).should.be.false();
+    immutableIs(iu8, iu7).should.be.false();
 
-    Immutable.is(iu5, iu9).should.be.false();
-    Immutable.is(iu9, iu10).should.be.true();
+    immutableIs(iu5, iu9).should.be.false();
+    immutableIs(iu9, iu10).should.be.true();
   });
 
   it('should properly match primitives', () => {
@@ -235,47 +235,47 @@ describe('ImmutableUtil Tests', () => {
     equals(c6, c6).should.be.true();
 
     // Immutable
-    Immutable.is(ic1, ic1).should.be.true();
-    Immutable.is(ic1, ic2).should.be.false();
-    Immutable.is(ic1, ic3).should.be.false();
-    Immutable.is(ic1, ic4).should.be.false();
-    Immutable.is(ic1, ic5).should.be.false();
-    Immutable.is(ic1, ic6).should.be.false();
+    immutableIs(ic1, ic1).should.be.true();
+    immutableIs(ic1, ic2).should.be.false();
+    immutableIs(ic1, ic3).should.be.false();
+    immutableIs(ic1, ic4).should.be.false();
+    immutableIs(ic1, ic5).should.be.false();
+    immutableIs(ic1, ic6).should.be.false();
 
-    Immutable.is(ic2, ic1).should.be.false();
-    Immutable.is(ic2, ic2).should.be.true();
-    Immutable.is(ic2, ic3).should.be.false();
-    Immutable.is(ic2, ic4).should.be.false();
-    Immutable.is(ic2, ic5).should.be.false();
-    Immutable.is(ic2, ic6).should.be.false();
+    immutableIs(ic2, ic1).should.be.false();
+    immutableIs(ic2, ic2).should.be.true();
+    immutableIs(ic2, ic3).should.be.false();
+    immutableIs(ic2, ic4).should.be.false();
+    immutableIs(ic2, ic5).should.be.false();
+    immutableIs(ic2, ic6).should.be.false();
 
-    Immutable.is(ic3, ic1).should.be.false();
-    Immutable.is(ic3, ic2).should.be.false();
-    Immutable.is(ic3, ic3).should.be.true();
-    Immutable.is(ic3, ic4).should.be.false();
-    Immutable.is(ic3, ic5).should.be.false();
-    Immutable.is(ic3, ic6).should.be.false();
+    immutableIs(ic3, ic1).should.be.false();
+    immutableIs(ic3, ic2).should.be.false();
+    immutableIs(ic3, ic3).should.be.true();
+    immutableIs(ic3, ic4).should.be.false();
+    immutableIs(ic3, ic5).should.be.false();
+    immutableIs(ic3, ic6).should.be.false();
 
-    Immutable.is(ic4, ic1).should.be.false();
-    Immutable.is(ic4, ic2).should.be.false();
-    Immutable.is(ic4, ic3).should.be.false();
-    Immutable.is(ic4, ic4).should.be.true();
-    Immutable.is(ic4, ic5).should.be.false();
-    Immutable.is(ic4, ic6).should.be.false();
+    immutableIs(ic4, ic1).should.be.false();
+    immutableIs(ic4, ic2).should.be.false();
+    immutableIs(ic4, ic3).should.be.false();
+    immutableIs(ic4, ic4).should.be.true();
+    immutableIs(ic4, ic5).should.be.false();
+    immutableIs(ic4, ic6).should.be.false();
 
-    Immutable.is(ic5, ic1).should.be.false();
-    Immutable.is(ic5, ic2).should.be.false();
-    Immutable.is(ic5, ic3).should.be.false();
-    Immutable.is(ic5, ic4).should.be.false();
-    Immutable.is(ic5, ic5).should.be.true();
-    Immutable.is(ic5, ic6).should.be.false();
+    immutableIs(ic5, ic1).should.be.false();
+    immutableIs(ic5, ic2).should.be.false();
+    immutableIs(ic5, ic3).should.be.false();
+    immutableIs(ic5, ic4).should.be.false();
+    immutableIs(ic5, ic5).should.be.true();
+    immutableIs(ic5, ic6).should.be.false();
 
-    Immutable.is(ic6, ic1).should.be.false();
-    Immutable.is(ic6, ic2).should.be.false();
-    Immutable.is(ic6, ic3).should.be.false();
-    Immutable.is(ic6, ic4).should.be.false();
-    Immutable.is(ic6, ic5).should.be.false();
-    Immutable.is(ic6, ic6).should.be.true();
+    immutableIs(ic6, ic1).should.be.false();
+    immutableIs(ic6, ic2).should.be.false();
+    immutableIs(ic6, ic3).should.be.false();
+    immutableIs(ic6, ic4).should.be.false();
+    immutableIs(ic6, ic5).should.be.false();
+    immutableIs(ic6, ic6).should.be.true();
   });
 
   it('should properly match classes', () => {
@@ -298,12 +298,12 @@ describe('ImmutableUtil Tests', () => {
     equals(c4, c1).should.be.false();
 
     // Immutable
-    Immutable.is(ic1, ic2).should.be.true();
-    Immutable.is(ic2, ic1).should.be.true();
-    Immutable.is(ic1, ic3).should.be.false();
-    Immutable.is(ic3, ic1).should.be.false();
-    Immutable.is(ic1, ic4).should.be.false();
-    Immutable.is(ic4, ic1).should.be.false();
+    immutableIs(ic1, ic2).should.be.true();
+    immutableIs(ic2, ic1).should.be.true();
+    immutableIs(ic1, ic3).should.be.false();
+    immutableIs(ic3, ic1).should.be.false();
+    immutableIs(ic1, ic4).should.be.false();
+    immutableIs(ic4, ic1).should.be.false();
   });
 
   it('should properly match javascript dates', () => {
@@ -322,10 +322,10 @@ describe('ImmutableUtil Tests', () => {
     equals(d3, d1).should.be.false();
 
     // Immutable
-    Immutable.is(id1, id2).should.be.true();
-    Immutable.is(id2, id1).should.be.true();
-    Immutable.is(id1, id3).should.be.false();
-    Immutable.is(id3, id1).should.be.false();
+    immutableIs(id1, id2).should.be.true();
+    immutableIs(id2, id1).should.be.true();
+    immutableIs(id1, id3).should.be.false();
+    immutableIs(id3, id1).should.be.false();
   });
 
   it('should properly match regular expressions', () => {
@@ -344,10 +344,10 @@ describe('ImmutableUtil Tests', () => {
     equals(r3, r1).should.be.false();
 
     // Immutable
-    Immutable.is(ir1, ir2).should.be.true();
-    Immutable.is(ir2, ir1).should.be.true();
-    Immutable.is(ir1, ir3).should.be.false();
-    Immutable.is(ir3, ir1).should.be.false();
+    immutableIs(ir1, ir2).should.be.true();
+    immutableIs(ir2, ir1).should.be.true();
+    immutableIs(ir1, ir3).should.be.false();
+    immutableIs(ir3, ir1).should.be.false();
   });
 
   it('should properly match arrays', () => {
@@ -372,8 +372,8 @@ describe('ImmutableUtil Tests', () => {
     // define "Example":
     //     ({ {1, null}, {1, null} }) q
     //     return q
-    Immutable.is(ic1, ic2).should.be.true();
-    Immutable.is(ic1, ic3).should.be.false();
+    immutableIs(ic1, ic2).should.be.true();
+    immutableIs(ic1, ic3).should.be.false();
   });
 
   it('should properly match functions', () => {
@@ -391,10 +391,10 @@ describe('ImmutableUtil Tests', () => {
     equals(f1, f3).should.be.false();
     equals(f3, f1).should.be.false();
 
-    Immutable.is(if1, if2).should.be.true();
-    Immutable.is(if2, if1).should.be.true();
-    Immutable.is(if1, if3).should.be.false();
-    Immutable.is(if3, if1).should.be.false();
+    immutableIs(if1, if2).should.be.true();
+    immutableIs(if2, if1).should.be.true();
+    immutableIs(if1, if3).should.be.false();
+    immutableIs(if3, if1).should.be.false();
   });
 
   it('should properly match Codes/Concepts/Valuesets', () => {
@@ -426,13 +426,13 @@ describe('ImmutableUtil Tests', () => {
     equals(c1, c5).should.be.false();
 
     // Immutable
-    Immutable.is(ic1, ic2).should.be.false();
-    Immutable.is(ic2, ic1).should.be.false();
-    Immutable.is(ic1, ic3).should.be.false();
-    Immutable.is(ic2, ic3).should.be.false();
-    Immutable.is(ic3, ic1).should.be.false();
-    Immutable.is(ic3, ic2).should.be.false();
-    Immutable.is(ic1, ic4).should.be.false();
-    Immutable.is(ic1, ic5).should.be.false();
+    immutableIs(ic1, ic2).should.be.false();
+    immutableIs(ic2, ic1).should.be.false();
+    immutableIs(ic1, ic3).should.be.false();
+    immutableIs(ic2, ic3).should.be.false();
+    immutableIs(ic3, ic1).should.be.false();
+    immutableIs(ic3, ic2).should.be.false();
+    immutableIs(ic1, ic4).should.be.false();
+    immutableIs(ic1, ic5).should.be.false();
   });
 });


### PR DESCRIPTION
Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

## Summary
This PR updates the `immutable` imports that were causing issues down the line when cql-execution is used as a dependency in a browser-bundling application. This was not clear with Node through CommonJS because it worked, but the Immutable ESM build that bundled browser environments use exposes `Set` (and others) as named exports. Therefore, this PR fixes errors that `Set` was undefined.

**Submitter:**

- [ ] This pull request describes why these changes were made
- [ ] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass
- [ ] Code coverage has not gone down and all code touched or added is covered.
- [ ] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [ ] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [ ] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name:

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
