### PR TITLE
Implement ProperContains/ProperIn for both List and Interval

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -1891,6 +1891,26 @@ class Interval {
         }
         return logic_1.ThreeValuedLogic.and(lowFn(this.low, item, precision), highFn(this.high, item, precision));
     }
+    properContains(item, precision) {
+        if (item != null && item.isInterval) {
+            throw new Error('Argument to contains must be a point');
+        }
+        let lowFn;
+        if (this.lowClosed && this.low == null) {
+            lowFn = () => true;
+        }
+        else {
+            lowFn = cmp.lessThan;
+        }
+        let highFn;
+        if (this.highClosed && this.high == null) {
+            highFn = () => true;
+        }
+        else {
+            highFn = cmp.greaterThan;
+        }
+        return logic_1.ThreeValuedLogic.and(lowFn(this.low, item, precision), highFn(this.high, item, precision));
+    }
     properlyIncludes(other, precision) {
         if (other == null || !other.isInterval) {
             throw new Error('Argument to properlyIncludes must be an interval');
@@ -4800,7 +4820,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.doContains = exports.doExcept = exports.doIncludes = exports.doIntersect = exports.doProperIncludes = exports.doAfter = exports.doUnion = exports.doBefore = void 0;
+exports.doProperContains = exports.doContains = exports.doExcept = exports.doIncludes = exports.doIntersect = exports.doProperIncludes = exports.doAfter = exports.doUnion = exports.doBefore = void 0;
 __exportStar(require("./expression"), exports);
 __exportStar(require("./aggregate"), exports);
 __exportStar(require("./arithmetic"), exports);
@@ -4839,6 +4859,7 @@ Object.defineProperty(exports, "doIntersect", { enumerable: true, get: function 
 Object.defineProperty(exports, "doIncludes", { enumerable: true, get: function () { return interval_1.doIncludes; } });
 Object.defineProperty(exports, "doExcept", { enumerable: true, get: function () { return interval_1.doExcept; } });
 Object.defineProperty(exports, "doContains", { enumerable: true, get: function () { return interval_1.doContains; } });
+Object.defineProperty(exports, "doProperContains", { enumerable: true, get: function () { return interval_1.doProperContains; } });
 
 },{"./aggregate":15,"./arithmetic":16,"./clinical":18,"./comparison":19,"./conditional":20,"./datetime":21,"./declaration":22,"./expression":23,"./external":25,"./instance":26,"./interval":27,"./list":29,"./literal":30,"./logical":31,"./message":32,"./nullological":33,"./overloaded":34,"./parameters":35,"./quantity":36,"./query":37,"./ratio":38,"./reusable":39,"./string":40,"./structured":41,"./type":42}],25:[function(require,module,exports){
 "use strict";
@@ -4991,6 +5012,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Collapse = exports.Expand = exports.Ends = exports.Starts = exports.End = exports.Start = exports.Size = exports.Width = exports.OverlapsBefore = exports.OverlapsAfter = exports.Overlaps = exports.MeetsBefore = exports.MeetsAfter = exports.Meets = exports.Interval = void 0;
 exports.doContains = doContains;
+exports.doProperContains = doProperContains;
 exports.doIncludes = doIncludes;
 exports.doProperIncludes = doProperIncludes;
 exports.doAfter = doAfter;
@@ -5049,6 +5071,9 @@ exports.Interval = Interval;
 // Delegated to by overloaded#Contains and overloaded#In
 function doContains(interval, item, precision) {
     return interval.contains(item, precision);
+}
+function doProperContains(interval, item, precision) {
+    return interval.properContains(item, precision);
 }
 // Delegated to by overloaded#Includes and overloaded#IncludedIn
 function doIncludes(interval, subinterval, precision) {
@@ -5861,6 +5886,7 @@ exports.doUnion = doUnion;
 exports.doExcept = doExcept;
 exports.doIntersect = doIntersect;
 exports.doContains = doContains;
+exports.doProperContains = doProperContains;
 exports.doIncludes = doIncludes;
 exports.doProperIncludes = doProperIncludes;
 const immutable_1 = require("immutable");
@@ -5989,6 +6015,9 @@ exports.IndexOf = IndexOf;
 // Delegated to by overloaded#Contains and overloaded#In
 function doContains(container, item) {
     return container.some((element) => (0, comparison_1.equals)(element, item) || (element == null && item == null));
+}
+function doProperContains(container, item) {
+    return container.length > 1 && doContains(container, item);
 }
 // Delegated to by overloaded#Includes and overloaded@IncludedIn
 function doIncludes(list, sublist) {
@@ -6427,7 +6456,7 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Precision = exports.SameOrBefore = exports.SameOrAfter = exports.SameAs = exports.Before = exports.After = exports.Length = exports.ProperIncludedIn = exports.ProperIncludes = exports.IncludedIn = exports.Includes = exports.Contains = exports.In = exports.Indexer = exports.Intersect = exports.Except = exports.Union = exports.NotEqual = exports.Equivalent = exports.Equal = void 0;
+exports.Precision = exports.SameOrBefore = exports.SameOrAfter = exports.SameAs = exports.Before = exports.After = exports.Length = exports.ProperContains = exports.ProperIn = exports.ProperIncludedIn = exports.ProperIncludes = exports.IncludedIn = exports.Includes = exports.Contains = exports.In = exports.Indexer = exports.Intersect = exports.Except = exports.Union = exports.NotEqual = exports.Equivalent = exports.Equal = void 0;
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 const expression_1 = require("./expression");
 const logic_1 = require("../datatypes/logic");
@@ -6675,6 +6704,50 @@ class ProperIncludedIn extends expression_1.Expression {
     }
 }
 exports.ProperIncludedIn = ProperIncludedIn;
+class ProperIn extends expression_1.Expression {
+    constructor(json) {
+        super(json);
+        this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
+    }
+    async exec(ctx) {
+        const [item, container] = await this.execArgs(ctx);
+        if (container == null) {
+            return false;
+        }
+        if ((0, util_1.typeIsArray)(container)) {
+            return LIST.doProperContains(container, item);
+        }
+        else {
+            if (item == null) {
+                return null;
+            }
+            return IVL.doProperContains(container, item, this.precision);
+        }
+    }
+}
+exports.ProperIn = ProperIn;
+class ProperContains extends expression_1.Expression {
+    constructor(json) {
+        super(json);
+        this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
+    }
+    async exec(ctx) {
+        const [container, item] = await this.execArgs(ctx);
+        if (container == null) {
+            return false;
+        }
+        if ((0, util_1.typeIsArray)(container)) {
+            return LIST.doProperContains(container, item);
+        }
+        else {
+            if (item == null) {
+                return null;
+            }
+            return IVL.doProperContains(container, item, this.precision);
+        }
+    }
+}
+exports.ProperContains = ProperContains;
 class Length extends expression_1.Expression {
     constructor(json) {
         super(json);

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -6714,9 +6714,6 @@ class ProperIn extends expression_1.Expression {
             return LIST.doProperContains(container, item);
         }
         else {
-            if (item == null) {
-                return null;
-            }
             return IVL.doProperContains(container, item, this.precision);
         }
     }
@@ -6736,9 +6733,6 @@ class ProperContains extends expression_1.Expression {
             return LIST.doProperContains(container, item);
         }
         else {
-            if (item == null) {
-                return null;
-            }
             return IVL.doProperContains(container, item, this.precision);
         }
     }

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -1892,7 +1892,10 @@ class Interval {
         return logic_1.ThreeValuedLogic.and(lowFn(this.low, item, precision), highFn(this.high, item, precision));
     }
     properContains(item, precision) {
-        if (item != null && item.isInterval) {
+        if (item == null) {
+            return null;
+        }
+        else if (item.isInterval) {
             throw new Error('Argument to contains must be a point');
         }
         return logic_1.ThreeValuedLogic.and(cmp.lessThan(this.start(), item, precision), cmp.greaterThan(this.end(), item, precision));

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -5072,6 +5072,7 @@ exports.Interval = Interval;
 function doContains(interval, item, precision) {
     return interval.contains(item, precision);
 }
+// Delegated to by overloaded#ProperContains and overloaded#ProperIn
 function doProperContains(interval, item, precision) {
     return interval.properContains(item, precision);
 }
@@ -6016,7 +6017,13 @@ exports.IndexOf = IndexOf;
 function doContains(container, item) {
     return container.some((element) => (0, comparison_1.equals)(element, item) || (element == null && item == null));
 }
+// Delegated to by overloaded#ProperContains and overloaded#ProperIn
 function doProperContains(container, item) {
+    // The "proper" membership operators have list semantics, not set semantics.
+    // The intent here is that given list semantics and a `distinct` operator,
+    // one can achieve set semantics, but the reverse isn't possible.
+    // These proper membership operators can then be described as
+    // the regular membership operators, plus the list is strictly larger.
     return container.length > 1 && doContains(container, item);
 }
 // Delegated to by overloaded#Includes and overloaded@IncludedIn

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -1895,21 +1895,7 @@ class Interval {
         if (item != null && item.isInterval) {
             throw new Error('Argument to contains must be a point');
         }
-        let lowFn;
-        if (this.lowClosed && this.low == null) {
-            lowFn = () => true;
-        }
-        else {
-            lowFn = cmp.lessThan;
-        }
-        let highFn;
-        if (this.highClosed && this.high == null) {
-            highFn = () => true;
-        }
-        else {
-            highFn = cmp.greaterThan;
-        }
-        return logic_1.ThreeValuedLogic.and(lowFn(this.low, item, precision), highFn(this.high, item, precision));
+        return logic_1.ThreeValuedLogic.and(cmp.lessThan(this.start(), item, precision), cmp.greaterThan(this.end(), item, precision));
     }
     properlyIncludes(other, precision) {
         if (other == null || !other.isInterval) {

--- a/src/datatypes/interval.ts
+++ b/src/datatypes/interval.ts
@@ -114,6 +114,28 @@ export class Interval {
     );
   }
 
+  properContains(item: any, precision?: any) {
+    if (item != null && item.isInterval) {
+      throw new Error('Argument to contains must be a point');
+    }
+    let lowFn;
+    if (this.lowClosed && this.low == null) {
+      lowFn = () => true;
+    } else {
+      lowFn = cmp.lessThan;
+    }
+    let highFn;
+    if (this.highClosed && this.high == null) {
+      highFn = () => true;
+    } else {
+      highFn = cmp.greaterThan;
+    }
+    return ThreeValuedLogic.and(
+      lowFn(this.low, item, precision),
+      highFn(this.high, item, precision)
+    );
+  }
+
   properlyIncludes(other: any, precision?: any) {
     if (other == null || !other.isInterval) {
       throw new Error('Argument to properlyIncludes must be an interval');

--- a/src/datatypes/interval.ts
+++ b/src/datatypes/interval.ts
@@ -115,7 +115,9 @@ export class Interval {
   }
 
   properContains(item: any, precision?: any) {
-    if (item != null && item.isInterval) {
+    if (item == null) {
+      return null;
+    } else if (item.isInterval) {
       throw new Error('Argument to contains must be a point');
     }
     return ThreeValuedLogic.and(

--- a/src/datatypes/interval.ts
+++ b/src/datatypes/interval.ts
@@ -118,21 +118,9 @@ export class Interval {
     if (item != null && item.isInterval) {
       throw new Error('Argument to contains must be a point');
     }
-    let lowFn;
-    if (this.lowClosed && this.low == null) {
-      lowFn = () => true;
-    } else {
-      lowFn = cmp.lessThan;
-    }
-    let highFn;
-    if (this.highClosed && this.high == null) {
-      highFn = () => true;
-    } else {
-      highFn = cmp.greaterThan;
-    }
     return ThreeValuedLogic.and(
-      lowFn(this.low, item, precision),
-      highFn(this.high, item, precision)
+      cmp.lessThan(this.start(), item, precision),
+      cmp.greaterThan(this.end(), item, precision)
     );
   }
 

--- a/src/elm/expressions.ts
+++ b/src/elm/expressions.ts
@@ -36,7 +36,8 @@ import {
   doIntersect,
   doIncludes,
   doExcept,
-  doContains
+  doContains,
+  doProperContains
 } from './interval';
 
 export {
@@ -47,5 +48,6 @@ export {
   doIntersect,
   doIncludes,
   doExcept,
-  doContains
+  doContains,
+  doProperContains
 };

--- a/src/elm/interval.ts
+++ b/src/elm/interval.ts
@@ -67,6 +67,7 @@ export function doContains(interval: any, item: any, precision?: any) {
   return interval.contains(item, precision);
 }
 
+// Delegated to by overloaded#ProperContains and overloaded#ProperIn
 export function doProperContains(interval: any, item: any, precision?: any) {
   return interval.properContains(item, precision);
 }

--- a/src/elm/interval.ts
+++ b/src/elm/interval.ts
@@ -67,6 +67,10 @@ export function doContains(interval: any, item: any, precision?: any) {
   return interval.contains(item, precision);
 }
 
+export function doProperContains(interval: any, item: any, precision?: any) {
+  return interval.properContains(item, precision);
+}
+
 // Delegated to by overloaded#Includes and overloaded#IncludedIn
 export function doIncludes(interval: any, subinterval: any, precision?: any) {
   return interval.includes(subinterval, precision);

--- a/src/elm/list.ts
+++ b/src/elm/list.ts
@@ -141,7 +141,13 @@ export function doContains(container: any[], item: any) {
   );
 }
 
+// Delegated to by overloaded#ProperContains and overloaded#ProperIn
 export function doProperContains(container: any[], item: any) {
+  // The "proper" membership operators have list semantics, not set semantics.
+  // The intent here is that given list semantics and a `distinct` operator,
+  // one can achieve set semantics, but the reverse isn't possible.
+  // These proper membership operators can then be described as
+  // the regular membership operators, plus the list is strictly larger.
   return container.length > 1 && doContains(container, item);
 }
 

--- a/src/elm/list.ts
+++ b/src/elm/list.ts
@@ -141,6 +141,10 @@ export function doContains(container: any[], item: any) {
   );
 }
 
+export function doProperContains(container: any[], item: any) {
+  return container.length > 1 && doContains(container, item);
+}
+
 // Delegated to by overloaded#Includes and overloaded@IncludedIn
 export function doIncludes(list: any, sublist: any) {
   if (list == null || sublist == null) {

--- a/src/elm/overloaded.ts
+++ b/src/elm/overloaded.ts
@@ -269,6 +269,54 @@ export class ProperIncludedIn extends Expression {
   }
 }
 
+export class ProperIn extends Expression {
+  precision?: any;
+
+  constructor(json: any) {
+    super(json);
+    this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
+  }
+
+  async exec(ctx: Context) {
+    const [item, container] = await this.execArgs(ctx);
+    if (container == null) {
+      return false;
+    }
+    if (typeIsArray(container)) {
+      return LIST.doProperContains(container, item);
+    } else {
+      if (item == null) {
+        return null;
+      }
+      return IVL.doProperContains(container, item, this.precision);
+    }
+  }
+}
+
+export class ProperContains extends Expression {
+  precision?: any;
+
+  constructor(json: any) {
+    super(json);
+    this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
+  }
+
+  async exec(ctx: Context) {
+    const [container, item] = await this.execArgs(ctx);
+    if (container == null) {
+      return false;
+    }
+    if (typeIsArray(container)) {
+      return LIST.doProperContains(container, item);
+    } else {
+      if (item == null) {
+        return null;
+      }
+      return IVL.doProperContains(container, item, this.precision);
+    }
+  }
+}
+
 export class Length extends Expression {
   constructor(json: any) {
     super(json);

--- a/src/elm/overloaded.ts
+++ b/src/elm/overloaded.ts
@@ -285,9 +285,6 @@ export class ProperIn extends Expression {
     if (typeIsArray(container)) {
       return LIST.doProperContains(container, item);
     } else {
-      if (item == null) {
-        return null;
-      }
       return IVL.doProperContains(container, item, this.precision);
     }
   }
@@ -309,9 +306,6 @@ export class ProperContains extends Expression {
     if (typeIsArray(container)) {
       return LIST.doProperContains(container, item);
     } else {
-      if (item == null) {
-        return null;
-      }
       return IVL.doProperContains(container, item, this.precision);
     }
   }

--- a/test/datatypes/interval-test.ts
+++ b/test/datatypes/interval-test.ts
@@ -2,7 +2,12 @@ import should from 'should';
 import { DateTime, MIN_DATETIME_VALUE, MAX_DATETIME_VALUE } from '../../src/datatypes/datetime';
 import { Interval } from '../../src/datatypes/interval';
 import { Uncertainty } from '../../src/datatypes/uncertainty';
-import { ELM_DECIMAL_TYPE } from '../../src/util/elmTypes';
+import {
+  ELM_DATETIME_TYPE,
+  ELM_DECIMAL_TYPE,
+  ELM_INTEGER_TYPE,
+  ELM_LONG_TYPE
+} from '../../src/util/elmTypes';
 import data from './interval-data';
 
 const xy = (obj: any) => [obj.x, obj.y];
@@ -3783,6 +3788,96 @@ describe('LongInterval', () => {
 
     it('should throw when the argument is an interval', () => {
       should(() => d.zeroToHundredLong.closed.contains(new Interval(5n, 10n))).throw(Error);
+    });
+  });
+
+  describe('properContains', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly calculate longs less than it', () => {
+      d.zeroToHundredLong.closed.properContains(-5n).should.be.false();
+    });
+
+    it('should properly calculate the left boundary long', () => {
+      d.zeroToHundredLong.closed.properContains(0n).should.be.false();
+      d.zeroToHundredLong.open.properContains(0n).should.be.false();
+      d.zeroToHundredLong.closed.properContains(1n).should.be.true();
+      d.zeroToHundredLong.open.properContains(1n).should.be.false();
+      d.zeroToHundredLong.closed.properContains(2n).should.be.true();
+      d.zeroToHundredLong.open.properContains(2n).should.be.true();
+    });
+
+    it('should properly calculate longs in the middle of it', () => {
+      d.zeroToHundredLong.closed.properContains(50n).should.be.true();
+    });
+
+    it('should properly calculate the right boundary long', () => {
+      d.zeroToHundredLong.closed.properContains(100n).should.be.false();
+      d.zeroToHundredLong.open.properContains(100n).should.be.false();
+      d.zeroToHundredLong.closed.properContains(99n).should.be.true();
+      d.zeroToHundredLong.open.properContains(99n).should.be.false();
+      d.zeroToHundredLong.closed.properContains(98n).should.be.true();
+      d.zeroToHundredLong.open.properContains(98n).should.be.true();
+    });
+
+    it('should properly calculate longs greater than it', () => {
+      d.zeroToHundredLong.closed.properContains(105n).should.be.false();
+    });
+
+    it('should properly handle null endpoints', () => {
+      new Interval(null, 0n).properContains(-123456789n).should.be.true();
+      new Interval(null, 0n).properContains(1n).should.be.false();
+      new Interval(null, 0n, false, true).properContains(0n).should.be.false();
+      should(new Interval(null, 0n, false, true).properContains(-123456789n)).be.null();
+      new Interval(null, 0n, false, true).properContains(1n).should.be.false();
+      new Interval(0n, null).properContains(123456789n).should.be.true();
+      new Interval(0n, null).properContains(-1n).should.be.false();
+      new Interval(0n, null, true, false).properContains(0n).should.be.false();
+      should(new Interval(0n, null, true, false).properContains(123456789n)).be.null();
+      new Interval(0n, null, true, false).properContains(-1n).should.be.false();
+    });
+
+    it.skip('should properly handle unbounded and unknown intervals', () => {
+      new Interval(null, null, true, true, ELM_LONG_TYPE).properContains(0).should.be.true();
+      should(new Interval(null, null, false, false, ELM_LONG_TYPE).properContains(0)).be.null();
+    });
+
+    it('should properly handle imprecision', () => {
+      d.zeroToHundredLong.closed.properContains(new Uncertainty(-20n, -10n)).should.be.false();
+      should.not.exist(d.zeroToHundredLong.closed.properContains(new Uncertainty(-20n, 20n)));
+      should.not.exist(d.zeroToHundredLong.closed.properContains(new Uncertainty(0n, 100n)));
+      d.zeroToHundredLong.closed.properContains(new Uncertainty(1n, 99n)).should.be.true();
+      should.not.exist(d.zeroToHundredLong.closed.properContains(new Uncertainty(80n, 120n)));
+      d.zeroToHundredLong.closed.properContains(new Uncertainty(120n, 140n)).should.be.false();
+      should.not.exist(d.zeroToHundredLong.closed.properContains(new Uncertainty(-20n, 120n)));
+
+      const uIvl = new Interval(new Uncertainty(5n, 10n), new Uncertainty(15n, 20n));
+
+      uIvl.properContains(0n).should.be.false();
+      uIvl.properContains(5n).should.be.false();
+      should.not.exist(uIvl.properContains(6n));
+      should.not.exist(uIvl.properContains(10n));
+      uIvl.properContains(12n).should.be.true();
+      should.not.exist(uIvl.properContains(15n));
+      should.not.exist(uIvl.properContains(16n));
+      uIvl.properContains(20n).should.be.false();
+      uIvl.properContains(25n).should.be.false();
+
+      uIvl.properContains(new Uncertainty(0n, 4n)).should.be.false();
+      uIvl.properContains(new Uncertainty(0n, 5n)).should.be.false();
+      should.not.exist(uIvl.properContains(new Uncertainty(5n, 10n)));
+      should.not.exist(uIvl.properContains(new Uncertainty(10n, 15n)));
+      uIvl.properContains(new Uncertainty(11n, 14n)).should.be.true();
+      should.not.exist(uIvl.properContains(new Uncertainty(15n, 20n)));
+      uIvl.properContains(new Uncertainty(20n, 25n)).should.be.false();
+      uIvl.properContains(new Uncertainty(25n, 30n)).should.be.false();
+    });
+
+    it('should throw when the argument is an interval', () => {
+      should(() => d.zeroToHundredLong.closed.properContains(new Interval(5n, 10n))).throw(Error);
     });
   });
 

--- a/test/datatypes/interval-test.ts
+++ b/test/datatypes/interval-test.ts
@@ -184,6 +184,14 @@ describe('DateTimeInterval', () => {
       new Interval(date, null, true, false).properContains(early).should.be.false();
     });
 
+    it.skip('should properly handle unbounded and unknown intervals', () => {
+      const date = DateTime.parse('2012-01-01T00:00:00.0');
+      new Interval(null, null, true, true, ELM_DATETIME_TYPE).properContains(date).should.be.true();
+      should(
+        new Interval(null, null, false, false, ELM_DATETIME_TYPE).properContains(date)
+      ).be.null();
+    });
+
     it('should properly handle imprecision', () => {
       d.all2012.closed.properContains(d.bef2012.toMonth).should.be.false();
       should.not.exist(d.all2012.closed.properContains(d.beg2012.toMonth));
@@ -2045,6 +2053,11 @@ describe('IntegerInterval', () => {
       new Interval(0, null, true, false).properContains(0).should.be.false();
       should(new Interval(0, null, true, false).properContains(123456789)).be.null();
       new Interval(0, null, true, false).properContains(-1).should.be.false();
+    });
+
+    it.skip('should properly handle unbounded and unknown intervals', () => {
+      new Interval(null, null, true, true, ELM_INTEGER_TYPE).properContains(0).should.be.true();
+      should(new Interval(null, null, false, false, ELM_INTEGER_TYPE).properContains(0)).be.null();
     });
 
     it('should properly handle imprecision', () => {

--- a/test/datatypes/interval-test.ts
+++ b/test/datatypes/interval-test.ts
@@ -1,5 +1,5 @@
 import should from 'should';
-import { DateTime } from '../../src/datatypes/datetime';
+import { DateTime, MIN_DATETIME_VALUE, MAX_DATETIME_VALUE } from '../../src/datatypes/datetime';
 import { Interval } from '../../src/datatypes/interval';
 import { Uncertainty } from '../../src/datatypes/uncertainty';
 import { ELM_DECIMAL_TYPE } from '../../src/util/elmTypes';
@@ -117,6 +117,86 @@ describe('DateTimeInterval', () => {
 
     it('should throw when the argument is an interval', () => {
       should(() => d.all2012.closed.contains(d.all2012.open)).throw(Error);
+    });
+  });
+
+  describe('properContains', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly calculate dates before it', () => {
+      d.all2012.closed.properContains(d.bef2012.full).should.be.false();
+    });
+
+    it('should properly calculate the left boundary date', () => {
+      d.all2012.closed.properContains(d.beg2012.full).should.be.false();
+      d.all2012.open.properContains(d.beg2012.full).should.be.false();
+    });
+
+    it('should properly calculate dates in the middle of it', () => {
+      d.all2012.closed.properContains(d.mid2012.full).should.be.true();
+    });
+
+    it('should properly calculate the right boundary date', () => {
+      d.all2012.closed.properContains(d.end2012.full).should.be.false();
+      d.all2012.open.properContains(d.end2012.full).should.be.false();
+    });
+
+    it('should properly calculate dates after it', () => {
+      d.all2012.closed.properContains(d.aft2012.full).should.be.false();
+    });
+
+    it('should properly handle null endpoints', () => {
+      const date = DateTime.parse('2012-01-01T00:00:00.0');
+      const minDate = MIN_DATETIME_VALUE;
+      const early = DateTime.parse('2000-01-01T00:00:00.0');
+      const late = DateTime.parse('2999-01-01T00:00:00.0');
+      const maxDate = MAX_DATETIME_VALUE;
+      new Interval(null, date).properContains(minDate).should.be.false();
+      new Interval(null, date).properContains(early).should.be.true();
+      new Interval(null, date).properContains(late).should.be.false();
+      new Interval(null, date, false, true).properContains(date).should.be.false();
+      should(new Interval(null, date, false, true).properContains(early)).be.null();
+      new Interval(null, date, false, true).properContains(late).should.be.false();
+      new Interval(date, null).properContains(late).should.be.true();
+      new Interval(date, null).properContains(early).should.be.false();
+      new Interval(date, null).properContains(maxDate).should.be.false();
+      new Interval(date, null, true, false).properContains(date).should.be.false();
+      should(new Interval(date, null, true, false).properContains(late)).be.null();
+      new Interval(date, null, true, false).properContains(early).should.be.false();
+    });
+
+    it('should properly handle imprecision', () => {
+      d.all2012.closed.properContains(d.bef2012.toMonth).should.be.false();
+      should.not.exist(d.all2012.closed.properContains(d.beg2012.toMonth));
+      d.all2012.closed.properContains(d.mid2012.toMonth).should.be.true();
+      should.not.exist(d.all2012.closed.properContains(d.end2012.toMonth));
+      d.all2012.closed.properContains(d.aft2012.toMonth).should.be.false();
+
+      d.all2012.toMonth.properContains(d.bef2012.toMonth).should.be.false();
+      d.all2012.toMonth.properContains(d.beg2012.toMonth).should.be.false();
+      d.all2012.toMonth.properContains(d.mid2012.toMonth).should.be.true();
+      d.all2012.toMonth.properContains(d.end2012.toMonth).should.be.false();
+      d.all2012.toMonth.properContains(d.aft2012.toMonth).should.be.false();
+
+      d.all2012.toMonth.properContains(d.bef2012.full).should.be.false();
+      should.not.exist(d.all2012.toMonth.properContains(d.beg2012.full));
+      d.all2012.toMonth.properContains(d.mid2012.full).should.be.true();
+      should.not.exist(d.all2012.toMonth.properContains(d.end2012.full));
+      d.all2012.toMonth.properContains(d.aft2012.full).should.be.false();
+
+      should.not.exist(d.all2012.closed.properContains(d.mid2012.toYear));
+    });
+
+    it('should return null when checking if interval contains null point', () => {
+      const date = DateTime.parse('2012-01-01T00:00:00.0');
+      should(new Interval(date, null, true, false).properContains(null)).be.null();
+    });
+
+    it('should throw when the argument is an interval', () => {
+      should(() => d.all2012.closed.properContains(d.all2012.open)).throw(Error);
     });
   });
 
@@ -1899,6 +1979,83 @@ describe('IntegerInterval', () => {
 
     it('should throw when the argument is an interval', () => {
       should(() => d.zeroToHundred.closed.contains(new Interval(5, 10))).throw(Error);
+    });
+  });
+
+  describe('properContains', () => {
+    let d: any;
+    beforeEach(() => {
+      d = data();
+    });
+
+    it('should properly calculate integers less than it', () => {
+      d.zeroToHundred.closed.properContains(-5).should.be.false();
+    });
+
+    it('should properly calculate the left boundary integer', () => {
+      d.zeroToHundred.closed.properContains(0).should.be.false();
+      d.zeroToHundred.open.properContains(0).should.be.false();
+    });
+
+    it('should properly calculate integers in the middle of it', () => {
+      d.zeroToHundred.closed.properContains(50).should.be.true();
+    });
+
+    it('should properly calculate the right boundary integer', () => {
+      d.zeroToHundred.closed.properContains(100).should.be.false();
+      d.zeroToHundred.open.properContains(100).should.be.false();
+    });
+
+    it('should properly calculate integers greater than it', () => {
+      d.zeroToHundred.closed.properContains(105).should.be.false();
+    });
+
+    it('should properly handle null endpoints', () => {
+      new Interval(null, 0).properContains(-123456789).should.be.true();
+      new Interval(null, 0).properContains(1).should.be.false();
+      new Interval(null, 0, false, true).properContains(0).should.be.false();
+      should(new Interval(null, 0, false, true).properContains(-123456789)).be.null();
+      new Interval(null, 0, false, true).properContains(1).should.be.false();
+      new Interval(0, null).properContains(123456789).should.be.true();
+      new Interval(0, null).properContains(-1).should.be.false();
+      new Interval(0, null, true, false).properContains(0).should.be.false();
+      should(new Interval(0, null, true, false).properContains(123456789)).be.null();
+      new Interval(0, null, true, false).properContains(-1).should.be.false();
+    });
+
+    it('should properly handle imprecision', () => {
+      d.zeroToHundred.closed.properContains(new Uncertainty(-20, -10)).should.be.false();
+      should.not.exist(d.zeroToHundred.closed.properContains(new Uncertainty(-20, 20)));
+      should.not.exist(d.zeroToHundred.closed.properContains(new Uncertainty(0, 100)));
+      d.zeroToHundred.closed.properContains(new Uncertainty(1, 99)).should.be.true();
+      should.not.exist(d.zeroToHundred.closed.properContains(new Uncertainty(80, 120)));
+      d.zeroToHundred.closed.properContains(new Uncertainty(120, 140)).should.be.false();
+      should.not.exist(d.zeroToHundred.closed.properContains(new Uncertainty(-20, 120)));
+
+      const uIvl = new Interval(new Uncertainty(5, 10), new Uncertainty(15, 20));
+
+      uIvl.properContains(0).should.be.false();
+      uIvl.properContains(5).should.be.false();
+      should.not.exist(uIvl.properContains(6));
+      should.not.exist(uIvl.properContains(10));
+      uIvl.properContains(12).should.be.true();
+      should.not.exist(uIvl.properContains(15));
+      should.not.exist(uIvl.properContains(16));
+      uIvl.properContains(20).should.be.false();
+      uIvl.properContains(25).should.be.false();
+
+      uIvl.properContains(new Uncertainty(0, 4)).should.be.false();
+      uIvl.properContains(new Uncertainty(0, 5)).should.be.false();
+      should.not.exist(uIvl.properContains(new Uncertainty(5, 10)));
+      should.not.exist(uIvl.properContains(new Uncertainty(10, 15)));
+      uIvl.properContains(new Uncertainty(11, 14)).should.be.true();
+      should.not.exist(uIvl.properContains(new Uncertainty(15, 20)));
+      uIvl.properContains(new Uncertainty(20, 25)).should.be.false();
+      uIvl.properContains(new Uncertainty(25, 30)).should.be.false();
+    });
+
+    it('should throw when the argument is an interval', () => {
+      should(() => d.zeroToHundred.closed.properContains(new Interval(5, 10))).throw(Error);
     });
   });
 

--- a/test/datatypes/interval-test.ts
+++ b/test/datatypes/interval-test.ts
@@ -133,6 +133,14 @@ describe('DateTimeInterval', () => {
     it('should properly calculate the left boundary date', () => {
       d.all2012.closed.properContains(d.beg2012.full).should.be.false();
       d.all2012.open.properContains(d.beg2012.full).should.be.false();
+
+      let next = d.beg2012.full.successor();
+      d.all2012.closed.properContains(next).should.be.true();
+      d.all2012.open.properContains(next).should.be.false();
+
+      next = next.successor();
+      d.all2012.closed.properContains(next).should.be.true();
+      d.all2012.open.properContains(next).should.be.true();
     });
 
     it('should properly calculate dates in the middle of it', () => {
@@ -142,6 +150,14 @@ describe('DateTimeInterval', () => {
     it('should properly calculate the right boundary date', () => {
       d.all2012.closed.properContains(d.end2012.full).should.be.false();
       d.all2012.open.properContains(d.end2012.full).should.be.false();
+
+      let prev = d.end2012.full.predecessor();
+      d.all2012.closed.properContains(prev).should.be.true();
+      d.all2012.open.properContains(prev).should.be.false();
+
+      prev = prev.predecessor();
+      d.all2012.closed.properContains(prev).should.be.true();
+      d.all2012.open.properContains(prev).should.be.true();
     });
 
     it('should properly calculate dates after it', () => {
@@ -1995,6 +2011,10 @@ describe('IntegerInterval', () => {
     it('should properly calculate the left boundary integer', () => {
       d.zeroToHundred.closed.properContains(0).should.be.false();
       d.zeroToHundred.open.properContains(0).should.be.false();
+      d.zeroToHundred.closed.properContains(1).should.be.true();
+      d.zeroToHundred.open.properContains(1).should.be.false();
+      d.zeroToHundred.closed.properContains(2).should.be.true();
+      d.zeroToHundred.open.properContains(2).should.be.true();
     });
 
     it('should properly calculate integers in the middle of it', () => {
@@ -2004,6 +2024,10 @@ describe('IntegerInterval', () => {
     it('should properly calculate the right boundary integer', () => {
       d.zeroToHundred.closed.properContains(100).should.be.false();
       d.zeroToHundred.open.properContains(100).should.be.false();
+      d.zeroToHundred.closed.properContains(99).should.be.true();
+      d.zeroToHundred.open.properContains(99).should.be.false();
+      d.zeroToHundred.closed.properContains(98).should.be.true();
+      d.zeroToHundred.open.properContains(98).should.be.true();
     });
 
     it('should properly calculate integers greater than it', () => {

--- a/test/elm/interval/data.cql
+++ b/test/elm/interval/data.cql
@@ -387,6 +387,51 @@ define MayProperlyIncludeDayOfIvlVeryImpreciseHigh: Interval[DateTime(2012, 6), 
 define MayProperlyIncludeDayOfIvlVeryImpreciseLowAndHigh: Interval[DateTime(2012, 3), DateTime(2012, 9)] properly included in day of PrecisionDateIvl
 define MayProperlyIncludeDayOfIvlVeryImpreciseSurrounding: Interval[DateTime(2012), DateTime(2012)] properly included in day of PrecisionDateIvl
 
+// @Test: ProperContains
+define ProperContainsInt: Interval[1, 5] properly includes 3
+define NotProperContainsInt: Interval[1, 5] properly includes 7
+define NotProperContainsIntLowEdge: Interval[1, 5] properly includes 1
+define NotProperContainsIntHighEdge: Interval[1, 5] properly includes 5
+define ProperContainsReal: Interval[1.234, 3.456] properly includes 2.345
+define NotProperContainsReal: Interval[1.234, 3.456] properly includes 4.567
+define ProperContainsQuantity: Interval[1 'mg', 5 'mg'] properly includes 3 'mg'
+define NotProperContainsQuantityEdge: Interval[1 'mg', 5 'mg'] properly includes 5 'mg'
+define DateIvlHighOpen: Interval[DateTime(2012, 3, 1, 0, 0, 0, 0), DateTime(2012, 9, 1, 0, 0, 0, 0))
+define DateIvlHighClosed: Interval[DateTime(2012, 3, 1, 0, 0, 0, 0), DateTime(2012, 9, 1, 0, 0, 0, 0)]
+define ProperContainsDate: DateIvlHighOpen properly includes DateTime(2012, 6, 1, 0, 0, 0, 0)
+define NotProperContainsDateHighEdgeOpen: DateIvlHighOpen properly includes DateTime(2012, 9, 1, 0, 0, 0, 0)
+define NotProperContainsDateHighEdgeClosed: DateIvlHighClosed properly includes DateTime(2012, 9, 1, 0, 0, 0, 0)
+define ProperContainsTime: Interval[@T12:00:00.000, @T21:59:59.999] properly includes @T12:00:00.001
+define NotProperContainsTimeLowEdge: Interval[@T12:00:00.000, @T21:59:59.999] properly includes @T12:00:00.000
+define MayProperContainsTime: Interval[@T12:00:00.001, @T21:59:59.999] properly includes @T12:00:00
+define ProperContainsSecondOfTime: Interval[@T12:00:00.000, @T21:59:59.999] properly includes second of @T12:00:01
+define NotProperContainsSecondOfTime: Interval[@T12:00:00.001, @T21:59:59.999] properly includes second of @T12:00:00
+define MayProperContainsMillisecondOfTime: Interval[@T12:00:00.001, @T21:59:59.999] properly includes millisecond of @T12:00:00
+define ProperContainsNull: Interval[1, 5] properly includes null
+
+
+// @Test: ProperIn
+define ProperInInt: 3 properly included in Interval[1, 5]
+define NotProperInInt: 7 properly included in Interval[1, 5]
+define NotProperInIntLowEdge: 1 properly included in Interval[1, 5]
+define NotProperInIntHighEdge: 5 properly included in Interval[1, 5]
+define ProperInReal: 2.345 properly included in Interval[1.234, 3.456]
+define NotProperInReal: 4.567 properly included in Interval[1.234, 3.456]
+define ProperInQuantity: 3 'mg' properly included in Interval[1 'mg', 5 'mg']
+define NotProperInQuantityEdge: 5 'mg' properly included in Interval[1 'mg', 5 'mg']
+define DateIvlHighOpen: Interval[DateTime(2012, 3, 1, 0, 0, 0, 0), DateTime(2012, 9, 1, 0, 0, 0, 0))
+define DateIvlHighClosed: Interval[DateTime(2012, 3, 1, 0, 0, 0, 0), DateTime(2012, 9, 1, 0, 0, 0, 0)]
+define ProperInDate: DateTime(2012, 6, 1, 0, 0, 0, 0) properly included in DateIvlHighOpen
+define NotProperInDateHighEdgeOpen: DateTime(2012, 9, 1, 0, 0, 0, 0) properly included in DateIvlHighOpen
+define NotProperInDateHighEdgeClosed: DateTime(2012, 9, 1, 0, 0, 0, 0) properly included in DateIvlHighClosed
+define ProperInTime: @T12:00:00.001 properly included in Interval[@T12:00:00.000, @T21:59:59.999]
+define NotProperInTimeLowEdge: @T12:00:00.000 properly included in Interval[@T12:00:00.000, @T21:59:59.999]
+define MayProperInTime: @T12:00:00 properly included in Interval[@T12:00:00.001, @T21:59:59.999]
+define ProperInSecondOfTime: @T12:00:01 properly included in second of Interval[@T12:00:00.000, @T21:59:59.999]
+define NotProperInSecondOfTime: @T12:00:00 properly included in second of Interval[@T12:00:00.001, @T21:59:59.999]
+define MayProperInMillisecondOfTime: @T12:00:00 properly included in millisecond of Interval[@T12:00:00.001, @T21:59:59.999]
+define ProperInNull: null properly included in Interval[1, 5]
+
 // @Test: After
 define AfterIntIvl: Interval[5, 10] after Interval[2, 4]
 define NotAfterIntIvl: Interval[5, 10] after Interval[2, 5]

--- a/test/elm/interval/interval-test.ts
+++ b/test/elm/interval/interval-test.ts
@@ -622,6 +622,78 @@ describe('ProperlyIncludedIn', () => {
   });
 });
 
+describe('ProperContains', () => {
+  beforeEach(function () {
+    setup(this, data);
+  });
+
+  it('should accept properly contained items', async function () {
+    (await this.properContainsInt.exec(this.ctx)).should.be.true();
+    (await this.properContainsReal.exec(this.ctx)).should.be.true();
+    (await this.properContainsQuantity.exec(this.ctx)).should.be.true();
+    (await this.properContainsDate.exec(this.ctx)).should.be.true();
+    (await this.properContainsTime.exec(this.ctx)).should.be.true();
+  });
+
+  it('should reject items outside the interval or on an edge', async function () {
+    (await this.notProperContainsInt.exec(this.ctx)).should.be.false();
+    (await this.notProperContainsIntLowEdge.exec(this.ctx)).should.be.false();
+    (await this.notProperContainsIntHighEdge.exec(this.ctx)).should.be.false();
+    (await this.notProperContainsReal.exec(this.ctx)).should.be.false();
+    (await this.notProperContainsQuantityEdge.exec(this.ctx)).should.be.false();
+    (await this.notProperContainsDateHighEdgeOpen.exec(this.ctx)).should.be.false();
+    (await this.notProperContainsDateHighEdgeClosed.exec(this.ctx)).should.be.false();
+    (await this.notProperContainsTimeLowEdge.exec(this.ctx)).should.be.false();
+  });
+
+  it('should correctly compare using the requested precision', async function () {
+    (await this.properContainsSecondOfTime.exec(this.ctx)).should.be.true();
+    (await this.notProperContainsSecondOfTime.exec(this.ctx)).should.be.false();
+    should(await this.mayProperContainsTime.exec(this.ctx)).be.null();
+    should(await this.mayProperContainsMillisecondOfTime.exec(this.ctx)).be.null();
+  });
+
+  it('should return null for a null item', async function () {
+    should(await this.properContainsNull.exec(this.ctx)).be.null();
+  });
+});
+
+describe('ProperIn', () => {
+  beforeEach(function () {
+    setup(this, data);
+  });
+
+  it('should accept properly contained items', async function () {
+    (await this.properInInt.exec(this.ctx)).should.be.true();
+    (await this.properInReal.exec(this.ctx)).should.be.true();
+    (await this.properInQuantity.exec(this.ctx)).should.be.true();
+    (await this.properInDate.exec(this.ctx)).should.be.true();
+    (await this.properInTime.exec(this.ctx)).should.be.true();
+  });
+
+  it('should reject items outside the interval or on an edge', async function () {
+    (await this.notProperInInt.exec(this.ctx)).should.be.false();
+    (await this.notProperInIntLowEdge.exec(this.ctx)).should.be.false();
+    (await this.notProperInIntHighEdge.exec(this.ctx)).should.be.false();
+    (await this.notProperInReal.exec(this.ctx)).should.be.false();
+    (await this.notProperInQuantityEdge.exec(this.ctx)).should.be.false();
+    (await this.notProperInDateHighEdgeOpen.exec(this.ctx)).should.be.false();
+    (await this.notProperInDateHighEdgeClosed.exec(this.ctx)).should.be.false();
+    (await this.notProperInTimeLowEdge.exec(this.ctx)).should.be.false();
+  });
+
+  it('should correctly compare using the requested precision', async function () {
+    (await this.properInSecondOfTime.exec(this.ctx)).should.be.true();
+    (await this.notProperInSecondOfTime.exec(this.ctx)).should.be.false();
+    should(await this.mayProperInTime.exec(this.ctx)).be.null();
+    should(await this.mayProperInMillisecondOfTime.exec(this.ctx)).be.null();
+  });
+
+  it('should return null for a null item', async function () {
+    should(await this.properInNull.exec(this.ctx)).be.null();
+  });
+});
+
 describe('After', () => {
   beforeEach(function () {
     setup(this, data);

--- a/test/elm/list/data.cql
+++ b/test/elm/list/data.cql
@@ -177,7 +177,7 @@ define IsSameLong: {1L, 2L, 3L, 4L, 5L} properly includes {1L, 2L, 3L, 4L, 5L}
 define IsNotIncludedLong: {1L, 2L, 3L, 4L, 5L} properly includes {4L, 5L, 6L}
 define TuplesIncluded: {Tuple{a:1, b:'d'}, Tuple{a:2, b:'d'}, Tuple{a:2, b:'c'}} properly includes {Tuple{a:2, b:'d'}, Tuple{a:2, b:'c'}}
 define TuplesNotIncluded: {Tuple{a:1, b:'d'}, Tuple{a:2, b:'d'}, Tuple{a:2, b:'c'}} properly includes {Tuple{a:2, b:'d'}, Tuple{a:3, b:'c'}}
-define NullIncluded: {1, 2, 3, 4, 5} properly includes null
+define NullIncluded: {1, 2, 3, 4, 5} properly includes (null as List<Integer>)
 define NullIncludes: null properly includes {1, 2, 3, 4, 5}
 
 // @Test: ProperIncludedIn
@@ -193,6 +193,30 @@ define TuplesIncluded: {Tuple{a:2, b:'d'}, Tuple{a:2, b:'c'}} properly included 
 define TuplesNotIncluded: {Tuple{a:2, b:'d'}, Tuple{a:3, b:'c'}} properly included in {Tuple{a:1, b:'d'}, Tuple{a:2, b:'d'}, Tuple{a:2, b:'c'}}
 define NullIncludes: {1, 2, 3, 4, 5} properly included in null as List<Integer>
 define NullIncluded: (null as List<Integer>) properly included in {1, 2, 3, 4, 5}
+
+// @Test: ProperIn
+define IsIn: 4 properly included in { 3, 4, 5 }
+define IsNotIn: 4 properly included in { 3, 5, 6 }
+define IsNotProperlyIn: 4 properly included in { 4 }
+define IsInNotUnique: 4 properly included in { 4, 4 }
+define IsInWithNull: 4 properly included in { 4, null }
+define TupleIsIn: Tuple{a: 1, b: 'c'} properly included in {Tuple{a:1, b:'d'}, Tuple{a:1, b:'c'}, Tuple{a:2, b:'c'}}
+define TupleIsNotIn: Tuple{a: 1, b: 'c'} properly included in {Tuple{a:1, b:'d'}, Tuple{a:2, b:'d'}, Tuple{a:2, b:'c'}}
+define NullIn: null properly included in {1, 2, null, 3}
+define InNull: 1 properly included in null
+define NullNotIn: null properly included in {1, 2, 3}
+
+// @Test: ProperContains
+define IsIn: { 3, 4, 5 } properly includes 4
+define IsNotIn: { 3, 5, 6 } properly includes 4
+define IsNotProperlyIn: { 4 } properly includes 4
+define IsInNotUnique: { 4, 4 } properly includes 4
+define IsInWithNull: { 4, null } properly includes 4
+define TupleIsIn: {Tuple{a:1, b:'d'}, Tuple{a:1, b:'c'}, Tuple{a:2, b:'c'}} properly includes Tuple{a: 1, b: 'c'}
+define TupleIsNotIn: {Tuple{a:1, b:'d'}, Tuple{a:2, b:'d'}, Tuple{a:2, b:'c'}} properly includes Tuple{a: 1, b: 'c'}
+define InNull: (null as List<Integer>) properly includes 1
+define NullIn: {1, 2, null, 3} properly includes null
+define NullNotIn: {1, 2, 3} properly includes null
 
 // @Test: Flatten
 define ListOfLists: flatten { {1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {9, 8, 7, 6, 5}, {4}, {3, 2, 1} }

--- a/test/elm/list/data.js
+++ b/test/elm/list/data.js
@@ -27425,7 +27425,7 @@ define IsSameLong: {1L, 2L, 3L, 4L, 5L} properly includes {1L, 2L, 3L, 4L, 5L}
 define IsNotIncludedLong: {1L, 2L, 3L, 4L, 5L} properly includes {4L, 5L, 6L}
 define TuplesIncluded: {Tuple{a:1, b:'d'}, Tuple{a:2, b:'d'}, Tuple{a:2, b:'c'}} properly includes {Tuple{a:2, b:'d'}, Tuple{a:2, b:'c'}}
 define TuplesNotIncluded: {Tuple{a:1, b:'d'}, Tuple{a:2, b:'d'}, Tuple{a:2, b:'c'}} properly includes {Tuple{a:2, b:'d'}, Tuple{a:3, b:'c'}}
-define NullIncluded: {1, 2, 3, 4, 5} properly includes null
+define NullIncluded: {1, 2, 3, 4, 5} properly includes (null as List<Integer>)
 define NullIncludes: null properly includes {1, 2, 3, 4, 5}
 */
 
@@ -27548,10 +27548,21 @@ module.exports['ProperIncludes'] = {
       "errorType" : "semantic",
       "errorSeverity" : "warning"
     }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 14,
+      "startChar" : 57,
+      "endLine" : 14,
+      "endChar" : 77,
+      "message" : "List-valued expression was demoted to a singleton.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
       "type" : "Annotation",
       "t" : [ ],
       "s" : {
-        "r" : "666",
+        "r" : "674",
         "s" : [ {
           "value" : [ "", "library TestSnippet version '1'" ]
         } ]
@@ -29990,7 +30001,7 @@ module.exports['ProperIncludes'] = {
             "s" : [ {
               "value" : [ "", "define ", "NullIncluded", ": " ]
             }, {
-              "r" : "659",
+              "r" : "660",
               "s" : [ {
                 "r" : "642",
                 "s" : [ {
@@ -29998,15 +30009,40 @@ module.exports['ProperIncludes'] = {
                   "value" : [ "{", "1", ", ", "2", ", ", "3", ", ", "4", ", ", "5", "}" ]
                 } ]
               }, {
-                "r" : "659",
-                "value" : [ " ", "properly includes", " ", "null" ]
+                "r" : "660",
+                "value" : [ " ", "properly includes", " " ]
+              }, {
+                "r" : "650",
+                "s" : [ {
+                  "value" : [ "(" ]
+                }, {
+                  "r" : "650",
+                  "s" : [ {
+                    "r" : "651",
+                    "value" : [ "null", " as " ]
+                  }, {
+                    "r" : "652",
+                    "s" : [ {
+                      "value" : [ "List<" ]
+                    }, {
+                      "r" : "653",
+                      "s" : [ {
+                        "value" : [ "Integer" ]
+                      } ]
+                    }, {
+                      "value" : [ ">" ]
+                    } ]
+                  } ]
+                }, {
+                  "value" : [ ")" ]
+                } ]
               } ]
             } ]
           }
         } ],
         "expression" : {
-          "type" : "ProperContains",
-          "localId" : "659",
+          "type" : "ProperIncludes",
+          "localId" : "660",
           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
           "annotation" : [ ],
           "signature" : [ {
@@ -30020,10 +30056,15 @@ module.exports['ProperIncludes'] = {
               "annotation" : [ ]
             }
           }, {
-            "type" : "NamedTypeSpecifier",
+            "type" : "ListTypeSpecifier",
             "localId" : "663",
-            "name" : "{urn:hl7-org:elm-types:r1}Integer",
-            "annotation" : [ ]
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "664",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
           } ],
           "operand" : [ {
             "type" : "List",
@@ -30078,20 +30119,54 @@ module.exports['ProperIncludes'] = {
             } ]
           }, {
             "type" : "As",
-            "localId" : "660",
-            "asType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "localId" : "650",
+            "strict" : false,
             "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "658",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "659",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
             "signature" : [ ],
             "operand" : {
               "type" : "Null",
-              "localId" : "650",
+              "localId" : "651",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
               "annotation" : [ ]
+            },
+            "asTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "652",
+              "annotation" : [ ],
+              "resultTypeSpecifier" : {
+                "type" : "ListTypeSpecifier",
+                "localId" : "654",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "655",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "annotation" : [ ]
+                }
+              },
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "653",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
             }
           } ]
         }
       }, {
-        "localId" : "666",
+        "localId" : "674",
         "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
         "name" : "NullIncludes",
         "context" : "Patient",
@@ -30100,18 +30175,18 @@ module.exports['ProperIncludes'] = {
           "type" : "Annotation",
           "t" : [ ],
           "s" : {
-            "r" : "666",
+            "r" : "674",
             "s" : [ {
               "value" : [ "", "define ", "NullIncludes", ": " ]
             }, {
-              "r" : "676",
+              "r" : "684",
               "s" : [ {
-                "r" : "667",
+                "r" : "675",
                 "value" : [ "null", " ", "properly includes", " " ]
               }, {
-                "r" : "668",
+                "r" : "676",
                 "s" : [ {
-                  "r" : "669",
+                  "r" : "677",
                   "value" : [ "{", "1", ", ", "2", ", ", "3", ", ", "4", ", ", "5", "}" ]
                 } ]
               } ]
@@ -30120,98 +30195,98 @@ module.exports['ProperIncludes'] = {
         } ],
         "expression" : {
           "type" : "ProperIncludes",
-          "localId" : "676",
+          "localId" : "684",
           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
           "annotation" : [ ],
           "signature" : [ {
             "type" : "ListTypeSpecifier",
-            "localId" : "680",
+            "localId" : "688",
             "annotation" : [ ],
             "elementType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "681",
+              "localId" : "689",
               "name" : "{urn:hl7-org:elm-types:r1}Integer",
               "annotation" : [ ]
             }
           }, {
             "type" : "ListTypeSpecifier",
-            "localId" : "682",
+            "localId" : "690",
             "annotation" : [ ],
             "elementType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "683",
+              "localId" : "691",
               "name" : "{urn:hl7-org:elm-types:r1}Integer",
               "annotation" : [ ]
             }
           } ],
           "operand" : [ {
             "type" : "As",
-            "localId" : "677",
+            "localId" : "685",
             "annotation" : [ ],
             "signature" : [ ],
             "operand" : {
               "type" : "Null",
-              "localId" : "667",
+              "localId" : "675",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
               "annotation" : [ ]
             },
             "asTypeSpecifier" : {
               "type" : "ListTypeSpecifier",
-              "localId" : "678",
+              "localId" : "686",
               "annotation" : [ ],
               "elementType" : {
                 "type" : "NamedTypeSpecifier",
-                "localId" : "679",
+                "localId" : "687",
                 "name" : "{urn:hl7-org:elm-types:r1}Integer",
                 "annotation" : [ ]
               }
             }
           }, {
             "type" : "List",
-            "localId" : "668",
+            "localId" : "676",
             "annotation" : [ ],
             "resultTypeSpecifier" : {
               "type" : "ListTypeSpecifier",
-              "localId" : "674",
+              "localId" : "682",
               "annotation" : [ ],
               "elementType" : {
                 "type" : "NamedTypeSpecifier",
-                "localId" : "675",
+                "localId" : "683",
                 "name" : "{urn:hl7-org:elm-types:r1}Integer",
                 "annotation" : [ ]
               }
             },
             "element" : [ {
               "type" : "Literal",
-              "localId" : "669",
+              "localId" : "677",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
               "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
               "value" : "1",
               "annotation" : [ ]
             }, {
               "type" : "Literal",
-              "localId" : "670",
+              "localId" : "678",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
               "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
               "value" : "2",
               "annotation" : [ ]
             }, {
               "type" : "Literal",
-              "localId" : "671",
+              "localId" : "679",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
               "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
               "value" : "3",
               "annotation" : [ ]
             }, {
               "type" : "Literal",
-              "localId" : "672",
+              "localId" : "680",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
               "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
               "value" : "4",
               "annotation" : [ ]
             }, {
               "type" : "Literal",
-              "localId" : "673",
+              "localId" : "681",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
               "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
               "value" : "5",
@@ -33137,6 +33212,3453 @@ module.exports['ProperIncludedIn'] = {
               "value" : "5",
               "annotation" : [ ]
             } ]
+          } ]
+        }
+      } ]
+    }
+  }
+}
+
+/* ProperIn
+library TestSnippet version '1'
+using Simple version '1.0.0'
+context Patient
+define IsIn: 4 properly included in { 3, 4, 5 }
+define IsNotIn: 4 properly included in { 3, 5, 6 }
+define IsNotProperlyIn: 4 properly included in { 4 }
+define IsInNotUnique: 4 properly included in { 4, 4 }
+define IsInWithNull: 4 properly included in { 4, null }
+define TupleIsIn: Tuple{a: 1, b: 'c'} properly included in {Tuple{a:1, b:'d'}, Tuple{a:1, b:'c'}, Tuple{a:2, b:'c'}}
+define TupleIsNotIn: Tuple{a: 1, b: 'c'} properly included in {Tuple{a:1, b:'d'}, Tuple{a:2, b:'d'}, Tuple{a:2, b:'c'}}
+define NullIn: null properly included in {1, 2, null, 3}
+define InNull: 1 properly included in null
+define NullNotIn: null properly included in {1, 2, 3}
+*/
+
+module.exports['ProperIn'] = {
+  "library" : {
+    "localId" : "0",
+    "annotation" : [ {
+      "type" : "CqlToElmInfo",
+      "translatorVersion" : "4.2.0",
+      "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations,EnableResultTypes",
+      "signatureLevel" : "All"
+    }, {
+      "type" : "Annotation",
+      "t" : [ ],
+      "s" : {
+        "r" : "501",
+        "s" : [ {
+          "value" : [ "", "library TestSnippet version '1'" ]
+        } ]
+      }
+    } ],
+    "identifier" : {
+      "id" : "TestSnippet",
+      "version" : "1"
+    },
+    "schemaIdentifier" : {
+      "id" : "urn:hl7-org:elm",
+      "version" : "r1"
+    },
+    "usings" : {
+      "def" : [ {
+        "localId" : "1",
+        "localIdentifier" : "System",
+        "uri" : "urn:hl7-org:elm-types:r1",
+        "annotation" : [ ]
+      }, {
+        "localId" : "206",
+        "localIdentifier" : "Simple",
+        "uri" : "https://github.com/cqframework/cql-execution/simple",
+        "version" : "1.0.0",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "206",
+            "s" : [ {
+              "value" : [ "", "using " ]
+            }, {
+              "s" : [ {
+                "value" : [ "Simple" ]
+              } ]
+            }, {
+              "value" : [ " version '1.0.0'" ]
+            } ]
+          }
+        } ]
+      } ]
+    },
+    "contexts" : {
+      "def" : [ {
+        "localId" : "211",
+        "name" : "Patient",
+        "annotation" : [ ]
+      } ]
+    },
+    "statements" : {
+      "def" : [ {
+        "localId" : "209",
+        "name" : "Patient",
+        "context" : "Patient",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "SingletonFrom",
+          "localId" : "210",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : {
+            "type" : "Retrieve",
+            "localId" : "208",
+            "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+            "annotation" : [ ],
+            "include" : [ ],
+            "codeFilter" : [ ],
+            "dateFilter" : [ ],
+            "otherFilter" : [ ]
+          }
+        }
+      }, {
+        "localId" : "214",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "IsIn",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "214",
+            "s" : [ {
+              "value" : [ "", "define ", "IsIn", ": " ]
+            }, {
+              "r" : "228",
+              "s" : [ {
+                "r" : "215",
+                "value" : [ "4", " ", "properly included in", " " ]
+              }, {
+                "r" : "216",
+                "s" : [ {
+                  "r" : "217",
+                  "value" : [ "{ ", "3", ", ", "4", ", ", "5", " }" ]
+                } ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperIn",
+          "localId" : "228",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "229",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          }, {
+            "type" : "ListTypeSpecifier",
+            "localId" : "230",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "231",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          } ],
+          "operand" : [ {
+            "type" : "Literal",
+            "localId" : "215",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "value" : "4",
+            "annotation" : [ ]
+          }, {
+            "type" : "List",
+            "localId" : "216",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "220",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "221",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "element" : [ {
+              "type" : "Literal",
+              "localId" : "217",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "3",
+              "annotation" : [ ]
+            }, {
+              "type" : "Literal",
+              "localId" : "218",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "4",
+              "annotation" : [ ]
+            }, {
+              "type" : "Literal",
+              "localId" : "219",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "5",
+              "annotation" : [ ]
+            } ]
+          } ]
+        }
+      }, {
+        "localId" : "234",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "IsNotIn",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "234",
+            "s" : [ {
+              "value" : [ "", "define ", "IsNotIn", ": " ]
+            }, {
+              "r" : "248",
+              "s" : [ {
+                "r" : "235",
+                "value" : [ "4", " ", "properly included in", " " ]
+              }, {
+                "r" : "236",
+                "s" : [ {
+                  "r" : "237",
+                  "value" : [ "{ ", "3", ", ", "5", ", ", "6", " }" ]
+                } ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperIn",
+          "localId" : "248",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "249",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          }, {
+            "type" : "ListTypeSpecifier",
+            "localId" : "250",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "251",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          } ],
+          "operand" : [ {
+            "type" : "Literal",
+            "localId" : "235",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "value" : "4",
+            "annotation" : [ ]
+          }, {
+            "type" : "List",
+            "localId" : "236",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "240",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "241",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "element" : [ {
+              "type" : "Literal",
+              "localId" : "237",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "3",
+              "annotation" : [ ]
+            }, {
+              "type" : "Literal",
+              "localId" : "238",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "5",
+              "annotation" : [ ]
+            }, {
+              "type" : "Literal",
+              "localId" : "239",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "6",
+              "annotation" : [ ]
+            } ]
+          } ]
+        }
+      }, {
+        "localId" : "254",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "IsNotProperlyIn",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "254",
+            "s" : [ {
+              "value" : [ "", "define ", "IsNotProperlyIn", ": " ]
+            }, {
+              "r" : "266",
+              "s" : [ {
+                "r" : "255",
+                "value" : [ "4", " ", "properly included in", " " ]
+              }, {
+                "r" : "256",
+                "s" : [ {
+                  "r" : "257",
+                  "value" : [ "{ ", "4", " }" ]
+                } ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperIn",
+          "localId" : "266",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "267",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          }, {
+            "type" : "ListTypeSpecifier",
+            "localId" : "268",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "269",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          } ],
+          "operand" : [ {
+            "type" : "Literal",
+            "localId" : "255",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "value" : "4",
+            "annotation" : [ ]
+          }, {
+            "type" : "List",
+            "localId" : "256",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "258",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "259",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "element" : [ {
+              "type" : "Literal",
+              "localId" : "257",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "4",
+              "annotation" : [ ]
+            } ]
+          } ]
+        }
+      }, {
+        "localId" : "272",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "IsInNotUnique",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "272",
+            "s" : [ {
+              "value" : [ "", "define ", "IsInNotUnique", ": " ]
+            }, {
+              "r" : "285",
+              "s" : [ {
+                "r" : "273",
+                "value" : [ "4", " ", "properly included in", " " ]
+              }, {
+                "r" : "274",
+                "s" : [ {
+                  "r" : "275",
+                  "value" : [ "{ ", "4", ", ", "4", " }" ]
+                } ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperIn",
+          "localId" : "285",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "286",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          }, {
+            "type" : "ListTypeSpecifier",
+            "localId" : "287",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "288",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          } ],
+          "operand" : [ {
+            "type" : "Literal",
+            "localId" : "273",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "value" : "4",
+            "annotation" : [ ]
+          }, {
+            "type" : "List",
+            "localId" : "274",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "277",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "278",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "element" : [ {
+              "type" : "Literal",
+              "localId" : "275",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "4",
+              "annotation" : [ ]
+            }, {
+              "type" : "Literal",
+              "localId" : "276",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "4",
+              "annotation" : [ ]
+            } ]
+          } ]
+        }
+      }, {
+        "localId" : "291",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "IsInWithNull",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "291",
+            "s" : [ {
+              "value" : [ "", "define ", "IsInWithNull", ": " ]
+            }, {
+              "r" : "305",
+              "s" : [ {
+                "r" : "292",
+                "value" : [ "4", " ", "properly included in", " " ]
+              }, {
+                "r" : "293",
+                "s" : [ {
+                  "r" : "294",
+                  "value" : [ "{ ", "4", ", ", "null", " }" ]
+                } ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperIn",
+          "localId" : "305",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "306",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          }, {
+            "type" : "ListTypeSpecifier",
+            "localId" : "307",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "308",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          } ],
+          "operand" : [ {
+            "type" : "Literal",
+            "localId" : "292",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "value" : "4",
+            "annotation" : [ ]
+          }, {
+            "type" : "List",
+            "localId" : "293",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "297",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "298",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "element" : [ {
+              "type" : "Literal",
+              "localId" : "294",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "4",
+              "annotation" : [ ]
+            }, {
+              "type" : "As",
+              "localId" : "296",
+              "asType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : {
+                "type" : "Null",
+                "localId" : "295",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                "annotation" : [ ]
+              }
+            } ]
+          } ]
+        }
+      }, {
+        "localId" : "311",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "TupleIsIn",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "311",
+            "s" : [ {
+              "value" : [ "", "define ", "TupleIsIn", ": " ]
+            }, {
+              "r" : "369",
+              "s" : [ {
+                "r" : "312",
+                "s" : [ {
+                  "value" : [ "Tuple{" ]
+                }, {
+                  "s" : [ {
+                    "r" : "313",
+                    "value" : [ "a", ": ", "1" ]
+                  } ]
+                }, {
+                  "value" : [ ", " ]
+                }, {
+                  "s" : [ {
+                    "value" : [ "b", ": " ]
+                  }, {
+                    "r" : "314",
+                    "s" : [ {
+                      "value" : [ "'c'" ]
+                    } ]
+                  } ]
+                }, {
+                  "value" : [ "}" ]
+                } ]
+              }, {
+                "r" : "369",
+                "value" : [ " ", "properly included in", " " ]
+              }, {
+                "r" : "321",
+                "s" : [ {
+                  "value" : [ "{" ]
+                }, {
+                  "r" : "322",
+                  "s" : [ {
+                    "value" : [ "Tuple{" ]
+                  }, {
+                    "s" : [ {
+                      "r" : "323",
+                      "value" : [ "a", ":", "1" ]
+                    } ]
+                  }, {
+                    "value" : [ ", " ]
+                  }, {
+                    "s" : [ {
+                      "value" : [ "b", ":" ]
+                    }, {
+                      "r" : "324",
+                      "s" : [ {
+                        "value" : [ "'d'" ]
+                      } ]
+                    } ]
+                  }, {
+                    "value" : [ "}" ]
+                  } ]
+                }, {
+                  "value" : [ ", " ]
+                }, {
+                  "r" : "331",
+                  "s" : [ {
+                    "value" : [ "Tuple{" ]
+                  }, {
+                    "s" : [ {
+                      "r" : "332",
+                      "value" : [ "a", ":", "1" ]
+                    } ]
+                  }, {
+                    "value" : [ ", " ]
+                  }, {
+                    "s" : [ {
+                      "value" : [ "b", ":" ]
+                    }, {
+                      "r" : "333",
+                      "s" : [ {
+                        "value" : [ "'c'" ]
+                      } ]
+                    } ]
+                  }, {
+                    "value" : [ "}" ]
+                  } ]
+                }, {
+                  "value" : [ ", " ]
+                }, {
+                  "r" : "340",
+                  "s" : [ {
+                    "value" : [ "Tuple{" ]
+                  }, {
+                    "s" : [ {
+                      "r" : "341",
+                      "value" : [ "a", ":", "2" ]
+                    } ]
+                  }, {
+                    "value" : [ ", " ]
+                  }, {
+                    "s" : [ {
+                      "value" : [ "b", ":" ]
+                    }, {
+                      "r" : "342",
+                      "s" : [ {
+                        "value" : [ "'c'" ]
+                      } ]
+                    } ]
+                  }, {
+                    "value" : [ "}" ]
+                  } ]
+                }, {
+                  "value" : [ "}" ]
+                } ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperIn",
+          "localId" : "369",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "TupleTypeSpecifier",
+            "localId" : "370",
+            "annotation" : [ ],
+            "element" : [ {
+              "localId" : "371",
+              "name" : "a",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "372",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            }, {
+              "localId" : "373",
+              "name" : "b",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "374",
+                "name" : "{urn:hl7-org:elm-types:r1}String",
+                "annotation" : [ ]
+              }
+            } ]
+          }, {
+            "type" : "ListTypeSpecifier",
+            "localId" : "375",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "TupleTypeSpecifier",
+              "localId" : "376",
+              "annotation" : [ ],
+              "element" : [ {
+                "localId" : "377",
+                "name" : "a",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "378",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "annotation" : [ ]
+                }
+              }, {
+                "localId" : "379",
+                "name" : "b",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "380",
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "annotation" : [ ]
+                }
+              } ]
+            }
+          } ],
+          "operand" : [ {
+            "type" : "Tuple",
+            "localId" : "312",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "TupleTypeSpecifier",
+              "localId" : "316",
+              "annotation" : [ ],
+              "element" : [ {
+                "localId" : "317",
+                "name" : "a",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "318",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "annotation" : [ ]
+                }
+              }, {
+                "localId" : "319",
+                "name" : "b",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "320",
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "annotation" : [ ]
+                }
+              } ]
+            },
+            "element" : [ {
+              "name" : "a",
+              "value" : {
+                "type" : "Literal",
+                "localId" : "313",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                "value" : "1",
+                "annotation" : [ ]
+              }
+            }, {
+              "name" : "b",
+              "value" : {
+                "type" : "Literal",
+                "localId" : "314",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                "value" : "c",
+                "annotation" : [ ]
+              }
+            } ]
+          }, {
+            "type" : "List",
+            "localId" : "321",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "349",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "TupleTypeSpecifier",
+                "localId" : "350",
+                "annotation" : [ ],
+                "element" : [ {
+                  "localId" : "351",
+                  "name" : "a",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "352",
+                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                    "annotation" : [ ]
+                  }
+                }, {
+                  "localId" : "353",
+                  "name" : "b",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "354",
+                    "name" : "{urn:hl7-org:elm-types:r1}String",
+                    "annotation" : [ ]
+                  }
+                } ]
+              }
+            },
+            "element" : [ {
+              "type" : "Tuple",
+              "localId" : "322",
+              "annotation" : [ ],
+              "resultTypeSpecifier" : {
+                "type" : "TupleTypeSpecifier",
+                "localId" : "326",
+                "annotation" : [ ],
+                "element" : [ {
+                  "localId" : "327",
+                  "name" : "a",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "328",
+                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                    "annotation" : [ ]
+                  }
+                }, {
+                  "localId" : "329",
+                  "name" : "b",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "330",
+                    "name" : "{urn:hl7-org:elm-types:r1}String",
+                    "annotation" : [ ]
+                  }
+                } ]
+              },
+              "element" : [ {
+                "name" : "a",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "323",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "1",
+                  "annotation" : [ ]
+                }
+              }, {
+                "name" : "b",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "324",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "d",
+                  "annotation" : [ ]
+                }
+              } ]
+            }, {
+              "type" : "Tuple",
+              "localId" : "331",
+              "annotation" : [ ],
+              "resultTypeSpecifier" : {
+                "type" : "TupleTypeSpecifier",
+                "localId" : "335",
+                "annotation" : [ ],
+                "element" : [ {
+                  "localId" : "336",
+                  "name" : "a",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "337",
+                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                    "annotation" : [ ]
+                  }
+                }, {
+                  "localId" : "338",
+                  "name" : "b",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "339",
+                    "name" : "{urn:hl7-org:elm-types:r1}String",
+                    "annotation" : [ ]
+                  }
+                } ]
+              },
+              "element" : [ {
+                "name" : "a",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "332",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "1",
+                  "annotation" : [ ]
+                }
+              }, {
+                "name" : "b",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "333",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "c",
+                  "annotation" : [ ]
+                }
+              } ]
+            }, {
+              "type" : "Tuple",
+              "localId" : "340",
+              "annotation" : [ ],
+              "resultTypeSpecifier" : {
+                "type" : "TupleTypeSpecifier",
+                "localId" : "344",
+                "annotation" : [ ],
+                "element" : [ {
+                  "localId" : "345",
+                  "name" : "a",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "346",
+                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                    "annotation" : [ ]
+                  }
+                }, {
+                  "localId" : "347",
+                  "name" : "b",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "348",
+                    "name" : "{urn:hl7-org:elm-types:r1}String",
+                    "annotation" : [ ]
+                  }
+                } ]
+              },
+              "element" : [ {
+                "name" : "a",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "341",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "2",
+                  "annotation" : [ ]
+                }
+              }, {
+                "name" : "b",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "342",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "c",
+                  "annotation" : [ ]
+                }
+              } ]
+            } ]
+          } ]
+        }
+      }, {
+        "localId" : "383",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "TupleIsNotIn",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "383",
+            "s" : [ {
+              "value" : [ "", "define ", "TupleIsNotIn", ": " ]
+            }, {
+              "r" : "441",
+              "s" : [ {
+                "r" : "384",
+                "s" : [ {
+                  "value" : [ "Tuple{" ]
+                }, {
+                  "s" : [ {
+                    "r" : "385",
+                    "value" : [ "a", ": ", "1" ]
+                  } ]
+                }, {
+                  "value" : [ ", " ]
+                }, {
+                  "s" : [ {
+                    "value" : [ "b", ": " ]
+                  }, {
+                    "r" : "386",
+                    "s" : [ {
+                      "value" : [ "'c'" ]
+                    } ]
+                  } ]
+                }, {
+                  "value" : [ "}" ]
+                } ]
+              }, {
+                "r" : "441",
+                "value" : [ " ", "properly included in", " " ]
+              }, {
+                "r" : "393",
+                "s" : [ {
+                  "value" : [ "{" ]
+                }, {
+                  "r" : "394",
+                  "s" : [ {
+                    "value" : [ "Tuple{" ]
+                  }, {
+                    "s" : [ {
+                      "r" : "395",
+                      "value" : [ "a", ":", "1" ]
+                    } ]
+                  }, {
+                    "value" : [ ", " ]
+                  }, {
+                    "s" : [ {
+                      "value" : [ "b", ":" ]
+                    }, {
+                      "r" : "396",
+                      "s" : [ {
+                        "value" : [ "'d'" ]
+                      } ]
+                    } ]
+                  }, {
+                    "value" : [ "}" ]
+                  } ]
+                }, {
+                  "value" : [ ", " ]
+                }, {
+                  "r" : "403",
+                  "s" : [ {
+                    "value" : [ "Tuple{" ]
+                  }, {
+                    "s" : [ {
+                      "r" : "404",
+                      "value" : [ "a", ":", "2" ]
+                    } ]
+                  }, {
+                    "value" : [ ", " ]
+                  }, {
+                    "s" : [ {
+                      "value" : [ "b", ":" ]
+                    }, {
+                      "r" : "405",
+                      "s" : [ {
+                        "value" : [ "'d'" ]
+                      } ]
+                    } ]
+                  }, {
+                    "value" : [ "}" ]
+                  } ]
+                }, {
+                  "value" : [ ", " ]
+                }, {
+                  "r" : "412",
+                  "s" : [ {
+                    "value" : [ "Tuple{" ]
+                  }, {
+                    "s" : [ {
+                      "r" : "413",
+                      "value" : [ "a", ":", "2" ]
+                    } ]
+                  }, {
+                    "value" : [ ", " ]
+                  }, {
+                    "s" : [ {
+                      "value" : [ "b", ":" ]
+                    }, {
+                      "r" : "414",
+                      "s" : [ {
+                        "value" : [ "'c'" ]
+                      } ]
+                    } ]
+                  }, {
+                    "value" : [ "}" ]
+                  } ]
+                }, {
+                  "value" : [ "}" ]
+                } ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperIn",
+          "localId" : "441",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "TupleTypeSpecifier",
+            "localId" : "442",
+            "annotation" : [ ],
+            "element" : [ {
+              "localId" : "443",
+              "name" : "a",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "444",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            }, {
+              "localId" : "445",
+              "name" : "b",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "446",
+                "name" : "{urn:hl7-org:elm-types:r1}String",
+                "annotation" : [ ]
+              }
+            } ]
+          }, {
+            "type" : "ListTypeSpecifier",
+            "localId" : "447",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "TupleTypeSpecifier",
+              "localId" : "448",
+              "annotation" : [ ],
+              "element" : [ {
+                "localId" : "449",
+                "name" : "a",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "450",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "annotation" : [ ]
+                }
+              }, {
+                "localId" : "451",
+                "name" : "b",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "452",
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "annotation" : [ ]
+                }
+              } ]
+            }
+          } ],
+          "operand" : [ {
+            "type" : "Tuple",
+            "localId" : "384",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "TupleTypeSpecifier",
+              "localId" : "388",
+              "annotation" : [ ],
+              "element" : [ {
+                "localId" : "389",
+                "name" : "a",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "390",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "annotation" : [ ]
+                }
+              }, {
+                "localId" : "391",
+                "name" : "b",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "392",
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "annotation" : [ ]
+                }
+              } ]
+            },
+            "element" : [ {
+              "name" : "a",
+              "value" : {
+                "type" : "Literal",
+                "localId" : "385",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                "value" : "1",
+                "annotation" : [ ]
+              }
+            }, {
+              "name" : "b",
+              "value" : {
+                "type" : "Literal",
+                "localId" : "386",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                "value" : "c",
+                "annotation" : [ ]
+              }
+            } ]
+          }, {
+            "type" : "List",
+            "localId" : "393",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "421",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "TupleTypeSpecifier",
+                "localId" : "422",
+                "annotation" : [ ],
+                "element" : [ {
+                  "localId" : "423",
+                  "name" : "a",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "424",
+                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                    "annotation" : [ ]
+                  }
+                }, {
+                  "localId" : "425",
+                  "name" : "b",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "426",
+                    "name" : "{urn:hl7-org:elm-types:r1}String",
+                    "annotation" : [ ]
+                  }
+                } ]
+              }
+            },
+            "element" : [ {
+              "type" : "Tuple",
+              "localId" : "394",
+              "annotation" : [ ],
+              "resultTypeSpecifier" : {
+                "type" : "TupleTypeSpecifier",
+                "localId" : "398",
+                "annotation" : [ ],
+                "element" : [ {
+                  "localId" : "399",
+                  "name" : "a",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "400",
+                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                    "annotation" : [ ]
+                  }
+                }, {
+                  "localId" : "401",
+                  "name" : "b",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "402",
+                    "name" : "{urn:hl7-org:elm-types:r1}String",
+                    "annotation" : [ ]
+                  }
+                } ]
+              },
+              "element" : [ {
+                "name" : "a",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "395",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "1",
+                  "annotation" : [ ]
+                }
+              }, {
+                "name" : "b",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "396",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "d",
+                  "annotation" : [ ]
+                }
+              } ]
+            }, {
+              "type" : "Tuple",
+              "localId" : "403",
+              "annotation" : [ ],
+              "resultTypeSpecifier" : {
+                "type" : "TupleTypeSpecifier",
+                "localId" : "407",
+                "annotation" : [ ],
+                "element" : [ {
+                  "localId" : "408",
+                  "name" : "a",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "409",
+                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                    "annotation" : [ ]
+                  }
+                }, {
+                  "localId" : "410",
+                  "name" : "b",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "411",
+                    "name" : "{urn:hl7-org:elm-types:r1}String",
+                    "annotation" : [ ]
+                  }
+                } ]
+              },
+              "element" : [ {
+                "name" : "a",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "404",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "2",
+                  "annotation" : [ ]
+                }
+              }, {
+                "name" : "b",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "405",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "d",
+                  "annotation" : [ ]
+                }
+              } ]
+            }, {
+              "type" : "Tuple",
+              "localId" : "412",
+              "annotation" : [ ],
+              "resultTypeSpecifier" : {
+                "type" : "TupleTypeSpecifier",
+                "localId" : "416",
+                "annotation" : [ ],
+                "element" : [ {
+                  "localId" : "417",
+                  "name" : "a",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "418",
+                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                    "annotation" : [ ]
+                  }
+                }, {
+                  "localId" : "419",
+                  "name" : "b",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "420",
+                    "name" : "{urn:hl7-org:elm-types:r1}String",
+                    "annotation" : [ ]
+                  }
+                } ]
+              },
+              "element" : [ {
+                "name" : "a",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "413",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "2",
+                  "annotation" : [ ]
+                }
+              }, {
+                "name" : "b",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "414",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "c",
+                  "annotation" : [ ]
+                }
+              } ]
+            } ]
+          } ]
+        }
+      }, {
+        "localId" : "455",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "NullIn",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "455",
+            "s" : [ {
+              "value" : [ "", "define ", "NullIn", ": " ]
+            }, {
+              "r" : "473",
+              "s" : [ {
+                "r" : "456",
+                "value" : [ "null", " ", "properly included in", " " ]
+              }, {
+                "r" : "457",
+                "s" : [ {
+                  "r" : "458",
+                  "value" : [ "{", "1", ", ", "2", ", ", "null", ", ", "3", "}" ]
+                } ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperIn",
+          "localId" : "473",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "475",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          }, {
+            "type" : "ListTypeSpecifier",
+            "localId" : "476",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "477",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          } ],
+          "operand" : [ {
+            "type" : "As",
+            "localId" : "474",
+            "asType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : {
+              "type" : "Null",
+              "localId" : "456",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+              "annotation" : [ ]
+            }
+          }, {
+            "type" : "List",
+            "localId" : "457",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "463",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "464",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "element" : [ {
+              "type" : "Literal",
+              "localId" : "458",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "annotation" : [ ]
+            }, {
+              "type" : "Literal",
+              "localId" : "459",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2",
+              "annotation" : [ ]
+            }, {
+              "type" : "As",
+              "localId" : "462",
+              "asType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : {
+                "type" : "Null",
+                "localId" : "460",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                "annotation" : [ ]
+              }
+            }, {
+              "type" : "Literal",
+              "localId" : "461",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "3",
+              "annotation" : [ ]
+            } ]
+          } ]
+        }
+      }, {
+        "localId" : "480",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "InNull",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "480",
+            "s" : [ {
+              "value" : [ "", "define ", "InNull", ": " ]
+            }, {
+              "r" : "492",
+              "s" : [ {
+                "r" : "481",
+                "value" : [ "1", " ", "properly included in", " ", "null" ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperIn",
+          "localId" : "492",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "496",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          }, {
+            "type" : "IntervalTypeSpecifier",
+            "localId" : "497",
+            "annotation" : [ ],
+            "pointType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "498",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          } ],
+          "operand" : [ {
+            "type" : "Literal",
+            "localId" : "481",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "value" : "1",
+            "annotation" : [ ]
+          }, {
+            "type" : "As",
+            "localId" : "493",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : {
+              "type" : "Null",
+              "localId" : "482",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+              "annotation" : [ ]
+            },
+            "asTypeSpecifier" : {
+              "type" : "IntervalTypeSpecifier",
+              "localId" : "494",
+              "annotation" : [ ],
+              "pointType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "495",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            }
+          } ]
+        }
+      }, {
+        "localId" : "501",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "NullNotIn",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "501",
+            "s" : [ {
+              "value" : [ "", "define ", "NullNotIn", ": " ]
+            }, {
+              "r" : "517",
+              "s" : [ {
+                "r" : "502",
+                "value" : [ "null", " ", "properly included in", " " ]
+              }, {
+                "r" : "503",
+                "s" : [ {
+                  "r" : "504",
+                  "value" : [ "{", "1", ", ", "2", ", ", "3", "}" ]
+                } ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperIn",
+          "localId" : "517",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "519",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          }, {
+            "type" : "ListTypeSpecifier",
+            "localId" : "520",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "521",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          } ],
+          "operand" : [ {
+            "type" : "As",
+            "localId" : "518",
+            "asType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : {
+              "type" : "Null",
+              "localId" : "502",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+              "annotation" : [ ]
+            }
+          }, {
+            "type" : "List",
+            "localId" : "503",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "507",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "508",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "element" : [ {
+              "type" : "Literal",
+              "localId" : "504",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "annotation" : [ ]
+            }, {
+              "type" : "Literal",
+              "localId" : "505",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2",
+              "annotation" : [ ]
+            }, {
+              "type" : "Literal",
+              "localId" : "506",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "3",
+              "annotation" : [ ]
+            } ]
+          } ]
+        }
+      } ]
+    }
+  }
+}
+
+/* ProperContains
+library TestSnippet version '1'
+using Simple version '1.0.0'
+context Patient
+define IsIn: { 3, 4, 5 } properly includes 4
+define IsNotIn: { 3, 5, 6 } properly includes 4
+define IsNotProperlyIn: { 4 } properly includes 4
+define IsInNotUnique: { 4, 4 } properly includes 4
+define IsInWithNull: { 4, null } properly includes 4
+define TupleIsIn: {Tuple{a:1, b:'d'}, Tuple{a:1, b:'c'}, Tuple{a:2, b:'c'}} properly includes Tuple{a: 1, b: 'c'}
+define TupleIsNotIn: {Tuple{a:1, b:'d'}, Tuple{a:2, b:'d'}, Tuple{a:2, b:'c'}} properly includes Tuple{a: 1, b: 'c'}
+define InNull: (null as List<Integer>) properly includes 1
+define NullIn: {1, 2, null, 3} properly includes null
+define NullNotIn: {1, 2, 3} properly includes null
+*/
+
+module.exports['ProperContains'] = {
+  "library" : {
+    "localId" : "0",
+    "annotation" : [ {
+      "type" : "CqlToElmInfo",
+      "translatorVersion" : "4.2.0",
+      "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations,EnableResultTypes",
+      "signatureLevel" : "All"
+    }, {
+      "type" : "Annotation",
+      "t" : [ ],
+      "s" : {
+        "r" : "504",
+        "s" : [ {
+          "value" : [ "", "library TestSnippet version '1'" ]
+        } ]
+      }
+    } ],
+    "identifier" : {
+      "id" : "TestSnippet",
+      "version" : "1"
+    },
+    "schemaIdentifier" : {
+      "id" : "urn:hl7-org:elm",
+      "version" : "r1"
+    },
+    "usings" : {
+      "def" : [ {
+        "localId" : "1",
+        "localIdentifier" : "System",
+        "uri" : "urn:hl7-org:elm-types:r1",
+        "annotation" : [ ]
+      }, {
+        "localId" : "206",
+        "localIdentifier" : "Simple",
+        "uri" : "https://github.com/cqframework/cql-execution/simple",
+        "version" : "1.0.0",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "206",
+            "s" : [ {
+              "value" : [ "", "using " ]
+            }, {
+              "s" : [ {
+                "value" : [ "Simple" ]
+              } ]
+            }, {
+              "value" : [ " version '1.0.0'" ]
+            } ]
+          }
+        } ]
+      } ]
+    },
+    "contexts" : {
+      "def" : [ {
+        "localId" : "211",
+        "name" : "Patient",
+        "annotation" : [ ]
+      } ]
+    },
+    "statements" : {
+      "def" : [ {
+        "localId" : "209",
+        "name" : "Patient",
+        "context" : "Patient",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "SingletonFrom",
+          "localId" : "210",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : {
+            "type" : "Retrieve",
+            "localId" : "208",
+            "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
+            "annotation" : [ ],
+            "include" : [ ],
+            "codeFilter" : [ ],
+            "dateFilter" : [ ],
+            "otherFilter" : [ ]
+          }
+        }
+      }, {
+        "localId" : "214",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "IsIn",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "214",
+            "s" : [ {
+              "value" : [ "", "define ", "IsIn", ": " ]
+            }, {
+              "r" : "228",
+              "s" : [ {
+                "r" : "215",
+                "s" : [ {
+                  "r" : "216",
+                  "value" : [ "{ ", "3", ", ", "4", ", ", "5", " }" ]
+                } ]
+              }, {
+                "r" : "228",
+                "value" : [ " ", "properly includes", " ", "4" ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperContains",
+          "localId" : "228",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "localId" : "229",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "230",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          }, {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "231",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          } ],
+          "operand" : [ {
+            "type" : "List",
+            "localId" : "215",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "219",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "220",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "element" : [ {
+              "type" : "Literal",
+              "localId" : "216",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "3",
+              "annotation" : [ ]
+            }, {
+              "type" : "Literal",
+              "localId" : "217",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "4",
+              "annotation" : [ ]
+            }, {
+              "type" : "Literal",
+              "localId" : "218",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "5",
+              "annotation" : [ ]
+            } ]
+          }, {
+            "type" : "Literal",
+            "localId" : "221",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "value" : "4",
+            "annotation" : [ ]
+          } ]
+        }
+      }, {
+        "localId" : "234",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "IsNotIn",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "234",
+            "s" : [ {
+              "value" : [ "", "define ", "IsNotIn", ": " ]
+            }, {
+              "r" : "248",
+              "s" : [ {
+                "r" : "235",
+                "s" : [ {
+                  "r" : "236",
+                  "value" : [ "{ ", "3", ", ", "5", ", ", "6", " }" ]
+                } ]
+              }, {
+                "r" : "248",
+                "value" : [ " ", "properly includes", " ", "4" ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperContains",
+          "localId" : "248",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "localId" : "249",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "250",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          }, {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "251",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          } ],
+          "operand" : [ {
+            "type" : "List",
+            "localId" : "235",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "239",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "240",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "element" : [ {
+              "type" : "Literal",
+              "localId" : "236",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "3",
+              "annotation" : [ ]
+            }, {
+              "type" : "Literal",
+              "localId" : "237",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "5",
+              "annotation" : [ ]
+            }, {
+              "type" : "Literal",
+              "localId" : "238",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "6",
+              "annotation" : [ ]
+            } ]
+          }, {
+            "type" : "Literal",
+            "localId" : "241",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "value" : "4",
+            "annotation" : [ ]
+          } ]
+        }
+      }, {
+        "localId" : "254",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "IsNotProperlyIn",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "254",
+            "s" : [ {
+              "value" : [ "", "define ", "IsNotProperlyIn", ": " ]
+            }, {
+              "r" : "266",
+              "s" : [ {
+                "r" : "255",
+                "s" : [ {
+                  "r" : "256",
+                  "value" : [ "{ ", "4", " }" ]
+                } ]
+              }, {
+                "r" : "266",
+                "value" : [ " ", "properly includes", " ", "4" ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperContains",
+          "localId" : "266",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "localId" : "267",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "268",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          }, {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "269",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          } ],
+          "operand" : [ {
+            "type" : "List",
+            "localId" : "255",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "257",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "258",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "element" : [ {
+              "type" : "Literal",
+              "localId" : "256",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "4",
+              "annotation" : [ ]
+            } ]
+          }, {
+            "type" : "Literal",
+            "localId" : "259",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "value" : "4",
+            "annotation" : [ ]
+          } ]
+        }
+      }, {
+        "localId" : "272",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "IsInNotUnique",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "272",
+            "s" : [ {
+              "value" : [ "", "define ", "IsInNotUnique", ": " ]
+            }, {
+              "r" : "285",
+              "s" : [ {
+                "r" : "273",
+                "s" : [ {
+                  "r" : "274",
+                  "value" : [ "{ ", "4", ", ", "4", " }" ]
+                } ]
+              }, {
+                "r" : "285",
+                "value" : [ " ", "properly includes", " ", "4" ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperContains",
+          "localId" : "285",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "localId" : "286",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "287",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          }, {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "288",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          } ],
+          "operand" : [ {
+            "type" : "List",
+            "localId" : "273",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "276",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "277",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "element" : [ {
+              "type" : "Literal",
+              "localId" : "274",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "4",
+              "annotation" : [ ]
+            }, {
+              "type" : "Literal",
+              "localId" : "275",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "4",
+              "annotation" : [ ]
+            } ]
+          }, {
+            "type" : "Literal",
+            "localId" : "278",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "value" : "4",
+            "annotation" : [ ]
+          } ]
+        }
+      }, {
+        "localId" : "291",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "IsInWithNull",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "291",
+            "s" : [ {
+              "value" : [ "", "define ", "IsInWithNull", ": " ]
+            }, {
+              "r" : "305",
+              "s" : [ {
+                "r" : "292",
+                "s" : [ {
+                  "r" : "293",
+                  "value" : [ "{ ", "4", ", ", "null", " }" ]
+                } ]
+              }, {
+                "r" : "305",
+                "value" : [ " ", "properly includes", " ", "4" ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperContains",
+          "localId" : "305",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "localId" : "306",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "307",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          }, {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "308",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          } ],
+          "operand" : [ {
+            "type" : "List",
+            "localId" : "292",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "296",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "297",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "element" : [ {
+              "type" : "Literal",
+              "localId" : "293",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "4",
+              "annotation" : [ ]
+            }, {
+              "type" : "As",
+              "localId" : "295",
+              "asType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : {
+                "type" : "Null",
+                "localId" : "294",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                "annotation" : [ ]
+              }
+            } ]
+          }, {
+            "type" : "Literal",
+            "localId" : "298",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "value" : "4",
+            "annotation" : [ ]
+          } ]
+        }
+      }, {
+        "localId" : "311",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "TupleIsIn",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "311",
+            "s" : [ {
+              "value" : [ "", "define ", "TupleIsIn", ": " ]
+            }, {
+              "r" : "369",
+              "s" : [ {
+                "r" : "312",
+                "s" : [ {
+                  "value" : [ "{" ]
+                }, {
+                  "r" : "313",
+                  "s" : [ {
+                    "value" : [ "Tuple{" ]
+                  }, {
+                    "s" : [ {
+                      "r" : "314",
+                      "value" : [ "a", ":", "1" ]
+                    } ]
+                  }, {
+                    "value" : [ ", " ]
+                  }, {
+                    "s" : [ {
+                      "value" : [ "b", ":" ]
+                    }, {
+                      "r" : "315",
+                      "s" : [ {
+                        "value" : [ "'d'" ]
+                      } ]
+                    } ]
+                  }, {
+                    "value" : [ "}" ]
+                  } ]
+                }, {
+                  "value" : [ ", " ]
+                }, {
+                  "r" : "322",
+                  "s" : [ {
+                    "value" : [ "Tuple{" ]
+                  }, {
+                    "s" : [ {
+                      "r" : "323",
+                      "value" : [ "a", ":", "1" ]
+                    } ]
+                  }, {
+                    "value" : [ ", " ]
+                  }, {
+                    "s" : [ {
+                      "value" : [ "b", ":" ]
+                    }, {
+                      "r" : "324",
+                      "s" : [ {
+                        "value" : [ "'c'" ]
+                      } ]
+                    } ]
+                  }, {
+                    "value" : [ "}" ]
+                  } ]
+                }, {
+                  "value" : [ ", " ]
+                }, {
+                  "r" : "331",
+                  "s" : [ {
+                    "value" : [ "Tuple{" ]
+                  }, {
+                    "s" : [ {
+                      "r" : "332",
+                      "value" : [ "a", ":", "2" ]
+                    } ]
+                  }, {
+                    "value" : [ ", " ]
+                  }, {
+                    "s" : [ {
+                      "value" : [ "b", ":" ]
+                    }, {
+                      "r" : "333",
+                      "s" : [ {
+                        "value" : [ "'c'" ]
+                      } ]
+                    } ]
+                  }, {
+                    "value" : [ "}" ]
+                  } ]
+                }, {
+                  "value" : [ "}" ]
+                } ]
+              }, {
+                "r" : "369",
+                "value" : [ " ", "properly includes", " " ]
+              }, {
+                "r" : "346",
+                "s" : [ {
+                  "value" : [ "Tuple{" ]
+                }, {
+                  "s" : [ {
+                    "r" : "347",
+                    "value" : [ "a", ": ", "1" ]
+                  } ]
+                }, {
+                  "value" : [ ", " ]
+                }, {
+                  "s" : [ {
+                    "value" : [ "b", ": " ]
+                  }, {
+                    "r" : "348",
+                    "s" : [ {
+                      "value" : [ "'c'" ]
+                    } ]
+                  } ]
+                }, {
+                  "value" : [ "}" ]
+                } ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperContains",
+          "localId" : "369",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "localId" : "370",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "TupleTypeSpecifier",
+              "localId" : "371",
+              "annotation" : [ ],
+              "element" : [ {
+                "localId" : "372",
+                "name" : "a",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "373",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "annotation" : [ ]
+                }
+              }, {
+                "localId" : "374",
+                "name" : "b",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "375",
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "annotation" : [ ]
+                }
+              } ]
+            }
+          }, {
+            "type" : "TupleTypeSpecifier",
+            "localId" : "376",
+            "annotation" : [ ],
+            "element" : [ {
+              "localId" : "377",
+              "name" : "a",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "378",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            }, {
+              "localId" : "379",
+              "name" : "b",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "380",
+                "name" : "{urn:hl7-org:elm-types:r1}String",
+                "annotation" : [ ]
+              }
+            } ]
+          } ],
+          "operand" : [ {
+            "type" : "List",
+            "localId" : "312",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "340",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "TupleTypeSpecifier",
+                "localId" : "341",
+                "annotation" : [ ],
+                "element" : [ {
+                  "localId" : "342",
+                  "name" : "a",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "343",
+                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                    "annotation" : [ ]
+                  }
+                }, {
+                  "localId" : "344",
+                  "name" : "b",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "345",
+                    "name" : "{urn:hl7-org:elm-types:r1}String",
+                    "annotation" : [ ]
+                  }
+                } ]
+              }
+            },
+            "element" : [ {
+              "type" : "Tuple",
+              "localId" : "313",
+              "annotation" : [ ],
+              "resultTypeSpecifier" : {
+                "type" : "TupleTypeSpecifier",
+                "localId" : "317",
+                "annotation" : [ ],
+                "element" : [ {
+                  "localId" : "318",
+                  "name" : "a",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "319",
+                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                    "annotation" : [ ]
+                  }
+                }, {
+                  "localId" : "320",
+                  "name" : "b",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "321",
+                    "name" : "{urn:hl7-org:elm-types:r1}String",
+                    "annotation" : [ ]
+                  }
+                } ]
+              },
+              "element" : [ {
+                "name" : "a",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "314",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "1",
+                  "annotation" : [ ]
+                }
+              }, {
+                "name" : "b",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "315",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "d",
+                  "annotation" : [ ]
+                }
+              } ]
+            }, {
+              "type" : "Tuple",
+              "localId" : "322",
+              "annotation" : [ ],
+              "resultTypeSpecifier" : {
+                "type" : "TupleTypeSpecifier",
+                "localId" : "326",
+                "annotation" : [ ],
+                "element" : [ {
+                  "localId" : "327",
+                  "name" : "a",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "328",
+                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                    "annotation" : [ ]
+                  }
+                }, {
+                  "localId" : "329",
+                  "name" : "b",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "330",
+                    "name" : "{urn:hl7-org:elm-types:r1}String",
+                    "annotation" : [ ]
+                  }
+                } ]
+              },
+              "element" : [ {
+                "name" : "a",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "323",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "1",
+                  "annotation" : [ ]
+                }
+              }, {
+                "name" : "b",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "324",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "c",
+                  "annotation" : [ ]
+                }
+              } ]
+            }, {
+              "type" : "Tuple",
+              "localId" : "331",
+              "annotation" : [ ],
+              "resultTypeSpecifier" : {
+                "type" : "TupleTypeSpecifier",
+                "localId" : "335",
+                "annotation" : [ ],
+                "element" : [ {
+                  "localId" : "336",
+                  "name" : "a",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "337",
+                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                    "annotation" : [ ]
+                  }
+                }, {
+                  "localId" : "338",
+                  "name" : "b",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "339",
+                    "name" : "{urn:hl7-org:elm-types:r1}String",
+                    "annotation" : [ ]
+                  }
+                } ]
+              },
+              "element" : [ {
+                "name" : "a",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "332",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "2",
+                  "annotation" : [ ]
+                }
+              }, {
+                "name" : "b",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "333",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "c",
+                  "annotation" : [ ]
+                }
+              } ]
+            } ]
+          }, {
+            "type" : "Tuple",
+            "localId" : "346",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "TupleTypeSpecifier",
+              "localId" : "350",
+              "annotation" : [ ],
+              "element" : [ {
+                "localId" : "351",
+                "name" : "a",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "352",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "annotation" : [ ]
+                }
+              }, {
+                "localId" : "353",
+                "name" : "b",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "354",
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "annotation" : [ ]
+                }
+              } ]
+            },
+            "element" : [ {
+              "name" : "a",
+              "value" : {
+                "type" : "Literal",
+                "localId" : "347",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                "value" : "1",
+                "annotation" : [ ]
+              }
+            }, {
+              "name" : "b",
+              "value" : {
+                "type" : "Literal",
+                "localId" : "348",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                "value" : "c",
+                "annotation" : [ ]
+              }
+            } ]
+          } ]
+        }
+      }, {
+        "localId" : "383",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "TupleIsNotIn",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "383",
+            "s" : [ {
+              "value" : [ "", "define ", "TupleIsNotIn", ": " ]
+            }, {
+              "r" : "441",
+              "s" : [ {
+                "r" : "384",
+                "s" : [ {
+                  "value" : [ "{" ]
+                }, {
+                  "r" : "385",
+                  "s" : [ {
+                    "value" : [ "Tuple{" ]
+                  }, {
+                    "s" : [ {
+                      "r" : "386",
+                      "value" : [ "a", ":", "1" ]
+                    } ]
+                  }, {
+                    "value" : [ ", " ]
+                  }, {
+                    "s" : [ {
+                      "value" : [ "b", ":" ]
+                    }, {
+                      "r" : "387",
+                      "s" : [ {
+                        "value" : [ "'d'" ]
+                      } ]
+                    } ]
+                  }, {
+                    "value" : [ "}" ]
+                  } ]
+                }, {
+                  "value" : [ ", " ]
+                }, {
+                  "r" : "394",
+                  "s" : [ {
+                    "value" : [ "Tuple{" ]
+                  }, {
+                    "s" : [ {
+                      "r" : "395",
+                      "value" : [ "a", ":", "2" ]
+                    } ]
+                  }, {
+                    "value" : [ ", " ]
+                  }, {
+                    "s" : [ {
+                      "value" : [ "b", ":" ]
+                    }, {
+                      "r" : "396",
+                      "s" : [ {
+                        "value" : [ "'d'" ]
+                      } ]
+                    } ]
+                  }, {
+                    "value" : [ "}" ]
+                  } ]
+                }, {
+                  "value" : [ ", " ]
+                }, {
+                  "r" : "403",
+                  "s" : [ {
+                    "value" : [ "Tuple{" ]
+                  }, {
+                    "s" : [ {
+                      "r" : "404",
+                      "value" : [ "a", ":", "2" ]
+                    } ]
+                  }, {
+                    "value" : [ ", " ]
+                  }, {
+                    "s" : [ {
+                      "value" : [ "b", ":" ]
+                    }, {
+                      "r" : "405",
+                      "s" : [ {
+                        "value" : [ "'c'" ]
+                      } ]
+                    } ]
+                  }, {
+                    "value" : [ "}" ]
+                  } ]
+                }, {
+                  "value" : [ "}" ]
+                } ]
+              }, {
+                "r" : "441",
+                "value" : [ " ", "properly includes", " " ]
+              }, {
+                "r" : "418",
+                "s" : [ {
+                  "value" : [ "Tuple{" ]
+                }, {
+                  "s" : [ {
+                    "r" : "419",
+                    "value" : [ "a", ": ", "1" ]
+                  } ]
+                }, {
+                  "value" : [ ", " ]
+                }, {
+                  "s" : [ {
+                    "value" : [ "b", ": " ]
+                  }, {
+                    "r" : "420",
+                    "s" : [ {
+                      "value" : [ "'c'" ]
+                    } ]
+                  } ]
+                }, {
+                  "value" : [ "}" ]
+                } ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperContains",
+          "localId" : "441",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "localId" : "442",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "TupleTypeSpecifier",
+              "localId" : "443",
+              "annotation" : [ ],
+              "element" : [ {
+                "localId" : "444",
+                "name" : "a",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "445",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "annotation" : [ ]
+                }
+              }, {
+                "localId" : "446",
+                "name" : "b",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "447",
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "annotation" : [ ]
+                }
+              } ]
+            }
+          }, {
+            "type" : "TupleTypeSpecifier",
+            "localId" : "448",
+            "annotation" : [ ],
+            "element" : [ {
+              "localId" : "449",
+              "name" : "a",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "450",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            }, {
+              "localId" : "451",
+              "name" : "b",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "452",
+                "name" : "{urn:hl7-org:elm-types:r1}String",
+                "annotation" : [ ]
+              }
+            } ]
+          } ],
+          "operand" : [ {
+            "type" : "List",
+            "localId" : "384",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "412",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "TupleTypeSpecifier",
+                "localId" : "413",
+                "annotation" : [ ],
+                "element" : [ {
+                  "localId" : "414",
+                  "name" : "a",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "415",
+                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                    "annotation" : [ ]
+                  }
+                }, {
+                  "localId" : "416",
+                  "name" : "b",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "417",
+                    "name" : "{urn:hl7-org:elm-types:r1}String",
+                    "annotation" : [ ]
+                  }
+                } ]
+              }
+            },
+            "element" : [ {
+              "type" : "Tuple",
+              "localId" : "385",
+              "annotation" : [ ],
+              "resultTypeSpecifier" : {
+                "type" : "TupleTypeSpecifier",
+                "localId" : "389",
+                "annotation" : [ ],
+                "element" : [ {
+                  "localId" : "390",
+                  "name" : "a",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "391",
+                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                    "annotation" : [ ]
+                  }
+                }, {
+                  "localId" : "392",
+                  "name" : "b",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "393",
+                    "name" : "{urn:hl7-org:elm-types:r1}String",
+                    "annotation" : [ ]
+                  }
+                } ]
+              },
+              "element" : [ {
+                "name" : "a",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "386",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "1",
+                  "annotation" : [ ]
+                }
+              }, {
+                "name" : "b",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "387",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "d",
+                  "annotation" : [ ]
+                }
+              } ]
+            }, {
+              "type" : "Tuple",
+              "localId" : "394",
+              "annotation" : [ ],
+              "resultTypeSpecifier" : {
+                "type" : "TupleTypeSpecifier",
+                "localId" : "398",
+                "annotation" : [ ],
+                "element" : [ {
+                  "localId" : "399",
+                  "name" : "a",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "400",
+                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                    "annotation" : [ ]
+                  }
+                }, {
+                  "localId" : "401",
+                  "name" : "b",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "402",
+                    "name" : "{urn:hl7-org:elm-types:r1}String",
+                    "annotation" : [ ]
+                  }
+                } ]
+              },
+              "element" : [ {
+                "name" : "a",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "395",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "2",
+                  "annotation" : [ ]
+                }
+              }, {
+                "name" : "b",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "396",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "d",
+                  "annotation" : [ ]
+                }
+              } ]
+            }, {
+              "type" : "Tuple",
+              "localId" : "403",
+              "annotation" : [ ],
+              "resultTypeSpecifier" : {
+                "type" : "TupleTypeSpecifier",
+                "localId" : "407",
+                "annotation" : [ ],
+                "element" : [ {
+                  "localId" : "408",
+                  "name" : "a",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "409",
+                    "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                    "annotation" : [ ]
+                  }
+                }, {
+                  "localId" : "410",
+                  "name" : "b",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "411",
+                    "name" : "{urn:hl7-org:elm-types:r1}String",
+                    "annotation" : [ ]
+                  }
+                } ]
+              },
+              "element" : [ {
+                "name" : "a",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "404",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "2",
+                  "annotation" : [ ]
+                }
+              }, {
+                "name" : "b",
+                "value" : {
+                  "type" : "Literal",
+                  "localId" : "405",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "c",
+                  "annotation" : [ ]
+                }
+              } ]
+            } ]
+          }, {
+            "type" : "Tuple",
+            "localId" : "418",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "TupleTypeSpecifier",
+              "localId" : "422",
+              "annotation" : [ ],
+              "element" : [ {
+                "localId" : "423",
+                "name" : "a",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "424",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "annotation" : [ ]
+                }
+              }, {
+                "localId" : "425",
+                "name" : "b",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "426",
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "annotation" : [ ]
+                }
+              } ]
+            },
+            "element" : [ {
+              "name" : "a",
+              "value" : {
+                "type" : "Literal",
+                "localId" : "419",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                "value" : "1",
+                "annotation" : [ ]
+              }
+            }, {
+              "name" : "b",
+              "value" : {
+                "type" : "Literal",
+                "localId" : "420",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                "value" : "c",
+                "annotation" : [ ]
+              }
+            } ]
+          } ]
+        }
+      }, {
+        "localId" : "455",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "InNull",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "455",
+            "s" : [ {
+              "value" : [ "", "define ", "InNull", ": " ]
+            }, {
+              "r" : "473",
+              "s" : [ {
+                "r" : "456",
+                "s" : [ {
+                  "value" : [ "(" ]
+                }, {
+                  "r" : "456",
+                  "s" : [ {
+                    "r" : "457",
+                    "value" : [ "null", " as " ]
+                  }, {
+                    "r" : "458",
+                    "s" : [ {
+                      "value" : [ "List<" ]
+                    }, {
+                      "r" : "459",
+                      "s" : [ {
+                        "value" : [ "Integer" ]
+                      } ]
+                    }, {
+                      "value" : [ ">" ]
+                    } ]
+                  } ]
+                }, {
+                  "value" : [ ")" ]
+                } ]
+              }, {
+                "r" : "473",
+                "value" : [ " ", "properly includes", " ", "1" ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperContains",
+          "localId" : "473",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "localId" : "474",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "475",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          }, {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "476",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          } ],
+          "operand" : [ {
+            "type" : "As",
+            "localId" : "456",
+            "strict" : false,
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "464",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "465",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "signature" : [ ],
+            "operand" : {
+              "type" : "Null",
+              "localId" : "457",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+              "annotation" : [ ]
+            },
+            "asTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "458",
+              "annotation" : [ ],
+              "resultTypeSpecifier" : {
+                "type" : "ListTypeSpecifier",
+                "localId" : "460",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "461",
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "annotation" : [ ]
+                }
+              },
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "459",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            }
+          }, {
+            "type" : "Literal",
+            "localId" : "466",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "value" : "1",
+            "annotation" : [ ]
+          } ]
+        }
+      }, {
+        "localId" : "479",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "NullIn",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "479",
+            "s" : [ {
+              "value" : [ "", "define ", "NullIn", ": " ]
+            }, {
+              "r" : "497",
+              "s" : [ {
+                "r" : "480",
+                "s" : [ {
+                  "r" : "481",
+                  "value" : [ "{", "1", ", ", "2", ", ", "null", ", ", "3", "}" ]
+                } ]
+              }, {
+                "r" : "497",
+                "value" : [ " ", "properly includes", " ", "null" ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperContains",
+          "localId" : "497",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "localId" : "499",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "500",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          }, {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "501",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          } ],
+          "operand" : [ {
+            "type" : "List",
+            "localId" : "480",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "486",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "487",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "element" : [ {
+              "type" : "Literal",
+              "localId" : "481",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "annotation" : [ ]
+            }, {
+              "type" : "Literal",
+              "localId" : "482",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2",
+              "annotation" : [ ]
+            }, {
+              "type" : "As",
+              "localId" : "485",
+              "asType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : {
+                "type" : "Null",
+                "localId" : "483",
+                "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                "annotation" : [ ]
+              }
+            }, {
+              "type" : "Literal",
+              "localId" : "484",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "3",
+              "annotation" : [ ]
+            } ]
+          }, {
+            "type" : "As",
+            "localId" : "498",
+            "asType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : {
+              "type" : "Null",
+              "localId" : "488",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+              "annotation" : [ ]
+            }
+          } ]
+        }
+      }, {
+        "localId" : "504",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+        "name" : "NullNotIn",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "504",
+            "s" : [ {
+              "value" : [ "", "define ", "NullNotIn", ": " ]
+            }, {
+              "r" : "520",
+              "s" : [ {
+                "r" : "505",
+                "s" : [ {
+                  "r" : "506",
+                  "value" : [ "{", "1", ", ", "2", ", ", "3", "}" ]
+                } ]
+              }, {
+                "r" : "520",
+                "value" : [ " ", "properly includes", " ", "null" ]
+              } ]
+            } ]
+          }
+        } ],
+        "expression" : {
+          "type" : "ProperContains",
+          "localId" : "520",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "localId" : "522",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "523",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation" : [ ]
+            }
+          }, {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "524",
+            "name" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ]
+          } ],
+          "operand" : [ {
+            "type" : "List",
+            "localId" : "505",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "509",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "510",
+                "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation" : [ ]
+              }
+            },
+            "element" : [ {
+              "type" : "Literal",
+              "localId" : "506",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "annotation" : [ ]
+            }, {
+              "type" : "Literal",
+              "localId" : "507",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2",
+              "annotation" : [ ]
+            }, {
+              "type" : "Literal",
+              "localId" : "508",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "3",
+              "annotation" : [ ]
+            } ]
+          }, {
+            "type" : "As",
+            "localId" : "521",
+            "asType" : "{urn:hl7-org:elm-types:r1}Integer",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : {
+              "type" : "Null",
+              "localId" : "511",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+              "annotation" : [ ]
+            }
           } ]
         }
       } ]

--- a/test/elm/list/list-test.ts
+++ b/test/elm/list/list-test.ts
@@ -646,8 +646,7 @@ describe('ProperIncludes', () => {
     (await this.tuplesNotIncluded.exec(this.ctx)).should.be.false();
   });
 
-  // TODO: Support for ProperContains
-  it.skip('should return null if either arg is null', async function () {
+  it('should return null if either arg is null', async function () {
     should(await this.nullIncluded.exec(this.ctx)).be.null();
     should(await this.nullIncludes.exec(this.ctx)).be.null();
   });
@@ -701,6 +700,98 @@ describe('ProperIncludedIn', () => {
   it('should return null if either arg is null', async function () {
     should(await this.nullIncluded.exec(this.ctx)).be.null();
     should(await this.nullIncludes.exec(this.ctx)).be.null();
+  });
+});
+
+describe('ProperIn', () => {
+  beforeEach(function () {
+    setup(this, data);
+  });
+
+  it('should execute to true when item is in list', async function () {
+    (await this.isIn.exec(this.ctx)).should.be.true();
+  });
+
+  it('should execute to false when item is not in list', async function () {
+    (await this.isNotIn.exec(this.ctx)).should.be.false();
+  });
+
+  it('should execute to false when item is the only item in list', async function () {
+    (await this.isNotProperlyIn.exec(this.ctx)).should.be.false();
+  });
+
+  it('should execute to true when item is in the list multiple times', async function () {
+    (await this.isInNotUnique.exec(this.ctx)).should.be.true();
+  });
+
+  it('should execute to true when item is in list with null', async function () {
+    (await this.isInWithNull.exec(this.ctx)).should.be.true();
+  });
+
+  it('should execute to true when tuple is in list', async function () {
+    (await this.tupleIsIn.exec(this.ctx)).should.be.true();
+  });
+
+  it('should execute to false when tuple is not in list', async function () {
+    (await this.tupleIsNotIn.exec(this.ctx)).should.be.false();
+  });
+
+  it('should return false if list is null', async function () {
+    (await this.inNull.exec(this.ctx)).should.be.false();
+  });
+
+  it('should return true if null is in list', async function () {
+    (await this.nullIn.exec(this.ctx)).should.be.true();
+  });
+
+  it('should return false if null is not in list', async function () {
+    (await this.nullNotIn.exec(this.ctx)).should.be.false();
+  });
+});
+
+describe('ProperContains', () => {
+  beforeEach(function () {
+    setup(this, data);
+  });
+
+  it('should execute to true when item is in list', async function () {
+    (await this.isIn.exec(this.ctx)).should.be.true();
+  });
+
+  it('should execute to false when item is not in list', async function () {
+    (await this.isNotIn.exec(this.ctx)).should.be.false();
+  });
+
+  it('should execute to false when item is the only item in list', async function () {
+    (await this.isNotProperlyIn.exec(this.ctx)).should.be.false();
+  });
+
+  it('should execute to true when item is in the list multiple times', async function () {
+    (await this.isInNotUnique.exec(this.ctx)).should.be.true();
+  });
+
+  it('should execute to true when item is in list with null', async function () {
+    (await this.isInWithNull.exec(this.ctx)).should.be.true();
+  });
+
+  it('should execute to true when tuple is in list', async function () {
+    (await this.tupleIsIn.exec(this.ctx)).should.be.true();
+  });
+
+  it('should execute to false when tuple is not in list', async function () {
+    (await this.tupleIsNotIn.exec(this.ctx)).should.be.false();
+  });
+
+  it('should return true if null is contained in the list', async function () {
+    (await this.nullIn.exec(this.ctx)).should.be.true();
+  });
+
+  it('should return false if null is not contained in the list', async function () {
+    (await this.nullNotIn.exec(this.ctx)).should.be.false();
+  });
+
+  it('should return false if list is null', async function () {
+    (await this.inNull.exec(this.ctx)).should.be.false();
   });
 });
 

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.cql
@@ -1430,80 +1430,56 @@ define "PointFrom": Tuple{
 
 define "ProperContains": Tuple{
   "TimeProperContainsTrue": Tuple{
-    skipped: 'ProperContains not implemented'
-    /*
     expression: Interval[@T12:00:00.000, @T21:59:59.999] properly includes @T12:00:00.001,
     output: true
-    */  },
+  },
   "TimeProperContainsFalse": Tuple{
-    skipped: 'ProperContains not implemented'
-    /*
     expression: Interval[@T12:00:00.000, @T21:59:59.999] properly includes @T12:00:00.000,
     output: false
-    */  },
+  },
   "TimeProperContainsNull": Tuple{
-    skipped: 'ProperContains not implemented'
-    /*
     expression: Interval[@T12:00:00.001, @T21:59:59.999] properly includes @T12:00:00,
     output: null
-    */  },
+  },
   "TimeProperContainsPrecisionTrue": Tuple{
-    skipped: 'ProperContains not implemented'
-    /*
     expression: Interval[@T12:00:00.000, @T21:59:59.999] properly includes second of @T12:00:01,
     output: true
-    */  },
+  },
   "TimeProperContainsPrecisionFalse": Tuple{
-    skipped: 'ProperContains not implemented'
-    /*
     expression: Interval[@T12:00:00.001, @T21:59:59.999] properly includes second of @T12:00:00,
     output: false
-    */  },
+  },
   "TimeProperContainsPrecisionNull": Tuple{
-    skipped: 'ProperContains not implemented'
-    /*
     expression: Interval[@T12:00:00.001, @T21:59:59.999] properly includes millisecond of @T12:00:00,
     output: null
-    */  }
+  }
 }
 
 define "ProperIn": Tuple{
   "TimeProperInTrue": Tuple{
-    skipped: 'ProperIn not implemented'
-    /*
     expression: @T12:00:00.001 properly included in Interval[@T12:00:00.000, @T21:59:59.999],
     output: true
-    */  },
+  },
   "TimeProperInFalse": Tuple{
-    skipped: 'ProperIn not implemented'
-    /*
     expression: @T12:00:00.000 properly included in  Interval[@T12:00:00.000, @T21:59:59.999],
     output: false
-    */  },
+  },
   "TimeProperInNull": Tuple{
-    skipped: 'ProperIn not implemented'
-    /*
     expression: @T12:00:00 properly included in Interval[@T12:00:00.001, @T21:59:59.999],
     output: null
-    */  },
+  },
   "TimeProperInPrecisionTrue": Tuple{
-    skipped: 'ProperIn not implemented'
-    /*
     expression: @T12:00:01 properly included in second of Interval[@T12:00:00.000, @T21:59:59.999],
     output: true
-    */  },
+  },
   "TimeProperInPrecisionFalse": Tuple{
-    skipped: 'ProperIn not implemented'
-    /*
     expression: @T12:00:00 properly included in second of Interval[@T12:00:00.001, @T21:59:59.999],
     output: false
-    */  },
+  },
   "TimeProperInPrecisionNull": Tuple{
-    skipped: 'ProperIn not implemented'
-    /*
     expression: @T12:00:00 properly included in millisecond of Interval[@T12:00:00.001, @T21:59:59.999],
     output: null
-    */  }
+  }
 }
 
 define "ProperlyIncludes": Tuple{

--- a/test/spec-tests/cql/CqlIntervalOperatorsTest.json
+++ b/test/spec-tests/cql/CqlIntervalOperatorsTest.json
@@ -68324,11 +68324,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
                         "annotation": []
                       }
                     }
@@ -68343,11 +68352,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
                         "annotation": []
                       }
                     }
@@ -68362,11 +68380,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -68381,11 +68408,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
                         "annotation": []
                       }
                     }
@@ -68400,11 +68436,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
                         "annotation": []
                       }
                     }
@@ -68419,11 +68464,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -68447,11 +68501,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -68466,11 +68529,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -68485,11 +68557,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -68504,11 +68585,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -68523,11 +68613,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -68542,11 +68641,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -68566,11 +68674,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -68578,12 +68695,128 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "12",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              }
+                            },
+                            "high": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "21",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "999",
+                                "annotation": []
+                              }
+                            }
+                          },
+                          {
+                            "type": "Time",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                            "annotation": [],
+                            "signature": [],
+                            "hour": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "12",
+                              "annotation": []
+                            },
+                            "minute": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            },
+                            "second": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            },
+                            "millisecond": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "1",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperContains not implemented",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
                         "annotation": []
                       }
                     }
@@ -68600,11 +68833,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -68612,12 +68854,128 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "12",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              }
+                            },
+                            "high": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "21",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "999",
+                                "annotation": []
+                              }
+                            }
+                          },
+                          {
+                            "type": "Time",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                            "annotation": [],
+                            "signature": [],
+                            "hour": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "12",
+                              "annotation": []
+                            },
+                            "minute": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            },
+                            "second": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            },
+                            "millisecond": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperContains not implemented",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
                         "annotation": []
                       }
                     }
@@ -68634,11 +68992,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -68646,12 +69013,120 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "value": {
-                        "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperContains not implemented",
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "12",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "1",
+                                "annotation": []
+                              }
+                            },
+                            "high": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "21",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "999",
+                                "annotation": []
+                              }
+                            }
+                          },
+                          {
+                            "type": "Time",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                            "annotation": [],
+                            "signature": [],
+                            "hour": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "12",
+                              "annotation": []
+                            },
+                            "minute": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            },
+                            "second": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Null",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -68668,11 +69143,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -68680,12 +69164,123 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "precision": "Second",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "12",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              }
+                            },
+                            "high": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "21",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "999",
+                                "annotation": []
+                              }
+                            }
+                          },
+                          {
+                            "type": "Time",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                            "annotation": [],
+                            "signature": [],
+                            "hour": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "12",
+                              "annotation": []
+                            },
+                            "minute": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            },
+                            "second": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "1",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperContains not implemented",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
                         "annotation": []
                       }
                     }
@@ -68702,11 +69297,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -68714,12 +69318,123 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "precision": "Second",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "12",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "1",
+                                "annotation": []
+                              }
+                            },
+                            "high": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "21",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "999",
+                                "annotation": []
+                              }
+                            }
+                          },
+                          {
+                            "type": "Time",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                            "annotation": [],
+                            "signature": [],
+                            "hour": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "12",
+                              "annotation": []
+                            },
+                            "minute": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            },
+                            "second": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperContains not implemented",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
                         "annotation": []
                       }
                     }
@@ -68736,11 +69451,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -68748,12 +69472,121 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "value": {
-                        "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperContains not implemented",
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "precision": "Millisecond",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "12",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "1",
+                                "annotation": []
+                              }
+                            },
+                            "high": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "21",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "999",
+                                "annotation": []
+                              }
+                            }
+                          },
+                          {
+                            "type": "Time",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                            "annotation": [],
+                            "signature": [],
+                            "hour": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "12",
+                              "annotation": []
+                            },
+                            "minute": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            },
+                            "second": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Null",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -68780,11 +69613,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
                         "annotation": []
                       }
                     }
@@ -68799,11 +69641,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
                         "annotation": []
                       }
                     }
@@ -68818,11 +69669,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -68837,11 +69697,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
                         "annotation": []
                       }
                     }
@@ -68856,11 +69725,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
                         "annotation": []
                       }
                     }
@@ -68875,11 +69753,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -68903,11 +69790,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -68922,11 +69818,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -68941,11 +69846,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -68960,11 +69874,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -68979,11 +69902,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -68998,11 +69930,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -69022,11 +69963,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -69034,12 +69984,128 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Time",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                            "annotation": [],
+                            "signature": [],
+                            "hour": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "12",
+                              "annotation": []
+                            },
+                            "minute": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            },
+                            "second": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            },
+                            "millisecond": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "1",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "12",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              }
+                            },
+                            "high": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "21",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "999",
+                                "annotation": []
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperIn not implemented",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
                         "annotation": []
                       }
                     }
@@ -69056,11 +70122,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -69068,12 +70143,128 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Time",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                            "annotation": [],
+                            "signature": [],
+                            "hour": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "12",
+                              "annotation": []
+                            },
+                            "minute": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            },
+                            "second": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            },
+                            "millisecond": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "12",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              }
+                            },
+                            "high": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "21",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "999",
+                                "annotation": []
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperIn not implemented",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
                         "annotation": []
                       }
                     }
@@ -69090,11 +70281,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -69102,12 +70302,120 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "value": {
-                        "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperIn not implemented",
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Time",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                            "annotation": [],
+                            "signature": [],
+                            "hour": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "12",
+                              "annotation": []
+                            },
+                            "minute": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            },
+                            "second": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "12",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "1",
+                                "annotation": []
+                              }
+                            },
+                            "high": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "21",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "999",
+                                "annotation": []
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Null",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -69124,11 +70432,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -69136,12 +70453,123 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "precision": "Second",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Time",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                            "annotation": [],
+                            "signature": [],
+                            "hour": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "12",
+                              "annotation": []
+                            },
+                            "minute": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            },
+                            "second": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "1",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "12",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              }
+                            },
+                            "high": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "21",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "999",
+                                "annotation": []
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperIn not implemented",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
                         "annotation": []
                       }
                     }
@@ -69158,11 +70586,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -69170,12 +70607,123 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "precision": "Second",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Time",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                            "annotation": [],
+                            "signature": [],
+                            "hour": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "12",
+                              "annotation": []
+                            },
+                            "minute": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            },
+                            "second": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "12",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "1",
+                                "annotation": []
+                              }
+                            },
+                            "high": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "21",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "999",
+                                "annotation": []
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperIn not implemented",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
                         "annotation": []
                       }
                     }
@@ -69192,11 +70740,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -69204,12 +70761,121 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "value": {
-                        "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperIn not implemented",
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "precision": "Millisecond",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Time",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                            "annotation": [],
+                            "signature": [],
+                            "hour": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "12",
+                              "annotation": []
+                            },
+                            "minute": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            },
+                            "second": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "0",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "Interval",
+                            "lowClosed": true,
+                            "highClosed": true,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "IntervalTypeSpecifier",
+                              "annotation": [],
+                              "pointType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": []
+                              }
+                            },
+                            "low": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "12",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "0",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "1",
+                                "annotation": []
+                              }
+                            },
+                            "high": {
+                              "type": "Time",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                              "annotation": [],
+                              "signature": [],
+                              "hour": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "21",
+                                "annotation": []
+                              },
+                              "minute": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "second": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "59",
+                                "annotation": []
+                              },
+                              "millisecond": {
+                                "type": "Literal",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "999",
+                                "annotation": []
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Null",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -79950,11 +81616,11 @@
                             "annotation": [],
                             "resultTypeSpecifier": {
                               "type": "IntervalTypeSpecifier",
-                              "localId": "14851",
+                              "localId": "15143",
                               "annotation": [],
                               "pointType": {
                                 "type": "NamedTypeSpecifier",
-                                "localId": "14852",
+                                "localId": "15144",
                                 "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }

--- a/test/spec-tests/cql/CqlListOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlListOperatorsTest.cql
@@ -4,13 +4,17 @@ context Patient
 
 define "Sort": Tuple{
   "simpleSortAsc": Tuple{
+    skipped: 'Wrong output: Queries return distinct lists by default; need to use "all" to retain duplicates'
+    /*
     expression: ({4, 5, 1, 6, 2, 1}) sL sort asc,
     output: {1, 1, 2, 4, 5, 6}
-  },
+    */  },
   "simpleSortDesc": Tuple{
+    skipped: 'Wrong output: Queries return distinct lists by default; need to use "all" to retain duplicates'
+    /*
     expression: ({4, 5, 1, 6, 2, 1}) sL sort desc,
     output: {6, 5, 4, 2, 1, 1}
-  },
+    */  },
   "simpleSortStringAsc": Tuple{
     expression: ({'back', 'aardvark', 'alligator', 'zebra', 'iguana', 'Wolf', 'Armadillo'}) sls sort asc,
     output: {'Armadillo', 'Wolf', 'aardvark', 'alligator', 'back', 'iguana', 'zebra'}
@@ -86,9 +90,11 @@ define "Contains": Tuple{
 
 define "Descendents": Tuple{
   "DescendentsEmptyList": Tuple{
+    skipped: 'Descendents not implemented'
+    /*
     expression: (null).descendents(),
     output: null
-  }
+    */  }
 }
 
 define "Distinct": Tuple{
@@ -132,9 +138,11 @@ define "Distinct": Tuple{
 
 define "Equal": Tuple{
   "EqualNullNull": Tuple{
+    skipped: 'Wrong output: According to spec, if either list contains a null, the result is null'
+    /*
     expression: {null} = {null},
     output: true
-  },
+    */  },
   "EqualEmptyListNull": Tuple{
     expression: {} as List<String> = null,
     output: null
@@ -935,45 +943,65 @@ define "Skip": Tuple{
 
 define "Slice": Tuple{
   "SliceAll": Tuple{
+    skipped: 'Slice not implemented'
+    /*
     expression: Slice({ 1, 2, 3, 4, 5 }),
     output: { 1, 2, 3, 4, 5 }
-  },
+    */  },
   "SliceEmpty": Tuple{
+    skipped: 'Slice not implemented'
+    /*
     expression: Slice({ }),
     output: { }
-  },
+    */  },
   "SliceNull": Tuple{
+    skipped: 'Slice not implemented'
+    /*
     expression: Slice(null),
     output: null
-  },
+    */  },
   "SliceStart": Tuple{
+    skipped: 'Slice not implemented'
+    /*
     expression: Slice({ 1, 2, 3, 4, 5 }, 1),
     output: { 2, 3, 4, 5 }
-  },
+    */  },
   "SliceStartNull": Tuple{
+    skipped: 'Slice not implemented'
+    /*
     expression: Slice({ 1, 2, 3, 4, 5 }, null),
     output: { 1, 2, 3, 4, 5 }
-  },
+    */  },
   "SliceEnd": Tuple{
+    skipped: 'Slice not implemented'
+    /*
     expression: Slice({ 1, 2, 3, 4, 5 }, 1, 3),
     output: { 2, 3 }
-  },
+    */  },
   "SliceEndNull": Tuple{
+    skipped: 'Slice not implemented'
+    /*
     expression: Slice({ 1, 2, 3, 4, 5 }, 1, null),
     output: { 2, 3, 4, 5 }
-  },
+    */  },
   "SliceNegative": Tuple{
+    skipped: 'Slice not implemented'
+    /*
     expression: Slice({ 1, 2, 3, 4, 5 }, -2),
     output: { 4, 5 }
-  },
+    */  },
   "SliceStartAndNegative": Tuple{
+    skipped: 'Slice not implemented'
+    /*
     expression: Slice({ 1, 2, 3, 4, 5 }, 1, -1),
     output: { 2, 3, 4 }
-  },
+    */  },
   "SlicePast": Tuple{
+    skipped: 'Slice not implemented'
+    /*
     expression: Slice({ 1, 2, 3, 4, 5 }, 5),
     output: { }
-  }
+    */  }
 }
 
 define "Tail": Tuple{

--- a/test/spec-tests/cql/CqlListOperatorsTest.cql
+++ b/test/spec-tests/cql/CqlListOperatorsTest.cql
@@ -4,17 +4,13 @@ context Patient
 
 define "Sort": Tuple{
   "simpleSortAsc": Tuple{
-    skipped: 'Wrong output: Queries return distinct lists by default; need to use "all" to retain duplicates'
-    /*
     expression: ({4, 5, 1, 6, 2, 1}) sL sort asc,
     output: {1, 1, 2, 4, 5, 6}
-    */  },
+  },
   "simpleSortDesc": Tuple{
-    skipped: 'Wrong output: Queries return distinct lists by default; need to use "all" to retain duplicates'
-    /*
     expression: ({4, 5, 1, 6, 2, 1}) sL sort desc,
     output: {6, 5, 4, 2, 1, 1}
-    */  },
+  },
   "simpleSortStringAsc": Tuple{
     expression: ({'back', 'aardvark', 'alligator', 'zebra', 'iguana', 'Wolf', 'Armadillo'}) sls sort asc,
     output: {'Armadillo', 'Wolf', 'aardvark', 'alligator', 'back', 'iguana', 'zebra'}
@@ -83,18 +79,16 @@ define "Contains": Tuple{
     output: false
   },
   "ContainsNullLeft": Tuple{
-    expression: null contains 'a',
+    expression: null as List<String> contains 'a',
     output: false
   }
 }
 
 define "Descendents": Tuple{
   "DescendentsEmptyList": Tuple{
-    skipped: 'Descendents not implemented'
-    /*
     expression: (null).descendents(),
     output: null
-    */  }
+  }
 }
 
 define "Distinct": Tuple{
@@ -138,11 +132,9 @@ define "Distinct": Tuple{
 
 define "Equal": Tuple{
   "EqualNullNull": Tuple{
-    skipped: 'Wrong output: According to spec, if either list contains a null, the result is null'
-    /*
     expression: {null} = {null},
     output: true
-    */  },
+  },
   "EqualEmptyListNull": Tuple{
     expression: {} as List<String> = null,
     output: null
@@ -164,15 +156,15 @@ define "Equal": Tuple{
     output: false
   },
   "EqualABCAnd123": Tuple{
-    expression: { 'a', 'b', 'c' } = { 1, 2, 3 },
+    expression: { 'a', 'b', 'c' } as List<Any> ~ { 1, 2, 3 } as List<Any>,
     output: false
   },
   "Equal123AndABC": Tuple{
-    expression: { 1, 2, 3 } = { 'a', 'b', 'c' },
+    expression: { 1, 2, 3 } as List<Any> = { 'a', 'b', 'c' } as List<Any>,
     output: false
   },
   "Equal123AndString123": Tuple{
-    expression: { 1, 2, 3 } = { '1', '2', '3' },
+    expression: { 1, 2, 3 } as List<Any> = { '1', '2', '3' } as List<Any>,
     output: false
   },
   "Equal12And123": Tuple{
@@ -323,7 +315,7 @@ define "In": Tuple{
     output: true
   },
   "In1Null": Tuple{
-    expression: 1 in null,
+    expression: 1 in null as List<Integer>,
     output: false
   },
   "In1And12": Tuple{
@@ -390,15 +382,13 @@ define "Includes": Tuple{
     output: false
   },
   "IncludesNullLeft": Tuple{
-    expression: null includes {2},
+    expression: null as List<Integer> includes {2},
     output: null
   },
   "IncludesNullRight": Tuple{
-    skipped: 'Treats null as point overload, translating to "Contains" operator, which has different semantics (and different result)'
-    /*
-    expression: {'s', 'a', 'm'} includes null,
+    expression: {'s', 'a', 'm'} includes null as List<String>,
     output: null
-    */  }
+  }
 }
 
 define "IncludedIn": Tuple{
@@ -439,17 +429,13 @@ define "IncludedIn": Tuple{
     output: false
   },
   "IncludedInNullLeft": Tuple{
-    skipped: 'Treats null as point overload, translating to "In" operator, which has different semantics (and different result)'
-    /*
-    expression: null included in {2},
+    expression: null as List<Integer> included in {2},
     output: null
-    */  },
+  },
   "IncludedInNullRight": Tuple{
-    skipped: 'Converts included in to in, which has different semantics when second argument is null'
-    /*
-    expression: {'s', 'a', 'm'} included in null,
+    expression: {'s', 'a', 'm'} included in null as List<String>,
     output: null
-    */  }
+  }
 }
 
 define "Indexer": Tuple{
@@ -613,15 +599,15 @@ define "Equivalent": Tuple{
     output: false
   },
   "EquivalentABCAnd123": Tuple{
-    expression: { 'a', 'b', 'c' } ~ { 1, 2, 3 },
+    expression: { 'a', 'b', 'c' } as List<Any> ~ { 1, 2, 3 } as List<Any>,
     output: false
   },
   "Equivalent123AndABC": Tuple{
-    expression: { 1, 2, 3 } ~ { 'a', 'b', 'c' },
+    expression: { 1, 2, 3 } as List<Any> ~ { 'a', 'b', 'c' } as List<Any>,
     output: false
   },
   "Equivalent123AndString123": Tuple{
-    expression: { 1, 2, 3 } ~ { '1', '2', '3' },
+    expression: { 1, 2, 3 } as List<Any> ~ { '1', '2', '3' } as List<Any>,
     output: false
   },
   "EquivalentDateTimeTrue": Tuple{
@@ -664,15 +650,15 @@ define "NotEqual": Tuple{
     output: true
   },
   "NotEqualABCAnd123": Tuple{
-    expression: { 'a', 'b', 'c' } != { 1, 2, 3 },
+    expression: { 'a', 'b', 'c' } as List<Any> != { 1, 2, 3 } as List<Any>,
     output: true
   },
   "NotEqual123AndABC": Tuple{
-    expression: { 1, 2, 3 } != { 'a', 'b', 'c' },
+    expression: { 1, 2, 3 } as List<Any> != { 'a', 'b', 'c' } as List<Any>,
     output: true
   },
   "NotEqual123AndString123": Tuple{
-    expression: { 1, 2, 3 } != { '1', '2', '3' },
+    expression: { 1, 2, 3 } as List<Any> != { '1', '2', '3' } as List<Any>,
     output: true
   },
   "NotEqualDateTimeTrue": Tuple{
@@ -694,57 +680,121 @@ define "NotEqual": Tuple{
 }
 
 define "ProperContains": Tuple{
-  "ProperContainsNullRightFalse": Tuple{
-    skipped: 'ProperContains not implemented'
-    /*
-    expression: {'s', 'u', 'n'} properly includes null,
+  "ProperContains1": Tuple{
+    expression: null as List<String> properly includes 'a',
     output: false
-    */  },
-  "ProperContainsNullRightTrue": Tuple{
-    skipped: 'ProperContains not implemented'
-    /*
-    expression: {'s', 'u', 'n', null} properly includes null,
+  },
+  "ProperContains2": Tuple{
+    expression: {} properly includes 'a',
+    output: false
+  },
+  "ProperContains3": Tuple{
+    expression: { 'a' } properly includes 'a',
+    output: false
+  },
+  "ProperContains4": Tuple{
+    expression: { null } properly includes null as String,
+    output: false
+  },
+  "ProperContainsNullRightFalse": Tuple{
+    expression: {'s', 'u', 'n'} properly includes null as String,
+    output: false
+  },
+  "ProperContains5": Tuple{
+    expression: { null, null } properly includes null as String,
     output: true
-    */  },
+  },
+  "ProperContainsNullRightTrue": Tuple{
+    expression: {'s', 'u', 'n', null} properly includes null as String,
+    output: true
+  },
+  "ProperContains6": Tuple{
+    expression: { 'a', 'b' } properly includes 'a',
+    output: true
+  },
+  "ProperContains7": Tuple{
+    expression: { 'a', 'a' } properly includes 'a',
+    output: true
+  },
+  "ProperContains8": Tuple{
+    expression: { 'a', 'b' } properly includes 'c',
+    output: false
+  },
+  "ProperContains9": Tuple{
+    expression: { 'a', null } properly includes 'a',
+    output: true
+  },
+  "ProperContains10": Tuple{
+    expression: { 'a', 'b', null } properly includes 'a',
+    output: true
+  },
   "ProperContainsTimeTrue": Tuple{
-    skipped: 'ProperContains not implemented'
-    /*
     expression: { @T15:59:59, @T20:59:59.999, @T20:59:49.999 } properly includes @T15:59:59,
     output: true
-    */  },
+  },
   "ProperContainsTimeNull": Tuple{
-    skipped: 'ProperContains not implemented'
-    /*
     expression: { @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 } properly includes @T15:59:59,
-    output: null
-    */  }
+    output: false
+  }
 }
 
 define "ProperIn": Tuple{
-  "ProperInNullRightFalse": Tuple{
-    skipped: 'ProperIn not implemented'
-    /*
-    expression: null properly included in {'s', 'u', 'n'},
+  "ProperIn1": Tuple{
+    expression: 'a' properly included in null as List<String>,
     output: false
-    */  },
+  },
+  "ProperIn2": Tuple{
+    expression: 'a' properly included in {},
+    output: false
+  },
+  "ProperIn3": Tuple{
+    expression: 'a' properly included in { 'a' },
+    output: false
+  },
+  "ProperIn4": Tuple{
+    expression: null as String properly included in { null },
+    output: false
+  },
+  "ProperInNullRightFalse": Tuple{
+    expression: null as String properly included in {'s', 'u', 'n'},
+    output: false
+  },
+  "ProperIn5": Tuple{
+    expression: null as String properly included in { null, null },
+    output: true
+  },
   "ProperInNullRightTrue": Tuple{
-    skipped: 'ProperIn not implemented'
-    /*
     expression: null properly included in {'s', 'u', 'n', null},
     output: true
-    */  },
+  },
+  "ProperIn6": Tuple{
+    expression: 'a' properly included in { 'a', 'b' },
+    output: true
+  },
+  "ProperIn7": Tuple{
+    expression: 'a' properly included in { 'a', 'a' },
+    output: true
+  },
+  "ProperIn8": Tuple{
+    expression: 'c' properly included in { 'a', 'b' },
+    output: false
+  },
+  "ProperIn9": Tuple{
+    expression: 'a' properly included in { 'a', null },
+    output: true
+  },
+  "ProperIn10": Tuple{
+    expression: 'a' properly included in { 'a', 'b', null },
+    output: true
+  },
   "ProperInTimeTrue": Tuple{
-    skipped: 'ProperIn not implemented'
-    /*
     expression: @T15:59:59 properly included in { @T15:59:59, @T20:59:59.999, @T20:59:49.999 },
     output: true
-    */  },
+  },
   "ProperInTimeNull": Tuple{
-    skipped: 'ProperIn not implemented'
-    /*
     expression: @T15:59:59 properly included in { @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 },
-    output: null
-    */  }
+    output: false
+  }
 }
 
 define "ProperlyIncludes": Tuple{
@@ -785,7 +835,7 @@ define "ProperlyIncludes": Tuple{
     output: false
   },
   "ProperlyIncludesNullLeft": Tuple{
-    expression: null properly includes {2},
+    expression: null as List<Integer> properly includes {2},
     output: null
   }
 }
@@ -828,11 +878,9 @@ define "ProperlyIncludedIn": Tuple{
     output: false
   },
   "ProperlyIncludedInNulRight": Tuple{
-    skipped: 'ProperIn not implemented'
-    /*
-    expression: {'s', 'u', 'n'} properly included in null,
+    expression: {'s', 'u', 'n'} properly included in null as List<String>,
     output: null
-    */  }
+  }
 }
 
 define "SingletonFrom": Tuple{
@@ -882,6 +930,49 @@ define "Skip": Tuple{
   "SkipAll": Tuple{
     expression: Skip({1,2,3,4,5}, 5),
     output: {}
+  }
+}
+
+define "Slice": Tuple{
+  "SliceAll": Tuple{
+    expression: Slice({ 1, 2, 3, 4, 5 }),
+    output: { 1, 2, 3, 4, 5 }
+  },
+  "SliceEmpty": Tuple{
+    expression: Slice({ }),
+    output: { }
+  },
+  "SliceNull": Tuple{
+    expression: Slice(null),
+    output: null
+  },
+  "SliceStart": Tuple{
+    expression: Slice({ 1, 2, 3, 4, 5 }, 1),
+    output: { 2, 3, 4, 5 }
+  },
+  "SliceStartNull": Tuple{
+    expression: Slice({ 1, 2, 3, 4, 5 }, null),
+    output: { 1, 2, 3, 4, 5 }
+  },
+  "SliceEnd": Tuple{
+    expression: Slice({ 1, 2, 3, 4, 5 }, 1, 3),
+    output: { 2, 3 }
+  },
+  "SliceEndNull": Tuple{
+    expression: Slice({ 1, 2, 3, 4, 5 }, 1, null),
+    output: { 2, 3, 4, 5 }
+  },
+  "SliceNegative": Tuple{
+    expression: Slice({ 1, 2, 3, 4, 5 }, -2),
+    output: { 4, 5 }
+  },
+  "SliceStartAndNegative": Tuple{
+    expression: Slice({ 1, 2, 3, 4, 5 }, 1, -1),
+    output: { 2, 3, 4 }
+  },
+  "SlicePast": Tuple{
+    expression: Slice({ 1, 2, 3, 4, 5 }, 5),
+    output: { }
   }
 }
 

--- a/test/spec-tests/cql/CqlListOperatorsTest.json
+++ b/test/spec-tests/cql/CqlListOperatorsTest.json
@@ -11,30 +11,6 @@
         "type": "CqlToElmError",
         "libraryId": "CqlListOperatorsTest",
         "libraryVersion": "1.4.0",
-        "startLine": 357,
-        "startChar": 17,
-        "endLine": 357,
-        "endChar": 18,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 361,
-        "startChar": 17,
-        "endLine": 361,
-        "endChar": 22,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
         "startLine": 365,
         "startChar": 36,
         "endLine": 365,
@@ -95,213 +71,9 @@
         "type": "CqlToElmError",
         "libraryId": "CqlListOperatorsTest",
         "libraryVersion": "1.4.0",
-        "startLine": 414,
-        "startChar": 17,
-        "endLine": 414,
-        "endChar": 18,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 418,
-        "startChar": 17,
-        "endLine": 418,
-        "endChar": 21,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 422,
-        "startChar": 17,
-        "endLine": 422,
-        "endChar": 21,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 426,
-        "startChar": 17,
-        "endLine": 426,
-        "endChar": 40,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 430,
-        "startChar": 17,
-        "endLine": 430,
-        "endChar": 39,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 760,
-        "startChar": 45,
-        "endLine": 760,
-        "endChar": 46,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 764,
-        "startChar": 45,
-        "endLine": 764,
-        "endChar": 47,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 768,
-        "startChar": 45,
-        "endLine": 768,
-        "endChar": 47,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 772,
-        "startChar": 106,
-        "endLine": 772,
-        "endChar": 152,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 776,
-        "startChar": 106,
-        "endLine": 776,
-        "endChar": 175,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 780,
-        "startChar": 86,
-        "endLine": 780,
-        "endChar": 119,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 784,
-        "startChar": 86,
-        "endLine": 784,
-        "endChar": 135,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 803,
-        "startChar": 17,
-        "endLine": 803,
-        "endChar": 18,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 807,
-        "startChar": 17,
-        "endLine": 807,
-        "endChar": 19,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 811,
-        "startChar": 17,
-        "endLine": 811,
-        "endChar": 19,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 815,
-        "startChar": 17,
-        "endLine": 815,
-        "endChar": 63,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 819,
-        "startChar": 17,
-        "endLine": 819,
-        "endChar": 86,
-        "message": "List-valued expression was demoted to a singleton.",
-        "errorType": "semantic",
-        "errorSeverity": "warning"
-      },
-      {
-        "type": "CqlToElmError",
-        "libraryId": "CqlListOperatorsTest",
-        "libraryVersion": "1.4.0",
-        "startLine": 823,
-        "startChar": 17,
-        "endLine": 823,
+        "startLine": 393,
+        "startChar": 48,
+        "endLine": 393,
         "endChar": 50,
         "message": "List-valued expression was demoted to a singleton.",
         "errorType": "semantic",
@@ -311,10 +83,286 @@
         "type": "CqlToElmError",
         "libraryId": "CqlListOperatorsTest",
         "libraryVersion": "1.4.0",
-        "startLine": 827,
+        "startLine": 397,
+        "startChar": 42,
+        "endLine": 397,
+        "endChar": 61,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 412,
         "startChar": 17,
-        "endLine": 827,
+        "endLine": 412,
+        "endChar": 18,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 416,
+        "startChar": 17,
+        "endLine": 416,
+        "endChar": 21,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 420,
+        "startChar": 17,
+        "endLine": 420,
+        "endChar": 21,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 424,
+        "startChar": 17,
+        "endLine": 424,
+        "endChar": 40,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 428,
+        "startChar": 17,
+        "endLine": 428,
+        "endChar": 39,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 440,
+        "startChar": 17,
+        "endLine": 440,
+        "endChar": 37,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 444,
+        "startChar": 17,
+        "endLine": 444,
+        "endChar": 31,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 818,
+        "startChar": 45,
+        "endLine": 818,
+        "endChar": 46,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 822,
+        "startChar": 45,
+        "endLine": 822,
+        "endChar": 47,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 826,
+        "startChar": 45,
+        "endLine": 826,
+        "endChar": 47,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 830,
+        "startChar": 106,
+        "endLine": 830,
+        "endChar": 152,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 834,
+        "startChar": 106,
+        "endLine": 834,
+        "endChar": 175,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 838,
+        "startChar": 86,
+        "endLine": 838,
+        "endChar": 119,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 842,
+        "startChar": 86,
+        "endLine": 842,
+        "endChar": 135,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 846,
+        "startChar": 57,
+        "endLine": 846,
+        "endChar": 59,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 861,
+        "startChar": 17,
+        "endLine": 861,
+        "endChar": 18,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 865,
+        "startChar": 17,
+        "endLine": 865,
+        "endChar": 19,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 869,
+        "startChar": 17,
+        "endLine": 869,
+        "endChar": 19,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 873,
+        "startChar": 17,
+        "endLine": 873,
+        "endChar": 63,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 877,
+        "startChar": 17,
+        "endLine": 877,
+        "endChar": 86,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 881,
+        "startChar": 17,
+        "endLine": 881,
+        "endChar": 50,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 885,
+        "startChar": 17,
+        "endLine": 885,
         "endChar": 66,
+        "message": "List-valued expression was demoted to a singleton.",
+        "errorType": "semantic",
+        "errorSeverity": "warning"
+      },
+      {
+        "type": "CqlToElmError",
+        "libraryId": "CqlListOperatorsTest",
+        "libraryVersion": "1.4.0",
+        "startLine": 889,
+        "startChar": 17,
+        "endLine": 889,
+        "endChar": 31,
         "message": "List-valued expression was demoted to a singleton.",
         "errorType": "semantic",
         "errorSeverity": "warning"
@@ -4623,7 +4671,17 @@
                         "operand": [
                           {
                             "type": "As",
+                            "strict": false,
                             "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
                             "signature": [],
                             "operand": {
                               "type": "Null",
@@ -4633,8 +4691,20 @@
                             "asTypeSpecifier": {
                               "type": "ListTypeSpecifier",
                               "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "980",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "981",
+                                  "name": "{urn:hl7-org:elm-types:r1}String",
+                                  "annotation": []
+                                }
+                              },
                               "elementType": {
                                 "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
                                 "name": "{urn:hl7-org:elm-types:r1}String",
                                 "annotation": []
                               }
@@ -7830,11 +7900,11 @@
                               "annotation": [],
                               "resultTypeSpecifier": {
                                 "type": "ListTypeSpecifier",
-                                "localId": "1544",
+                                "localId": "1548",
                                 "annotation": [],
                                 "elementType": {
                                   "type": "NamedTypeSpecifier",
-                                  "localId": "1545",
+                                  "localId": "1549",
                                   "name": "{urn:hl7-org:elm-types:r1}String",
                                   "annotation": []
                                 }
@@ -7970,11 +8040,11 @@
                               "annotation": [],
                               "resultTypeSpecifier": {
                                 "type": "ListTypeSpecifier",
-                                "localId": "1567",
+                                "localId": "1571",
                                 "annotation": [],
                                 "elementType": {
                                   "type": "NamedTypeSpecifier",
-                                  "localId": "1568",
+                                  "localId": "1572",
                                   "name": "{urn:hl7-org:elm-types:r1}String",
                                   "annotation": []
                                 }
@@ -8361,82 +8431,154 @@
                     {
                       "name": "expression",
                       "value": {
-                        "type": "Equal",
+                        "type": "Equivalent",
                         "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
                         "annotation": [],
                         "signature": [],
                         "operand": [
                           {
-                            "type": "List",
+                            "type": "As",
+                            "strict": false,
                             "annotation": [],
                             "resultTypeSpecifier": {
                               "type": "ListTypeSpecifier",
                               "annotation": [],
                               "elementType": {
                                 "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
                             },
-                            "element": [
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "a",
-                                "annotation": []
+                            "signature": [],
+                            "operand": {
+                              "type": "List",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "name": "{urn:hl7-org:elm-types:r1}String",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "b",
-                                "annotation": []
+                              "element": [
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "a",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "b",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "c",
+                                  "annotation": []
+                                }
+                              ]
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "1662",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "1663",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "c",
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
-                            ]
+                            }
                           },
                           {
-                            "type": "List",
+                            "type": "As",
+                            "strict": false,
                             "annotation": [],
                             "resultTypeSpecifier": {
                               "type": "ListTypeSpecifier",
                               "annotation": [],
                               "elementType": {
                                 "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
                             },
-                            "element": [
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "1",
-                                "annotation": []
+                            "signature": [],
+                            "operand": {
+                              "type": "List",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "2",
-                                "annotation": []
+                              "element": [
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "1",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "2",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "3",
+                                  "annotation": []
+                                }
+                              ]
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "1675",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "1676",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "3",
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
-                            ]
+                            }
                           }
                         ]
                       }
@@ -8493,76 +8635,148 @@
                         "signature": [],
                         "operand": [
                           {
-                            "type": "List",
+                            "type": "As",
+                            "strict": false,
                             "annotation": [],
                             "resultTypeSpecifier": {
                               "type": "ListTypeSpecifier",
                               "annotation": [],
                               "elementType": {
                                 "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
                             },
-                            "element": [
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "1",
-                                "annotation": []
+                            "signature": [],
+                            "operand": {
+                              "type": "List",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "2",
-                                "annotation": []
+                              "element": [
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "1",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "2",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "3",
+                                  "annotation": []
+                                }
+                              ]
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "1696",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "1697",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "3",
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
-                            ]
+                            }
                           },
                           {
-                            "type": "List",
+                            "type": "As",
+                            "strict": false,
                             "annotation": [],
                             "resultTypeSpecifier": {
                               "type": "ListTypeSpecifier",
                               "annotation": [],
                               "elementType": {
                                 "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
                             },
-                            "element": [
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "a",
-                                "annotation": []
+                            "signature": [],
+                            "operand": {
+                              "type": "List",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "name": "{urn:hl7-org:elm-types:r1}String",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "b",
-                                "annotation": []
+                              "element": [
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "a",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "b",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "c",
+                                  "annotation": []
+                                }
+                              ]
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "1712",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "1713",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "c",
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
-                            ]
+                            }
                           }
                         ]
                       }
@@ -8619,76 +8833,148 @@
                         "signature": [],
                         "operand": [
                           {
-                            "type": "List",
+                            "type": "As",
+                            "strict": false,
                             "annotation": [],
                             "resultTypeSpecifier": {
                               "type": "ListTypeSpecifier",
                               "annotation": [],
                               "elementType": {
                                 "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
                             },
-                            "element": [
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "1",
-                                "annotation": []
+                            "signature": [],
+                            "operand": {
+                              "type": "List",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "2",
-                                "annotation": []
+                              "element": [
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "1",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "2",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "3",
+                                  "annotation": []
+                                }
+                              ]
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "1733",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "1734",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "3",
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
-                            ]
+                            }
                           },
                           {
-                            "type": "List",
+                            "type": "As",
+                            "strict": false,
                             "annotation": [],
                             "resultTypeSpecifier": {
                               "type": "ListTypeSpecifier",
                               "annotation": [],
                               "elementType": {
                                 "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
                             },
-                            "element": [
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "1",
-                                "annotation": []
+                            "signature": [],
+                            "operand": {
+                              "type": "List",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "name": "{urn:hl7-org:elm-types:r1}String",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "2",
-                                "annotation": []
+                              "element": [
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "1",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "2",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "3",
+                                  "annotation": []
+                                }
+                              ]
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "1749",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "1750",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "3",
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
-                            ]
+                            }
                           }
                         ]
                       }
@@ -15808,7 +16094,17 @@
                           },
                           {
                             "type": "As",
+                            "strict": false,
                             "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                "annotation": []
+                              }
+                            },
                             "signature": [],
                             "operand": {
                               "type": "Null",
@@ -15816,10 +16112,22 @@
                               "annotation": []
                             },
                             "asTypeSpecifier": {
-                              "type": "IntervalTypeSpecifier",
+                              "type": "ListTypeSpecifier",
                               "annotation": [],
-                              "pointType": {
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "3217",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "3218",
+                                  "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "annotation": []
+                                }
+                              },
+                              "elementType": {
                                 "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
                                 "name": "{urn:hl7-org:elm-types:r1}Integer",
                                 "annotation": []
                               }
@@ -17053,11 +17361,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -17361,11 +17678,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -18708,7 +19034,17 @@
                         "operand": [
                           {
                             "type": "As",
+                            "strict": false,
                             "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                "annotation": []
+                              }
+                            },
                             "signature": [],
                             "operand": {
                               "type": "Null",
@@ -18718,8 +19054,20 @@
                             "asTypeSpecifier": {
                               "type": "ListTypeSpecifier",
                               "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "3750",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "3751",
+                                  "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "annotation": []
+                                }
+                              },
                               "elementType": {
                                 "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
                                 "name": "{urn:hl7-org:elm-types:r1}Integer",
                                 "annotation": []
                               }
@@ -18771,11 +19119,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -18783,12 +19140,98 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "value": {
-                        "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "Treats null as point overload, translating to \"Contains\" operator, which has different semantics (and different result)",
+                        "type": "Includes",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "s",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "a",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "m",
+                                "annotation": []
+                              }
+                            ]
+                          },
+                          {
+                            "type": "As",
+                            "strict": false,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "signature": [],
+                            "operand": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "3781",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "3782",
+                                  "name": "{urn:hl7-org:elm-types:r1}String",
+                                  "annotation": []
+                                }
+                              },
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Null",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -19067,11 +19510,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -19086,11 +19538,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -19366,11 +19827,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -19385,11 +19855,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -20675,11 +21154,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -20687,12 +21175,84 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "value": {
-                        "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "Treats null as point overload, translating to \"In\" operator, which has different semantics (and different result)",
+                        "type": "IncludedIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "As",
+                            "strict": false,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                "annotation": []
+                              }
+                            },
+                            "signature": [],
+                            "operand": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "4189",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "4190",
+                                  "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "annotation": []
+                                }
+                              },
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                "annotation": []
+                              }
+                            }
+                          },
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                "value": "2",
+                                "annotation": []
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Null",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -20709,11 +21269,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -20721,12 +21290,98 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "value": {
-                        "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "Converts included in to in, which has different semantics when second argument is null",
+                        "type": "IncludedIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "s",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "a",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "m",
+                                "annotation": []
+                              }
+                            ]
+                          },
+                          {
+                            "type": "As",
+                            "strict": false,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "signature": [],
+                            "operand": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "4220",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "4221",
+                                  "name": "{urn:hl7-org:elm-types:r1}String",
+                                  "annotation": []
+                                }
+                              },
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Null",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -21211,11 +21866,11 @@
                               "annotation": [],
                               "resultTypeSpecifier": {
                                 "type": "ListTypeSpecifier",
-                                "localId": "4263",
+                                "localId": "4377",
                                 "annotation": [],
                                 "elementType": {
                                   "type": "NamedTypeSpecifier",
-                                  "localId": "4264",
+                                  "localId": "4378",
                                   "name": "{urn:hl7-org:elm-types:r1}Any",
                                   "annotation": []
                                 }
@@ -26957,11 +27612,11 @@
                             "annotation": [],
                             "resultTypeSpecifier": {
                               "type": "ListTypeSpecifier",
-                              "localId": "5379",
+                              "localId": "5493",
                               "annotation": [],
                               "elementType": {
                                 "type": "NamedTypeSpecifier",
-                                "localId": "5380",
+                                "localId": "5494",
                                 "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
@@ -28051,76 +28706,148 @@
                         "signature": [],
                         "operand": [
                           {
-                            "type": "List",
+                            "type": "As",
+                            "strict": false,
                             "annotation": [],
                             "resultTypeSpecifier": {
                               "type": "ListTypeSpecifier",
                               "annotation": [],
                               "elementType": {
                                 "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
                             },
-                            "element": [
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "a",
-                                "annotation": []
+                            "signature": [],
+                            "operand": {
+                              "type": "List",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "name": "{urn:hl7-org:elm-types:r1}String",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "b",
-                                "annotation": []
+                              "element": [
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "a",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "b",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "c",
+                                  "annotation": []
+                                }
+                              ]
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "5674",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "5675",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "c",
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
-                            ]
+                            }
                           },
                           {
-                            "type": "List",
+                            "type": "As",
+                            "strict": false,
                             "annotation": [],
                             "resultTypeSpecifier": {
                               "type": "ListTypeSpecifier",
                               "annotation": [],
                               "elementType": {
                                 "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
                             },
-                            "element": [
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "1",
-                                "annotation": []
+                            "signature": [],
+                            "operand": {
+                              "type": "List",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "2",
-                                "annotation": []
+                              "element": [
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "1",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "2",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "3",
+                                  "annotation": []
+                                }
+                              ]
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "5687",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "5688",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "3",
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
-                            ]
+                            }
                           }
                         ]
                       }
@@ -28177,76 +28904,148 @@
                         "signature": [],
                         "operand": [
                           {
-                            "type": "List",
+                            "type": "As",
+                            "strict": false,
                             "annotation": [],
                             "resultTypeSpecifier": {
                               "type": "ListTypeSpecifier",
                               "annotation": [],
                               "elementType": {
                                 "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
                             },
-                            "element": [
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "1",
-                                "annotation": []
+                            "signature": [],
+                            "operand": {
+                              "type": "List",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "2",
-                                "annotation": []
+                              "element": [
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "1",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "2",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "3",
+                                  "annotation": []
+                                }
+                              ]
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "5708",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "5709",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "3",
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
-                            ]
+                            }
                           },
                           {
-                            "type": "List",
+                            "type": "As",
+                            "strict": false,
                             "annotation": [],
                             "resultTypeSpecifier": {
                               "type": "ListTypeSpecifier",
                               "annotation": [],
                               "elementType": {
                                 "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
                             },
-                            "element": [
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "a",
-                                "annotation": []
+                            "signature": [],
+                            "operand": {
+                              "type": "List",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "name": "{urn:hl7-org:elm-types:r1}String",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "b",
-                                "annotation": []
+                              "element": [
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "a",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "b",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "c",
+                                  "annotation": []
+                                }
+                              ]
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "5724",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "5725",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "c",
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
-                            ]
+                            }
                           }
                         ]
                       }
@@ -28303,76 +29102,148 @@
                         "signature": [],
                         "operand": [
                           {
-                            "type": "List",
+                            "type": "As",
+                            "strict": false,
                             "annotation": [],
                             "resultTypeSpecifier": {
                               "type": "ListTypeSpecifier",
                               "annotation": [],
                               "elementType": {
                                 "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
                             },
-                            "element": [
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "1",
-                                "annotation": []
+                            "signature": [],
+                            "operand": {
+                              "type": "List",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "2",
-                                "annotation": []
+                              "element": [
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "1",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "2",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "3",
+                                  "annotation": []
+                                }
+                              ]
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "5745",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "5746",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                "value": "3",
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
-                            ]
+                            }
                           },
                           {
-                            "type": "List",
+                            "type": "As",
+                            "strict": false,
                             "annotation": [],
                             "resultTypeSpecifier": {
                               "type": "ListTypeSpecifier",
                               "annotation": [],
                               "elementType": {
                                 "type": "NamedTypeSpecifier",
-                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
                             },
-                            "element": [
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "1",
-                                "annotation": []
+                            "signature": [],
+                            "operand": {
+                              "type": "List",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "name": "{urn:hl7-org:elm-types:r1}String",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "2",
-                                "annotation": []
+                              "element": [
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "1",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "2",
+                                  "annotation": []
+                                },
+                                {
+                                  "type": "Literal",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                  "value": "3",
+                                  "annotation": []
+                                }
+                              ]
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "5761",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "5762",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
                               },
-                              {
-                                "type": "Literal",
-                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                "value": "3",
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                "name": "{urn:hl7-org:elm-types:r1}Any",
                                 "annotation": []
                               }
-                            ]
+                            }
                           }
                         ]
                       }
@@ -30757,76 +31628,148 @@
                           "signature": [],
                           "operand": [
                             {
-                              "type": "List",
+                              "type": "As",
+                              "strict": false,
                               "annotation": [],
                               "resultTypeSpecifier": {
                                 "type": "ListTypeSpecifier",
                                 "annotation": [],
                                 "elementType": {
                                   "type": "NamedTypeSpecifier",
-                                  "name": "{urn:hl7-org:elm-types:r1}String",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
                                   "annotation": []
                                 }
                               },
-                              "element": [
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                  "value": "a",
-                                  "annotation": []
+                              "signature": [],
+                              "operand": {
+                                "type": "List",
+                                "annotation": [],
+                                "resultTypeSpecifier": {
+                                  "type": "ListTypeSpecifier",
+                                  "annotation": [],
+                                  "elementType": {
+                                    "type": "NamedTypeSpecifier",
+                                    "name": "{urn:hl7-org:elm-types:r1}String",
+                                    "annotation": []
+                                  }
                                 },
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                  "value": "b",
-                                  "annotation": []
+                                "element": [
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                    "value": "a",
+                                    "annotation": []
+                                  },
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                    "value": "b",
+                                    "annotation": []
+                                  },
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                    "value": "c",
+                                    "annotation": []
+                                  }
+                                ]
+                              },
+                              "asTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "resultTypeSpecifier": {
+                                  "type": "ListTypeSpecifier",
+                                  "localId": "6262",
+                                  "annotation": [],
+                                  "elementType": {
+                                    "type": "NamedTypeSpecifier",
+                                    "localId": "6263",
+                                    "name": "{urn:hl7-org:elm-types:r1}Any",
+                                    "annotation": []
+                                  }
                                 },
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                  "value": "c",
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
                                   "annotation": []
                                 }
-                              ]
+                              }
                             },
                             {
-                              "type": "List",
+                              "type": "As",
+                              "strict": false,
                               "annotation": [],
                               "resultTypeSpecifier": {
                                 "type": "ListTypeSpecifier",
                                 "annotation": [],
                                 "elementType": {
                                   "type": "NamedTypeSpecifier",
-                                  "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
                                   "annotation": []
                                 }
                               },
-                              "element": [
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "value": "1",
-                                  "annotation": []
+                              "signature": [],
+                              "operand": {
+                                "type": "List",
+                                "annotation": [],
+                                "resultTypeSpecifier": {
+                                  "type": "ListTypeSpecifier",
+                                  "annotation": [],
+                                  "elementType": {
+                                    "type": "NamedTypeSpecifier",
+                                    "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "annotation": []
+                                  }
                                 },
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "value": "2",
-                                  "annotation": []
+                                "element": [
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value": "1",
+                                    "annotation": []
+                                  },
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value": "2",
+                                    "annotation": []
+                                  },
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value": "3",
+                                    "annotation": []
+                                  }
+                                ]
+                              },
+                              "asTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "resultTypeSpecifier": {
+                                  "type": "ListTypeSpecifier",
+                                  "localId": "6275",
+                                  "annotation": [],
+                                  "elementType": {
+                                    "type": "NamedTypeSpecifier",
+                                    "localId": "6276",
+                                    "name": "{urn:hl7-org:elm-types:r1}Any",
+                                    "annotation": []
+                                  }
                                 },
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "value": "3",
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
                                   "annotation": []
                                 }
-                              ]
+                              }
                             }
                           ]
                         }
@@ -30889,76 +31832,148 @@
                           "signature": [],
                           "operand": [
                             {
-                              "type": "List",
+                              "type": "As",
+                              "strict": false,
                               "annotation": [],
                               "resultTypeSpecifier": {
                                 "type": "ListTypeSpecifier",
                                 "annotation": [],
                                 "elementType": {
                                   "type": "NamedTypeSpecifier",
-                                  "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
                                   "annotation": []
                                 }
                               },
-                              "element": [
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "value": "1",
-                                  "annotation": []
+                              "signature": [],
+                              "operand": {
+                                "type": "List",
+                                "annotation": [],
+                                "resultTypeSpecifier": {
+                                  "type": "ListTypeSpecifier",
+                                  "annotation": [],
+                                  "elementType": {
+                                    "type": "NamedTypeSpecifier",
+                                    "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "annotation": []
+                                  }
                                 },
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "value": "2",
-                                  "annotation": []
+                                "element": [
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value": "1",
+                                    "annotation": []
+                                  },
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value": "2",
+                                    "annotation": []
+                                  },
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value": "3",
+                                    "annotation": []
+                                  }
+                                ]
+                              },
+                              "asTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "resultTypeSpecifier": {
+                                  "type": "ListTypeSpecifier",
+                                  "localId": "6297",
+                                  "annotation": [],
+                                  "elementType": {
+                                    "type": "NamedTypeSpecifier",
+                                    "localId": "6298",
+                                    "name": "{urn:hl7-org:elm-types:r1}Any",
+                                    "annotation": []
+                                  }
                                 },
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "value": "3",
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
                                   "annotation": []
                                 }
-                              ]
+                              }
                             },
                             {
-                              "type": "List",
+                              "type": "As",
+                              "strict": false,
                               "annotation": [],
                               "resultTypeSpecifier": {
                                 "type": "ListTypeSpecifier",
                                 "annotation": [],
                                 "elementType": {
                                   "type": "NamedTypeSpecifier",
-                                  "name": "{urn:hl7-org:elm-types:r1}String",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
                                   "annotation": []
                                 }
                               },
-                              "element": [
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                  "value": "a",
-                                  "annotation": []
+                              "signature": [],
+                              "operand": {
+                                "type": "List",
+                                "annotation": [],
+                                "resultTypeSpecifier": {
+                                  "type": "ListTypeSpecifier",
+                                  "annotation": [],
+                                  "elementType": {
+                                    "type": "NamedTypeSpecifier",
+                                    "name": "{urn:hl7-org:elm-types:r1}String",
+                                    "annotation": []
+                                  }
                                 },
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                  "value": "b",
-                                  "annotation": []
+                                "element": [
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                    "value": "a",
+                                    "annotation": []
+                                  },
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                    "value": "b",
+                                    "annotation": []
+                                  },
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                    "value": "c",
+                                    "annotation": []
+                                  }
+                                ]
+                              },
+                              "asTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "resultTypeSpecifier": {
+                                  "type": "ListTypeSpecifier",
+                                  "localId": "6313",
+                                  "annotation": [],
+                                  "elementType": {
+                                    "type": "NamedTypeSpecifier",
+                                    "localId": "6314",
+                                    "name": "{urn:hl7-org:elm-types:r1}Any",
+                                    "annotation": []
+                                  }
                                 },
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                  "value": "c",
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
                                   "annotation": []
                                 }
-                              ]
+                              }
                             }
                           ]
                         }
@@ -31021,76 +32036,148 @@
                           "signature": [],
                           "operand": [
                             {
-                              "type": "List",
+                              "type": "As",
+                              "strict": false,
                               "annotation": [],
                               "resultTypeSpecifier": {
                                 "type": "ListTypeSpecifier",
                                 "annotation": [],
                                 "elementType": {
                                   "type": "NamedTypeSpecifier",
-                                  "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
                                   "annotation": []
                                 }
                               },
-                              "element": [
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "value": "1",
-                                  "annotation": []
+                              "signature": [],
+                              "operand": {
+                                "type": "List",
+                                "annotation": [],
+                                "resultTypeSpecifier": {
+                                  "type": "ListTypeSpecifier",
+                                  "annotation": [],
+                                  "elementType": {
+                                    "type": "NamedTypeSpecifier",
+                                    "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "annotation": []
+                                  }
                                 },
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "value": "2",
-                                  "annotation": []
+                                "element": [
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value": "1",
+                                    "annotation": []
+                                  },
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value": "2",
+                                    "annotation": []
+                                  },
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value": "3",
+                                    "annotation": []
+                                  }
+                                ]
+                              },
+                              "asTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "resultTypeSpecifier": {
+                                  "type": "ListTypeSpecifier",
+                                  "localId": "6335",
+                                  "annotation": [],
+                                  "elementType": {
+                                    "type": "NamedTypeSpecifier",
+                                    "localId": "6336",
+                                    "name": "{urn:hl7-org:elm-types:r1}Any",
+                                    "annotation": []
+                                  }
                                 },
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
-                                  "value": "3",
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
                                   "annotation": []
                                 }
-                              ]
+                              }
                             },
                             {
-                              "type": "List",
+                              "type": "As",
+                              "strict": false,
                               "annotation": [],
                               "resultTypeSpecifier": {
                                 "type": "ListTypeSpecifier",
                                 "annotation": [],
                                 "elementType": {
                                   "type": "NamedTypeSpecifier",
-                                  "name": "{urn:hl7-org:elm-types:r1}String",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
                                   "annotation": []
                                 }
                               },
-                              "element": [
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                  "value": "1",
-                                  "annotation": []
+                              "signature": [],
+                              "operand": {
+                                "type": "List",
+                                "annotation": [],
+                                "resultTypeSpecifier": {
+                                  "type": "ListTypeSpecifier",
+                                  "annotation": [],
+                                  "elementType": {
+                                    "type": "NamedTypeSpecifier",
+                                    "name": "{urn:hl7-org:elm-types:r1}String",
+                                    "annotation": []
+                                  }
                                 },
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                  "value": "2",
-                                  "annotation": []
+                                "element": [
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                    "value": "1",
+                                    "annotation": []
+                                  },
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                    "value": "2",
+                                    "annotation": []
+                                  },
+                                  {
+                                    "type": "Literal",
+                                    "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                    "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                    "value": "3",
+                                    "annotation": []
+                                  }
+                                ]
+                              },
+                              "asTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "annotation": [],
+                                "resultTypeSpecifier": {
+                                  "type": "ListTypeSpecifier",
+                                  "localId": "6351",
+                                  "annotation": [],
+                                  "elementType": {
+                                    "type": "NamedTypeSpecifier",
+                                    "localId": "6352",
+                                    "name": "{urn:hl7-org:elm-types:r1}Any",
+                                    "annotation": []
+                                  }
                                 },
-                                {
-                                  "type": "Literal",
-                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                                  "valueType": "{urn:hl7-org:elm-types:r1}String",
-                                  "value": "3",
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                  "name": "{urn:hl7-org:elm-types:r1}Any",
                                   "annotation": []
                                 }
-                              ]
+                              }
                             }
                           ]
                         }
@@ -32370,6 +33457,118 @@
             "annotation": [],
             "element": [
               {
+                "name": "ProperContains1",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains2",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains3",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains4",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
                 "name": "ProperContainsNullRightFalse",
                 "annotation": [],
                 "elementType": {
@@ -32377,11 +33576,48 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains5",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
                         "annotation": []
                       }
                     }
@@ -32396,11 +33632,160 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains6",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains7",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains8",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains9",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains10",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
                         "annotation": []
                       }
                     }
@@ -32415,11 +33800,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
                         "annotation": []
                       }
                     }
@@ -32434,11 +33828,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
                         "annotation": []
                       }
                     }
@@ -32455,6 +33858,118 @@
               "annotation": [],
               "element": [
                 {
+                  "name": "ProperContains1",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperContains2",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperContains3",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperContains4",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
                   "name": "ProperContainsNullRightFalse",
                   "annotation": [],
                   "elementType": {
@@ -32462,11 +33977,48 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperContains5",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -32481,11 +34033,160 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperContains6",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperContains7",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperContains8",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperContains9",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperContains10",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -32500,11 +34201,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -32519,11 +34229,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -32534,6 +34253,412 @@
             },
             "element": [
               {
+                "name": "ProperContains1",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "As",
+                            "strict": false,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "signature": [],
+                            "operand": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "6711",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "6712",
+                                  "name": "{urn:hl7-org:elm-types:r1}String",
+                                  "annotation": []
+                                }
+                              },
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            }
+                          },
+                          {
+                            "type": "Literal",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "a",
+                            "annotation": []
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains2",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Query",
+                            "annotation": [],
+                            "source": [
+                              {
+                                "alias": "X",
+                                "annotation": [],
+                                "expression": {
+                                  "type": "List",
+                                  "annotation": [],
+                                  "resultTypeSpecifier": {
+                                    "type": "ListTypeSpecifier",
+                                    "annotation": [],
+                                    "elementType": {
+                                      "type": "NamedTypeSpecifier",
+                                      "name": "{urn:hl7-org:elm-types:r1}Any",
+                                      "annotation": []
+                                    }
+                                  },
+                                  "element": []
+                                }
+                              }
+                            ],
+                            "let": [],
+                            "relationship": [],
+                            "return": {
+                              "distinct": false,
+                              "annotation": [],
+                              "expression": {
+                                "type": "As",
+                                "asType": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": [],
+                                "signature": [],
+                                "operand": {
+                                  "type": "AliasRef",
+                                  "name": "X",
+                                  "annotation": []
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "Literal",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "a",
+                            "annotation": []
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains3",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "a",
+                                "annotation": []
+                              }
+                            ]
+                          },
+                          {
+                            "type": "Literal",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "a",
+                            "annotation": []
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains4",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Query",
+                            "annotation": [],
+                            "source": [
+                              {
+                                "alias": "X",
+                                "annotation": [],
+                                "expression": {
+                                  "type": "List",
+                                  "annotation": [],
+                                  "resultTypeSpecifier": {
+                                    "type": "ListTypeSpecifier",
+                                    "annotation": [],
+                                    "elementType": {
+                                      "type": "NamedTypeSpecifier",
+                                      "name": "{urn:hl7-org:elm-types:r1}Any",
+                                      "annotation": []
+                                    }
+                                  },
+                                  "element": [
+                                    {
+                                      "type": "Null",
+                                      "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                      "annotation": []
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "let": [],
+                            "relationship": [],
+                            "return": {
+                              "distinct": false,
+                              "annotation": [],
+                              "expression": {
+                                "type": "As",
+                                "asType": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": [],
+                                "signature": [],
+                                "operand": {
+                                  "type": "AliasRef",
+                                  "name": "X",
+                                  "annotation": []
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "As",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "strict": false,
+                            "annotation": [],
+                            "signature": [],
+                            "operand": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "asTypeSpecifier": {
+                              "type": "NamedTypeSpecifier",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                              "name": "{urn:hl7-org:elm-types:r1}String",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
                 "name": "ProperContainsNullRightFalse",
                 "value": {
                   "type": "Tuple",
@@ -32543,11 +34668,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -32555,12 +34689,201 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "s",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "u",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "n",
+                                "annotation": []
+                              }
+                            ]
+                          },
+                          {
+                            "type": "As",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "strict": false,
+                            "annotation": [],
+                            "signature": [],
+                            "operand": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "asTypeSpecifier": {
+                              "type": "NamedTypeSpecifier",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                              "name": "{urn:hl7-org:elm-types:r1}String",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperContains not implemented",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains5",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Query",
+                            "annotation": [],
+                            "source": [
+                              {
+                                "alias": "X",
+                                "annotation": [],
+                                "expression": {
+                                  "type": "List",
+                                  "annotation": [],
+                                  "resultTypeSpecifier": {
+                                    "type": "ListTypeSpecifier",
+                                    "annotation": [],
+                                    "elementType": {
+                                      "type": "NamedTypeSpecifier",
+                                      "name": "{urn:hl7-org:elm-types:r1}Any",
+                                      "annotation": []
+                                    }
+                                  },
+                                  "element": [
+                                    {
+                                      "type": "Null",
+                                      "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                      "annotation": []
+                                    },
+                                    {
+                                      "type": "Null",
+                                      "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                      "annotation": []
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "let": [],
+                            "relationship": [],
+                            "return": {
+                              "distinct": false,
+                              "annotation": [],
+                              "expression": {
+                                "type": "As",
+                                "asType": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": [],
+                                "signature": [],
+                                "operand": {
+                                  "type": "AliasRef",
+                                  "name": "X",
+                                  "annotation": []
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "As",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "strict": false,
+                            "annotation": [],
+                            "signature": [],
+                            "operand": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "asTypeSpecifier": {
+                              "type": "NamedTypeSpecifier",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                              "name": "{urn:hl7-org:elm-types:r1}String",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
                         "annotation": []
                       }
                     }
@@ -32577,11 +34900,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -32589,12 +34921,553 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "s",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "u",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "n",
+                                "annotation": []
+                              },
+                              {
+                                "type": "As",
+                                "asType": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": [],
+                                "signature": [],
+                                "operand": {
+                                  "type": "Null",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "type": "As",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "strict": false,
+                            "annotation": [],
+                            "signature": [],
+                            "operand": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "asTypeSpecifier": {
+                              "type": "NamedTypeSpecifier",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                              "name": "{urn:hl7-org:elm-types:r1}String",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperContains not implemented",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains6",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "a",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "b",
+                                "annotation": []
+                              }
+                            ]
+                          },
+                          {
+                            "type": "Literal",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "a",
+                            "annotation": []
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains7",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "a",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "a",
+                                "annotation": []
+                              }
+                            ]
+                          },
+                          {
+                            "type": "Literal",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "a",
+                            "annotation": []
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains8",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "a",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "b",
+                                "annotation": []
+                              }
+                            ]
+                          },
+                          {
+                            "type": "Literal",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "c",
+                            "annotation": []
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains9",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "a",
+                                "annotation": []
+                              },
+                              {
+                                "type": "As",
+                                "asType": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": [],
+                                "signature": [],
+                                "operand": {
+                                  "type": "Null",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "type": "Literal",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "a",
+                            "annotation": []
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperContains10",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "a",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "b",
+                                "annotation": []
+                              },
+                              {
+                                "type": "As",
+                                "asType": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": [],
+                                "signature": [],
+                                "operand": {
+                                  "type": "Null",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "type": "Literal",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "a",
+                            "annotation": []
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
                         "annotation": []
                       }
                     }
@@ -32611,11 +35484,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -32623,12 +35505,146 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Time",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": [],
+                                "signature": [],
+                                "hour": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "15",
+                                  "annotation": []
+                                },
+                                "minute": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "second": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                }
+                              },
+                              {
+                                "type": "Time",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": [],
+                                "signature": [],
+                                "hour": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "20",
+                                  "annotation": []
+                                },
+                                "minute": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "second": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "millisecond": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "999",
+                                  "annotation": []
+                                }
+                              },
+                              {
+                                "type": "Time",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": [],
+                                "signature": [],
+                                "hour": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "20",
+                                  "annotation": []
+                                },
+                                "minute": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "second": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "49",
+                                  "annotation": []
+                                },
+                                "millisecond": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "999",
+                                  "annotation": []
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "type": "Time",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                            "annotation": [],
+                            "signature": [],
+                            "hour": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "15",
+                              "annotation": []
+                            },
+                            "minute": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "59",
+                              "annotation": []
+                            },
+                            "second": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "59",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperContains not implemented",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
                         "annotation": []
                       }
                     }
@@ -32645,11 +35661,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -32657,12 +35682,152 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperContains",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Time",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": [],
+                                "signature": [],
+                                "hour": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "15",
+                                  "annotation": []
+                                },
+                                "minute": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "second": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "millisecond": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "999",
+                                  "annotation": []
+                                }
+                              },
+                              {
+                                "type": "Time",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": [],
+                                "signature": [],
+                                "hour": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "20",
+                                  "annotation": []
+                                },
+                                "minute": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "second": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "millisecond": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "999",
+                                  "annotation": []
+                                }
+                              },
+                              {
+                                "type": "Time",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": [],
+                                "signature": [],
+                                "hour": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "20",
+                                  "annotation": []
+                                },
+                                "minute": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "second": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "49",
+                                  "annotation": []
+                                },
+                                "millisecond": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "999",
+                                  "annotation": []
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "type": "Time",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                            "annotation": [],
+                            "signature": [],
+                            "hour": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "15",
+                              "annotation": []
+                            },
+                            "minute": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "59",
+                              "annotation": []
+                            },
+                            "second": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "59",
+                              "annotation": []
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperContains not implemented",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
                         "annotation": []
                       }
                     }
@@ -32682,6 +35847,118 @@
             "annotation": [],
             "element": [
               {
+                "name": "ProperIn1",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn2",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn3",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn4",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
                 "name": "ProperInNullRightFalse",
                 "annotation": [],
                 "elementType": {
@@ -32689,11 +35966,48 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn5",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
                         "annotation": []
                       }
                     }
@@ -32708,11 +36022,160 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn6",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn7",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn8",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn9",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn10",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "expression",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
                         "annotation": []
                       }
                     }
@@ -32727,11 +36190,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
                         "annotation": []
                       }
                     }
@@ -32746,11 +36218,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
                         "annotation": []
                       }
                     }
@@ -32767,6 +36248,118 @@
               "annotation": [],
               "element": [
                 {
+                  "name": "ProperIn1",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperIn2",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperIn3",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperIn4",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
                   "name": "ProperInNullRightFalse",
                   "annotation": [],
                   "elementType": {
@@ -32774,11 +36367,48 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperIn5",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -32793,11 +36423,160 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperIn6",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperIn7",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperIn8",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperIn9",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "ProperIn10",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -32812,11 +36591,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -32831,11 +36619,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -32846,6 +36643,412 @@
             },
             "element": [
               {
+                "name": "ProperIn1",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Literal",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "a",
+                            "annotation": []
+                          },
+                          {
+                            "type": "As",
+                            "strict": false,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "signature": [],
+                            "operand": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "7210",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "7211",
+                                  "name": "{urn:hl7-org:elm-types:r1}String",
+                                  "annotation": []
+                                }
+                              },
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn2",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Literal",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "a",
+                            "annotation": []
+                          },
+                          {
+                            "type": "Query",
+                            "annotation": [],
+                            "source": [
+                              {
+                                "alias": "X",
+                                "annotation": [],
+                                "expression": {
+                                  "type": "List",
+                                  "annotation": [],
+                                  "resultTypeSpecifier": {
+                                    "type": "ListTypeSpecifier",
+                                    "annotation": [],
+                                    "elementType": {
+                                      "type": "NamedTypeSpecifier",
+                                      "name": "{urn:hl7-org:elm-types:r1}Any",
+                                      "annotation": []
+                                    }
+                                  },
+                                  "element": []
+                                }
+                              }
+                            ],
+                            "let": [],
+                            "relationship": [],
+                            "return": {
+                              "distinct": false,
+                              "annotation": [],
+                              "expression": {
+                                "type": "As",
+                                "asType": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": [],
+                                "signature": [],
+                                "operand": {
+                                  "type": "AliasRef",
+                                  "name": "X",
+                                  "annotation": []
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn3",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Literal",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "a",
+                            "annotation": []
+                          },
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "a",
+                                "annotation": []
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn4",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "As",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "strict": false,
+                            "annotation": [],
+                            "signature": [],
+                            "operand": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "asTypeSpecifier": {
+                              "type": "NamedTypeSpecifier",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                              "name": "{urn:hl7-org:elm-types:r1}String",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "Query",
+                            "annotation": [],
+                            "source": [
+                              {
+                                "alias": "X",
+                                "annotation": [],
+                                "expression": {
+                                  "type": "List",
+                                  "annotation": [],
+                                  "resultTypeSpecifier": {
+                                    "type": "ListTypeSpecifier",
+                                    "annotation": [],
+                                    "elementType": {
+                                      "type": "NamedTypeSpecifier",
+                                      "name": "{urn:hl7-org:elm-types:r1}Any",
+                                      "annotation": []
+                                    }
+                                  },
+                                  "element": [
+                                    {
+                                      "type": "Null",
+                                      "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                      "annotation": []
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "let": [],
+                            "relationship": [],
+                            "return": {
+                              "distinct": false,
+                              "annotation": [],
+                              "expression": {
+                                "type": "As",
+                                "asType": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": [],
+                                "signature": [],
+                                "operand": {
+                                  "type": "AliasRef",
+                                  "name": "X",
+                                  "annotation": []
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
                 "name": "ProperInNullRightFalse",
                 "value": {
                   "type": "Tuple",
@@ -32855,11 +37058,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -32867,12 +37079,201 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "As",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "strict": false,
+                            "annotation": [],
+                            "signature": [],
+                            "operand": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "asTypeSpecifier": {
+                              "type": "NamedTypeSpecifier",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                              "name": "{urn:hl7-org:elm-types:r1}String",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "s",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "u",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "n",
+                                "annotation": []
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperIn not implemented",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn5",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "As",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "strict": false,
+                            "annotation": [],
+                            "signature": [],
+                            "operand": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "asTypeSpecifier": {
+                              "type": "NamedTypeSpecifier",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                              "name": "{urn:hl7-org:elm-types:r1}String",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "Query",
+                            "annotation": [],
+                            "source": [
+                              {
+                                "alias": "X",
+                                "annotation": [],
+                                "expression": {
+                                  "type": "List",
+                                  "annotation": [],
+                                  "resultTypeSpecifier": {
+                                    "type": "ListTypeSpecifier",
+                                    "annotation": [],
+                                    "elementType": {
+                                      "type": "NamedTypeSpecifier",
+                                      "name": "{urn:hl7-org:elm-types:r1}Any",
+                                      "annotation": []
+                                    }
+                                  },
+                                  "element": [
+                                    {
+                                      "type": "Null",
+                                      "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                      "annotation": []
+                                    },
+                                    {
+                                      "type": "Null",
+                                      "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                      "annotation": []
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "let": [],
+                            "relationship": [],
+                            "return": {
+                              "distinct": false,
+                              "annotation": [],
+                              "expression": {
+                                "type": "As",
+                                "asType": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": [],
+                                "signature": [],
+                                "operand": {
+                                  "type": "AliasRef",
+                                  "name": "X",
+                                  "annotation": []
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
                         "annotation": []
                       }
                     }
@@ -32889,11 +37290,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -32901,12 +37311,546 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "As",
+                            "asType": "{urn:hl7-org:elm-types:r1}String",
+                            "annotation": [],
+                            "signature": [],
+                            "operand": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "s",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "u",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "n",
+                                "annotation": []
+                              },
+                              {
+                                "type": "As",
+                                "asType": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": [],
+                                "signature": [],
+                                "operand": {
+                                  "type": "Null",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperIn not implemented",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn6",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Literal",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "a",
+                            "annotation": []
+                          },
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "a",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "b",
+                                "annotation": []
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn7",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Literal",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "a",
+                            "annotation": []
+                          },
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "a",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "a",
+                                "annotation": []
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn8",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Literal",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "c",
+                            "annotation": []
+                          },
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "a",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "b",
+                                "annotation": []
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn9",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Literal",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "a",
+                            "annotation": []
+                          },
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "a",
+                                "annotation": []
+                              },
+                              {
+                                "type": "As",
+                                "asType": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": [],
+                                "signature": [],
+                                "operand": {
+                                  "type": "Null",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "ProperIn10",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "expression",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Literal",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                            "valueType": "{urn:hl7-org:elm-types:r1}String",
+                            "value": "a",
+                            "annotation": []
+                          },
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "a",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "b",
+                                "annotation": []
+                              },
+                              {
+                                "type": "As",
+                                "asType": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": [],
+                                "signature": [],
+                                "operand": {
+                                  "type": "Null",
+                                  "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                                  "annotation": []
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
                         "annotation": []
                       }
                     }
@@ -32923,11 +37867,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -32935,12 +37888,146 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Time",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                            "annotation": [],
+                            "signature": [],
+                            "hour": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "15",
+                              "annotation": []
+                            },
+                            "minute": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "59",
+                              "annotation": []
+                            },
+                            "second": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "59",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Time",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": [],
+                                "signature": [],
+                                "hour": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "15",
+                                  "annotation": []
+                                },
+                                "minute": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "second": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                }
+                              },
+                              {
+                                "type": "Time",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": [],
+                                "signature": [],
+                                "hour": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "20",
+                                  "annotation": []
+                                },
+                                "minute": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "second": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "millisecond": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "999",
+                                  "annotation": []
+                                }
+                              },
+                              {
+                                "type": "Time",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": [],
+                                "signature": [],
+                                "hour": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "20",
+                                  "annotation": []
+                                },
+                                "minute": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "second": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "49",
+                                  "annotation": []
+                                },
+                                "millisecond": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "999",
+                                  "annotation": []
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperIn not implemented",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "true",
                         "annotation": []
                       }
                     }
@@ -32957,11 +38044,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
                           "annotation": []
                         }
                       }
@@ -32969,12 +38065,152 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
+                      "value": {
+                        "type": "ProperIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "Time",
+                            "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                            "annotation": [],
+                            "signature": [],
+                            "hour": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "15",
+                              "annotation": []
+                            },
+                            "minute": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "59",
+                              "annotation": []
+                            },
+                            "second": {
+                              "type": "Literal",
+                              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                              "value": "59",
+                              "annotation": []
+                            }
+                          },
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Time",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": [],
+                                "signature": [],
+                                "hour": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "15",
+                                  "annotation": []
+                                },
+                                "minute": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "second": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "millisecond": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "999",
+                                  "annotation": []
+                                }
+                              },
+                              {
+                                "type": "Time",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": [],
+                                "signature": [],
+                                "hour": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "20",
+                                  "annotation": []
+                                },
+                                "minute": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "second": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "millisecond": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "999",
+                                  "annotation": []
+                                }
+                              },
+                              {
+                                "type": "Time",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Time",
+                                "annotation": [],
+                                "signature": [],
+                                "hour": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "20",
+                                  "annotation": []
+                                },
+                                "minute": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "59",
+                                  "annotation": []
+                                },
+                                "second": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "49",
+                                  "annotation": []
+                                },
+                                "millisecond": {
+                                  "type": "Literal",
+                                  "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "value": "999",
+                                  "annotation": []
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
                       "value": {
                         "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperIn not implemented",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "valueType": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "value": "false",
                         "annotation": []
                       }
                     }
@@ -35099,7 +40335,17 @@
                         "operand": [
                           {
                             "type": "As",
+                            "strict": false,
                             "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                "annotation": []
+                              }
+                            },
                             "signature": [],
                             "operand": {
                               "type": "Null",
@@ -35109,8 +40355,20 @@
                             "asTypeSpecifier": {
                               "type": "ListTypeSpecifier",
                               "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "7988",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "7989",
+                                  "name": "{urn:hl7-org:elm-types:r1}Integer",
+                                  "annotation": []
+                                }
+                              },
                               "elementType": {
                                 "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
                                 "name": "{urn:hl7-org:elm-types:r1}Integer",
                                 "annotation": []
                               }
@@ -35424,11 +40682,20 @@
                   "annotation": [],
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "annotation": [],
                       "elementType": {
                         "type": "NamedTypeSpecifier",
-                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": []
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -35704,11 +40971,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -37195,11 +42471,20 @@
                     "annotation": [],
                     "element": [
                       {
-                        "name": "skipped",
+                        "name": "expression",
                         "annotation": [],
                         "elementType": {
                           "type": "NamedTypeSpecifier",
-                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "name": "{urn:hl7-org:elm-types:r1}Boolean",
+                          "annotation": []
+                        }
+                      },
+                      {
+                        "name": "output",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}Any",
                           "annotation": []
                         }
                       }
@@ -37207,12 +42492,98 @@
                   },
                   "element": [
                     {
-                      "name": "skipped",
+                      "name": "expression",
                       "value": {
-                        "type": "Literal",
-                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
-                        "valueType": "{urn:hl7-org:elm-types:r1}String",
-                        "value": "ProperIn not implemented",
+                        "type": "ProperIncludedIn",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Boolean",
+                        "annotation": [],
+                        "signature": [],
+                        "operand": [
+                          {
+                            "type": "List",
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "element": [
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "s",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "u",
+                                "annotation": []
+                              },
+                              {
+                                "type": "Literal",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                                "value": "n",
+                                "annotation": []
+                              }
+                            ]
+                          },
+                          {
+                            "type": "As",
+                            "strict": false,
+                            "annotation": [],
+                            "resultTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            },
+                            "signature": [],
+                            "operand": {
+                              "type": "Null",
+                              "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
+                              "annotation": []
+                            },
+                            "asTypeSpecifier": {
+                              "type": "ListTypeSpecifier",
+                              "annotation": [],
+                              "resultTypeSpecifier": {
+                                "type": "ListTypeSpecifier",
+                                "localId": "8436",
+                                "annotation": [],
+                                "elementType": {
+                                  "type": "NamedTypeSpecifier",
+                                  "localId": "8437",
+                                  "name": "{urn:hl7-org:elm-types:r1}String",
+                                  "annotation": []
+                                }
+                              },
+                              "elementType": {
+                                "type": "NamedTypeSpecifier",
+                                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                                "name": "{urn:hl7-org:elm-types:r1}String",
+                                "annotation": []
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "output",
+                      "value": {
+                        "type": "Null",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}Any",
                         "annotation": []
                       }
                     }
@@ -39184,6 +44555,750 @@
                           }
                         },
                         "element": []
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "Slice",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [],
+          "resultTypeSpecifier": {
+            "type": "TupleTypeSpecifier",
+            "annotation": [],
+            "element": [
+              {
+                "name": "SliceAll",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SliceEmpty",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SliceNull",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SliceStart",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SliceStartNull",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SliceEnd",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SliceEndNull",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SliceNegative",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SliceStartAndNegative",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SlicePast",
+                "annotation": [],
+                "elementType": {
+                  "type": "TupleTypeSpecifier",
+                  "annotation": [],
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "annotation": [],
+                      "elementType": {
+                        "type": "NamedTypeSpecifier",
+                        "name": "{urn:hl7-org:elm-types:r1}String",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expression": {
+            "type": "Tuple",
+            "annotation": [],
+            "resultTypeSpecifier": {
+              "type": "TupleTypeSpecifier",
+              "annotation": [],
+              "element": [
+                {
+                  "name": "SliceAll",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "SliceEmpty",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "SliceNull",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "SliceStart",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "SliceStartNull",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "SliceEnd",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "SliceEndNull",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "SliceNegative",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "SliceStartAndNegative",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "SlicePast",
+                  "annotation": [],
+                  "elementType": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "element": [
+              {
+                "name": "SliceAll",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "Slice not implemented",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SliceEmpty",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "Slice not implemented",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SliceNull",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "Slice not implemented",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SliceStart",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "Slice not implemented",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SliceStartNull",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "Slice not implemented",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SliceEnd",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "Slice not implemented",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SliceEndNull",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "Slice not implemented",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SliceNegative",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "Slice not implemented",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SliceStartAndNegative",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "Slice not implemented",
+                        "annotation": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "SlicePast",
+                "value": {
+                  "type": "Tuple",
+                  "annotation": [],
+                  "resultTypeSpecifier": {
+                    "type": "TupleTypeSpecifier",
+                    "annotation": [],
+                    "element": [
+                      {
+                        "name": "skipped",
+                        "annotation": [],
+                        "elementType": {
+                          "type": "NamedTypeSpecifier",
+                          "name": "{urn:hl7-org:elm-types:r1}String",
+                          "annotation": []
+                        }
+                      }
+                    ]
+                  },
+                  "element": [
+                    {
+                      "name": "skipped",
+                      "value": {
+                        "type": "Literal",
+                        "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                        "valueType": "{urn:hl7-org:elm-types:r1}String",
+                        "value": "Slice not implemented",
+                        "annotation": []
                       }
                     }
                   ]

--- a/test/spec-tests/skip-list.txt
+++ b/test/spec-tests/skip-list.txt
@@ -8,6 +8,9 @@ CqlAggregateTest.AggregateTests.RolledOutIntervals  CQL adds an integer to a dat
 
 # Incorrect Expected Output
 CqlIntervalOperatorsTest.In.TestInNullBoundaries                Wrong output: According to spec, comparison against null closed boundaries should result in true
+CqlListOperatorsTest.Equal.EqualNullNull                        Wrong output: According to spec, if either list contains a null, the result is null
+CqlListOperatorsTest.Sort.simpleSortAsc                         Wrong output: Queries return distinct lists by default; need to use "all" to retain duplicates
+CqlListOperatorsTest.Sort.simpleSortDesc                        Wrong output: Queries return distinct lists by default; need to use "all" to retain duplicates
 
 # Potentially Incorrect Expected Output
 "CqlStringOperatorsTest.toString tests.DateTimeToString2"         Answer does not include timezone offset, but default offset depends on test environment
@@ -50,6 +53,7 @@ CqlArithmeticFunctionsTest.HighBoundary                 HighBoundary not impleme
 CqlArithmeticFunctionsTest.LowBoundary                  LowBoundary not implemented
 CqlArithmeticFunctionsTest.Precision.PrecisionDecimal   Precision for Decimal not implemented
 CqlIntervalOperatorsTest.PointFrom                      PointFrom not implemented
+CqlListOperatorsTest.Descendents                        Descendents not implemented
 
 # Unimplemented (New in CQL 1.5)
 CqlArithmeticFunctionsTest.Modulo.ModuloQuantity                      Modulo not implemented for Quantity

--- a/test/spec-tests/skip-list.txt
+++ b/test/spec-tests/skip-list.txt
@@ -3,17 +3,11 @@ CqlIntervalOperatorsTest.Expand.ExpandPer0D1        Translation Error: Could not
 
 # Invalid Translation (translates, but translates wrong)
 CqlAggregateTest.AggregateTests.RolledOutIntervals  CQL adds an integer to a date ("S + duration in days of X"). Should be "S + Quantity{ value: duration in days of X, unit: 'days' }". Translator translates it, but probably shouldn't.
-CqlListOperatorsTest.IncludedIn.IncludedInNullRight Converts included in to in, which has different semantics when second argument is null
 
 # Potentially Invalid Translation (translates, but potentially translates wrong)
-CqlListOperatorsTest.IncludedIn.IncludedInNullLeft    Treats null as point overload, translating to "In" operator, which has different semantics (and different result)
-CqlListOperatorsTest.Includes.IncludesNullRight       Treats null as point overload, translating to "Contains" operator, which has different semantics (and different result)
 
 # Incorrect Expected Output
 CqlIntervalOperatorsTest.In.TestInNullBoundaries                Wrong output: According to spec, comparison against null closed boundaries should result in true
-CqlListOperatorsTest.Equal.EqualNullNull                        Wrong output: According to spec, if either list contains a null, the result is null
-CqlListOperatorsTest.Sort.simpleSortAsc                         Wrong output: Queries return distinct lists by default; need to use "all" to retain duplicates
-CqlListOperatorsTest.Sort.simpleSortDesc                        Wrong output: Queries return distinct lists by default; need to use "all" to retain duplicates
 
 # Potentially Incorrect Expected Output
 "CqlStringOperatorsTest.toString tests.DateTimeToString2"         Answer does not include timezone offset, but default offset depends on test environment
@@ -56,12 +50,6 @@ CqlArithmeticFunctionsTest.HighBoundary                 HighBoundary not impleme
 CqlArithmeticFunctionsTest.LowBoundary                  LowBoundary not implemented
 CqlArithmeticFunctionsTest.Precision.PrecisionDecimal   Precision for Decimal not implemented
 CqlIntervalOperatorsTest.PointFrom                      PointFrom not implemented
-CqlIntervalOperatorsTest.ProperContains                 ProperContains not implemented
-CqlIntervalOperatorsTest.ProperIn                       ProperIn not implemented
-CqlListOperatorsTest.Descendents                        Descendents not implemented
-CqlListOperatorsTest.ProperContains                     ProperContains not implemented
-CqlListOperatorsTest.ProperIn                           ProperIn not implemented
-CqlListOperatorsTest.ProperlyIncludedIn.ProperlyIncludedInNulRight  ProperIn not implemented
 
 # Unimplemented (New in CQL 1.5)
 CqlArithmeticFunctionsTest.Modulo.ModuloQuantity                      Modulo not implemented for Quantity

--- a/test/spec-tests/skip-list.txt
+++ b/test/spec-tests/skip-list.txt
@@ -57,3 +57,6 @@ CqlArithmeticFunctionsTest.Modulo.Modulo10By3Quantity                 Modulo not
 "CqlArithmeticFunctionsTest.Truncated Divide.TruncatedDivide10d1ByNeg3D1Quantity"     Truncated divide not implemented for Quantity
 "CqlArithmeticFunctionsTest.Truncated Divide.TruncatedDivide10By5DQuantity"           Truncated divide not implemented for Quantity
 "CqlArithmeticFunctionsTest.Truncated Divide.TruncatedDivide414By206DQuantity"        Truncated divide not implemented for Quantity
+
+# Unimplemented (New in CQL 2.0)
+CqlListOperatorsTest.Slice                              Slice not implemented

--- a/test/spec-tests/xml/CqlListOperatorsTest.xml
+++ b/test/spec-tests/xml/CqlListOperatorsTest.xml
@@ -1,916 +1,1308 @@
 <?xml version="1.0" encoding="utf-8"?>
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://hl7.org/fhirpath/tests" xsi:schemaLocation="http://hl7.org/fhirpath/tests ../../testSchema/testSchema.xsd"
 	name="CqlListOperatorsTest" reference="https://cql.hl7.org/09-b-cqlreference.html#list-operators-2" version="1.0">
+	<capability code="list-operators" />
 	<group name="Sort" version="1.0">
+		<capability code="list-operators" />
 		<test name="simpleSortAsc" version="1.0">
+			<capability code="list-operators" />
 			<expression>({4, 5, 1, 6, 2, 1}) sL sort asc</expression>
 			<output>{1, 1, 2, 4, 5, 6}</output>
 		</test>
 		<test name="simpleSortDesc" version="1.0">
+			<capability code="list-operators" />
 			<expression>({4, 5, 1, 6, 2, 1}) sL sort desc</expression>
 			<output>{6, 5, 4, 2, 1, 1}</output>
 		</test>
 		<test name="simpleSortStringAsc" version="1.0">
+			<capability code="list-operators" />
 			<expression>({'back', 'aardvark', 'alligator', 'zebra', 'iguana', 'Wolf', 'Armadillo'}) sls sort asc</expression>
 			<output>{'Armadillo', 'Wolf', 'aardvark', 'alligator', 'back', 'iguana', 'zebra'}</output>
 		</test>
 		<test name="simpleSortStringDesc" version="1.0">
+			<capability code="list-operators" />
 			<expression>({'back', 'aardvark', 'alligator', 'zebra', 'iguana', 'Wolf', 'Armadillo'}) sls sort desc</expression>
 			<output>{'zebra', 'iguana', 'back', 'alligator', 'aardvark', 'Wolf', 'Armadillo'}</output>
 		</test>
 		<test name="SortDatesAsc" version="1.0">
+			<capability code="list-operators" />
 			<expression>({ DateTime(2012, 10, 5, 10), DateTime(2012, 1, 1), DateTime(2012, 1, 1, 12), DateTime(2012, 10, 5) }) S sort asc</expression>
 			<output>{ @2012-01-01T, @2012-01-01T12, @2012-10-05T, @2012-10-05T10 }</output>
 		</test>
 		<test name="SortDatesDesc" version="1.0">
+			<capability code="list-operators" />
 			<expression>({ DateTime(2012, 10, 5, 10), DateTime(2012, 1, 1), DateTime(2012, 1, 1, 12), DateTime(2012, 10, 5) }) S sort desc</expression>
 			<output>{ @2012-10-05T10, @2012-10-05T, @2012-01-01T12, @2012-01-01T }</output>
 		</test>
 		<test name="intList" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 3, 2, 1 }</expression>
 			<output>{3, 2, 1}</output>
 		</test>
 		<test name="decimalList" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 3.8, 2.4, 1.9 }</expression>
 			<output>{3.8, 2.4, 1.9}</output>
 		</test>
 		<test name="quantityList" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 19.99 '[lb_av]', 17.33 '[lb_av]', 10.66 '[lb_av]' }</expression>
 			<output>{19.99 '[lb_av]', 17.33 '[lb_av]', 10.66 '[lb_av]'}</output>
 		</test>
 		<test name="dateTimeList" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ DateTime(2016), DateTime(2015), DateTime(2010) }</expression>
 			<output>{@2016T, @2015T, @2010T}</output>
 		</test>
 		<test name="timeList" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59.999, @T15:12:59.999, @T15:12:13.999 }</expression>
 			<output>{@T15:59:59.999, @T15:12:59.999, @T15:12:13.999}</output>
 		</test>
 	</group>
 	<group name="Contains" version="1.0">
+		<capability code="list-operators" />
 		<test name="ContainsABNullHasNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 'a', 'b', null } contains null</expression>
 			<output>true</output>
 		</test>
 		<test name="ContainsNullFirst" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ null, 'b', 'c' } contains 'a'</expression>
 			<output>false</output>
 		</test>
 		<test name="ContainsABCHasA" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 'a', 'b', 'c' } contains 'a'</expression>
 			<output>true</output>
 		</test>
 		<test name="ContainsJan2012True" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ DateTime(2012, 10, 5), DateTime(2012, 9, 5), DateTime(2012, 1, 1) } contains DateTime(2012, 1, 1)</expression>
 			<output>true</output>
 		</test>
 		<test name="ContainsJan2012False" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ DateTime(2012, 10, 5), DateTime(2012, 9, 5), DateTime(2012, 10, 1) } contains DateTime(2012, 1, 1)</expression>
 			<output>false</output>
 		</test>
 		<test name="ContainsTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59.999, @T05:59:59.999, @T20:59:59.999 } contains @T05:59:59.999</expression>
 			<output>true</output>
 		</test>
 		<test name="ContainsTimeFalse" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59.999, @T05:59:59.999, @T20:59:59.999 } contains @T08:59:59.999</expression>
 			<output>false</output>
 		</test>
 		<test name="ContainsNullLeft" version="1.0">
-			<expression>null contains 'a'</expression>
+			<capability code="list-operators" />
+			<expression>null as List&lt;String&gt; contains 'a'</expression>
 			<output>false</output>
 		</test>
 	</group>
 	<group name="Descendents" version="1.0">
+		<capability code="list-operators" />
 		<test name="DescendentsEmptyList" version="1.0">
+			<capability code="list-operators" />
 			<expression>(null).descendents()</expression>
 			<output>null</output>
 		</test>
 		<!-- TODO: how to call without fhirpath syntax -->
 	</group>
 	<group name="Distinct" version="1.0">
+		<capability code="list-operators" />
 		<test name="DistinctEmptyList" version="1.0">
+			<capability code="list-operators" />
 			<expression>distinct {}</expression>
 			<output>{}</output>
 		</test>
 		<test name="DistinctNullNullNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>distinct { null, null, null}</expression>
 			<output>{ null }</output>
 		</test>
 		<test name="DistinctANullANull" version="1.0">
+			<capability code="list-operators" />
 			<expression>distinct { 'a', null, 'a', null}</expression>
 			<output>{'a', null}</output>
 		</test>
 		<test name="Distinct112233" version="1.0">
+			<capability code="list-operators" />
 			<expression>distinct { 1, 1, 2, 2, 3, 3}</expression>
 			<output>{1,2,3}</output>
 		</test>
 		<test name="Distinct123123" version="1.0">
+			<capability code="list-operators" />
 			<expression>distinct { 1, 2, 3, 1, 2, 3}</expression>
 			<output>{1,2,3}</output>
 		</test>
 		<test name="DistinctAABBCC" version="1.0">
+			<capability code="list-operators" />
 			<expression>distinct { 'a', 'a', 'b', 'b', 'c', 'c'}</expression>
 			<output>{'a','b','c'}</output>
 		</test>
 		<test name="DistinctABCABC" version="1.0">
+			<capability code="list-operators" />
 			<expression>distinct { 'a', 'b', 'c', 'a', 'b', 'c'}</expression>
 			<output>{'a','b','c'}</output>
 		</test>
 		<test name="DistinctDateTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>distinct { DateTime(2012, 10, 5), DateTime(2012, 1, 1), DateTime(2012, 1, 1)}</expression>
 			<output>{ @2012-10-05T, @2012-01-01T }</output>
 		</test>
 		<test name="DistinctTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>distinct { @T15:59:59.999, @T20:59:59.999 }</expression>
 			<output>{ @T15:59:59.999, @T20:59:59.999 }</output>
 		</test>
 	</group>
 	<group name="Equal" version="1.0">
+		<capability code="list-operators" />
 		<test name="EqualNullNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>{null} = {null}</expression>
 			<output>true</output>
 		</test>
 		<test name="EqualEmptyListNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>{} as List&lt;String&gt; = null</expression>
 			<output>null</output>
 		</test>
 		<test name="EqualNullEmptyList" version="1.0">
+			<capability code="list-operators" />
 			<expression>null = {} as List&lt;String&gt;</expression>
 			<output>null</output>
 		</test>
 		<test name="EqualEmptyListAndEmptyList" version="1.0">
+			<capability code="list-operators" />
 			<expression>{} = {}</expression>
 			<output>true</output>
 		</test>
 		<test name="EqualABCAndABC" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 'a', 'b', 'c' } = { 'a', 'b', 'c' }</expression>
 			<output>true</output>
 		</test>
 		<test name="EqualABCAndAB" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 'a', 'b', 'c' } = { 'a', 'b' }</expression>
 			<output>false</output>
 		</test>
 		<test name="EqualABCAnd123" version="1.0">
-			<expression>{ 'a', 'b', 'c' } = { 1, 2, 3 }</expression>
+			<capability code="list-operators" />
+			<expression>{ 'a', 'b', 'c' } as List&lt;Any&gt; ~ { 1, 2, 3 } as List&lt;Any&gt;</expression>
 			<output>false</output>
 		</test>
 		<test name="Equal123AndABC" version="1.0">
-			<expression>{ 1, 2, 3 } = { 'a', 'b', 'c' }</expression>
+			<capability code="list-operators" />
+			<expression>{ 1, 2, 3 } as List&lt;Any&gt; = { 'a', 'b', 'c' } as List&lt;Any&gt;</expression>
 			<output>false</output>
 		</test>
 		<test name="Equal123AndString123" version="1.0">
-			<expression>{ 1, 2, 3 } = { '1', '2', '3' }</expression>
+			<capability code="list-operators" />
+			<expression>{ 1, 2, 3 } as List&lt;Any&gt; = { '1', '2', '3' } as List&lt;Any&gt;</expression>
 			<output>false</output>
 		</test>
 		<test name="Equal12And123" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 1, 2 } = { 1, 2, 3 }</expression>
 			<output>false</output>
 		</test>
 		<test name="Equal123And12" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 1, 2, 3 } = { 1, 2 }</expression>
 			<output>false</output>
 		</test>
 		<test name="Equal123And123" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 1, 2, 3 } = { 1, 2, 3 }</expression>
 			<output>true</output>
 		</test>
 		<test name="EqualDateTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>{DateTime(2012, 5, 10, 0, 0, 0, 0), DateTime(2014, 12, 10, 0, 0, 0, 0)} = {DateTime(2012, 5, 10, 0, 0, 0, 0), DateTime(2014, 12, 10, 0, 0, 0, 0)}</expression>
 			<output>true</output>
 		</test>
 		<test name="EqualDateTimeFalse" version="1.0">
+			<capability code="list-operators" />
 			<expression>{DateTime(2012, 5, 10, 0, 0, 0, 0), DateTime(2014, 12, 10, 0, 0, 0, 0)} = {DateTime(2012, 1, 10, 0, 0, 0, 0), DateTime(2014, 12, 10, 0, 0, 0, 0)}</expression>
 			<output>false</output>
 		</test>
 		<test name="EqualTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59.999, @T20:59:59.999, @T20:59:59.999 } = { @T15:59:59.999, @T20:59:59.999, @T20:59:59.999 }</expression>
 			<output>true</output>
 		</test>
 		<test name="EqualTimeFalse" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59.999, @T20:59:59.999, @T20:59:59.999 } = { @T10:59:59.999, @T20:59:59.999, @T20:59:59.999 }</expression>
 			<output>false</output>
 		</test>
 	</group>
 	<group name="Except" version="1.0">
+		<capability code="list-operators" />
 		<test name="ExceptEmptyListAndEmptyList" version="1.0">
+			<capability code="list-operators" />
 			<expression>{} except {}</expression>
 			<output>{}</output>
 		</test>
 		<test name="Except1234And23" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 1, 2, 3, 4 } except { 2, 3 }</expression>
 			<output>{ 1, 4 }</output>
 		</test>
 		<test name="Except23And1234" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 2, 3 } except { 1, 2, 3, 4 }</expression>
 			<output>{}</output>
 		</test>
 		<test name="ExceptDateTimeList" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ DateTime(2012, 5, 10), DateTime(2014, 12, 10), DateTime(2010, 1, 1)} except {DateTime(2014, 12, 10), DateTime(2010, 1, 1) }</expression>
 			<output>{@2012-05-10T}</output>
 		</test>
 		<test name="ExceptTimeList" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59.999, @T20:59:59.999, @T12:59:59.999 } except { @T20:59:59.999, @T12:59:59.999 }</expression>
 			<output>{@T15:59:59.999}</output>
 		</test>
 		<test name="ExceptNullRight" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 1, 4 } except null</expression>
 			<output>{1, 4}</output>
 		</test>
 	</group>
 	<group name="Exists" version="1.0">
+		<capability code="list-operators" />
 		<test name="ExistsEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>Exists({})</expression>
 			<output>false</output>
 		</test>
 		<test name="ExistsListNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>Exists({ null })</expression>
 			<output>false</output>
 		</test>
 		<test name="Exists1" version="1.0">
+			<capability code="list-operators" />
 			<expression>Exists({ 1 })</expression>
 			<output>true</output>
 		</test>
 		<test name="Exists12" version="1.0">
+			<capability code="list-operators" />
 			<expression>Exists({ 1, 2 })</expression>
 			<output>true</output>
 		</test>
 		<test name="ExistsDateTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>Exists({ DateTime(2012, 5, 10), DateTime(2014, 12, 10) })</expression>
 			<output>true</output>
 		</test>
 		<test name="ExistsTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>Exists({ @T15:59:59.999, @T20:59:59.999 })</expression>
 			<output>true</output>
 		</test>
 		<test name="ExistsNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>Exists(null)</expression>
 			<output>false</output>
 		</test>
 	</group>
 	<group name="Flatten" version="1.0">
+		<capability code="list-operators" />
 		<test name="FlattenEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>Flatten({{},{}})</expression>
 			<output>{}</output>
 		</test>
 		<test name="FlattenListNullAndNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>Flatten({{null}, {null}})</expression>
 			<output>{null, null}</output>
 		</test>
 		<test name="FlattenList12And34" version="1.0">
+			<capability code="list-operators" />
 			<expression>Flatten({{1,2}, {3,4}})</expression>
 			<output>{1,2,3,4}</output>
 		</test>
 		<test name="FlattenDateTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>Flatten({ {DateTime(2012, 5, 10)}, {DateTime(2014, 12, 10)} })</expression>
 			<output>{ @2012-05-10T, @2014-12-10T }</output>
 		</test>
 		<test name="FlattenTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>Flatten({ {@T15:59:59.999}, {@T20:59:59.999} })</expression>
 			<output>{ @T15:59:59.999, @T20:59:59.999 }</output>
 		</test>
 	</group>
 	<group name="First" version="1.0">
+		<capability code="list-operators" />
 		<test name="FirstEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>First({})</expression>
 			<output>null</output>
 		</test>
 		<test name="FirstNull1" version="1.0">
+			<capability code="list-operators" />
 			<expression>First({ null, 1 })</expression>
 			<output>null</output>
 		</test>
 		<test name="First1Null" version="1.0">
+			<capability code="list-operators" />
 			<expression>First({ 1, null })</expression>
 			<output>1</output>
 		</test>
 		<test name="First12" version="1.0">
+			<capability code="list-operators" />
 			<expression>First({ 1, 2 })</expression>
 			<output>1</output>
 		</test>
 		<test name="FirstDateTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>First({ DateTime(2012, 5, 10), DateTime(2014, 12, 10) })</expression>
 			<output>@2012-05-10T</output>
 		</test>
 		<test name="FirstTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>First({ @T15:59:59.999, @T20:59:59.999 })</expression>
 			<output>@T15:59:59.999</output>
 		</test>
 	</group>
 	<group name="In" version="1.0">
+		<capability code="list-operators" />
 		<test name="InNullEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>null in {}</expression>
 			<output>false</output>
 		</test>
 		<test name="InNullAnd1Null" version="1.0">
+			<capability code="list-operators" />
 			<expression>null in { 1, null }</expression>
 			<output>true</output>
 		</test>
 		<test name="In1Null" version="1.0">
-			<expression>1 in null</expression>
+			<capability code="list-operators" />
+			<expression>1 in null as List&lt;Integer&gt;</expression>
 			<output>false</output>
 		</test>
 		<test name="In1And12" version="1.0">
+			<capability code="list-operators" />
 			<expression>1 in { 1, 2 }</expression>
 			<output>true</output>
 		</test>
 		<test name="In3And12" version="1.0">
+			<capability code="list-operators" />
 			<expression>3 in { 1, 2 }</expression>
 			<output>false</output>
 		</test>
 		<test name="InDateTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>DateTime(2012, 5, 10) in { DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10) }</expression>
 			<output>true</output>
 		</test>
 		<test name="InDateTimeFalse" version="1.0">
+			<capability code="list-operators" />
 			<expression>DateTime(2012, 6, 10) in { DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10) }</expression>
 			<output>false</output>
 		</test>
 		<test name="InTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>@T15:59:59.999 in { @T02:29:15.156, @T15:59:59.999, @T20:59:59.999 }</expression>
 			<output>true</output>
 		</test>
 		<test name="InTimeFalse" version="1.0">
+			<capability code="list-operators" />
 			<expression>@T16:59:59.999 in { @T02:29:15.156, @T15:59:59.999, @T20:59:59.999 }</expression>
 			<output>false</output>
 		</test>
 	</group>
 	<group name="Includes" version="1.0">
+		<capability code="list-operators" />
 		<test name="IncludesEmptyAndEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>{} includes {}</expression>
 			<output>true</output>
 		</test>
 		<test name="IncludesListNullAndListNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>{null} includes {null}</expression>
 			<output>true</output>
 		</test>
 		<test name="Includes123AndEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>{1, 2, 3} includes {}</expression>
 			<output>true</output>
 		</test>
 		<test name="Includes123And2" version="1.0">
+			<capability code="list-operators" />
 			<expression>{1, 2, 3} includes {2}</expression>
 			<output>true</output>
 		</test>
 		<test name="Includes123And4" version="1.0">
+			<capability code="list-operators" />
 			<expression>{1, 2, 3} includes {4}</expression>
 			<output>false</output>
 		</test>
 		<test name="IncludesDateTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>{DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)} includes {DateTime(2012, 5, 10)}</expression>
 			<output>true</output>
 		</test>
 		<test name="IncludesDateTimeFalse" version="1.0">
+			<capability code="list-operators" />
 			<expression>{DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)} includes {DateTime(2012, 5, 11)}</expression>
 			<output>false</output>
 		</test>
 		<test name="IncludesTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T02:29:15.156, @T15:59:59.999, @T20:59:59.999 } includes @T15:59:59.999</expression>
 			<output>true</output>
 		</test>
 		<test name="IncludesTimeFalse" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T02:29:15.156, @T15:59:59.999, @T20:59:59.999 } includes @T16:59:59.999</expression>
 			<output>false</output>
 		</test>
 		<test name="IncludesNullLeft" version="1.0">
-			<expression>null includes {2}</expression>
+			<capability code="list-operators" />
+			<expression>null as List&lt;Integer&gt; includes {2}</expression>
 			<output>null</output>
 		</test>
-		<!-- this test is going to the ContainsEvaluator -->
 		<test name="IncludesNullRight" version="1.0">
-			<expression>{'s', 'a', 'm'} includes null</expression>
+			<capability code="list-operators" />
+			<expression>{'s', 'a', 'm'} includes null as List&lt;String&gt;</expression>
 			<output>null</output>
 		</test>
 	</group>
 	<group name="IncludedIn" version="1.0">
+		<capability code="list-operators" />
 		<test name="IncludedInEmptyAndEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>{} included in {}</expression>
 			<output>true</output>
 		</test>
 		<test name="IncludedInListNullAndListNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ null } included in { null }</expression>
 			<output>true</output>
 		</test>
 		<test name="IncludedInEmptyAnd123" version="1.0">
+			<capability code="list-operators" />
 			<expression>{} included in { 1, 2, 3 }</expression>
 			<output>true</output>
 		</test>
 		<test name="IncludedIn2And123" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 2 } included in { 1, 2, 3 }</expression>
 			<output>true</output>
 		</test>
 		<test name="IncludedIn4And123" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 4 } included in { 1, 2, 3 }</expression>
 			<output>false</output>
 		</test>
 		<test name="IncludedInDateTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ DateTime(2012, 5, 10)} included in {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)}</expression>
 			<output>true</output>
 		</test>
 		<test name="IncludedInDateTimeFalse" version="1.0">
+			<capability code="list-operators" />
 			<expression>{DateTime(2012, 5, 11)} included in {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)}</expression>
 			<output>false</output>
 		</test>
 		<test name="IncludedInTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>@T15:59:59.999 included in { @T02:29:15.156, @T15:59:59.999, @T20:59:59.999 }</expression>
 			<output>true</output>
 		</test>
 		<test name="IncludedInTimeFalse" version="1.0">
+			<capability code="list-operators" />
 			<expression>@T16:59:59.999 included in { @T02:29:15.156, @T15:59:59.999, @T20:59:59.999 }</expression>
 			<output>false</output>
 		</test>
-		<!-- the following expression is going to the InEvaluator -->
 		<test name="IncludedInNullLeft" version="1.0">
-			<expression>null included in {2}</expression>
+			<capability code="list-operators" />
+			<expression>null as List&lt;Integer&gt; included in {2}</expression>
 			<output>null</output>
 		</test>
 		<test name="IncludedInNullRight" version="1.0">
-			<expression>{'s', 'a', 'm'} included in null</expression>
+			<capability code="list-operators" />
+			<expression>{'s', 'a', 'm'} included in null as List&lt;String&gt;</expression>
 			<output>null</output>
 		</test>
 	</group>
 	<group name="Indexer" version="1.0">
+		<capability code="list-operators" />
 		<test name="IndexerNull1List" version="1.0">
+			<capability code="list-operators" />
 			<expression>(null as List&lt;System.Any&gt;)[1]</expression>
 			<output>null</output>
 		</test>
 		<!-- Cast is required due to ambiguity with Indexer(String) and Indexer(List&lt;Any&gt;) -->
 		<test name="Indexer0Of12" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 1, 2 }[0]</expression>
 			<output>1</output>
 		</test>
 		<test name="Indexer1Of12" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 1, 2 }[1]</expression>
 			<output>2</output>
 		</test>
 		<test name="Indexer2Of12" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 1, 2 }[2]</expression>
 			<output>null</output>
 		</test>
 		<test name="IndexerNeg1Of12" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 1, 2 }[-1]</expression>
 			<output>null</output>
 		</test>
 		<test name="IndexerDateTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10) }[1]</expression>
 			<output>@2012-05-10T</output>
 		</test>
 		<test name="IndexerTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T02:29:15.156, @T15:59:59.999, @T20:59:59.999 }[1]</expression>
 			<output>@T15:59:59.999</output>
 		</test>
 	</group>
 	<group name="IndexOf" version="1.0">
+		<capability code="list-operators" />
 		<test name="IndexOfEmptyNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>IndexOf({}, null)</expression>
 			<output>null</output>
 		</test>
 		<test name="IndexOfNullEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>IndexOf(null, {})</expression>
 			<output>null</output>
 		</test>
 		<test name="IndexOfNullIn1Null" version="1.0">
+			<capability code="list-operators" />
 			<expression>IndexOf({ 1, null }, null)</expression>
 			<output>null</output>
 		</test>
 		<test name="IndexOf1In12" version="1.0">
+			<capability code="list-operators" />
 			<expression>IndexOf({ 1, 2 }, 1)</expression>
 			<output>0</output>
 		</test>
 		<test name="IndexOf2In12" version="1.0">
+			<capability code="list-operators" />
 			<expression>IndexOf({ 1, 2 }, 2)</expression>
 			<output>1</output>
 		</test>
 		<test name="IndexOf3In12" version="1.0">
+			<capability code="list-operators" />
 			<expression>IndexOf({ 1, 2 }, 3)</expression>
 			<output>-1</output>
 		</test>
 		<test name="IndexOfDateTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>IndexOf({ DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10) }, DateTime(2014, 12, 10))</expression>
 			<output>2</output>
 		</test>
 		<test name="IndexOfTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>IndexOf({ @T02:29:15.156, @T15:59:59.999, @T20:59:59.999 }, @T15:59:59.999)</expression>
 			<output>1</output>
 		</test>
 	</group>
 	<group name="Intersect" version="1.0">
+		<capability code="list-operators" />
 		<test name="IntersectEmptyListAndEmptyList" version="1.0">
+			<capability code="list-operators" />
 			<expression>{} intersect {}</expression>
 			<output>{}</output>
 		</test>
 		<test name="Intersect1234And23" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 1, 2, 3, 4 } intersect { 2, 3 }</expression>
 			<output>{ 2, 3 }</output>
 		</test>
 		<test name="Intersect23And1234" version="1.0">
+			<capability code="list-operators" />
 			<expression>{2, 3} intersect { 1, 2, 3, 4 }</expression>
 			<output>{ 2, 3 }</output>
 		</test>
 		<test name="IntersectDateTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10) } intersect { DateTime(2012, 5, 10), DateTime(2014, 12, 10), DateTime(2000, 5, 5) }</expression>
 			<output>{@2012-05-10T, @2014-12-10T}</output>
 		</test>
 		<test name="IntersectTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T02:29:15.156, @T15:59:59.999, @T20:59:59.999 } intersect { @T01:29:15.156, @T15:59:59.999, @T20:59:59.999 }</expression>
 			<output>{@T15:59:59.999, @T20:59:59.999}</output>
 		</test>
 	</group>
 	<group name="Last" version="1.0">
+		<capability code="list-operators" />
 		<test name="LastEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>Last({})</expression>
 			<output>null</output>
 		</test>
 		<test name="LastNull1" version="1.0">
+			<capability code="list-operators" />
 			<expression>Last({null, 1})</expression>
 			<output>1</output>
 		</test>
 		<test name="Last1Null" version="1.0">
+			<capability code="list-operators" />
 			<expression>Last({1, null})</expression>
 			<output>null</output>
 		</test>
 		<test name="Last12" version="1.0">
+			<capability code="list-operators" />
 			<expression>Last({1, 2})</expression>
 			<output>2</output>
 		</test>
 		<test name="LastDateTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>Last({DateTime(2012, 5, 10), DateTime(2014, 12, 10)})</expression>
 			<output>@2014-12-10T</output>
 		</test>
 		<test name="LastTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>Last({ @T15:59:59.999, @T20:59:59.999 })</expression>
 			<output>@T20:59:59.999</output>
 		</test>
 	</group>
 	<group name="Length" version="1.0">
+		<capability code="list-operators" />
 		<test name="LengthEmptyList" version="1.0">
+			<capability code="list-operators" />
 			<expression>Length({})</expression>
 			<output>0</output>
 		</test>
 		<test name="LengthNull1" version="1.0">
+			<capability code="list-operators" />
 			<expression>Length({null, 1})</expression>
 			<output>2</output>
 		</test>
 		<test name="Length1Null" version="1.0">
+			<capability code="list-operators" />
 			<expression>Length({1, null})</expression>
 			<output>2</output>
 		</test>
 		<test name="Length12" version="1.0">
+			<capability code="list-operators" />
 			<expression>Length({1, 2})</expression>
 			<output>2</output>
 		</test>
 		<test name="LengthDateTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>Length({DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)})</expression>
 			<output>3</output>
 		</test>
 		<test name="LengthTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>Length({ @T15:59:59.999, @T20:59:59.999, @T15:59:59.999, @T20:59:59.999, @T15:59:59.999, @T20:59:59.999 })</expression>
 			<output>6</output>
 		</test>
 		<test name="LengthNullList" version="1.0">
+			<capability code="list-operators" />
 			<expression>Length(null as List&lt;Any&gt;)</expression>
 			<output>0</output>
 		</test>
 	</group>
 	<group name="Equivalent" version="1.0">
+		<capability code="list-operators" />
 		<test name="EquivalentEmptyAndEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>{} ~ {}</expression>
 			<output>true</output>
 		</test>
 		<test name="EquivalentABCAndABC" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 'a', 'b', 'c' } ~ { 'a', 'b', 'c' }</expression>
 			<output>true</output>
 		</test>
 		<test name="EquivalentABCAndAB" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 'a', 'b', 'c' } ~ { 'a', 'b' }</expression>
 			<output>false</output>
 		</test>
 		<test name="EquivalentABCAnd123" version="1.0">
-			<expression>{ 'a', 'b', 'c' } ~ { 1, 2, 3 }</expression>
+			<capability code="list-operators" />
+			<expression>{ 'a', 'b', 'c' } as List&lt;Any&gt; ~ { 1, 2, 3 } as List&lt;Any&gt;</expression>
 			<output>false</output>
 			<!-- TODO: make Translator resolve isolated Equivalent operator signatures -->
 		</test>
 		<test name="Equivalent123AndABC" version="1.0">
-			<expression>{ 1, 2, 3 } ~ { 'a', 'b', 'c' }</expression>
+			<capability code="list-operators" />
+			<expression>{ 1, 2, 3 } as List&lt;Any&gt; ~ { 'a', 'b', 'c' } as List&lt;Any&gt;</expression>
 			<output>false</output>
 			<!-- TODO: make Translator resolve isolated Equivalent operator signatures -->
 		</test>
 		<test name="Equivalent123AndString123" version="1.0">
-			<expression>{ 1, 2, 3 } ~ { '1', '2', '3' }</expression>
+			<capability code="list-operators" />
+			<expression>{ 1, 2, 3 } as List&lt;Any&gt; ~ { '1', '2', '3' } as List&lt;Any&gt;</expression>
 			<output>false</output>
 			<!-- TODO: make Translator resolve isolated Equivalent operator signatures -->
 		</test>
 		<test name="EquivalentDateTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>{DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10), null} ~ {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10), null}</expression>
 			<output>true</output>
 		</test>
 		<test name="EquivalentDateTimeNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>{DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)} ~ {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10), null}</expression>
 			<output>false</output>
 		</test>
 		<test name="EquivalentDateTimeFalse" version="1.0">
+			<capability code="list-operators" />
 			<expression>{DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)} ~ {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 1)}</expression>
 			<output>false</output>
 		</test>
 		<test name="EquivalentTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59.999, @T20:59:59.999 } ~ { @T15:59:59.999, @T20:59:59.999 }</expression>
 			<output>true</output>
 		</test>
 		<test name="EquivalentTimeNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59.999, @T20:59:59.999 } ~ { @T15:59:59.999, @T20:59:59.999, null }</expression>
 			<output>false</output>
 		</test>
 		<test name="EquivalentTimeFalse" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59.999, @T20:59:59.999 } ~ { @T15:59:59.999, @T20:59:59.995 }</expression>
 			<output>false</output>
 		</test>
 	</group>
 	<group name="NotEqual" version="1.0">
+		<capability code="list-operators" />
 		<test name="NotEqualEmptyAndEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>{} != {}</expression>
 			<output>false</output>
 		</test>
 		<test name="NotEqualABCAndABC" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 'a', 'b', 'c' } != { 'a', 'b', 'c' }</expression>
 			<output>false</output>
 		</test>
 		<test name="NotEqualABCAndAB" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 'a', 'b', 'c' } != { 'a', 'b' }</expression>
 			<output>true</output>
 		</test>
 		<test name="NotEqualABCAnd123" version="1.0">
-			<expression>{ 'a', 'b', 'c' } != { 1, 2, 3 }</expression>
+			<capability code="list-operators" />
+			<expression>{ 'a', 'b', 'c' } as List&lt;Any&gt; != { 1, 2, 3 } as List&lt;Any&gt;</expression>
 			<output>true</output>
 			<!-- TODO: make Translator resolve isolated Equivalent operator signatures -->
 		</test>
 		<test name="NotEqual123AndABC" version="1.0">
-			<expression>{ 1, 2, 3 } != { 'a', 'b', 'c' }</expression>
+			<capability code="list-operators" />
+			<expression>{ 1, 2, 3 } as List&lt;Any&gt; != { 'a', 'b', 'c' } as List&lt;Any&gt;</expression>
 			<output>true</output>
 			<!-- TODO: make Translator resolve isolated Equivalent operator signatures -->
 		</test>
 		<test name="NotEqual123AndString123" version="1.0">
-			<expression>{ 1, 2, 3 } != { '1', '2', '3' }</expression>
+			<capability code="list-operators" />
+			<expression>{ 1, 2, 3 } as List&lt;Any&gt; != { '1', '2', '3' } as List&lt;Any&gt;</expression>
 			<output>true</output>
 			<!-- TODO: make Translator resolve isolated Equivalent operator signatures -->
 		</test>
 		<test name="NotEqualDateTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>{DateTime(2001, 9, 11, 0, 0, 0, 0), DateTime(2012, 5, 10, 0, 0, 0, 0), DateTime(2014, 12, 10, 0, 0, 0, 0)} != {DateTime(2001, 9, 11, 0, 0, 0, 0), DateTime(2012, 5, 10, 0, 0, 0, 0), DateTime(2014, 12, 1, 0, 0, 0, 0)}</expression>
 			<output>true</output>
 		</test>
 		<test name="NotEqualDateTimeFalse" version="1.0">
+			<capability code="list-operators" />
 			<expression>{DateTime(2001, 9, 11, 0, 0, 0, 0), DateTime(2012, 5, 10, 0, 0, 0, 0), DateTime(2014, 12, 10, 0, 0, 0, 0)} != {DateTime(2001, 9, 11, 0, 0, 0, 0), DateTime(2012, 5, 10, 0, 0, 0, 0), DateTime(2014, 12, 10, 0, 0, 0, 0)}</expression>
 			<output>false</output>
 		</test>
 		<test name="NotEqualTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59.999, @T20:59:59.999 } = { @T15:59:59.999, @T20:59:59.999 }</expression>
 			<output>true</output>
 		</test>
 		<test name="NotEqualTimeFalse" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59.999, @T20:59:59.999 } = { @T15:59:59.999, @T20:59:49.999 }</expression>
 			<output>false</output>
 		</test>
 	</group>
 	<group name="ProperContains" version="1.0">
-		<test name="ProperContainsNullRightFalse" version="1.0">
-			<expression>{'s', 'u', 'n'} properly includes null</expression>
+		<capability code="list-operators" />
+		<test name="ProperContains1" version="1.0">
+			<capability code="list-operators" />
+			<expression>null as List&lt;String&gt; properly includes 'a'</expression>
 			<output>false</output>
 		</test>
+		<test name="ProperContains2" version="1.0">
+			<capability code="list-operators" />
+			<expression>{} properly includes 'a'</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperContains3" version="1.0">
+			<capability code="list-operators" />
+			<expression>{ 'a' } properly includes 'a'</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperContains4" version="1.0">
+			<capability code="list-operators" />
+			<expression>{ null } properly includes null as String</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperContainsNullRightFalse" version="1.0">
+			<capability code="list-operators" />
+			<expression>{'s', 'u', 'n'} properly includes null as String</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperContains5" version="1.0">
+			<capability code="list-operators" />
+			<expression>{ null, null } properly includes null as String</expression>
+			<output>true</output>
+		</test>
 		<test name="ProperContainsNullRightTrue" version="1.0">
-			<expression>{'s', 'u', 'n', null} properly includes null</expression>
+			<capability code="list-operators" />
+			<expression>{'s', 'u', 'n', null} properly includes null as String</expression>
+			<output>true</output>
+		</test>
+		<test name="ProperContains6" version="1.0">
+			<capability code="list-operators" />
+			<expression>{ 'a', 'b' } properly includes 'a'</expression>
+			<output>true</output>
+		</test>
+		<test name="ProperContains7" version="1.0">
+			<capability code="list-operators" />
+			<expression>{ 'a', 'a' } properly includes 'a'</expression>
+			<output>true</output>
+		</test>
+		<test name="ProperContains8" version="1.0">
+			<capability code="list-operators" />
+			<expression>{ 'a', 'b' } properly includes 'c'</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperContains9" version="1.0">
+			<capability code="list-operators" />
+			<expression>{ 'a', null } properly includes 'a'</expression>
+			<output>true</output>
+		</test>
+		<test name="ProperContains10" version="1.0">
+			<capability code="list-operators" />
+			<expression>{ 'a', 'b', null } properly includes 'a'</expression>
 			<output>true</output>
 		</test>
 		<test name="ProperContainsTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59, @T20:59:59.999, @T20:59:49.999 } properly includes @T15:59:59</expression>
 			<output>true</output>
 		</test>
 		<test name="ProperContainsTimeNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 } properly includes @T15:59:59</expression>
-			<output>null</output>
+			<output>false</output>
 		</test>
 	</group>
 	<group name="ProperIn" version="1.0">
-		<test name="ProperInNullRightFalse" version="1.0">
-			<expression>null properly included in {'s', 'u', 'n'}</expression>
+		<capability code="list-operators" />
+		<test name="ProperIn1" version="1.0">
+			<capability code="list-operators" />
+			<expression>'a' properly included in null as List&lt;String&gt;</expression>
 			<output>false</output>
 		</test>
+		<test name="ProperIn2" version="1.0">
+			<capability code="list-operators" />
+			<expression>'a' properly included in {}</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperIn3" version="1.0">
+			<capability code="list-operators" />
+			<expression>'a' properly included in { 'a' }</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperIn4" version="1.0">
+			<capability code="list-operators" />
+			<expression>null as String properly included in { null }</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperInNullRightFalse" version="1.0">
+			<capability code="list-operators" />
+			<expression>null as String properly included in {'s', 'u', 'n'}</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperIn5" version="1.0">
+			<capability code="list-operators" />
+			<expression>null as String properly included in { null, null }</expression>
+			<output>true</output>
+		</test>
 		<test name="ProperInNullRightTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>null properly included in {'s', 'u', 'n', null}</expression>
 			<output>true</output>
 		</test>
+		<test name="ProperIn6" version="1.0">
+			<capability code="list-operators" />
+			<expression>'a' properly included in { 'a', 'b' }</expression>
+			<output>true</output>
+		</test>
+		<test name="ProperIn7" version="1.0">
+			<capability code="list-operators" />
+			<expression>'a' properly included in { 'a', 'a' }</expression>
+			<output>true</output>
+		</test>
+		<test name="ProperIn8" version="1.0">
+			<capability code="list-operators" />
+			<expression>'c' properly included in { 'a', 'b' }</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperIn9" version="1.0">
+			<capability code="list-operators" />
+			<expression>'a' properly included in { 'a', null }</expression>
+			<output>true</output>
+		</test>
+		<test name="ProperIn10" version="1.0">
+			<capability code="list-operators" />
+			<expression>'a' properly included in { 'a', 'b', null }</expression>
+			<output>true</output>
+		</test>
 		<test name="ProperInTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>@T15:59:59 properly included in { @T15:59:59, @T20:59:59.999, @T20:59:49.999 }</expression>
 			<output>true</output>
 		</test>
 		<test name="ProperInTimeNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>@T15:59:59 properly included in { @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 }</expression>
-			<output>null</output>
+			<output>false</output>
 		</test>
 	</group>
 	<group name="ProperlyIncludes" version="1.0">
+		<capability code="list-operators" />
 		<test name="ProperIncludesEmptyAndEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>{} properly includes {}</expression>
 			<output>false</output>
 		</test>
 		<test name="ProperIncludesListNullAndListNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>{null} properly includes {null}</expression>
 			<output>false</output>
 		</test>
 		<test name="ProperIncludes123AndEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>{1, 2, 3} properly includes {}</expression>
 			<output>true</output>
 		</test>
 		<test name="ProperIncludes123And2" version="1.0">
+			<capability code="list-operators" />
 			<expression>{1, 2, 3} properly includes {2}</expression>
 			<output>true</output>
 		</test>
 		<test name="ProperIncludes123And4" version="1.0">
+			<capability code="list-operators" />
 			<expression>{1, 2, 3} properly includes {4}</expression>
 			<output>false</output>
 		</test>
 		<test name="ProperIncludesDateTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>{DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)} properly includes {DateTime(2012, 5, 10), DateTime(2014, 12, 10)}</expression>
 			<output>true</output>
 		</test>
 		<test name="ProperIncludesDateTimeFalse" version="1.0">
+			<capability code="list-operators" />
 			<expression>{DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)} properly includes {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)}</expression>
 			<output>false</output>
 		</test>
 		<test name="ProperIncludesTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 } properly includes { @T15:59:59.999, @T20:59:59.999 }</expression>
 			<output>true</output>
 		</test>
 		<test name="ProperIncludesTimeFalse" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 } properly includes { @T15:59:59.999, @T20:59:59.999, @T14:59:22.999 }</expression>
 			<output>false</output>
 		</test>
 		<test name="ProperlyIncludesNullLeft" version="1.0">
-			<expression>null properly includes {2}</expression>
+			<capability code="list-operators" />
+			<expression>null as List&lt;Integer&gt; properly includes {2}</expression>
 			<output>null</output>
 		</test>
 	</group>
 	<group name="ProperlyIncludedIn" version="1.0">
+		<capability code="list-operators" />
 		<test name="ProperIncludedInEmptyAndEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>{} properly included in {}</expression>
 			<output>false</output>
 		</test>
 		<test name="ProperIncludedInListNullAndListNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>{null} properly included in {null}</expression>
 			<output>false</output>
 		</test>
 		<test name="ProperIncludedInEmptyAnd123" version="1.0">
+			<capability code="list-operators" />
 			<expression>{} properly included in {1, 2, 3}</expression>
 			<output>true</output>
 		</test>
 		<test name="ProperIncludedIn2And123" version="1.0">
+			<capability code="list-operators" />
 			<expression>{2} properly included in {1, 2, 3}</expression>
 			<output>true</output>
 		</test>
 		<test name="ProperIncludedIn4And123" version="1.0">
+			<capability code="list-operators" />
 			<expression>{4} properly included in {1, 2, 3}</expression>
 			<output>false</output>
 		</test>
 		<test name="ProperIncludedInDateTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>{DateTime(2012, 5, 10), DateTime(2014, 12, 10)} properly included in {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)}</expression>
 			<output>true</output>
 		</test>
 		<test name="ProperIncludedInDateTimeFalse" version="1.0">
+			<capability code="list-operators" />
 			<expression>{DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)} properly included in {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)}</expression>
 			<output>false</output>
 		</test>
 		<test name="ProperIncludedInTimeTrue" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59.999, @T20:59:59.999 } properly included in { @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 }</expression>
 			<output>true</output>
 		</test>
 		<test name="ProperIncludedInTimeFalse" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59.999, @T20:59:59.999, @T14:59:22.999 } properly included in { @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 }</expression>
 			<output>false</output>
 		</test>
 		<test name="ProperlyIncludedInNulRight" version="1.0">
-			<expression>{'s', 'u', 'n'} properly included in null</expression>
+			<capability code="list-operators" />
+			<expression>{'s', 'u', 'n'} properly included in null as List&lt;String&gt;</expression>
 			<output>null</output>
 		</test>
 	</group>
 	<group name="SingletonFrom" version="1.0">
+		<capability code="list-operators" />
 		<test name="SingletonFromEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>singleton from {}</expression>
 			<output>null</output>
 		</test>
 		<test name="SingletonFromListNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>singleton from {null}</expression>
 			<output>null</output>
 		</test>
 		<test name="SingletonFrom1" version="1.0">
+			<capability code="list-operators" />
 			<expression>singleton from { 1 }</expression>
 			<output>1</output>
 		</test>
 		<test name="SingletonFrom12" version="1.0">
+			<capability code="list-operators" />
 			<expression invalid="true">singleton from { 1, 2 }</expression>
 			<!-- EXPECT: Expected a list with at most one element, but found a list with multiple elements. -->
 		</test>
 		<test name="SingletonFromDateTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>singleton from { DateTime(2012, 5, 10) }</expression>
 			<output>@2012-05-10T</output>
 		</test>
 		<test name="SingletonFromTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>singleton from { @T15:59:59.999 }</expression>
 			<output>@T15:59:59.999</output>
 		</test>
 	</group>
 	<group name="Skip" version="1.0">
+		<capability code="list-operators" />
 		<test name="SkipNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>Skip(null, 3)</expression>
 			<output>null</output>
 		</test>
 		<test name="SkipEven" version="1.0">
+			<capability code="list-operators" />
 			<expression>Skip({1,2,3,4,5}, 2)</expression>
 			<output>{3, 4, 5}</output>
 		</test>
 		<test name="SkipOdd" version="1.0">
+			<capability code="list-operators" />
 			<expression>Skip({1,2,3,4,5}, 3)</expression>
 			<output>{4, 5}</output>
 		</test>
 		<test name="SkipNone" version="1.0">
+			<capability code="list-operators" />
 			<expression>Skip({1,2,3,4,5}, 0)</expression>
 			<output>{1,2,3,4,5}</output>
 		</test>
 		<test name="SkipAll" version="1.0">
+			<capability code="list-operators" />
 			<expression>Skip({1,2,3,4,5}, 5)</expression>
 			<output>{}</output>
 		</test>
 	</group>
+	<group name="Slice" version="2.0" reference="http://cql.hl7.org/09-b-cqlreference.html#slice">
+		<capability code="list-operators" />
+		<test name="SliceAll" version="2.0">
+	  		<capability code="list-operators" />
+			<expression>Slice({ 1, 2, 3, 4, 5 })</expression>
+			<output>{ 1, 2, 3, 4, 5 }</output>
+		</test>
+		<test name="SliceEmpty" version="2.0">
+  			<capability code="list-operators" />
+			<expression>Slice({ })</expression>
+			<output>{ }</output>
+		</test>
+		<test name="SliceNull" version="2.0">
+  			<capability code="list-operators" />
+			<expression>Slice(null)</expression>
+			<output>null</output>
+		</test>
+		<test name="SliceStart" version="2.0">
+	  		<capability code="list-operators" />
+			<expression>Slice({ 1, 2, 3, 4, 5 }, 1)</expression>
+			<output>{ 2, 3, 4, 5 }</output>
+		</test>
+		<test name="SliceStartNull" version="2.0">
+  			<capability code="list-operators" />
+			<expression>Slice({ 1, 2, 3, 4, 5 }, null)</expression>
+			<output>{ 1, 2, 3, 4, 5 }</output>
+		</test>
+		<test name="SliceEnd" version="2.0">
+  			<capability code="list-operators" />
+			<expression>Slice({ 1, 2, 3, 4, 5 }, 1, 3)</expression>
+			<output>{ 2, 3 }</output>
+		</test>
+		<test name="SliceEndNull" version="2.0">
+  			<capability code="list-operators" />
+			<expression>Slice({ 1, 2, 3, 4, 5 }, 1, null)</expression>
+			<output>{ 2, 3, 4, 5 }</output>
+		</test>
+		<test name="SliceNegative" version="2.0">
+  			<capability code="list-operators" />
+			<expression>Slice({ 1, 2, 3, 4, 5 }, -2)</expression>
+			<output>{ 4, 5 }</output>
+		</test>
+		<test name="SliceStartAndNegative" version="2.0">
+	  		<capability code="list-operators" />
+			<expression>Slice({ 1, 2, 3, 4, 5 }, 1, -1)</expression>
+			<output>{ 2, 3, 4 }</output>
+		</test>
+		<test name="SlicePast" version="2.0">
+  			<capability code="list-operators" />
+			<expression>Slice({ 1, 2, 3, 4, 5 }, 5)</expression>
+			<output>{ }</output>
+		</test>
+	</group>
 	<group name="Tail" version="1.0">
+		<capability code="list-operators" />
 		<test name="TailNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>Tail(null)</expression>
 			<output>null</output>
 		</test>
 		<test name="TailEven" version="1.0">
+			<capability code="list-operators" />
 			<expression>Tail({1,2,3,4})</expression>
 			<output>{2,3,4}</output>
 		</test>
 		<test name="TailOdd" version="1.0">
+			<capability code="list-operators" />
 			<expression>Tail({1,2,3,4,5})</expression>
 			<output>{2,3,4,5}</output>
 		</test>
 		<test name="TailEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>Tail({})</expression>
 			<output>{}</output>
 		</test>
 		<test name="TailOneElement" version="1.0">
+			<capability code="list-operators" />
 			<expression>Tail({1})</expression>
 			<output>{}</output>
 		</test>
 	</group>
 	<group name="Take" version="1.0">
+		<capability code="list-operators" />
 		<test name="TakeNull">
+			<capability code="list-operators" />
 			<expression>Take(null, 3)</expression>
 			<output>null</output>
 		</test>
 		<test name="TakeNullEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>Take({1,2,3}, null as Integer)</expression>
 			<output>{}</output>
 		</test>
 		<test name="TakeEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>Take({1,2,3}, 0)</expression>
 			<output>{}</output>
 		</test>
 		<test name="TakeEven" version="1.0">
+			<capability code="list-operators" />
 			<expression>Take({1,2,3,4}, 2)</expression>
 			<output>{1, 2}</output>
 		</test>
 		<test name="TakeOdd" version="1.0">
+			<capability code="list-operators" />
 			<expression>Take({1,2,3,4}, 3)</expression>
 			<output>{1, 2, 3}</output>
 		</test>
 		<test name="TakeAll" version="1.0">
+			<capability code="list-operators" />
 			<expression>Take({1,2,3,4}, 4)</expression>
 			<output>{1, 2, 3, 4}</output>
 		</test>
 	</group>
 	<group name="Union" version="1.0">
+		<capability code="list-operators" />
 		<test name="UnionEmptyAndEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>{} union {}</expression>
 			<output>{}</output>
 		</test>
 		<test name="UnionListNullAndListNull" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ null } union { null }</expression>
 			<output>{null}</output>
 		</test>
 		<test name="Union123AndEmpty" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 1, 2, 3 } union {}</expression>
 			<output>{1, 2, 3}</output>
 		</test>
 		<test name="Union123And2" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 1, 2, 3 } union { 2 }</expression>
 			<output>{1, 2, 3}</output>
 		</test>
 		<test name="Union123And4" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 1, 2, 3 } union { 4 }</expression>
 			<output>{1, 2, 3, 4}</output>
 		</test>
 		<test name="UnionDateTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ DateTime(2001, 9, 11)} union {DateTime(2012, 5, 10), DateTime(2014, 12, 10) }</expression>
 			<output>{@2001-09-11T, @2012-05-10T, @2014-12-10T}</output>
 		</test>
 		<test name="UnionTime" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ @T15:59:59.999, @T20:59:59.999, @T12:59:59.999 } union { @T10:59:59.999 }</expression>
 			<output>{@T15:59:59.999, @T20:59:59.999, @T12:59:59.999, @T10:59:59.999}</output>
 		</test>


### PR DESCRIPTION
This PR implements the [ProperContains](https://cql.hl7.org/04-logicalspecification.html#proper-contains) and [ProperIn](https://cql.hl7.org/04-logicalspecification.html#proper-in) operators, for Lists (implements #291) and Intervals (implements #292)
As of today, the spec reads as follows:
> The ProperContains operator returns true if the first operand properly contains the second.
> 
> There are two overloads of this operator: List, T: The type of T must be the same as the element type of the list. Interval, T : The type of T must be the same as the point type of the interval.
> 
> For the List, T overload, this operator returns true if the given element is in the list, and it is not the only element in the list, using equality semantics, with the exception that null elements are considered equal. If the first argument is null, the result is false. If the second argument is null, the result is true if the list contains any null elements and at least one other element, and false otherwise.
> 
> For the Interval, T overload, this operator returns true if the given point is greater than the starting point of the interval, and less than the ending point of the interval, as determined by the Start and End operators. If precision is specified and the point type is a Date, DateTime, or Time type, comparisons used in the operation are performed at the specified precision. If the first argument is null, the result is false. If the second argument is null, the result is null.

(ProperIn is just the inverse - ProperContains is `myList properly includes myItem`, ProperIn is `myItem properly included in myList`)

However, there is an upcoming clarification to the spec that will clarify two aspects of these operators for Lists:
1. that the list membership operators will [always] return true or false (i.e. we add "otherwise the result is false" to clarify)
2. that the proper list operators (membership and otherwise) have list, not set, semantics.

This PR is implemented per these clarifications.

Note also that the cql tests are being updated as part of that clarification, see https://github.com/cqframework/cql-tests/pull/119 , so I have copied the latest from that PR in here. As of now that PR has a couple approvals already but if it changes again I'll re-update. 


Fortunately, the spec is pretty unambiguous for the Interval operators.

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

**Submitter:**

- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [N/A] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name:

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
