### PR TITLE
Implement Retrieve:codeComparator

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -191,18 +191,12 @@ class Record {
     }
     getCode(field) {
         const val = this._recursiveGet(field);
-        if (val != null && typeof val === 'object') {
-            return new DT.Code(val.code, val.system, val.version, val.display);
-        }
-    }
-    getCodeOrCodes(field) {
-        const val = this._recursiveGet(field);
         if (val != null) {
             if (Array.isArray(val)) {
                 return val.map(v => new DT.Code(v.code, v.system, v.version, v.display));
             }
             else if (typeof val === 'object') {
-                return [new DT.Code(val.code, val.system, val.version, val.display)];
+                return new DT.Code(val.code, val.system, val.version, val.display);
             }
         }
     }
@@ -4928,45 +4922,84 @@ class Retrieve extends expression_1.Expression {
         return records;
     }
     recordMatchesCodesOrVS(record, codes) {
-        const recordCodeValue = record.getCodeOrCodes(this.codeProperty);
-        if (!recordCodeValue || recordCodeValue.length == 0) {
+        let recordCodeValue = record.getCode(this.codeProperty);
+        if (Array.isArray(recordCodeValue)) {
+            if (recordCodeValue.length == 0) {
+                return false;
+            }
+        }
+        else if (!recordCodeValue) {
             return false;
+        }
+        else {
+            recordCodeValue = [recordCodeValue];
         }
         switch (this.codeComparator) {
             case 'in':
-                return this._in(recordCodeValue, codes);
+                return this.in(recordCodeValue, codes);
             case '~':
-                return this._equivalent(recordCodeValue, codes);
+                return this.equivalent(recordCodeValue, codes);
             case '=':
-                return this._equal(recordCodeValue, codes);
+                return this.equal(recordCodeValue, codes);
+            default:
+                // if there's a terminology filter, there should always be a comparator,
+                // but just in case, default to ~
+                return this.equivalent(recordCodeValue, codes);
         }
     }
-    _in(lhs, rhs) {
+    in(lhs, rhs) {
         if (rhs instanceof clinical_1.ValueSet || rhs instanceof clinical_1.CodeSystem) {
             return rhs.hasMatch(lhs);
         }
         else {
-            // for code lists, fallback to the implementation in ~
-            return this._equivalent(lhs, rhs);
+            // For code lists, fallback to the implementation in ~ . See comments below.
+            return this.equivalent(lhs, rhs);
         }
     }
-    _equivalent(lhs, rhs) {
+    equivalent(lhs, rhs) {
         if (rhs instanceof clinical_1.CodeSystem) {
             throw new Error("Operator '~' is not defined for Code ~ CodeSystem");
         }
         else if (rhs instanceof clinical_1.ValueSet) {
-            // TODO: explain
+            // It's not obvious that this combination should even be allowed.
+            // If in the CQL representation of the Retrieve, the terminology is a ValueSet,
+            // eg [Condition: code ~ "SomeValueSet"],
+            // the CQL-to-ELM translation may turn that into either:
+            //  - a `ValueSetRef` expression (appears here as a `ValueSet`)
+            //  -  or an `ExpandValueSet` expression wrapping the `ValueSetRef` (appears here as a `Code[]`).
+            // Because we can't tell the original intent here, we treat the ValueSet as if it were a Code[].
             return rhs.hasMatch(lhs);
         }
-        else {
+        else if (Array.isArray(rhs)) {
+            // It's also not obvious that this should be allowed.
+            // But because the RHS is always list-promoted, there's no way to tell
+            // if the original CQL referred to a single code or to a list.
+            // So, we treat the operators ~ and = to mean
+            // "some match exists between the LHS and RHS, with the appropriate operator"
+            // instead of the usual meaning
+            // "the LHS and RHS themselves are a match, with the appropriate operator"
             return rhs.some(c => c.hasMatch(lhs));
         }
+        else {
+            // Unexpected, but just in case a single code came through
+            return rhs.hasMatch(lhs);
+        }
     }
-    _equal(lhs, rhs) {
+    equal(lhs, rhs) {
         if (rhs instanceof clinical_1.CodeSystem) {
             throw new Error("Operator '=' is not defined for Code = CodeSystem");
         }
-        const rhsCodes = rhs instanceof clinical_1.ValueSet ? rhs.expand() : rhs;
+        let rhsCodes;
+        if (rhs instanceof clinical_1.ValueSet) {
+            rhsCodes = rhs.expand();
+        }
+        else if (Array.isArray(rhs)) {
+            rhsCodes = rhs;
+        }
+        else {
+            // unexpected, but just in case a single code came through
+            rhsCodes = [rhs];
+        }
         return rhsCodes.some(c => lhs.some(v => (0, comparison_1.equals)(c, v)));
     }
 }
@@ -16537,6 +16570,26 @@ const UnitTables = exports.UnitTables = {
         }
         return smi(hashed);
     }
+    // Per-process seed for the secondary collision hash. Never exposed nor
+    // serialized, so the public `hash()` stays deterministic. An odd base in
+    // [3, 2^20) keeps `base * h` exact as a double (no `Math.imul`).
+    var COLLISION_HASH_BASE = ((Math.random() * 0x100000) | 1) % 0x100000 || 0x9e37;
+    // Secondary hash to index entries within a `HashCollisionNode`, where every key
+    // shares the same primary `hash()`. Using a different, seeded base scatters
+    // crafted collision families (e.g. "Aa"/"BB", which only collide under base 31)
+    // that an attacker cannot precompute without the seed. It only narrows
+    // candidates — `is()` still decides equality — so non-string keys can safely
+    // fall back to the (here constant) primary hash and a linear scan.
+    function hashCollisionKey(key) {
+        if (typeof key !== 'string') {
+            return hash(key);
+        }
+        var hashed = 0;
+        for (var ii = 0; ii < key.length; ii++) {
+            hashed = (COLLISION_HASH_BASE * hashed + key.charCodeAt(ii)) | 0;
+        }
+        return hashed;
+    }
     function hashSymbol(sym) {
         var hashed = symbolMap[sym];
         if (hashed !== undefined) {
@@ -18469,20 +18522,79 @@ const UnitTables = exports.UnitTables = {
       return new HashArrayMapNode(ownerID, newCount, newNodes);
     };
 
+    /**
+     * Trie leaf gathering entries whose keys all share the same 32-bit `hash()`.
+     * The trie routes by hash, so colliding keys cannot be separated and land here
+     * in a flat `entries` array, disambiguated by `is()`.
+     *
+     * To guard against hash-flooding DoS (CWE-407), large buckets build a secondary
+     * index keyed by a per-process seeded hash (`hashCollisionKey`). `is()` still
+     * decides equality, so the index can only ever narrow candidates, never lose a key.
+     */
     var HashCollisionNode = function HashCollisionNode(ownerID, keyHash, entries) {
       this.ownerID = ownerID;
       this.keyHash = keyHash;
       this.entries = entries;
+      // Lazy `{ [secondaryHash]: number[] }`, built only past
+      // MIN_HASH_COLLISION_INDEX_SIZE so small buckets keep their linear path.
+      this._index = undefined;
+    };
+
+    // Returns the position of `key` in `this.entries`, or -1. Uses the secondary
+    // index when present; builds it only when `buildIndex` is true (reads and
+    // transient inserts, where the node is reused so the O(n) build amortizes).
+    // Persistent inserts already pay an O(n) copy, so a throwaway index is skipped.
+    HashCollisionNode.prototype._positionOf = function _positionOf (key, buildIndex) {
+      var entries = this.entries;
+      var index = this._index;
+      if (
+        index === undefined &&
+        buildIndex &&
+        entries.length >= MIN_HASH_COLLISION_INDEX_SIZE
+      ) {
+        index = this._buildIndex();
+      }
+      if (index !== undefined) {
+        var positions = index[hashCollisionKey(key)];
+        if (positions !== undefined) {
+          for (var jj = 0; jj < positions.length; jj++) {
+            var ii = positions[jj];
+            if (is(key, entries[ii][0])) {
+              return ii;
+            }
+          }
+        }
+        return -1;
+      }
+      for (var ii$1 = 0, len = entries.length; ii$1 < len; ii$1++) {
+        if (is(key, entries[ii$1][0])) {
+          return ii$1;
+        }
+      }
+      return -1;
+    };
+
+    // Builds and memoizes the secondary index. A plain object, not `Map` — which
+    // in this module resolves to the *Immutable* Map, not the native one.
+    HashCollisionNode.prototype._buildIndex = function _buildIndex () {
+      var index = Object.create(null);
+      var entries = this.entries;
+      for (var ii = 0, len = entries.length; ii < len; ii++) {
+        var secondaryHash = hashCollisionKey(entries[ii][0]);
+        var positions = index[secondaryHash];
+        if (positions !== undefined) {
+          positions.push(ii);
+        } else {
+          index[secondaryHash] = [ii];
+        }
+      }
+      this._index = index;
+      return index;
     };
 
     HashCollisionNode.prototype.get = function get (shift, keyHash, key, notSetValue) {
-      var entries = this.entries;
-      for (var ii = 0, len = entries.length; ii < len; ii++) {
-        if (is(key, entries[ii][0])) {
-          return entries[ii][1];
-        }
-      }
-      return notSetValue;
+      var idx = this._positionOf(key, true);
+      return idx === -1 ? notSetValue : this.entries[idx][1];
     };
 
     HashCollisionNode.prototype.update = function update (ownerID, shift, keyHash, key, value, didChangeSize, didAlter) {
@@ -18502,14 +18614,11 @@ const UnitTables = exports.UnitTables = {
       }
 
       var entries = this.entries;
-      var idx = 0;
       var len = entries.length;
-      for (; idx < len; idx++) {
-        if (is(key, entries[idx][0])) {
-          break;
-        }
-      }
-      var exists = idx < len;
+      var isEditable = ownerID && ownerID === this.ownerID;
+      var foundIdx = this._positionOf(key, isEditable);
+      var idx = foundIdx === -1 ? len : foundIdx;
+      var exists = foundIdx !== -1;
 
       if (exists ? entries[idx][1] === value : removed) {
         return this;
@@ -18523,7 +18632,6 @@ const UnitTables = exports.UnitTables = {
         return new ValueNode(ownerID, this.keyHash, entries[idx ^ 1]);
       }
 
-      var isEditable = ownerID && ownerID === this.ownerID;
       var newEntries = isEditable ? entries : arrCopy(entries);
 
       if (exists) {
@@ -18532,11 +18640,27 @@ const UnitTables = exports.UnitTables = {
           idx === len - 1
             ? newEntries.pop()
             : (newEntries[idx] = newEntries.pop());
+          // The swap-pop reshuffles positions; drop the stale index (rebuilt lazily).
+          if (isEditable) {
+            this._index = undefined;
+          }
         } else {
+          // Same key, same position: the index stays valid.
           newEntries[idx] = [key, value];
         }
       } else {
         newEntries.push([key, value]);
+        // Keep the index in sync on the transient insert path. Persistent inserts
+        // return a fresh node below whose index rebuilds lazily, so skip them.
+        if (isEditable && this._index !== undefined) {
+          var secondaryHash = hashCollisionKey(key);
+          var positions = this._index[secondaryHash];
+          if (positions !== undefined) {
+            positions.push(len);
+          } else {
+            this._index[secondaryHash] = [len];
+          }
+        }
       }
 
       if (isEditable) {
@@ -18870,6 +18994,12 @@ const UnitTables = exports.UnitTables = {
     var MAX_BITMAP_INDEXED_SIZE = SIZE / 2;
     var MIN_HASH_ARRAY_MAP_SIZE = SIZE / 4;
 
+    // Above this many colliding entries, a `HashCollisionNode` builds a seeded
+    // secondary index instead of scanning linearly. Kept small so the rare,
+    // naturally-occurring collision buckets stay overhead-free, while adversarial
+    // hash-flooding (thousands of keys sharing one hash) degrades gracefully.
+    var MIN_HASH_COLLISION_INDEX_SIZE = 16;
+
     function coerceKeyPath(keyPath) {
         if (isArrayLike(keyPath) && typeof keyPath !== 'string') {
             return keyPath;
@@ -19058,7 +19188,7 @@ const UnitTables = exports.UnitTables = {
         assertNotInfinite(size);
         if (size > 0 && size < SIZE) {
           // eslint-disable-next-line no-constructor-return
-          return makeList(0, size, SHIFT, null, new VNode(iter.toArray()));
+          return makeList(0, size, SHIFT, undefined, new VNode(iter.toArray()));
         }
         // eslint-disable-next-line no-constructor-return
         return empty.withMutations(function (list) {
@@ -19301,6 +19431,13 @@ const UnitTables = exports.UnitTables = {
       return obj.asImmutable();
     };
 
+    /**
+     * A node in the List's 32-wide trie. At inner levels `array` holds child
+     * `VNode`s; at the leaf level it holds the List's values. Missing slots are
+     * `undefined` array holes.
+     *
+     * @template T
+     */
     var VNode = function VNode(array, ownerID) {
       this.array = array;
       this.ownerID = ownerID;
@@ -19437,6 +19574,16 @@ const UnitTables = exports.UnitTables = {
       }
     }
 
+    /**
+     * @param {number} origin
+     * @param {number} capacity
+     * @param {number} level
+     * @param {VNode | undefined} [root] The trie root, or `undefined` when every
+     *   in-range value lives in the tail (or is a virtual `undefined`).
+     * @param {VNode | undefined} [tail]
+     * @param {OwnerID} [ownerID]
+     * @param {number} [hash]
+     */
     function makeList(origin, capacity, level, root, tail, ownerID, hash) {
       var list = Object.create(ListPrototype);
       list.size = capacity - origin;
@@ -19554,6 +19701,14 @@ const UnitTables = exports.UnitTables = {
       return new VNode(node ? node.array.slice() : [], ownerID);
     }
 
+    /**
+     * Returns the leaf `VNode` holding `rawIndex`, or `undefined` when no node is
+     * allocated for it (an all-`undefined` region).
+     *
+     * @param {List} list
+     * @param {number} rawIndex
+     * @returns {VNode | undefined}
+     */
     function listNodeFor(list, rawIndex) {
       if (rawIndex >= getTailOffset(list._capacity)) {
         return list._tail;
@@ -19569,7 +19724,39 @@ const UnitTables = exports.UnitTables = {
       }
     }
 
+    /**
+     * Validates requested bounds before int32 coercion in setListBounds().
+     * Throws when origin/capacity would exceed the trie's safe range.
+     */
+    function validateListBoundsRequest(list, begin, end) {
+      var requestedOrigin = list._origin + (begin === undefined ? 0 : begin);
+      var requestedCapacity =
+        end === undefined
+          ? list._capacity
+          : end < 0
+            ? list._capacity + end
+            : list._origin + end;
+
+      // Keep origin/capacity within the trie's safe signed 32-bit range.
+      if (
+        (Number.isFinite(requestedCapacity) && requestedCapacity > MAX_LIST_SIZE) ||
+        (Number.isFinite(requestedOrigin) && requestedOrigin < -MAX_LIST_SIZE) ||
+        (Number.isFinite(requestedCapacity) &&
+          Number.isFinite(requestedOrigin) &&
+          requestedCapacity - requestedOrigin > MAX_LIST_SIZE)
+      ) {
+        throw new RangeError(
+          'Invalid List size: a List cannot hold more than ' +
+            MAX_LIST_SIZE +
+            ' (2 ** 30) values.'
+        );
+      }
+    }
+
     function setListBounds(list, begin, end) {
+      // Validate full-precision bounds before int32 coercion.
+      validateListBoundsRequest(list, begin, end);
+
       // Sanitize begin & end using this shorthand for ToInt32(argument)
       // http://www.ecma-international.org/ecma-262/6.0/#sec-toint32
       if (begin !== undefined) {
@@ -19608,7 +19795,8 @@ const UnitTables = exports.UnitTables = {
           owner
         );
         newLevel += SHIFT;
-        offsetShift += 1 << newLevel;
+        // Shift origin into non-negative space as trie height grows.
+        offsetShift += levelCapacity(newLevel);
       }
       if (offsetShift) {
         newOrigin += offsetShift;
@@ -19621,7 +19809,7 @@ const UnitTables = exports.UnitTables = {
       var newTailOffset = getTailOffset(newCapacity);
 
       // New size might need creating a higher root.
-      while (newTailOffset >= 1 << (newLevel + SHIFT)) {
+      while (newTailOffset >= levelCapacity(newLevel + SHIFT)) {
         newRoot = new VNode(
           newRoot && newRoot.array.length ? [newRoot] : [],
           owner
@@ -19664,7 +19852,7 @@ const UnitTables = exports.UnitTables = {
         newOrigin -= newTailOffset;
         newCapacity -= newTailOffset;
         newLevel = SHIFT;
-        newRoot = null;
+        newRoot = undefined;
         newTail = newTail && newTail.removeBefore(owner, 0, newOrigin);
 
         // Otherwise, if the root has been trimmed, garbage collect.
@@ -19717,6 +19905,19 @@ const UnitTables = exports.UnitTables = {
 
     function getTailOffset(size) {
       return size < SIZE ? 0 : ((size - 1) >>> SHIFT) << SHIFT;
+    }
+
+    // The largest number of values a List can hold. Above this the 32-bit trie math
+    // in setListBounds() stays in the safe signed 32-bit range.
+    var MAX_LIST_SIZE = Math.pow( 2, 30 ); // 1073741824
+
+    /**
+     * Computes 2 ** exp for the trie level-raising loops in setListBounds().
+     * Use the cheap bitwise operator shift whenever possible, otherwise fall back to exponentiation.
+     * This is necessary because bitwise operators in JavaScript only work on 32-bit signed integers, so for exp >= 31, we need to use exponentiation to avoid overflow.
+     */
+    function levelCapacity(exp) {
+      return exp < 31 ? 1 << exp : Math.pow( 2, exp );
     }
 
     /**
@@ -20134,6 +20335,9 @@ const UnitTables = exports.UnitTables = {
                 reduction = v;
             }
             else {
+                // `reduction` has already been seeded here (either with the provided
+                // initial value or with the first iterated value), so it is never the
+                // `undefined` placeholder — only a `V` or a `R`.
                 reduction = reducer.call(context, reduction, v, k, c);
             }
         }, reverse);
@@ -21318,11 +21522,12 @@ const UnitTables = exports.UnitTables = {
 
       has: function has(index) {
         index = wrapIndex(this, index);
+
         return (
           index >= 0 &&
           (this.size !== undefined
             ? this.size === Infinity || index < this.size
-            : this.indexOf(index) !== -1)
+            : this.find(function (_, key) { return key === index; }, undefined, NOT_SET) !== NOT_SET)
         );
       },
 
@@ -21783,15 +21988,15 @@ const UnitTables = exports.UnitTables = {
       };
 
       Repeat.prototype.indexOf = function indexOf (searchValue) {
-        if (is(this._value, searchValue)) {
+        if (this.size !== 0 && is(this._value, searchValue)) {
           return 0;
         }
         return -1;
       };
 
       Repeat.prototype.lastIndexOf = function lastIndexOf (searchValue) {
-        if (is(this._value, searchValue)) {
-          return this.size;
+        if (this.size !== 0 && is(this._value, searchValue)) {
+          return this.size - 1;
         }
         return -1;
       };
@@ -21872,7 +22077,7 @@ const UnitTables = exports.UnitTables = {
       return isIndexed(v) ? v.toList() : isKeyed(v) ? v.toMap() : v.toSet();
     }
 
-    var version = "5.1.6";
+    var version = "5.1.9";
 
     /* eslint-disable import/order */
 

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -45,7 +45,7 @@ class CodeService {
         for (const oid in valueSetsJson) {
             this.valueSets[oid] = {};
             for (const version in valueSetsJson[oid]) {
-                const codes = valueSetsJson[oid][version].map((code) => new datatypes_1.Code(code.code, code.system, code.version));
+                const codes = valueSetsJson[oid][version].map((code) => new datatypes_1.Code(code.code, code.system, code.version, code.display));
                 this.valueSets[oid][version] = new datatypes_1.ValueSet(oid, version, codes);
             }
         }
@@ -192,7 +192,18 @@ class Record {
     getCode(field) {
         const val = this._recursiveGet(field);
         if (val != null && typeof val === 'object') {
-            return new DT.Code(val.code, val.system, val.version);
+            return new DT.Code(val.code, val.system, val.version, val.display);
+        }
+    }
+    getCodeOrCodes(field) {
+        const val = this._recursiveGet(field);
+        if (val != null) {
+            if (Array.isArray(val)) {
+                return val.map(v => new DT.Code(v.code, v.system, v.version, v.display));
+            }
+            else if (typeof val === 'object') {
+                return [new DT.Code(val.code, val.system, val.version, val.display)];
+            }
         }
     }
 }
@@ -400,6 +411,9 @@ class CodeSystem extends Vocabulary {
         this.id = id;
         this.version = version;
         this.name = name;
+    }
+    hasMatch(_code) {
+        throw new Error('In CodeSystem operation not yet supported.');
     }
 }
 exports.CodeSystem = CodeSystem;
@@ -4856,23 +4870,27 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.Retrieve = void 0;
 const expression_1 = require("./expression");
 const util_1 = require("../util/util");
+const comparison_1 = require("../util/comparison");
 const builder_1 = require("./builder");
+const clinical_1 = require("../datatypes/clinical");
 class Retrieve extends expression_1.Expression {
     constructor(json) {
         super(json);
         this.datatype = json.dataType;
         this.templateId = json.templateId;
         this.codeProperty = json.codeProperty;
+        this.codeComparator = json.codeComparator;
         this.codes = (0, builder_1.build)(json.codes);
         this.dateProperty = json.dateProperty;
         this.dateRange = (0, builder_1.build)(json.dateRange);
     }
     async exec(ctx) {
         // Object with retrieve information to pass back to patient source
-        // Always assign datatype. Assign codeProperty and dateProperty if present
+        // Always assign datatype. Assign the others only if present
         const retrieveDetails = {
             datatype: this.datatype,
             ...(this.codeProperty ? { codeProperty: this.codeProperty } : {}),
+            ...(this.codeComparator ? { codeComparator: this.codeComparator } : {}),
             ...(this.dateProperty ? { dateProperty: this.dateProperty } : {})
         };
         if (this.codes) {
@@ -4910,17 +4928,51 @@ class Retrieve extends expression_1.Expression {
         return records;
     }
     recordMatchesCodesOrVS(record, codes) {
-        if ((0, util_1.typeIsArray)(codes)) {
-            return codes.some(c => c.hasMatch(record.getCode(this.codeProperty)));
+        const recordCodeValue = record.getCodeOrCodes(this.codeProperty);
+        if (!recordCodeValue || recordCodeValue.length == 0) {
+            return false;
+        }
+        switch (this.codeComparator) {
+            case 'in':
+                return this._in(recordCodeValue, codes);
+            case '~':
+                return this._equivalent(recordCodeValue, codes);
+            case '=':
+                return this._equal(recordCodeValue, codes);
+        }
+    }
+    _in(lhs, rhs) {
+        if (rhs instanceof clinical_1.ValueSet || rhs instanceof clinical_1.CodeSystem) {
+            return rhs.hasMatch(lhs);
         }
         else {
-            return codes.hasMatch(record.getCode(this.codeProperty));
+            // for code lists, fallback to the implementation in ~
+            return this._equivalent(lhs, rhs);
         }
+    }
+    _equivalent(lhs, rhs) {
+        if (rhs instanceof clinical_1.CodeSystem) {
+            throw new Error("Operator '~' is not defined for Code ~ CodeSystem");
+        }
+        else if (rhs instanceof clinical_1.ValueSet) {
+            // TODO: explain
+            return rhs.hasMatch(lhs);
+        }
+        else {
+            return rhs.some(c => c.hasMatch(lhs));
+        }
+    }
+    _equal(lhs, rhs) {
+        if (rhs instanceof clinical_1.CodeSystem) {
+            throw new Error("Operator '=' is not defined for Code = CodeSystem");
+        }
+        const rhsCodes = rhs instanceof clinical_1.ValueSet ? rhs.expand() : rhs;
+        return rhsCodes.some(c => lhs.some(v => (0, comparison_1.equals)(c, v)));
     }
 }
 exports.Retrieve = Retrieve;
 
-},{"../util/util":59,"./builder":17,"./expression":23}],26:[function(require,module,exports){
+},{"../datatypes/clinical":6,"../util/comparison":53,"../util/util":59,"./builder":17,"./expression":23}],26:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Instance = void 0;

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -4961,19 +4961,20 @@ class Retrieve extends expression_1.Expression {
             throw new Error("Operator '~' is not defined for Code ~ CodeSystem");
         }
         else if (rhs instanceof clinical_1.ValueSet) {
-            // It's not obvious that this combination should even be allowed.
-            // If in the CQL representation of the Retrieve, the terminology is a ValueSet,
-            // eg [Condition: code ~ "SomeValueSet"],
-            // the CQL-to-ELM translation may turn that into either:
-            //  - a `ValueSetRef` expression (appears here as a `ValueSet`)
-            //  -  or an `ExpandValueSet` expression wrapping the `ValueSetRef` (appears here as a `Code[]`).
-            // Because we can't tell the original intent here, we treat the ValueSet as if it were a Code[].
+            // It's not obvious that code ~ ValueSet and code ~ Code[] should be allowed,
+            // when code ~ CodeSystem is disallowed. Same for operator = below.
+            // In short, due to various translator behaviors, when `rhs` here is Code[],
+            // it's possible it was originally written in the CQL as a Code, a List<Code>, or a ValueSet.
+            // We can't distinguish, so we have to allow all of them.
+            // Then, again because of translator behaviors, x ~ ValueSet could reach this point
+            // with `rhs` either being a Code[] or a ValueSet object.
+            // Because we can't filter it out in the Code[] path, we should allow it in the ValueSet path as well
+            // to reduce unexpected inconsistencies.
+            // See full description and discussion at https://github.com/cqframework/cql-execution/pull/370
             return rhs.hasMatch(lhs);
         }
         else if (Array.isArray(rhs)) {
-            // It's also not obvious that this should be allowed.
-            // But because the RHS is always list-promoted, there's no way to tell
-            // if the original CQL referred to a single code or to a list.
+            // As noted above, there's no way to tell if the original CQL referred to a single code or to a list.
             // So, we treat the operators ~ and = to mean
             // "some match exists between the LHS and RHS, with the appropriate operator"
             // instead of the usual meaning

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -4943,8 +4943,8 @@ class Retrieve extends expression_1.Expression {
                 return this.equal(recordCodeValue, codes);
             default:
                 // if there's a terminology filter, there should always be a comparator,
-                // but just in case, default to ~
-                return this.equivalent(recordCodeValue, codes);
+                // but just in case, default to "in"
+                return this.in(recordCodeValue, codes);
         }
     }
     in(lhs, rhs) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -394,16 +394,16 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
@@ -727,9 +727,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1227,16 +1227,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -2714,16 +2714,16 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -3433,9 +3433,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
-      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -3927,9 +3927,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -4308,9 +4308,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4475,16 +4475,16 @@
       }
     },
     "node_modules/nyc/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/nyc/node_modules/cliui": {
@@ -5367,16 +5367,16 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/rimraf/node_modules/glob": {
@@ -5625,9 +5625,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6153,16 +6153,16 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/test-exclude/node_modules/glob": {

--- a/src/cql-code-service.ts
+++ b/src/cql-code-service.ts
@@ -10,7 +10,7 @@ export class CodeService implements TerminologyProvider {
       this.valueSets[oid] = {};
       for (const version in valueSetsJson[oid]) {
         const codes = valueSetsJson[oid][version].map(
-          (code: any) => new Code(code.code, code.system, code.version)
+          (code: any) => new Code(code.code, code.system, code.version, code.display)
         );
         this.valueSets[oid][version] = new ValueSet(oid, version, codes);
       }

--- a/src/cql-patient.ts
+++ b/src/cql-patient.ts
@@ -89,18 +89,11 @@ export class Record implements RecordObject {
 
   getCode(field: any) {
     const val = this._recursiveGet(field);
-    if (val != null && typeof val === 'object') {
-      return new DT.Code(val.code, val.system, val.version, val.display);
-    }
-  }
-
-  getCodeOrCodes(field: any): DT.Code[] | undefined {
-    const val = this._recursiveGet(field);
     if (val != null) {
       if (Array.isArray(val)) {
         return val.map(v => new DT.Code(v.code, v.system, v.version, v.display));
       } else if (typeof val === 'object') {
-        return [new DT.Code(val.code, val.system, val.version, val.display)];
+        return new DT.Code(val.code, val.system, val.version, val.display);
       }
     }
   }

--- a/src/cql-patient.ts
+++ b/src/cql-patient.ts
@@ -90,7 +90,18 @@ export class Record implements RecordObject {
   getCode(field: any) {
     const val = this._recursiveGet(field);
     if (val != null && typeof val === 'object') {
-      return new DT.Code(val.code, val.system, val.version);
+      return new DT.Code(val.code, val.system, val.version, val.display);
+    }
+  }
+
+  getCodeOrCodes(field: any): DT.Code[] | undefined {
+    const val = this._recursiveGet(field);
+    if (val != null) {
+      if (Array.isArray(val)) {
+        return val.map(v => new DT.Code(v.code, v.system, v.version, v.display));
+      } else if (typeof val === 'object') {
+        return [new DT.Code(val.code, val.system, val.version, val.display)];
+      }
     }
   }
 }

--- a/src/datatypes/clinical.ts
+++ b/src/datatypes/clinical.ts
@@ -55,6 +55,10 @@ export class CodeSystem extends Vocabulary {
   ) {
     super(id, version, name);
   }
+
+  hasMatch(_code: any) {
+    throw new Error('In CodeSystem operation not yet supported.');
+  }
 }
 
 export class CQLValueSet extends Vocabulary {

--- a/src/elm/external.ts
+++ b/src/elm/external.ts
@@ -107,8 +107,8 @@ export class Retrieve extends Expression {
 
       default:
         // if there's a terminology filter, there should always be a comparator,
-        // but just in case, default to ~
-        return this.equivalent(recordCodeValue, codes);
+        // but just in case, default to "in"
+        return this.in(recordCodeValue, codes);
     }
   }
 

--- a/src/elm/external.ts
+++ b/src/elm/external.ts
@@ -125,9 +125,22 @@ export class Retrieve extends Expression {
     if (rhs instanceof CodeSystem) {
       throw new Error("Operator '~' is not defined for Code ~ CodeSystem");
     } else if (rhs instanceof ValueSet) {
-      // TODO: explain
+      // It's not obvious that this combination should even be allowed.
+      // If in the CQL representation of the Retrieve, the terminology is a ValueSet,
+      // eg [Condition: code ~ "SomeValueSet"],
+      // the CQL-to-ELM translation may turn that into either:
+      //  - a `ValueSetRef` expression (appears here as a `ValueSet`)
+      //  -  or an `ExpandValueSet` expression wrapping the `ValueSetRef` (appears here as a `Code[]`).
+      // Because we can't tell the original intent here, we treat the ValueSet as if it were a Code[].
       return rhs.hasMatch(lhs);
-    } else {
+    } else if (Array.isArray(rhs)) {
+      // It's also not obvious that this should be allowed.
+      // But because the RHS is always list-promoted, there's no way to tell
+      // if the original CQL referred to a single code or to a list.
+      // So, we treat the operators ~ and = to mean
+      // "some match exists between the LHS and RHS, with the appropriate operator"
+      // instead of the usual meaning
+      // "the LHS and RHS themselves are a match, with the appropriate operator"
       return (rhs as Code[]).some(c => c.hasMatch(lhs));
     } else {
       // Unexpected, but just in case a single code came through

--- a/src/elm/external.ts
+++ b/src/elm/external.ts
@@ -1,14 +1,16 @@
 import { Expression } from './expression';
 import { resolveValueSet, typeIsArray } from '../util/util';
+import { equals } from '../util/comparison';
 import { Context } from '../runtime/context';
 import { build } from './builder';
 import { RetrieveDetails } from '../types/cql-patient.interfaces';
-import { Code, CQLValueSet } from '../datatypes/clinical';
+import { Code, CodeSystem, CQLValueSet, ValueSet } from '../datatypes/clinical';
 
 export class Retrieve extends Expression {
   datatype: string;
   templateId?: string;
   codeProperty?: string;
+  codeComparator?: 'in' | '=' | '~';
   codes?: Expression | null;
   dateProperty?: string;
   dateRange?: Expression | null;
@@ -18,6 +20,7 @@ export class Retrieve extends Expression {
     this.datatype = json.dataType;
     this.templateId = json.templateId;
     this.codeProperty = json.codeProperty;
+    this.codeComparator = json.codeComparator;
     this.codes = build(json.codes) as Expression;
     this.dateProperty = json.dateProperty;
     this.dateRange = build(json.dateRange) as Expression;
@@ -25,10 +28,11 @@ export class Retrieve extends Expression {
 
   async exec(ctx: Context) {
     // Object with retrieve information to pass back to patient source
-    // Always assign datatype. Assign codeProperty and dateProperty if present
+    // Always assign datatype. Assign the others only if present
     const retrieveDetails: RetrieveDetails = {
       datatype: this.datatype,
       ...(this.codeProperty ? { codeProperty: this.codeProperty } : {}),
+      ...(this.codeComparator ? { codeComparator: this.codeComparator } : {}),
       ...(this.dateProperty ? { dateProperty: this.dateProperty } : {})
     };
 
@@ -79,10 +83,50 @@ export class Retrieve extends Expression {
   }
 
   recordMatchesCodesOrVS(record: any, codes: any) {
-    if (typeIsArray(codes)) {
-      return (codes as any[]).some(c => c.hasMatch(record.getCode(this.codeProperty)));
-    } else {
-      return codes.hasMatch(record.getCode(this.codeProperty));
+    const recordCodeValue = record.getCodeOrCodes(this.codeProperty);
+
+    if (!recordCodeValue || recordCodeValue.length == 0) {
+      return false;
     }
+
+    switch (this.codeComparator) {
+      case 'in':
+        return this._in(recordCodeValue, codes);
+
+      case '~':
+        return this._equivalent(recordCodeValue, codes);
+
+      case '=':
+        return this._equal(recordCodeValue, codes);
+    }
+  }
+
+  _in(lhs: Code[], rhs: any) {
+    if (rhs instanceof ValueSet || rhs instanceof CodeSystem) {
+      return rhs.hasMatch(lhs);
+    } else {
+      // for code lists, fallback to the implementation in ~
+      return this._equivalent(lhs, rhs);
+    }
+  }
+
+  _equivalent(lhs: Code[], rhs: any) {
+    if (rhs instanceof CodeSystem) {
+      throw new Error("Operator '~' is not defined for Code ~ CodeSystem");
+    } else if (rhs instanceof ValueSet) {
+      // TODO: explain
+      return rhs.hasMatch(lhs);
+    } else {
+      return (rhs as Code[]).some(c => c.hasMatch(lhs));
+    }
+  }
+
+  _equal(lhs: Code[], rhs: any) {
+    if (rhs instanceof CodeSystem) {
+      throw new Error("Operator '=' is not defined for Code = CodeSystem");
+    }
+
+    const rhsCodes = rhs instanceof ValueSet ? rhs.expand() : (rhs as Code[]);
+    return rhsCodes.some(c => lhs.some(v => equals(c, v)));
   }
 }

--- a/src/elm/external.ts
+++ b/src/elm/external.ts
@@ -97,26 +97,26 @@ export class Retrieve extends Expression {
 
     switch (this.codeComparator) {
       case 'in':
-        return this._in(recordCodeValue, codes);
+        return this.in(recordCodeValue, codes);
 
       case '~':
-        return this._equivalent(recordCodeValue, codes);
+        return this.equivalent(recordCodeValue, codes);
 
       case '=':
         return this._equal(recordCodeValue, codes);
     }
   }
 
-  _in(lhs: Code[], rhs: any) {
+  private in(lhs: Code[], rhs: any) {
     if (rhs instanceof ValueSet || rhs instanceof CodeSystem) {
       return rhs.hasMatch(lhs);
     } else {
-      // for code lists, fallback to the implementation in ~
-      return this._equivalent(lhs, rhs);
+      // For code lists, fallback to the implementation in ~ . See comments below.
+      return this.equivalent(lhs, rhs);
     }
   }
 
-  _equivalent(lhs: Code[], rhs: any) {
+  private equivalent(lhs: Code[], rhs: any) {
     if (rhs instanceof CodeSystem) {
       throw new Error("Operator '~' is not defined for Code ~ CodeSystem");
     } else if (rhs instanceof ValueSet) {
@@ -127,7 +127,7 @@ export class Retrieve extends Expression {
     }
   }
 
-  _equal(lhs: Code[], rhs: any) {
+  private equal(lhs: Code[], rhs: any) {
     if (rhs instanceof CodeSystem) {
       throw new Error("Operator '=' is not defined for Code = CodeSystem");
     }

--- a/src/elm/external.ts
+++ b/src/elm/external.ts
@@ -83,10 +83,16 @@ export class Retrieve extends Expression {
   }
 
   recordMatchesCodesOrVS(record: any, codes: any) {
-    const recordCodeValue = record.getCodeOrCodes(this.codeProperty);
+    let recordCodeValue = record.getCode(this.codeProperty);
 
-    if (!recordCodeValue || recordCodeValue.length == 0) {
+    if (Array.isArray(recordCodeValue)) {
+      if (recordCodeValue.length == 0) {
+        return false;
+      }
+    } else if (!recordCodeValue) {
       return false;
+    } else {
+      recordCodeValue = [recordCodeValue];
     }
 
     switch (this.codeComparator) {

--- a/src/elm/external.ts
+++ b/src/elm/external.ts
@@ -125,18 +125,19 @@ export class Retrieve extends Expression {
     if (rhs instanceof CodeSystem) {
       throw new Error("Operator '~' is not defined for Code ~ CodeSystem");
     } else if (rhs instanceof ValueSet) {
-      // It's not obvious that this combination should even be allowed.
-      // If in the CQL representation of the Retrieve, the terminology is a ValueSet,
-      // eg [Condition: code ~ "SomeValueSet"],
-      // the CQL-to-ELM translation may turn that into either:
-      //  - a `ValueSetRef` expression (appears here as a `ValueSet`)
-      //  -  or an `ExpandValueSet` expression wrapping the `ValueSetRef` (appears here as a `Code[]`).
-      // Because we can't tell the original intent here, we treat the ValueSet as if it were a Code[].
+      // It's not obvious that code ~ ValueSet and code ~ Code[] should be allowed,
+      // when code ~ CodeSystem is disallowed. Same for operator = below.
+      // In short, due to various translator behaviors, when `rhs` here is Code[],
+      // it's possible it was originally written in the CQL as a Code, a List<Code>, or a ValueSet.
+      // We can't distinguish, so we have to allow all of them.
+      // Then, again because of translator behaviors, x ~ ValueSet could reach this point
+      // with `rhs` either being a Code[] or a ValueSet object.
+      // Because we can't filter it out in the Code[] path, we should allow it in the ValueSet path as well
+      // to reduce unexpected inconsistencies.
+      // See full description and discussion at https://github.com/cqframework/cql-execution/pull/370
       return rhs.hasMatch(lhs);
     } else if (Array.isArray(rhs)) {
-      // It's also not obvious that this should be allowed.
-      // But because the RHS is always list-promoted, there's no way to tell
-      // if the original CQL referred to a single code or to a list.
+      // As noted above, there's no way to tell if the original CQL referred to a single code or to a list.
       // So, we treat the operators ~ and = to mean
       // "some match exists between the LHS and RHS, with the appropriate operator"
       // instead of the usual meaning

--- a/src/elm/external.ts
+++ b/src/elm/external.ts
@@ -103,7 +103,12 @@ export class Retrieve extends Expression {
         return this.equivalent(recordCodeValue, codes);
 
       case '=':
-        return this._equal(recordCodeValue, codes);
+        return this.equal(recordCodeValue, codes);
+
+      default:
+        // if there's a terminology filter, there should always be a comparator,
+        // but just in case, default to ~
+        return this.equivalent(recordCodeValue, codes);
     }
   }
 
@@ -124,6 +129,9 @@ export class Retrieve extends Expression {
       return rhs.hasMatch(lhs);
     } else {
       return (rhs as Code[]).some(c => c.hasMatch(lhs));
+    } else {
+      // Unexpected, but just in case a single code came through
+      return (rhs as Code).hasMatch(lhs);
     }
   }
 
@@ -132,7 +140,17 @@ export class Retrieve extends Expression {
       throw new Error("Operator '=' is not defined for Code = CodeSystem");
     }
 
-    const rhsCodes = rhs instanceof ValueSet ? rhs.expand() : (rhs as Code[]);
+    let rhsCodes: Code[];
+
+    if (rhs instanceof ValueSet) {
+      rhsCodes = rhs.expand();
+    } else if (Array.isArray(rhs)) {
+      rhsCodes = rhs as Code[];
+    } else {
+      // unexpected, but just in case a single code came through
+      rhsCodes = [rhs];
+    }
+
     return rhsCodes.some(c => lhs.some(v => equals(c, v)));
   }
 }

--- a/src/types/cql-patient.interfaces.ts
+++ b/src/types/cql-patient.interfaces.ts
@@ -17,7 +17,6 @@ export interface RecordObject {
   get(field: any): any;
   getId(): any;
   getCode(field: any): any;
-  getCodeOrCodes(field: any): Code[] | undefined;
   getDate(field: any): any;
   getDateOrInterval(field: any): any;
   _is?(typeSpecifier: AnyTypeSpecifier): boolean;

--- a/src/types/cql-patient.interfaces.ts
+++ b/src/types/cql-patient.interfaces.ts
@@ -17,6 +17,7 @@ export interface RecordObject {
   get(field: any): any;
   getId(): any;
   getCode(field: any): any;
+  getCodeOrCodes(field: any): Code[] | undefined;
   getDate(field: any): any;
   getDateOrInterval(field: any): any;
   _is?(typeSpecifier: AnyTypeSpecifier): boolean;
@@ -31,6 +32,7 @@ export interface RetrieveDetails {
   datatype: string;
   templateId?: string;
   codeProperty?: string;
+  codeComparator?: 'in' | '=' | '~';
   codes?: Code[] | ValueSet;
   dateProperty?: string;
   dateRange?: Interval;

--- a/test/cql-patient-test.ts
+++ b/test/cql-patient-test.ts
@@ -44,7 +44,14 @@ describe('Record', () => {
   it('should get codes', () => {
     encRecord
       .getCode('code')
-      .should.eql(new DT.Code('185349003', '2.16.840.1.113883.6.96', '2013-09'));
+      .should.eql(
+        new DT.Code(
+          '185349003',
+          '2.16.840.1.113883.6.96',
+          '2013-09',
+          'Encounter for "check-up" (procedure)'
+        )
+      );
   });
 
   it('should get dates', () => {

--- a/test/cql-patient-test.ts
+++ b/test/cql-patient-test.ts
@@ -27,6 +27,20 @@ describe('Record', () => {
             version: '2013-09',
             display: 'Viral pharyngitis (disorder)'
           },
+          bodySite: [
+            {
+              code: '2175005',
+              system: '2.16.840.1.113883.6.96',
+              version: '2013-09',
+              display: 'Structure of pharyngeal cavity (body structure)'
+            },
+            {
+              code: '45206002',
+              system: '2.16.840.1.113883.6.96',
+              version: '2013-09',
+              display: 'Nasal structure (body structure)'
+            }
+          ],
           period: { low: '1982-03-12', high: '1982-03-26' }
         }
       ]
@@ -41,7 +55,7 @@ describe('Record', () => {
     cndRecord.get('recordType').should.equal('Condition');
   });
 
-  it('should get codes', () => {
+  it('should get code for a single code', () => {
     encRecord
       .getCode('code')
       .should.eql(
@@ -52,6 +66,25 @@ describe('Record', () => {
           'Encounter for "check-up" (procedure)'
         )
       );
+  });
+
+  it('should get code for a code list', () => {
+    cndRecord
+      .getCode('bodySite')
+      .should.eql([
+        new DT.Code(
+          '2175005',
+          '2.16.840.1.113883.6.96',
+          '2013-09',
+          'Structure of pharyngeal cavity (body structure)'
+        ),
+        new DT.Code(
+          '45206002',
+          '2.16.840.1.113883.6.96',
+          '2013-09',
+          'Nasal structure (body structure)'
+        )
+      ]);
   });
 
   it('should get dates', () => {

--- a/test/elm/external/data.cql
+++ b/test/elm/external/data.cql
@@ -10,39 +10,41 @@ concept "Viral pharyngitis": { "Viral pharyngitis code" } display 'Viral pharyng
 valueset "Body locations": '2.16.840.1.113762.1.4.1181.77' // Pain body location reference set
 code "Nose code": '45206002' from "SNOMED" display 'Nasal structure (body structure)'
 
-// duplicated definitions purely for readability of the large cross-product of test cases
-codesystem "myCodesystem": '2.16.840.1.113883.6.96' version '2013-09'
-valueset "myValueSet": '2.16.840.1.113883.3.464.1003.102.12.1011'
-code "myCode": '1532007' from "myCodesystem" display 'Viral pharyngitis (disorder)'
-concept "myConcept": { "myCode" } display 'Viral pharyngitis (disorder)'
-define myCodeList: { myCode }
+// NOTE: These are duplicated definitions of the above terminology,
+// purely so that the cross-product of test cases in this file is obvious.
+// These names do not follow CQL best practice; don't copy this example.
+codesystem "TestCodeSystem": '2.16.840.1.113883.6.96' version '2013-09'
+valueset "TestValueSet": '2.16.840.1.113883.3.464.1003.102.12.1011'
+code "TestCode": '1532007' from "TestCodeSystem" display 'Viral pharyngitis (disorder)'
+concept "TestConcept": { "TestCode" } display 'Viral pharyngitis (disorder)'
+define TestCodeList: { TestCode }
 
 define Conditions: [Condition]
-define ConditionsByVS: [Condition: "myValueSet"]
-define ConditionsByCS: [Condition: "myCodesystem"]
-define ConditionsByCode: [Condition: "myCode"]
-define ConditionsByConcept: [Condition: "myConcept"]
-define ConditionsByCodeList: [Condition: "myCodeList"]
+define ConditionsByVS: [Condition: "TestValueSet"]
+define ConditionsByCS: [Condition: "TestCodeSystem"]
+define ConditionsByCode: [Condition: "TestCode"]
+define ConditionsByConcept: [Condition: "TestConcept"]
+define ConditionsByCodeList: [Condition: "TestCodeList"]
 
-define ConditionsByCodeInCS:     [Condition: code in "myCodesystem"]
-define ConditionsByCodeEqualsCS: [Condition: code = "myCodesystem"]
-define ConditionsByCodeEquivCS:  [Condition: code ~ "myCodesystem"]
+define ConditionsByCodeInCS:     [Condition: code in "TestCodeSystem"]
+define ConditionsByCodeEqualsCS: [Condition: code = "TestCodeSystem"]
+define ConditionsByCodeEquivCS:  [Condition: code ~ "TestCodeSystem"]
 
-define ConditionsByCodeInVS:     [Condition: code in "myValueSet"]
-define ConditionsByCodeEqualsVS: [Condition: code = "myValueSet"]
-define ConditionsByCodeEquivVS:  [Condition: code ~ "myValueSet"]
+define ConditionsByCodeInVS:     [Condition: code in "TestValueSet"]
+define ConditionsByCodeEqualsVS: [Condition: code = "TestValueSet"]
+define ConditionsByCodeEquivVS:  [Condition: code ~ "TestValueSet"]
 
-define ConditionsByCodeInCode:     [Condition: code in "myCode"]
-define ConditionsByCodeEqualsCode: [Condition: code = "myCode"]
-define ConditionsByCodeEquivCode:  [Condition: code ~ "myCode"]
+define ConditionsByCodeInCode:     [Condition: code in "TestCode"]
+define ConditionsByCodeEqualsCode: [Condition: code = "TestCode"]
+define ConditionsByCodeEquivCode:  [Condition: code ~ "TestCode"]
 
-define ConditionsByCodeInConcept:     [Condition: code in "myConcept"]
-define ConditionsByCodeEqualsConcept: [Condition: code = "myConcept"]
-define ConditionsByCodeEquivConcept:  [Condition: code ~ "myConcept"]
+define ConditionsByCodeInConcept:     [Condition: code in "TestConcept"]
+define ConditionsByCodeEqualsConcept: [Condition: code = "TestConcept"]
+define ConditionsByCodeEquivConcept:  [Condition: code ~ "TestConcept"]
 
-define ConditionsByCodeInCodeList:     [Condition: code in "myCodeList"]
-define ConditionsByCodeEqualsCodeList: [Condition: code = "myCodeList"]
-define ConditionsByCodeEquivCodeList:  [Condition: code ~ "myCodeList"]
+define ConditionsByCodeInCodeList:     [Condition: code in "TestCodeList"]
+define ConditionsByCodeEqualsCodeList: [Condition: code = "TestCodeList"]
+define ConditionsByCodeEquivCodeList:  [Condition: code ~ "TestCodeList"]
 
 
 define ConditionsByBodySiteInVS:     [Condition: bodySite in "Body locations"]

--- a/test/elm/external/data.cql
+++ b/test/elm/external/data.cql
@@ -1,20 +1,65 @@
 // @Test: Retrieve
 include Included version '1' called included
 
-codesystem "SNOMED": '2.16.840.1.113883.6.96'
+codesystem "SNOMED": '2.16.840.1.113883.6.96' version '2013-09'
 valueset "Ambulatory/ED Visit": '2.16.840.1.113883.3.464.1003.101.12.1061'
 valueset "Annual Wellness Visit": '2.16.840.1.113883.3.526.3.1240'
 code "Viral pharyngitis code": '1532007' from "SNOMED" display 'Viral pharyngitis (disorder)'
 concept "Viral pharyngitis": { "Viral pharyngitis code" } display 'Viral pharyngitis (disorder)'
+
+valueset "Body locations": '2.16.840.1.113762.1.4.1181.77' // Pain body location reference set
+code "Nose code": '45206002' from "SNOMED" display 'Nasal structure (body structure)'
+
+// duplicated definitions purely for readability of the large cross-product of test cases
+codesystem "myCodesystem": '2.16.840.1.113883.6.96' version '2013-09'
+valueset "myValueSet": '2.16.840.1.113883.3.464.1003.102.12.1011'
+code "myCode": '1532007' from "myCodesystem" display 'Viral pharyngitis (disorder)'
+concept "myConcept": { "myCode" } display 'Viral pharyngitis (disorder)'
+define myCodeList: { myCode }
+
 define Conditions: [Condition]
+define ConditionsByVS: [Condition: "myValueSet"]
+define ConditionsByCS: [Condition: "myCodesystem"]
+define ConditionsByCode: [Condition: "myCode"]
+define ConditionsByConcept: [Condition: "myConcept"]
+define ConditionsByCodeList: [Condition: "myCodeList"]
+
+define ConditionsByCodeInCS:     [Condition: code in "myCodesystem"]
+define ConditionsByCodeEqualsCS: [Condition: code = "myCodesystem"]
+define ConditionsByCodeEquivCS:  [Condition: code ~ "myCodesystem"]
+
+define ConditionsByCodeInVS:     [Condition: code in "myValueSet"]
+define ConditionsByCodeEqualsVS: [Condition: code = "myValueSet"]
+define ConditionsByCodeEquivVS:  [Condition: code ~ "myValueSet"]
+
+define ConditionsByCodeInCode:     [Condition: code in "myCode"]
+define ConditionsByCodeEqualsCode: [Condition: code = "myCode"]
+define ConditionsByCodeEquivCode:  [Condition: code ~ "myCode"]
+
+define ConditionsByCodeInConcept:     [Condition: code in "myConcept"]
+define ConditionsByCodeEqualsConcept: [Condition: code = "myConcept"]
+define ConditionsByCodeEquivConcept:  [Condition: code ~ "myConcept"]
+
+define ConditionsByCodeInCodeList:     [Condition: code in "myCodeList"]
+define ConditionsByCodeEqualsCodeList: [Condition: code = "myCodeList"]
+define ConditionsByCodeEquivCodeList:  [Condition: code ~ "myCodeList"]
+
+
+define ConditionsByBodySiteInVS:     [Condition: bodySite in "Body locations"]
+define ConditionsByBodySiteEqualsVS: [Condition: bodySite = "Body locations"]
+define ConditionsByBodySiteEquivVS:  [Condition: bodySite ~ "Body locations"]
+
+define ConditionsByBodySiteInCode:     [Condition: bodySite in "Nose code"]
+define ConditionsByBodySiteEqualsCode: [Condition: bodySite = "Nose code"]
+define ConditionsByBodySiteEquivCode:  [Condition: bodySite ~ "Nose code"]
+
+
 define Encounters: [Encounter]
 define PharyngitisConditions: [Condition: included."Acute Pharyngitis"]
 define AmbulatoryEncounters: [Encounter: "Ambulatory/ED Visit"]
 define EncountersByCode: [Encounter: code in "Ambulatory/ED Visit"]
 define WrongValueSet: [Condition: "Ambulatory/ED Visit"]
 define WrongCodeProperty: [Encounter: status in "Ambulatory/ED Visit"]
-define ConditionsByCode: [Condition: "Viral pharyngitis code"]
-define ConditionsByConcept: [Condition: "Viral pharyngitis"]
 define ConditionsByDate: [Condition] C where C.period during Interval[@2013-03-01T00:00:00.0, @2013-03-31T00:00:00.0)
 
 // @Test: Included

--- a/test/elm/external/data.js
+++ b/test/elm/external/data.js
@@ -22,40 +22,42 @@ concept "Viral pharyngitis": { "Viral pharyngitis code" } display 'Viral pharyng
 valueset "Body locations": '2.16.840.1.113762.1.4.1181.77' // Pain body location reference set
 code "Nose code": '45206002' from "SNOMED" display 'Nasal structure (body structure)'
 
-// duplicated definitions purely for readability of the large cross-product of test cases
-codesystem "myCodesystem": '2.16.840.1.113883.6.96' version '2013-09'
-valueset "myValueSet": '2.16.840.1.113883.3.464.1003.102.12.1011'
-code "myCode": '1532007' from "myCodesystem" display 'Viral pharyngitis (disorder)'
-concept "myConcept": { "myCode" } display 'Viral pharyngitis (disorder)'
+// NOTE: These are duplicated definitions of the above terminology,
+// purely so that the cross-product of test cases in this file is obvious.
+// These names do not follow CQL best practice; don't copy this example.
+codesystem "TestCodeSystem": '2.16.840.1.113883.6.96' version '2013-09'
+valueset "TestValueSet": '2.16.840.1.113883.3.464.1003.102.12.1011'
+code "TestCode": '1532007' from "TestCodeSystem" display 'Viral pharyngitis (disorder)'
+concept "TestConcept": { "TestCode" } display 'Viral pharyngitis (disorder)'
 context Patient
-define myCodeList: { myCode }
+define TestCodeList: { TestCode }
 
 define Conditions: [Condition]
-define ConditionsByVS: [Condition: "myValueSet"]
-define ConditionsByCS: [Condition: "myCodesystem"]
-define ConditionsByCode: [Condition: "myCode"]
-define ConditionsByConcept: [Condition: "myConcept"]
-define ConditionsByCodeList: [Condition: "myCodeList"]
+define ConditionsByVS: [Condition: "TestValueSet"]
+define ConditionsByCS: [Condition: "TestCodeSystem"]
+define ConditionsByCode: [Condition: "TestCode"]
+define ConditionsByConcept: [Condition: "TestConcept"]
+define ConditionsByCodeList: [Condition: "TestCodeList"]
 
-define ConditionsByCodeInCS:     [Condition: code in "myCodesystem"]
-define ConditionsByCodeEqualsCS: [Condition: code = "myCodesystem"]
-define ConditionsByCodeEquivCS:  [Condition: code ~ "myCodesystem"]
+define ConditionsByCodeInCS:     [Condition: code in "TestCodeSystem"]
+define ConditionsByCodeEqualsCS: [Condition: code = "TestCodeSystem"]
+define ConditionsByCodeEquivCS:  [Condition: code ~ "TestCodeSystem"]
 
-define ConditionsByCodeInVS:     [Condition: code in "myValueSet"]
-define ConditionsByCodeEqualsVS: [Condition: code = "myValueSet"]
-define ConditionsByCodeEquivVS:  [Condition: code ~ "myValueSet"]
+define ConditionsByCodeInVS:     [Condition: code in "TestValueSet"]
+define ConditionsByCodeEqualsVS: [Condition: code = "TestValueSet"]
+define ConditionsByCodeEquivVS:  [Condition: code ~ "TestValueSet"]
 
-define ConditionsByCodeInCode:     [Condition: code in "myCode"]
-define ConditionsByCodeEqualsCode: [Condition: code = "myCode"]
-define ConditionsByCodeEquivCode:  [Condition: code ~ "myCode"]
+define ConditionsByCodeInCode:     [Condition: code in "TestCode"]
+define ConditionsByCodeEqualsCode: [Condition: code = "TestCode"]
+define ConditionsByCodeEquivCode:  [Condition: code ~ "TestCode"]
 
-define ConditionsByCodeInConcept:     [Condition: code in "myConcept"]
-define ConditionsByCodeEqualsConcept: [Condition: code = "myConcept"]
-define ConditionsByCodeEquivConcept:  [Condition: code ~ "myConcept"]
+define ConditionsByCodeInConcept:     [Condition: code in "TestConcept"]
+define ConditionsByCodeEqualsConcept: [Condition: code = "TestConcept"]
+define ConditionsByCodeEquivConcept:  [Condition: code ~ "TestConcept"]
 
-define ConditionsByCodeInCodeList:     [Condition: code in "myCodeList"]
-define ConditionsByCodeEqualsCodeList: [Condition: code = "myCodeList"]
-define ConditionsByCodeEquivCodeList:  [Condition: code ~ "myCodeList"]
+define ConditionsByCodeInCodeList:     [Condition: code in "TestCodeList"]
+define ConditionsByCodeEqualsCodeList: [Condition: code = "TestCodeList"]
+define ConditionsByCodeEquivCodeList:  [Condition: code ~ "TestCodeList"]
 
 
 define ConditionsByBodySiteInVS:     [Condition: bodySite in "Body locations"]
@@ -88,10 +90,10 @@ module.exports['Retrieve'] = {
       "type" : "CqlToElmError",
       "libraryId" : "TestSnippet",
       "libraryVersion" : "1",
-      "startLine" : 30,
+      "startLine" : 32,
       "startChar" : 34,
-      "endLine" : 30,
-      "endChar" : 67,
+      "endLine" : 32,
+      "endChar" : 69,
       "message" : "Could not resolve membership operator for terminology target of the retrieve.",
       "errorType" : "semantic",
       "errorSeverity" : "warning"
@@ -99,10 +101,10 @@ module.exports['Retrieve'] = {
       "type" : "CqlToElmError",
       "libraryId" : "TestSnippet",
       "libraryVersion" : "1",
-      "startLine" : 31,
+      "startLine" : 33,
       "startChar" : 34,
-      "endLine" : 31,
-      "endChar" : 67,
+      "endLine" : 33,
+      "endChar" : 69,
       "message" : "Could not resolve membership operator for terminology target of the retrieve.",
       "errorType" : "semantic",
       "errorSeverity" : "warning"
@@ -110,10 +112,10 @@ module.exports['Retrieve'] = {
       "type" : "CqlToElmError",
       "libraryId" : "TestSnippet",
       "libraryVersion" : "1",
-      "startLine" : 46,
+      "startLine" : 48,
       "startChar" : 59,
-      "endLine" : 46,
-      "endChar" : 70,
+      "endLine" : 48,
+      "endChar" : 72,
       "message" : "List-valued expression was demoted to a singleton.",
       "errorType" : "semantic",
       "errorSeverity" : "warning"
@@ -121,55 +123,11 @@ module.exports['Retrieve'] = {
       "type" : "CqlToElmError",
       "libraryId" : "TestSnippet",
       "libraryVersion" : "1",
-      "startLine" : 47,
+      "startLine" : 49,
       "startChar" : 59,
-      "endLine" : 47,
-      "endChar" : 70,
+      "endLine" : 49,
+      "endChar" : 72,
       "message" : "List-valued expression was demoted to a singleton.",
-      "errorType" : "semantic",
-      "errorSeverity" : "warning"
-    }, {
-      "type" : "CqlToElmError",
-      "libraryId" : "TestSnippet",
-      "libraryVersion" : "1",
-      "startLine" : 50,
-      "startChar" : 38,
-      "endLine" : 50,
-      "endChar" : 78,
-      "message" : "Could not resolve code path bodySite for the type of the retrieve Simple.Condition.",
-      "errorType" : "semantic",
-      "errorSeverity" : "warning"
-    }, {
-      "type" : "CqlToElmError",
-      "libraryId" : "TestSnippet",
-      "libraryVersion" : "1",
-      "startLine" : 50,
-      "startChar" : 38,
-      "endLine" : 50,
-      "endChar" : 78,
-      "message" : "Could not resolve membership operator for terminology target of the retrieve.",
-      "errorType" : "semantic",
-      "errorSeverity" : "warning"
-    }, {
-      "type" : "CqlToElmError",
-      "libraryId" : "TestSnippet",
-      "libraryVersion" : "1",
-      "startLine" : 51,
-      "startChar" : 38,
-      "endLine" : 51,
-      "endChar" : 77,
-      "message" : "Could not resolve code path bodySite for the type of the retrieve Simple.Condition.",
-      "errorType" : "semantic",
-      "errorSeverity" : "warning"
-    }, {
-      "type" : "CqlToElmError",
-      "libraryId" : "TestSnippet",
-      "libraryVersion" : "1",
-      "startLine" : 51,
-      "startChar" : 38,
-      "endLine" : 51,
-      "endChar" : 77,
-      "message" : "Could not resolve membership operator for terminology target of the retrieve.",
       "errorType" : "semantic",
       "errorSeverity" : "warning"
     }, {
@@ -179,7 +137,7 @@ module.exports['Retrieve'] = {
       "startLine" : 52,
       "startChar" : 38,
       "endLine" : 52,
-      "endChar" : 77,
+      "endChar" : 78,
       "message" : "Could not resolve code path bodySite for the type of the retrieve Simple.Condition.",
       "errorType" : "semantic",
       "errorSeverity" : "warning"
@@ -190,6 +148,28 @@ module.exports['Retrieve'] = {
       "startLine" : 52,
       "startChar" : 38,
       "endLine" : 52,
+      "endChar" : 78,
+      "message" : "Could not resolve membership operator for terminology target of the retrieve.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 53,
+      "startChar" : 38,
+      "endLine" : 53,
+      "endChar" : 77,
+      "message" : "Could not resolve code path bodySite for the type of the retrieve Simple.Condition.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 53,
+      "startChar" : 38,
+      "endLine" : 53,
       "endChar" : 77,
       "message" : "Could not resolve membership operator for terminology target of the retrieve.",
       "errorType" : "semantic",
@@ -199,9 +179,9 @@ module.exports['Retrieve'] = {
       "libraryId" : "TestSnippet",
       "libraryVersion" : "1",
       "startLine" : 54,
-      "startChar" : 40,
+      "startChar" : 38,
       "endLine" : 54,
-      "endChar" : 75,
+      "endChar" : 77,
       "message" : "Could not resolve code path bodySite for the type of the retrieve Simple.Condition.",
       "errorType" : "semantic",
       "errorSeverity" : "warning"
@@ -210,8 +190,30 @@ module.exports['Retrieve'] = {
       "libraryId" : "TestSnippet",
       "libraryVersion" : "1",
       "startLine" : 54,
-      "startChar" : 40,
+      "startChar" : 38,
       "endLine" : 54,
+      "endChar" : 77,
+      "message" : "Could not resolve membership operator for terminology target of the retrieve.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 56,
+      "startChar" : 40,
+      "endLine" : 56,
+      "endChar" : 75,
+      "message" : "Could not resolve code path bodySite for the type of the retrieve Simple.Condition.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 56,
+      "startChar" : 40,
+      "endLine" : 56,
       "endChar" : 75,
       "message" : "Could not resolve membership operator for terminology target of the retrieve.",
       "errorType" : "semantic",
@@ -220,9 +222,9 @@ module.exports['Retrieve'] = {
       "type" : "CqlToElmError",
       "libraryId" : "TestSnippet",
       "libraryVersion" : "1",
-      "startLine" : 55,
+      "startLine" : 57,
       "startChar" : 40,
-      "endLine" : 55,
+      "endLine" : 57,
       "endChar" : 74,
       "message" : "Could not resolve code path bodySite for the type of the retrieve Simple.Condition.",
       "errorType" : "semantic",
@@ -231,9 +233,9 @@ module.exports['Retrieve'] = {
       "type" : "CqlToElmError",
       "libraryId" : "TestSnippet",
       "libraryVersion" : "1",
-      "startLine" : 55,
+      "startLine" : 57,
       "startChar" : 40,
-      "endLine" : 55,
+      "endLine" : 57,
       "endChar" : 74,
       "message" : "Could not resolve membership operator for terminology target of the retrieve.",
       "errorType" : "semantic",
@@ -242,9 +244,9 @@ module.exports['Retrieve'] = {
       "type" : "CqlToElmError",
       "libraryId" : "TestSnippet",
       "libraryVersion" : "1",
-      "startLine" : 56,
+      "startLine" : 58,
       "startChar" : 40,
-      "endLine" : 56,
+      "endLine" : 58,
       "endChar" : 74,
       "message" : "Could not resolve code path bodySite for the type of the retrieve Simple.Condition.",
       "errorType" : "semantic",
@@ -253,9 +255,9 @@ module.exports['Retrieve'] = {
       "type" : "CqlToElmError",
       "libraryId" : "TestSnippet",
       "libraryVersion" : "1",
-      "startLine" : 56,
+      "startLine" : 58,
       "startChar" : 40,
-      "endLine" : 56,
+      "endLine" : 58,
       "endChar" : 74,
       "message" : "Could not resolve membership operator for terminology target of the retrieve.",
       "errorType" : "semantic",
@@ -352,7 +354,7 @@ module.exports['Retrieve'] = {
       }, {
         "localId" : "226",
         "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-        "name" : "myCodesystem",
+        "name" : "TestCodeSystem",
         "id" : "2.16.840.1.113883.6.96",
         "version" : "2013-09",
         "accessLevel" : "Public",
@@ -362,7 +364,7 @@ module.exports['Retrieve'] = {
           "s" : {
             "r" : "226",
             "s" : [ {
-              "value" : [ "// duplicated definitions purely for readability of the large cross-product of test cases\n", "codesystem ", "\"myCodesystem\"", ": ", "'2.16.840.1.113883.6.96'", " version ", "'2013-09'" ]
+              "value" : [ "// NOTE: These are duplicated definitions of the above terminology,\n// purely so that the cross-product of test cases in this file is obvious.\n// These names do not follow CQL best practice; don't copy this example.\n", "codesystem ", "\"TestCodeSystem\"", ": ", "'2.16.840.1.113883.6.96'", " version ", "'2013-09'" ]
             } ]
           }
         } ]
@@ -423,7 +425,7 @@ module.exports['Retrieve'] = {
       }, {
         "localId" : "228",
         "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-        "name" : "myValueSet",
+        "name" : "TestValueSet",
         "id" : "2.16.840.1.113883.3.464.1003.102.12.1011",
         "accessLevel" : "Public",
         "annotation" : [ {
@@ -432,7 +434,7 @@ module.exports['Retrieve'] = {
           "s" : {
             "r" : "228",
             "s" : [ {
-              "value" : [ "", "valueset ", "\"myValueSet\"", ": ", "'2.16.840.1.113883.3.464.1003.102.12.1011'" ]
+              "value" : [ "", "valueset ", "\"TestValueSet\"", ": ", "'2.16.840.1.113883.3.464.1003.102.12.1011'" ]
             } ]
           }
         } ],
@@ -503,7 +505,7 @@ module.exports['Retrieve'] = {
       }, {
         "localId" : "230",
         "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-        "name" : "myCode",
+        "name" : "TestCode",
         "id" : "1532007",
         "display" : "Viral pharyngitis (disorder)",
         "accessLevel" : "Public",
@@ -513,11 +515,11 @@ module.exports['Retrieve'] = {
           "s" : {
             "r" : "230",
             "s" : [ {
-              "value" : [ "", "code ", "\"myCode\"", ": ", "'1532007'", " from " ]
+              "value" : [ "", "code ", "\"TestCode\"", ": ", "'1532007'", " from " ]
             }, {
               "r" : "231",
               "s" : [ {
-                "value" : [ "\"myCodesystem\"" ]
+                "value" : [ "\"TestCodeSystem\"" ]
               } ]
             }, {
               "value" : [ " display ", "'Viral pharyngitis (disorder)'" ]
@@ -527,7 +529,7 @@ module.exports['Retrieve'] = {
         "codeSystem" : {
           "localId" : "231",
           "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-          "name" : "myCodesystem",
+          "name" : "TestCodeSystem",
           "annotation" : [ ]
         }
       } ]
@@ -565,7 +567,7 @@ module.exports['Retrieve'] = {
       }, {
         "localId" : "233",
         "resultTypeName" : "{urn:hl7-org:elm-types:r1}Concept",
-        "name" : "myConcept",
+        "name" : "TestConcept",
         "display" : "Viral pharyngitis (disorder)",
         "accessLevel" : "Public",
         "annotation" : [ {
@@ -574,11 +576,11 @@ module.exports['Retrieve'] = {
           "s" : {
             "r" : "233",
             "s" : [ {
-              "value" : [ "", "concept ", "\"myConcept\"", ": { " ]
+              "value" : [ "", "concept ", "\"TestConcept\"", ": { " ]
             }, {
               "r" : "234",
               "s" : [ {
-                "value" : [ "\"myCode\"" ]
+                "value" : [ "\"TestCode\"" ]
               } ]
             }, {
               "value" : [ " } display ", "'Viral pharyngitis (disorder)'" ]
@@ -588,7 +590,7 @@ module.exports['Retrieve'] = {
         "code" : [ {
           "localId" : "234",
           "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-          "name" : "myCode",
+          "name" : "TestCode",
           "annotation" : [ ]
         } ]
       } ]
@@ -624,7 +626,7 @@ module.exports['Retrieve'] = {
         }
       }, {
         "localId" : "241",
-        "name" : "myCodeList",
+        "name" : "TestCodeList",
         "context" : "Patient",
         "accessLevel" : "Public",
         "annotation" : [ {
@@ -633,7 +635,7 @@ module.exports['Retrieve'] = {
           "s" : {
             "r" : "241",
             "s" : [ {
-              "value" : [ "", "define ", "myCodeList", ": " ]
+              "value" : [ "", "define ", "TestCodeList", ": " ]
             }, {
               "r" : "242",
               "s" : [ {
@@ -641,7 +643,7 @@ module.exports['Retrieve'] = {
               }, {
                 "r" : "243",
                 "s" : [ {
-                  "value" : [ "myCode" ]
+                  "value" : [ "TestCode" ]
                 } ]
               }, {
                 "value" : [ " }" ]
@@ -679,7 +681,7 @@ module.exports['Retrieve'] = {
             "type" : "CodeRef",
             "localId" : "243",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-            "name" : "myCode",
+            "name" : "TestCode",
             "annotation" : [ ]
           } ]
         }
@@ -753,7 +755,7 @@ module.exports['Retrieve'] = {
                 "value" : [ "[", "Condition", ": " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myValueSet\"" ]
+                  "value" : [ "\"TestValueSet\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -794,7 +796,7 @@ module.exports['Retrieve'] = {
             "type" : "ValueSetRef",
             "localId" : "260",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-            "name" : "myValueSet",
+            "name" : "TestValueSet",
             "preserve" : true,
             "annotation" : [ ]
           },
@@ -821,7 +823,7 @@ module.exports['Retrieve'] = {
                 "value" : [ "[", "Condition", ": " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myCodesystem\"" ]
+                  "value" : [ "\"TestCodeSystem\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -862,7 +864,7 @@ module.exports['Retrieve'] = {
             "type" : "CodeSystemRef",
             "localId" : "272",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-            "name" : "myCodesystem",
+            "name" : "TestCodeSystem",
             "annotation" : [ ]
           },
           "include" : [ ],
@@ -888,7 +890,7 @@ module.exports['Retrieve'] = {
                 "value" : [ "[", "Condition", ": " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myCode\"" ]
+                  "value" : [ "\"TestCode\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -934,7 +936,7 @@ module.exports['Retrieve'] = {
               "type" : "CodeRef",
               "localId" : "284",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-              "name" : "myCode",
+              "name" : "TestCode",
               "annotation" : [ ]
             }
           },
@@ -961,7 +963,7 @@ module.exports['Retrieve'] = {
                 "value" : [ "[", "Condition", ": " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myConcept\"" ]
+                  "value" : [ "\"TestConcept\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -1007,7 +1009,7 @@ module.exports['Retrieve'] = {
               "type" : "ConceptRef",
               "localId" : "298",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Concept",
-              "name" : "myConcept",
+              "name" : "TestConcept",
               "annotation" : [ ]
             }
           },
@@ -1034,7 +1036,7 @@ module.exports['Retrieve'] = {
                 "value" : [ "[", "Condition", ": " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myCodeList\"" ]
+                  "value" : [ "\"TestCodeList\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -1074,7 +1076,7 @@ module.exports['Retrieve'] = {
           "codes" : {
             "type" : "ExpressionRef",
             "localId" : "316",
-            "name" : "myCodeList",
+            "name" : "TestCodeList",
             "annotation" : [ ],
             "resultTypeSpecifier" : {
               "type" : "ListTypeSpecifier",
@@ -1117,7 +1119,7 @@ module.exports['Retrieve'] = {
                 "value" : [ " ", "in", " " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myCodesystem\"" ]
+                  "value" : [ "\"TestCodeSystem\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -1158,7 +1160,7 @@ module.exports['Retrieve'] = {
             "type" : "CodeSystemRef",
             "localId" : "332",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-            "name" : "myCodesystem",
+            "name" : "TestCodeSystem",
             "annotation" : [ ]
           },
           "include" : [ ],
@@ -1190,7 +1192,7 @@ module.exports['Retrieve'] = {
                 "value" : [ " ", "=", " " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myCodesystem\"" ]
+                  "value" : [ "\"TestCodeSystem\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -1231,7 +1233,7 @@ module.exports['Retrieve'] = {
             "type" : "CodeSystemRef",
             "localId" : "344",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-            "name" : "myCodesystem",
+            "name" : "TestCodeSystem",
             "annotation" : [ ]
           },
           "include" : [ ],
@@ -1263,7 +1265,7 @@ module.exports['Retrieve'] = {
                 "value" : [ " ", "~", " " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myCodesystem\"" ]
+                  "value" : [ "\"TestCodeSystem\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -1304,7 +1306,7 @@ module.exports['Retrieve'] = {
             "type" : "CodeSystemRef",
             "localId" : "355",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
-            "name" : "myCodesystem",
+            "name" : "TestCodeSystem",
             "annotation" : [ ]
           },
           "include" : [ ],
@@ -1336,7 +1338,7 @@ module.exports['Retrieve'] = {
                 "value" : [ " ", "in", " " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myValueSet\"" ]
+                  "value" : [ "\"TestValueSet\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -1377,7 +1379,7 @@ module.exports['Retrieve'] = {
             "type" : "ValueSetRef",
             "localId" : "366",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-            "name" : "myValueSet",
+            "name" : "TestValueSet",
             "preserve" : true,
             "annotation" : [ ]
           },
@@ -1410,7 +1412,7 @@ module.exports['Retrieve'] = {
                 "value" : [ " ", "=", " " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myValueSet\"" ]
+                  "value" : [ "\"TestValueSet\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -1461,7 +1463,7 @@ module.exports['Retrieve'] = {
               "type" : "ValueSetRef",
               "localId" : "378",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-              "name" : "myValueSet",
+              "name" : "TestValueSet",
               "preserve" : true,
               "annotation" : [ ]
             }
@@ -1495,7 +1497,7 @@ module.exports['Retrieve'] = {
                 "value" : [ " ", "~", " " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myValueSet\"" ]
+                  "value" : [ "\"TestValueSet\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -1546,7 +1548,7 @@ module.exports['Retrieve'] = {
               "type" : "ValueSetRef",
               "localId" : "397",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
-              "name" : "myValueSet",
+              "name" : "TestValueSet",
               "preserve" : true,
               "annotation" : [ ]
             }
@@ -1580,7 +1582,7 @@ module.exports['Retrieve'] = {
                 "value" : [ " ", "in", " " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myCode\"" ]
+                  "value" : [ "\"TestCode\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -1626,7 +1628,7 @@ module.exports['Retrieve'] = {
               "type" : "CodeRef",
               "localId" : "416",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-              "name" : "myCode",
+              "name" : "TestCode",
               "annotation" : [ ]
             }
           },
@@ -1659,7 +1661,7 @@ module.exports['Retrieve'] = {
                 "value" : [ " ", "=", " " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myCode\"" ]
+                  "value" : [ "\"TestCode\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -1705,7 +1707,7 @@ module.exports['Retrieve'] = {
               "type" : "CodeRef",
               "localId" : "431",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-              "name" : "myCode",
+              "name" : "TestCode",
               "annotation" : [ ]
             }
           },
@@ -1738,7 +1740,7 @@ module.exports['Retrieve'] = {
                 "value" : [ " ", "~", " " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myCode\"" ]
+                  "value" : [ "\"TestCode\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -1784,7 +1786,7 @@ module.exports['Retrieve'] = {
               "type" : "CodeRef",
               "localId" : "445",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-              "name" : "myCode",
+              "name" : "TestCode",
               "annotation" : [ ]
             }
           },
@@ -1817,7 +1819,7 @@ module.exports['Retrieve'] = {
                 "value" : [ " ", "in", " " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myConcept\"" ]
+                  "value" : [ "\"TestConcept\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -1863,7 +1865,7 @@ module.exports['Retrieve'] = {
               "type" : "ConceptRef",
               "localId" : "459",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Concept",
-              "name" : "myConcept",
+              "name" : "TestConcept",
               "annotation" : [ ]
             }
           },
@@ -1896,7 +1898,7 @@ module.exports['Retrieve'] = {
                 "value" : [ " ", "=", " " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myConcept\"" ]
+                  "value" : [ "\"TestConcept\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -1942,7 +1944,7 @@ module.exports['Retrieve'] = {
               "type" : "ConceptRef",
               "localId" : "478",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Concept",
-              "name" : "myConcept",
+              "name" : "TestConcept",
               "annotation" : [ ]
             }
           },
@@ -1975,7 +1977,7 @@ module.exports['Retrieve'] = {
                 "value" : [ " ", "~", " " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myConcept\"" ]
+                  "value" : [ "\"TestConcept\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -2021,7 +2023,7 @@ module.exports['Retrieve'] = {
               "type" : "ConceptRef",
               "localId" : "496",
               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Concept",
-              "name" : "myConcept",
+              "name" : "TestConcept",
               "annotation" : [ ]
             }
           },
@@ -2054,7 +2056,7 @@ module.exports['Retrieve'] = {
                 "value" : [ " ", "in", " " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myCodeList\"" ]
+                  "value" : [ "\"TestCodeList\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -2094,7 +2096,7 @@ module.exports['Retrieve'] = {
           "codes" : {
             "type" : "ExpressionRef",
             "localId" : "514",
-            "name" : "myCodeList",
+            "name" : "TestCodeList",
             "annotation" : [ ],
             "resultTypeSpecifier" : {
               "type" : "ListTypeSpecifier",
@@ -2137,7 +2139,7 @@ module.exports['Retrieve'] = {
                 "value" : [ " ", "=", " " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myCodeList\"" ]
+                  "value" : [ "\"TestCodeList\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -2197,7 +2199,7 @@ module.exports['Retrieve'] = {
               "operand" : {
                 "type" : "ExpressionRef",
                 "localId" : "530",
-                "name" : "myCodeList",
+                "name" : "TestCodeList",
                 "annotation" : [ ],
                 "resultTypeSpecifier" : {
                   "type" : "ListTypeSpecifier",
@@ -2242,7 +2244,7 @@ module.exports['Retrieve'] = {
                 "value" : [ " ", "~", " " ]
               }, {
                 "s" : [ {
-                  "value" : [ "\"myCodeList\"" ]
+                  "value" : [ "\"TestCodeList\"" ]
                 } ]
               }, {
                 "value" : [ "]" ]
@@ -2302,7 +2304,7 @@ module.exports['Retrieve'] = {
               "operand" : {
                 "type" : "ExpressionRef",
                 "localId" : "549",
-                "name" : "myCodeList",
+                "name" : "TestCodeList",
                 "annotation" : [ ],
                 "resultTypeSpecifier" : {
                   "type" : "ListTypeSpecifier",

--- a/test/elm/external/data.js
+++ b/test/elm/external/data.js
@@ -13,21 +13,66 @@ library TestSnippet version '1'
 using Simple version '1.0.0'
 include Included version '1' called included
 
-codesystem "SNOMED": '2.16.840.1.113883.6.96'
+codesystem "SNOMED": '2.16.840.1.113883.6.96' version '2013-09'
 valueset "Ambulatory/ED Visit": '2.16.840.1.113883.3.464.1003.101.12.1061'
 valueset "Annual Wellness Visit": '2.16.840.1.113883.3.526.3.1240'
 code "Viral pharyngitis code": '1532007' from "SNOMED" display 'Viral pharyngitis (disorder)'
 concept "Viral pharyngitis": { "Viral pharyngitis code" } display 'Viral pharyngitis (disorder)'
+
+valueset "Body locations": '2.16.840.1.113762.1.4.1181.77' // Pain body location reference set
+code "Nose code": '45206002' from "SNOMED" display 'Nasal structure (body structure)'
+
+// duplicated definitions purely for readability of the large cross-product of test cases
+codesystem "myCodesystem": '2.16.840.1.113883.6.96' version '2013-09'
+valueset "myValueSet": '2.16.840.1.113883.3.464.1003.102.12.1011'
+code "myCode": '1532007' from "myCodesystem" display 'Viral pharyngitis (disorder)'
+concept "myConcept": { "myCode" } display 'Viral pharyngitis (disorder)'
 context Patient
+define myCodeList: { myCode }
+
 define Conditions: [Condition]
+define ConditionsByVS: [Condition: "myValueSet"]
+define ConditionsByCS: [Condition: "myCodesystem"]
+define ConditionsByCode: [Condition: "myCode"]
+define ConditionsByConcept: [Condition: "myConcept"]
+define ConditionsByCodeList: [Condition: "myCodeList"]
+
+define ConditionsByCodeInCS:     [Condition: code in "myCodesystem"]
+define ConditionsByCodeEqualsCS: [Condition: code = "myCodesystem"]
+define ConditionsByCodeEquivCS:  [Condition: code ~ "myCodesystem"]
+
+define ConditionsByCodeInVS:     [Condition: code in "myValueSet"]
+define ConditionsByCodeEqualsVS: [Condition: code = "myValueSet"]
+define ConditionsByCodeEquivVS:  [Condition: code ~ "myValueSet"]
+
+define ConditionsByCodeInCode:     [Condition: code in "myCode"]
+define ConditionsByCodeEqualsCode: [Condition: code = "myCode"]
+define ConditionsByCodeEquivCode:  [Condition: code ~ "myCode"]
+
+define ConditionsByCodeInConcept:     [Condition: code in "myConcept"]
+define ConditionsByCodeEqualsConcept: [Condition: code = "myConcept"]
+define ConditionsByCodeEquivConcept:  [Condition: code ~ "myConcept"]
+
+define ConditionsByCodeInCodeList:     [Condition: code in "myCodeList"]
+define ConditionsByCodeEqualsCodeList: [Condition: code = "myCodeList"]
+define ConditionsByCodeEquivCodeList:  [Condition: code ~ "myCodeList"]
+
+
+define ConditionsByBodySiteInVS:     [Condition: bodySite in "Body locations"]
+define ConditionsByBodySiteEqualsVS: [Condition: bodySite = "Body locations"]
+define ConditionsByBodySiteEquivVS:  [Condition: bodySite ~ "Body locations"]
+
+define ConditionsByBodySiteInCode:     [Condition: bodySite in "Nose code"]
+define ConditionsByBodySiteEqualsCode: [Condition: bodySite = "Nose code"]
+define ConditionsByBodySiteEquivCode:  [Condition: bodySite ~ "Nose code"]
+
+
 define Encounters: [Encounter]
 define PharyngitisConditions: [Condition: included."Acute Pharyngitis"]
 define AmbulatoryEncounters: [Encounter: "Ambulatory/ED Visit"]
 define EncountersByCode: [Encounter: code in "Ambulatory/ED Visit"]
 define WrongValueSet: [Condition: "Ambulatory/ED Visit"]
 define WrongCodeProperty: [Encounter: status in "Ambulatory/ED Visit"]
-define ConditionsByCode: [Condition: "Viral pharyngitis code"]
-define ConditionsByConcept: [Condition: "Viral pharyngitis"]
 define ConditionsByDate: [Condition] C where C.period during Interval[@2013-03-01T00:00:00.0, @2013-03-31T00:00:00.0)
 */
 
@@ -40,10 +85,186 @@ module.exports['Retrieve'] = {
       "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations,EnableResultTypes",
       "signatureLevel" : "All"
     }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 30,
+      "startChar" : 34,
+      "endLine" : 30,
+      "endChar" : 67,
+      "message" : "Could not resolve membership operator for terminology target of the retrieve.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 31,
+      "startChar" : 34,
+      "endLine" : 31,
+      "endChar" : 67,
+      "message" : "Could not resolve membership operator for terminology target of the retrieve.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 46,
+      "startChar" : 59,
+      "endLine" : 46,
+      "endChar" : 70,
+      "message" : "List-valued expression was demoted to a singleton.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 47,
+      "startChar" : 59,
+      "endLine" : 47,
+      "endChar" : 70,
+      "message" : "List-valued expression was demoted to a singleton.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 50,
+      "startChar" : 38,
+      "endLine" : 50,
+      "endChar" : 78,
+      "message" : "Could not resolve code path bodySite for the type of the retrieve Simple.Condition.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 50,
+      "startChar" : 38,
+      "endLine" : 50,
+      "endChar" : 78,
+      "message" : "Could not resolve membership operator for terminology target of the retrieve.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 51,
+      "startChar" : 38,
+      "endLine" : 51,
+      "endChar" : 77,
+      "message" : "Could not resolve code path bodySite for the type of the retrieve Simple.Condition.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 51,
+      "startChar" : 38,
+      "endLine" : 51,
+      "endChar" : 77,
+      "message" : "Could not resolve membership operator for terminology target of the retrieve.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 52,
+      "startChar" : 38,
+      "endLine" : 52,
+      "endChar" : 77,
+      "message" : "Could not resolve code path bodySite for the type of the retrieve Simple.Condition.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 52,
+      "startChar" : 38,
+      "endLine" : 52,
+      "endChar" : 77,
+      "message" : "Could not resolve membership operator for terminology target of the retrieve.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 54,
+      "startChar" : 40,
+      "endLine" : 54,
+      "endChar" : 75,
+      "message" : "Could not resolve code path bodySite for the type of the retrieve Simple.Condition.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 54,
+      "startChar" : 40,
+      "endLine" : 54,
+      "endChar" : 75,
+      "message" : "Could not resolve membership operator for terminology target of the retrieve.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 55,
+      "startChar" : 40,
+      "endLine" : 55,
+      "endChar" : 74,
+      "message" : "Could not resolve code path bodySite for the type of the retrieve Simple.Condition.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 55,
+      "startChar" : 40,
+      "endLine" : 55,
+      "endChar" : 74,
+      "message" : "Could not resolve membership operator for terminology target of the retrieve.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 56,
+      "startChar" : 40,
+      "endLine" : 56,
+      "endChar" : 74,
+      "message" : "Could not resolve code path bodySite for the type of the retrieve Simple.Condition.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "TestSnippet",
+      "libraryVersion" : "1",
+      "startLine" : 56,
+      "startChar" : 40,
+      "endLine" : 56,
+      "endChar" : 74,
+      "message" : "Could not resolve membership operator for terminology target of the retrieve.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
       "type" : "Annotation",
       "t" : [ ],
       "s" : {
-        "r" : "336",
+        "r" : "692",
         "s" : [ {
           "value" : [ "", "library TestSnippet version '1'" ]
         } ]
@@ -116,6 +337,7 @@ module.exports['Retrieve'] = {
         "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
         "name" : "SNOMED",
         "id" : "2.16.840.1.113883.6.96",
+        "version" : "2013-09",
         "accessLevel" : "Public",
         "annotation" : [ {
           "type" : "Annotation",
@@ -123,7 +345,24 @@ module.exports['Retrieve'] = {
           "s" : {
             "r" : "210",
             "s" : [ {
-              "value" : [ "", "codesystem ", "\"SNOMED\"", ": ", "'2.16.840.1.113883.6.96'" ]
+              "value" : [ "", "codesystem ", "\"SNOMED\"", ": ", "'2.16.840.1.113883.6.96'", " version ", "'2013-09'" ]
+            } ]
+          }
+        } ]
+      }, {
+        "localId" : "226",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+        "name" : "myCodesystem",
+        "id" : "2.16.840.1.113883.6.96",
+        "version" : "2013-09",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "226",
+            "s" : [ {
+              "value" : [ "// duplicated definitions purely for readability of the large cross-product of test cases\n", "codesystem ", "\"myCodesystem\"", ": ", "'2.16.840.1.113883.6.96'", " version ", "'2013-09'" ]
             } ]
           }
         } ]
@@ -164,6 +403,40 @@ module.exports['Retrieve'] = {
           }
         } ],
         "codeSystem" : [ ]
+      }, {
+        "localId" : "221",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+        "name" : "Body locations",
+        "id" : "2.16.840.1.113762.1.4.1181.77",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "221",
+            "s" : [ {
+              "value" : [ "", "valueset ", "\"Body locations\"", ": ", "'2.16.840.1.113762.1.4.1181.77'" ]
+            } ]
+          }
+        } ],
+        "codeSystem" : [ ]
+      }, {
+        "localId" : "228",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+        "name" : "myValueSet",
+        "id" : "2.16.840.1.113883.3.464.1003.102.12.1011",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "228",
+            "s" : [ {
+              "value" : [ "", "valueset ", "\"myValueSet\"", ": ", "'2.16.840.1.113883.3.464.1003.102.12.1011'" ]
+            } ]
+          }
+        } ],
+        "codeSystem" : [ ]
       } ]
     },
     "codes" : {
@@ -195,6 +468,66 @@ module.exports['Retrieve'] = {
           "localId" : "217",
           "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
           "name" : "SNOMED",
+          "annotation" : [ ]
+        }
+      }, {
+        "localId" : "223",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+        "name" : "Nose code",
+        "id" : "45206002",
+        "display" : "Nasal structure (body structure)",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "223",
+            "s" : [ {
+              "value" : [ "// Pain body location reference set\n", "code ", "\"Nose code\"", ": ", "'45206002'", " from " ]
+            }, {
+              "r" : "224",
+              "s" : [ {
+                "value" : [ "\"SNOMED\"" ]
+              } ]
+            }, {
+              "value" : [ " display ", "'Nasal structure (body structure)'" ]
+            } ]
+          }
+        } ],
+        "codeSystem" : {
+          "localId" : "224",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+          "name" : "SNOMED",
+          "annotation" : [ ]
+        }
+      }, {
+        "localId" : "230",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+        "name" : "myCode",
+        "id" : "1532007",
+        "display" : "Viral pharyngitis (disorder)",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "230",
+            "s" : [ {
+              "value" : [ "", "code ", "\"myCode\"", ": ", "'1532007'", " from " ]
+            }, {
+              "r" : "231",
+              "s" : [ {
+                "value" : [ "\"myCodesystem\"" ]
+              } ]
+            }, {
+              "value" : [ " display ", "'Viral pharyngitis (disorder)'" ]
+            } ]
+          }
+        } ],
+        "codeSystem" : {
+          "localId" : "231",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+          "name" : "myCodesystem",
           "annotation" : [ ]
         }
       } ]
@@ -229,29 +562,58 @@ module.exports['Retrieve'] = {
           "name" : "Viral pharyngitis code",
           "annotation" : [ ]
         } ]
+      }, {
+        "localId" : "233",
+        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Concept",
+        "name" : "myConcept",
+        "display" : "Viral pharyngitis (disorder)",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "233",
+            "s" : [ {
+              "value" : [ "", "concept ", "\"myConcept\"", ": { " ]
+            }, {
+              "r" : "234",
+              "s" : [ {
+                "value" : [ "\"myCode\"" ]
+              } ]
+            }, {
+              "value" : [ " } display ", "'Viral pharyngitis (disorder)'" ]
+            } ]
+          }
+        } ],
+        "code" : [ {
+          "localId" : "234",
+          "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+          "name" : "myCode",
+          "annotation" : [ ]
+        } ]
       } ]
     },
     "contexts" : {
       "def" : [ {
-        "localId" : "224",
+        "localId" : "238",
         "name" : "Patient",
         "annotation" : [ ]
       } ]
     },
     "statements" : {
       "def" : [ {
-        "localId" : "222",
+        "localId" : "236",
         "name" : "Patient",
         "context" : "Patient",
         "annotation" : [ ],
         "expression" : {
           "type" : "SingletonFrom",
-          "localId" : "223",
+          "localId" : "237",
           "annotation" : [ ],
           "signature" : [ ],
           "operand" : {
             "type" : "Retrieve",
-            "localId" : "221",
+            "localId" : "235",
             "dataType" : "{https://github.com/cqframework/cql-execution/simple}Patient",
             "annotation" : [ ],
             "include" : [ ],
@@ -261,7 +623,68 @@ module.exports['Retrieve'] = {
           }
         }
       }, {
-        "localId" : "227",
+        "localId" : "241",
+        "name" : "myCodeList",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "241",
+            "s" : [ {
+              "value" : [ "", "define ", "myCodeList", ": " ]
+            }, {
+              "r" : "242",
+              "s" : [ {
+                "value" : [ "{ " ]
+              }, {
+                "r" : "243",
+                "s" : [ {
+                  "value" : [ "myCode" ]
+                } ]
+              }, {
+                "value" : [ " }" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "246",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "247",
+            "name" : "{urn:hl7-org:elm-types:r1}Code",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "List",
+          "localId" : "242",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "244",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "245",
+              "name" : "{urn:hl7-org:elm-types:r1}Code",
+              "annotation" : [ ]
+            }
+          },
+          "element" : [ {
+            "type" : "CodeRef",
+            "localId" : "243",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+            "name" : "myCode",
+            "annotation" : [ ]
+          } ]
+        }
+      }, {
+        "localId" : "250",
         "name" : "Conditions",
         "context" : "Patient",
         "accessLevel" : "Public",
@@ -269,11 +692,11 @@ module.exports['Retrieve'] = {
           "type" : "Annotation",
           "t" : [ ],
           "s" : {
-            "r" : "227",
+            "r" : "250",
             "s" : [ {
               "value" : [ "", "define ", "Conditions", ": " ]
             }, {
-              "r" : "228",
+              "r" : "251",
               "s" : [ {
                 "value" : [ "[", "Condition", "]" ]
               } ]
@@ -282,27 +705,27 @@ module.exports['Retrieve'] = {
         } ],
         "resultTypeSpecifier" : {
           "type" : "ListTypeSpecifier",
-          "localId" : "231",
+          "localId" : "254",
           "annotation" : [ ],
           "elementType" : {
             "type" : "NamedTypeSpecifier",
-            "localId" : "232",
+            "localId" : "255",
             "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
             "annotation" : [ ]
           }
         },
         "expression" : {
           "type" : "Retrieve",
-          "localId" : "228",
+          "localId" : "251",
           "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
           "annotation" : [ ],
           "resultTypeSpecifier" : {
             "type" : "ListTypeSpecifier",
-            "localId" : "229",
+            "localId" : "252",
             "annotation" : [ ],
             "elementType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "230",
+              "localId" : "253",
               "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
               "annotation" : [ ]
             }
@@ -313,7 +736,2054 @@ module.exports['Retrieve'] = {
           "otherFilter" : [ ]
         }
       }, {
-        "localId" : "235",
+        "localId" : "258",
+        "name" : "ConditionsByVS",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "258",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByVS", ": " ]
+            }, {
+              "r" : "261",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myValueSet\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "266",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "267",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "261",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "in",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "264",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "265",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ValueSetRef",
+            "localId" : "260",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "myValueSet",
+            "preserve" : true,
+            "annotation" : [ ]
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "270",
+        "name" : "ConditionsByCS",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "270",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCS", ": " ]
+            }, {
+              "r" : "273",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myCodesystem\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "278",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "279",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "273",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "in",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "276",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "277",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "CodeSystemRef",
+            "localId" : "272",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+            "name" : "myCodesystem",
+            "annotation" : [ ]
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "282",
+        "name" : "ConditionsByCode",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "282",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCode", ": " ]
+            }, {
+              "r" : "285",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myCode\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "292",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "293",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "285",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "~",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "290",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "291",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ToList",
+            "localId" : "289",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : {
+              "type" : "CodeRef",
+              "localId" : "284",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+              "name" : "myCode",
+              "annotation" : [ ]
+            }
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "296",
+        "name" : "ConditionsByConcept",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "296",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByConcept", ": " ]
+            }, {
+              "r" : "299",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myConcept\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "310",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "311",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "299",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "~",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "308",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "309",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "Property",
+            "localId" : "307",
+            "path" : "codes",
+            "annotation" : [ ],
+            "source" : {
+              "type" : "ConceptRef",
+              "localId" : "298",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Concept",
+              "name" : "myConcept",
+              "annotation" : [ ]
+            }
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "314",
+        "name" : "ConditionsByCodeList",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "314",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCodeList", ": " ]
+            }, {
+              "r" : "319",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myCodeList\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "326",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "327",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "319",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "in",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "324",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "325",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ExpressionRef",
+            "localId" : "316",
+            "name" : "myCodeList",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "317",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "318",
+                "name" : "{urn:hl7-org:elm-types:r1}Code",
+                "annotation" : [ ]
+              }
+            }
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "330",
+        "name" : "ConditionsByCodeInCS",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "330",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCodeInCS", ":     " ]
+            }, {
+              "r" : "333",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "code" ]
+                } ]
+              }, {
+                "value" : [ " ", "in", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myCodesystem\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "338",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "339",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "333",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "in",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "336",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "337",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "CodeSystemRef",
+            "localId" : "332",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+            "name" : "myCodesystem",
+            "annotation" : [ ]
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "342",
+        "name" : "ConditionsByCodeEqualsCS",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "342",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCodeEqualsCS", ": " ]
+            }, {
+              "r" : "345",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "code" ]
+                } ]
+              }, {
+                "value" : [ " ", "=", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myCodesystem\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "349",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "350",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "345",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "=",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "347",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "348",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "CodeSystemRef",
+            "localId" : "344",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+            "name" : "myCodesystem",
+            "annotation" : [ ]
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "353",
+        "name" : "ConditionsByCodeEquivCS",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "353",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCodeEquivCS", ":  " ]
+            }, {
+              "r" : "356",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "code" ]
+                } ]
+              }, {
+                "value" : [ " ", "~", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myCodesystem\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "360",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "361",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "356",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "~",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "358",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "359",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "CodeSystemRef",
+            "localId" : "355",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+            "name" : "myCodesystem",
+            "annotation" : [ ]
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "364",
+        "name" : "ConditionsByCodeInVS",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "364",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCodeInVS", ":     " ]
+            }, {
+              "r" : "367",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "code" ]
+                } ]
+              }, {
+                "value" : [ " ", "in", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myValueSet\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "372",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "373",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "367",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "in",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "370",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "371",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ValueSetRef",
+            "localId" : "366",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "myValueSet",
+            "preserve" : true,
+            "annotation" : [ ]
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "376",
+        "name" : "ConditionsByCodeEqualsVS",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "376",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCodeEqualsVS", ": " ]
+            }, {
+              "r" : "379",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "code" ]
+                } ]
+              }, {
+                "value" : [ " ", "=", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myValueSet\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "391",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "392",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "379",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "=",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "389",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "390",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ExpandValueSet",
+            "localId" : "383",
+            "annotation" : [ ],
+            "signature" : [ {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "384",
+              "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+              "annotation" : [ ]
+            } ],
+            "operand" : {
+              "type" : "ValueSetRef",
+              "localId" : "378",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+              "name" : "myValueSet",
+              "preserve" : true,
+              "annotation" : [ ]
+            }
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "395",
+        "name" : "ConditionsByCodeEquivVS",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "395",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCodeEquivVS", ":  " ]
+            }, {
+              "r" : "398",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "code" ]
+                } ]
+              }, {
+                "value" : [ " ", "~", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myValueSet\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "410",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "411",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "398",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "~",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "408",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "409",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ExpandValueSet",
+            "localId" : "402",
+            "annotation" : [ ],
+            "signature" : [ {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "403",
+              "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+              "annotation" : [ ]
+            } ],
+            "operand" : {
+              "type" : "ValueSetRef",
+              "localId" : "397",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+              "name" : "myValueSet",
+              "preserve" : true,
+              "annotation" : [ ]
+            }
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "414",
+        "name" : "ConditionsByCodeInCode",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "414",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCodeInCode", ":     " ]
+            }, {
+              "r" : "417",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "code" ]
+                } ]
+              }, {
+                "value" : [ " ", "in", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myCode\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "425",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "426",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "417",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "in",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "423",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "424",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ToList",
+            "localId" : "419",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : {
+              "type" : "CodeRef",
+              "localId" : "416",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+              "name" : "myCode",
+              "annotation" : [ ]
+            }
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "429",
+        "name" : "ConditionsByCodeEqualsCode",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "429",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCodeEqualsCode", ": " ]
+            }, {
+              "r" : "432",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "code" ]
+                } ]
+              }, {
+                "value" : [ " ", "=", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myCode\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "439",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "440",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "432",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "=",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "437",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "438",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ToList",
+            "localId" : "436",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : {
+              "type" : "CodeRef",
+              "localId" : "431",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+              "name" : "myCode",
+              "annotation" : [ ]
+            }
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "443",
+        "name" : "ConditionsByCodeEquivCode",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "443",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCodeEquivCode", ":  " ]
+            }, {
+              "r" : "446",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "code" ]
+                } ]
+              }, {
+                "value" : [ " ", "~", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myCode\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "453",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "454",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "446",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "~",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "451",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "452",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ToList",
+            "localId" : "450",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : {
+              "type" : "CodeRef",
+              "localId" : "445",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+              "name" : "myCode",
+              "annotation" : [ ]
+            }
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "457",
+        "name" : "ConditionsByCodeInConcept",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "457",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCodeInConcept", ":     " ]
+            }, {
+              "r" : "460",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "code" ]
+                } ]
+              }, {
+                "value" : [ " ", "in", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myConcept\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "472",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "473",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "460",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "in",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "470",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "471",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "Property",
+            "localId" : "469",
+            "path" : "codes",
+            "annotation" : [ ],
+            "source" : {
+              "type" : "ConceptRef",
+              "localId" : "459",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Concept",
+              "name" : "myConcept",
+              "annotation" : [ ]
+            }
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "476",
+        "name" : "ConditionsByCodeEqualsConcept",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "476",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCodeEqualsConcept", ": " ]
+            }, {
+              "r" : "479",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "code" ]
+                } ]
+              }, {
+                "value" : [ " ", "=", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myConcept\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "490",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "491",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "479",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "=",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "488",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "489",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "Property",
+            "localId" : "487",
+            "path" : "codes",
+            "annotation" : [ ],
+            "source" : {
+              "type" : "ConceptRef",
+              "localId" : "478",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Concept",
+              "name" : "myConcept",
+              "annotation" : [ ]
+            }
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "494",
+        "name" : "ConditionsByCodeEquivConcept",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "494",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCodeEquivConcept", ":  " ]
+            }, {
+              "r" : "497",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "code" ]
+                } ]
+              }, {
+                "value" : [ " ", "~", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myConcept\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "508",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "509",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "497",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "~",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "506",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "507",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "Property",
+            "localId" : "505",
+            "path" : "codes",
+            "annotation" : [ ],
+            "source" : {
+              "type" : "ConceptRef",
+              "localId" : "496",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Concept",
+              "name" : "myConcept",
+              "annotation" : [ ]
+            }
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "512",
+        "name" : "ConditionsByCodeInCodeList",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "512",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCodeInCodeList", ":     " ]
+            }, {
+              "r" : "517",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "code" ]
+                } ]
+              }, {
+                "value" : [ " ", "in", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myCodeList\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "524",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "525",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "517",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "in",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "522",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "523",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ExpressionRef",
+            "localId" : "514",
+            "name" : "myCodeList",
+            "annotation" : [ ],
+            "resultTypeSpecifier" : {
+              "type" : "ListTypeSpecifier",
+              "localId" : "515",
+              "annotation" : [ ],
+              "elementType" : {
+                "type" : "NamedTypeSpecifier",
+                "localId" : "516",
+                "name" : "{urn:hl7-org:elm-types:r1}Code",
+                "annotation" : [ ]
+              }
+            }
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "528",
+        "name" : "ConditionsByCodeEqualsCodeList",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "528",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCodeEqualsCodeList", ": " ]
+            }, {
+              "r" : "533",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "code" ]
+                } ]
+              }, {
+                "value" : [ " ", "=", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myCodeList\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "543",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "544",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "533",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "=",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "541",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "542",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ToList",
+            "localId" : "540",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : {
+              "type" : "SingletonFrom",
+              "localId" : "535",
+              "annotation" : [ ],
+              "signature" : [ {
+                "type" : "ListTypeSpecifier",
+                "localId" : "536",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "537",
+                  "name" : "{urn:hl7-org:elm-types:r1}Code",
+                  "annotation" : [ ]
+                }
+              } ],
+              "operand" : {
+                "type" : "ExpressionRef",
+                "localId" : "530",
+                "name" : "myCodeList",
+                "annotation" : [ ],
+                "resultTypeSpecifier" : {
+                  "type" : "ListTypeSpecifier",
+                  "localId" : "531",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "532",
+                    "name" : "{urn:hl7-org:elm-types:r1}Code",
+                    "annotation" : [ ]
+                  }
+                }
+              }
+            }
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "547",
+        "name" : "ConditionsByCodeEquivCodeList",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "547",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByCodeEquivCodeList", ":  " ]
+            }, {
+              "r" : "552",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "code" ]
+                } ]
+              }, {
+                "value" : [ " ", "~", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"myCodeList\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "562",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "563",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "552",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "code",
+          "codeComparator" : "~",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "560",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "561",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ToList",
+            "localId" : "559",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : {
+              "type" : "SingletonFrom",
+              "localId" : "554",
+              "annotation" : [ ],
+              "signature" : [ {
+                "type" : "ListTypeSpecifier",
+                "localId" : "555",
+                "annotation" : [ ],
+                "elementType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "localId" : "556",
+                  "name" : "{urn:hl7-org:elm-types:r1}Code",
+                  "annotation" : [ ]
+                }
+              } ],
+              "operand" : {
+                "type" : "ExpressionRef",
+                "localId" : "549",
+                "name" : "myCodeList",
+                "annotation" : [ ],
+                "resultTypeSpecifier" : {
+                  "type" : "ListTypeSpecifier",
+                  "localId" : "550",
+                  "annotation" : [ ],
+                  "elementType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "localId" : "551",
+                    "name" : "{urn:hl7-org:elm-types:r1}Code",
+                    "annotation" : [ ]
+                  }
+                }
+              }
+            }
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "566",
+        "name" : "ConditionsByBodySiteInVS",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "566",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByBodySiteInVS", ":     " ]
+            }, {
+              "r" : "568",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "bodySite" ]
+                } ]
+              }, {
+                "value" : [ " ", "in", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"Body locations\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "571",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "572",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "568",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "bodySite",
+          "codeComparator" : "in",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "569",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "570",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ValueSetRef",
+            "localId" : "567",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "Body locations",
+            "preserve" : true,
+            "annotation" : [ ]
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "575",
+        "name" : "ConditionsByBodySiteEqualsVS",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "575",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByBodySiteEqualsVS", ": " ]
+            }, {
+              "r" : "577",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "bodySite" ]
+                } ]
+              }, {
+                "value" : [ " ", "=", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"Body locations\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "580",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "581",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "577",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "bodySite",
+          "codeComparator" : "=",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "578",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "579",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ValueSetRef",
+            "localId" : "576",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "Body locations",
+            "preserve" : true,
+            "annotation" : [ ]
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "584",
+        "name" : "ConditionsByBodySiteEquivVS",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "584",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByBodySiteEquivVS", ":  " ]
+            }, {
+              "r" : "586",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "bodySite" ]
+                } ]
+              }, {
+                "value" : [ " ", "~", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"Body locations\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "589",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "590",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "586",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "bodySite",
+          "codeComparator" : "~",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "587",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "588",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ValueSetRef",
+            "localId" : "585",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "Body locations",
+            "preserve" : true,
+            "annotation" : [ ]
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "593",
+        "name" : "ConditionsByBodySiteInCode",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "593",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByBodySiteInCode", ":     " ]
+            }, {
+              "r" : "595",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "bodySite" ]
+                } ]
+              }, {
+                "value" : [ " ", "in", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"Nose code\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "599",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "600",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "595",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "bodySite",
+          "codeComparator" : "in",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "597",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "598",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ToList",
+            "localId" : "596",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : {
+              "type" : "CodeRef",
+              "localId" : "594",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+              "name" : "Nose code",
+              "annotation" : [ ]
+            }
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "603",
+        "name" : "ConditionsByBodySiteEqualsCode",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "603",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByBodySiteEqualsCode", ": " ]
+            }, {
+              "r" : "605",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "bodySite" ]
+                } ]
+              }, {
+                "value" : [ " ", "=", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"Nose code\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "609",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "610",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "605",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "bodySite",
+          "codeComparator" : "=",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "607",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "608",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ToList",
+            "localId" : "606",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : {
+              "type" : "CodeRef",
+              "localId" : "604",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+              "name" : "Nose code",
+              "annotation" : [ ]
+            }
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "613",
+        "name" : "ConditionsByBodySiteEquivCode",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ {
+          "type" : "Annotation",
+          "t" : [ ],
+          "s" : {
+            "r" : "613",
+            "s" : [ {
+              "value" : [ "", "define ", "ConditionsByBodySiteEquivCode", ":  " ]
+            }, {
+              "r" : "615",
+              "s" : [ {
+                "value" : [ "[", "Condition", ": " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "bodySite" ]
+                } ]
+              }, {
+                "value" : [ " ", "~", " " ]
+              }, {
+                "s" : [ {
+                  "value" : [ "\"Nose code\"" ]
+                } ]
+              }, {
+                "value" : [ "]" ]
+              } ]
+            } ]
+          }
+        } ],
+        "resultTypeSpecifier" : {
+          "type" : "ListTypeSpecifier",
+          "localId" : "619",
+          "annotation" : [ ],
+          "elementType" : {
+            "type" : "NamedTypeSpecifier",
+            "localId" : "620",
+            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+            "annotation" : [ ]
+          }
+        },
+        "expression" : {
+          "type" : "Retrieve",
+          "localId" : "615",
+          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+          "codeProperty" : "bodySite",
+          "codeComparator" : "~",
+          "annotation" : [ ],
+          "resultTypeSpecifier" : {
+            "type" : "ListTypeSpecifier",
+            "localId" : "617",
+            "annotation" : [ ],
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "localId" : "618",
+              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
+              "annotation" : [ ]
+            }
+          },
+          "codes" : {
+            "type" : "ToList",
+            "localId" : "616",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : {
+              "type" : "CodeRef",
+              "localId" : "614",
+              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+              "name" : "Nose code",
+              "annotation" : [ ]
+            }
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "localId" : "623",
         "name" : "Encounters",
         "context" : "Patient",
         "accessLevel" : "Public",
@@ -321,11 +2791,11 @@ module.exports['Retrieve'] = {
           "type" : "Annotation",
           "t" : [ ],
           "s" : {
-            "r" : "235",
+            "r" : "623",
             "s" : [ {
               "value" : [ "", "define ", "Encounters", ": " ]
             }, {
-              "r" : "236",
+              "r" : "624",
               "s" : [ {
                 "value" : [ "[", "Encounter", "]" ]
               } ]
@@ -334,27 +2804,27 @@ module.exports['Retrieve'] = {
         } ],
         "resultTypeSpecifier" : {
           "type" : "ListTypeSpecifier",
-          "localId" : "239",
+          "localId" : "627",
           "annotation" : [ ],
           "elementType" : {
             "type" : "NamedTypeSpecifier",
-            "localId" : "240",
+            "localId" : "628",
             "name" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
             "annotation" : [ ]
           }
         },
         "expression" : {
           "type" : "Retrieve",
-          "localId" : "236",
+          "localId" : "624",
           "dataType" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
           "annotation" : [ ],
           "resultTypeSpecifier" : {
             "type" : "ListTypeSpecifier",
-            "localId" : "237",
+            "localId" : "625",
             "annotation" : [ ],
             "elementType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "238",
+              "localId" : "626",
               "name" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
               "annotation" : [ ]
             }
@@ -365,7 +2835,7 @@ module.exports['Retrieve'] = {
           "otherFilter" : [ ]
         }
       }, {
-        "localId" : "243",
+        "localId" : "631",
         "name" : "PharyngitisConditions",
         "context" : "Patient",
         "accessLevel" : "Public",
@@ -373,11 +2843,11 @@ module.exports['Retrieve'] = {
           "type" : "Annotation",
           "t" : [ ],
           "s" : {
-            "r" : "243",
+            "r" : "631",
             "s" : [ {
               "value" : [ "", "define ", "PharyngitisConditions", ": " ]
             }, {
-              "r" : "247",
+              "r" : "635",
               "s" : [ {
                 "value" : [ "[", "Condition", ": " ]
               }, {
@@ -392,36 +2862,36 @@ module.exports['Retrieve'] = {
         } ],
         "resultTypeSpecifier" : {
           "type" : "ListTypeSpecifier",
-          "localId" : "252",
+          "localId" : "640",
           "annotation" : [ ],
           "elementType" : {
             "type" : "NamedTypeSpecifier",
-            "localId" : "253",
+            "localId" : "641",
             "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
             "annotation" : [ ]
           }
         },
         "expression" : {
           "type" : "Retrieve",
-          "localId" : "247",
+          "localId" : "635",
           "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
           "codeProperty" : "code",
           "codeComparator" : "in",
           "annotation" : [ ],
           "resultTypeSpecifier" : {
             "type" : "ListTypeSpecifier",
-            "localId" : "250",
+            "localId" : "638",
             "annotation" : [ ],
             "elementType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "251",
+              "localId" : "639",
               "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
               "annotation" : [ ]
             }
           },
           "codes" : {
             "type" : "ValueSetRef",
-            "localId" : "246",
+            "localId" : "634",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
             "name" : "Acute Pharyngitis",
             "libraryName" : "included",
@@ -434,7 +2904,7 @@ module.exports['Retrieve'] = {
           "otherFilter" : [ ]
         }
       }, {
-        "localId" : "256",
+        "localId" : "644",
         "name" : "AmbulatoryEncounters",
         "context" : "Patient",
         "accessLevel" : "Public",
@@ -442,11 +2912,11 @@ module.exports['Retrieve'] = {
           "type" : "Annotation",
           "t" : [ ],
           "s" : {
-            "r" : "256",
+            "r" : "644",
             "s" : [ {
               "value" : [ "", "define ", "AmbulatoryEncounters", ": " ]
             }, {
-              "r" : "259",
+              "r" : "647",
               "s" : [ {
                 "value" : [ "[", "Encounter", ": " ]
               }, {
@@ -461,36 +2931,36 @@ module.exports['Retrieve'] = {
         } ],
         "resultTypeSpecifier" : {
           "type" : "ListTypeSpecifier",
-          "localId" : "264",
+          "localId" : "652",
           "annotation" : [ ],
           "elementType" : {
             "type" : "NamedTypeSpecifier",
-            "localId" : "265",
+            "localId" : "653",
             "name" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
             "annotation" : [ ]
           }
         },
         "expression" : {
           "type" : "Retrieve",
-          "localId" : "259",
+          "localId" : "647",
           "dataType" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
           "codeProperty" : "code",
           "codeComparator" : "in",
           "annotation" : [ ],
           "resultTypeSpecifier" : {
             "type" : "ListTypeSpecifier",
-            "localId" : "262",
+            "localId" : "650",
             "annotation" : [ ],
             "elementType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "263",
+              "localId" : "651",
               "name" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
               "annotation" : [ ]
             }
           },
           "codes" : {
             "type" : "ValueSetRef",
-            "localId" : "258",
+            "localId" : "646",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
             "name" : "Ambulatory/ED Visit",
             "preserve" : true,
@@ -502,7 +2972,7 @@ module.exports['Retrieve'] = {
           "otherFilter" : [ ]
         }
       }, {
-        "localId" : "268",
+        "localId" : "656",
         "name" : "EncountersByCode",
         "context" : "Patient",
         "accessLevel" : "Public",
@@ -510,11 +2980,11 @@ module.exports['Retrieve'] = {
           "type" : "Annotation",
           "t" : [ ],
           "s" : {
-            "r" : "268",
+            "r" : "656",
             "s" : [ {
               "value" : [ "", "define ", "EncountersByCode", ": " ]
             }, {
-              "r" : "271",
+              "r" : "659",
               "s" : [ {
                 "value" : [ "[", "Encounter", ": " ]
               }, {
@@ -535,36 +3005,36 @@ module.exports['Retrieve'] = {
         } ],
         "resultTypeSpecifier" : {
           "type" : "ListTypeSpecifier",
-          "localId" : "276",
+          "localId" : "664",
           "annotation" : [ ],
           "elementType" : {
             "type" : "NamedTypeSpecifier",
-            "localId" : "277",
+            "localId" : "665",
             "name" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
             "annotation" : [ ]
           }
         },
         "expression" : {
           "type" : "Retrieve",
-          "localId" : "271",
+          "localId" : "659",
           "dataType" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
           "codeProperty" : "code",
           "codeComparator" : "in",
           "annotation" : [ ],
           "resultTypeSpecifier" : {
             "type" : "ListTypeSpecifier",
-            "localId" : "274",
+            "localId" : "662",
             "annotation" : [ ],
             "elementType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "275",
+              "localId" : "663",
               "name" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
               "annotation" : [ ]
             }
           },
           "codes" : {
             "type" : "ValueSetRef",
-            "localId" : "270",
+            "localId" : "658",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
             "name" : "Ambulatory/ED Visit",
             "preserve" : true,
@@ -576,7 +3046,7 @@ module.exports['Retrieve'] = {
           "otherFilter" : [ ]
         }
       }, {
-        "localId" : "280",
+        "localId" : "668",
         "name" : "WrongValueSet",
         "context" : "Patient",
         "accessLevel" : "Public",
@@ -584,11 +3054,11 @@ module.exports['Retrieve'] = {
           "type" : "Annotation",
           "t" : [ ],
           "s" : {
-            "r" : "280",
+            "r" : "668",
             "s" : [ {
               "value" : [ "", "define ", "WrongValueSet", ": " ]
             }, {
-              "r" : "283",
+              "r" : "671",
               "s" : [ {
                 "value" : [ "[", "Condition", ": " ]
               }, {
@@ -603,36 +3073,36 @@ module.exports['Retrieve'] = {
         } ],
         "resultTypeSpecifier" : {
           "type" : "ListTypeSpecifier",
-          "localId" : "288",
+          "localId" : "676",
           "annotation" : [ ],
           "elementType" : {
             "type" : "NamedTypeSpecifier",
-            "localId" : "289",
+            "localId" : "677",
             "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
             "annotation" : [ ]
           }
         },
         "expression" : {
           "type" : "Retrieve",
-          "localId" : "283",
+          "localId" : "671",
           "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
           "codeProperty" : "code",
           "codeComparator" : "in",
           "annotation" : [ ],
           "resultTypeSpecifier" : {
             "type" : "ListTypeSpecifier",
-            "localId" : "286",
+            "localId" : "674",
             "annotation" : [ ],
             "elementType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "287",
+              "localId" : "675",
               "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
               "annotation" : [ ]
             }
           },
           "codes" : {
             "type" : "ValueSetRef",
-            "localId" : "282",
+            "localId" : "670",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
             "name" : "Ambulatory/ED Visit",
             "preserve" : true,
@@ -644,7 +3114,7 @@ module.exports['Retrieve'] = {
           "otherFilter" : [ ]
         }
       }, {
-        "localId" : "292",
+        "localId" : "680",
         "name" : "WrongCodeProperty",
         "context" : "Patient",
         "accessLevel" : "Public",
@@ -652,11 +3122,11 @@ module.exports['Retrieve'] = {
           "type" : "Annotation",
           "t" : [ ],
           "s" : {
-            "r" : "292",
+            "r" : "680",
             "s" : [ {
               "value" : [ "", "define ", "WrongCodeProperty", ": " ]
             }, {
-              "r" : "295",
+              "r" : "683",
               "s" : [ {
                 "value" : [ "[", "Encounter", ": " ]
               }, {
@@ -677,36 +3147,36 @@ module.exports['Retrieve'] = {
         } ],
         "resultTypeSpecifier" : {
           "type" : "ListTypeSpecifier",
-          "localId" : "300",
+          "localId" : "688",
           "annotation" : [ ],
           "elementType" : {
             "type" : "NamedTypeSpecifier",
-            "localId" : "301",
+            "localId" : "689",
             "name" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
             "annotation" : [ ]
           }
         },
         "expression" : {
           "type" : "Retrieve",
-          "localId" : "295",
+          "localId" : "683",
           "dataType" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
           "codeProperty" : "status",
           "codeComparator" : "in",
           "annotation" : [ ],
           "resultTypeSpecifier" : {
             "type" : "ListTypeSpecifier",
-            "localId" : "298",
+            "localId" : "686",
             "annotation" : [ ],
             "elementType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "299",
+              "localId" : "687",
               "name" : "{https://github.com/cqframework/cql-execution/simple}Encounter",
               "annotation" : [ ]
             }
           },
           "codes" : {
             "type" : "ValueSetRef",
-            "localId" : "294",
+            "localId" : "682",
             "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
             "name" : "Ambulatory/ED Visit",
             "preserve" : true,
@@ -718,153 +3188,7 @@ module.exports['Retrieve'] = {
           "otherFilter" : [ ]
         }
       }, {
-        "localId" : "304",
-        "name" : "ConditionsByCode",
-        "context" : "Patient",
-        "accessLevel" : "Public",
-        "annotation" : [ {
-          "type" : "Annotation",
-          "t" : [ ],
-          "s" : {
-            "r" : "304",
-            "s" : [ {
-              "value" : [ "", "define ", "ConditionsByCode", ": " ]
-            }, {
-              "r" : "307",
-              "s" : [ {
-                "value" : [ "[", "Condition", ": " ]
-              }, {
-                "s" : [ {
-                  "value" : [ "\"Viral pharyngitis code\"" ]
-                } ]
-              }, {
-                "value" : [ "]" ]
-              } ]
-            } ]
-          }
-        } ],
-        "resultTypeSpecifier" : {
-          "type" : "ListTypeSpecifier",
-          "localId" : "314",
-          "annotation" : [ ],
-          "elementType" : {
-            "type" : "NamedTypeSpecifier",
-            "localId" : "315",
-            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
-            "annotation" : [ ]
-          }
-        },
-        "expression" : {
-          "type" : "Retrieve",
-          "localId" : "307",
-          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
-          "codeProperty" : "code",
-          "codeComparator" : "~",
-          "annotation" : [ ],
-          "resultTypeSpecifier" : {
-            "type" : "ListTypeSpecifier",
-            "localId" : "312",
-            "annotation" : [ ],
-            "elementType" : {
-              "type" : "NamedTypeSpecifier",
-              "localId" : "313",
-              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
-              "annotation" : [ ]
-            }
-          },
-          "codes" : {
-            "type" : "ToList",
-            "localId" : "311",
-            "annotation" : [ ],
-            "signature" : [ ],
-            "operand" : {
-              "type" : "CodeRef",
-              "localId" : "306",
-              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
-              "name" : "Viral pharyngitis code",
-              "annotation" : [ ]
-            }
-          },
-          "include" : [ ],
-          "codeFilter" : [ ],
-          "dateFilter" : [ ],
-          "otherFilter" : [ ]
-        }
-      }, {
-        "localId" : "318",
-        "name" : "ConditionsByConcept",
-        "context" : "Patient",
-        "accessLevel" : "Public",
-        "annotation" : [ {
-          "type" : "Annotation",
-          "t" : [ ],
-          "s" : {
-            "r" : "318",
-            "s" : [ {
-              "value" : [ "", "define ", "ConditionsByConcept", ": " ]
-            }, {
-              "r" : "321",
-              "s" : [ {
-                "value" : [ "[", "Condition", ": " ]
-              }, {
-                "s" : [ {
-                  "value" : [ "\"Viral pharyngitis\"" ]
-                } ]
-              }, {
-                "value" : [ "]" ]
-              } ]
-            } ]
-          }
-        } ],
-        "resultTypeSpecifier" : {
-          "type" : "ListTypeSpecifier",
-          "localId" : "332",
-          "annotation" : [ ],
-          "elementType" : {
-            "type" : "NamedTypeSpecifier",
-            "localId" : "333",
-            "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
-            "annotation" : [ ]
-          }
-        },
-        "expression" : {
-          "type" : "Retrieve",
-          "localId" : "321",
-          "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
-          "codeProperty" : "code",
-          "codeComparator" : "~",
-          "annotation" : [ ],
-          "resultTypeSpecifier" : {
-            "type" : "ListTypeSpecifier",
-            "localId" : "330",
-            "annotation" : [ ],
-            "elementType" : {
-              "type" : "NamedTypeSpecifier",
-              "localId" : "331",
-              "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
-              "annotation" : [ ]
-            }
-          },
-          "codes" : {
-            "type" : "Property",
-            "localId" : "329",
-            "path" : "codes",
-            "annotation" : [ ],
-            "source" : {
-              "type" : "ConceptRef",
-              "localId" : "320",
-              "resultTypeName" : "{urn:hl7-org:elm-types:r1}Concept",
-              "name" : "Viral pharyngitis",
-              "annotation" : [ ]
-            }
-          },
-          "include" : [ ],
-          "codeFilter" : [ ],
-          "dateFilter" : [ ],
-          "otherFilter" : [ ]
-        }
-      }, {
-        "localId" : "336",
+        "localId" : "692",
         "name" : "ConditionsByDate",
         "context" : "Patient",
         "accessLevel" : "Public",
@@ -872,18 +3196,18 @@ module.exports['Retrieve'] = {
           "type" : "Annotation",
           "t" : [ ],
           "s" : {
-            "r" : "336",
+            "r" : "692",
             "s" : [ {
               "value" : [ "", "define ", "ConditionsByDate", ": " ]
             }, {
-              "r" : "383",
+              "r" : "739",
               "s" : [ {
                 "s" : [ {
-                  "r" : "337",
+                  "r" : "693",
                   "s" : [ {
-                    "r" : "338",
+                    "r" : "694",
                     "s" : [ {
-                      "r" : "338",
+                      "r" : "694",
                       "s" : [ {
                         "value" : [ "[", "Condition", "]" ]
                       } ]
@@ -895,33 +3219,33 @@ module.exports['Retrieve'] = {
               }, {
                 "value" : [ " " ]
               }, {
-                "r" : "371",
+                "r" : "727",
                 "s" : [ {
                   "value" : [ "where " ]
                 }, {
-                  "r" : "371",
+                  "r" : "727",
                   "s" : [ {
-                    "r" : "347",
+                    "r" : "703",
                     "s" : [ {
-                      "r" : "346",
+                      "r" : "702",
                       "s" : [ {
                         "value" : [ "C" ]
                       } ]
                     }, {
                       "value" : [ "." ]
                     }, {
-                      "r" : "347",
+                      "r" : "703",
                       "s" : [ {
                         "value" : [ "period" ]
                       } ]
                     } ]
                   }, {
-                    "r" : "371",
+                    "r" : "727",
                     "value" : [ " ", "during", " " ]
                   }, {
-                    "r" : "368",
+                    "r" : "724",
                     "s" : [ {
-                      "r" : "352",
+                      "r" : "708",
                       "value" : [ "Interval[", "@2013-03-01T00:00:00.0", ", ", "@2013-03-31T00:00:00.0", ")" ]
                     } ]
                   } ]
@@ -932,130 +3256,130 @@ module.exports['Retrieve'] = {
         } ],
         "resultTypeSpecifier" : {
           "type" : "ListTypeSpecifier",
-          "localId" : "386",
+          "localId" : "742",
           "annotation" : [ ],
           "elementType" : {
             "type" : "NamedTypeSpecifier",
-            "localId" : "387",
+            "localId" : "743",
             "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
             "annotation" : [ ]
           }
         },
         "expression" : {
           "type" : "Query",
-          "localId" : "383",
+          "localId" : "739",
           "annotation" : [ ],
           "resultTypeSpecifier" : {
             "type" : "ListTypeSpecifier",
-            "localId" : "384",
+            "localId" : "740",
             "annotation" : [ ],
             "elementType" : {
               "type" : "NamedTypeSpecifier",
-              "localId" : "385",
+              "localId" : "741",
               "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
               "annotation" : [ ]
             }
           },
           "source" : [ {
-            "localId" : "337",
+            "localId" : "693",
             "alias" : "C",
             "annotation" : [ ],
             "resultTypeSpecifier" : {
               "type" : "ListTypeSpecifier",
-              "localId" : "343",
+              "localId" : "699",
               "annotation" : [ ],
               "elementType" : {
                 "type" : "NamedTypeSpecifier",
-                "localId" : "344",
+                "localId" : "700",
                 "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
                 "annotation" : [ ]
               }
             },
             "expression" : {
               "type" : "Retrieve",
-              "localId" : "338",
+              "localId" : "694",
               "dataType" : "{https://github.com/cqframework/cql-execution/simple}Condition",
               "dateProperty" : "period",
               "annotation" : [ ],
               "resultTypeSpecifier" : {
                 "type" : "ListTypeSpecifier",
-                "localId" : "341",
+                "localId" : "697",
                 "annotation" : [ ],
                 "elementType" : {
                   "type" : "NamedTypeSpecifier",
-                  "localId" : "342",
+                  "localId" : "698",
                   "name" : "{https://github.com/cqframework/cql-execution/simple}Condition",
                   "annotation" : [ ]
                 }
               },
               "dateRange" : {
                 "type" : "Interval",
-                "localId" : "368",
+                "localId" : "724",
                 "lowClosed" : true,
                 "highClosed" : false,
                 "annotation" : [ ],
                 "resultTypeSpecifier" : {
                   "type" : "IntervalTypeSpecifier",
-                  "localId" : "369",
+                  "localId" : "725",
                   "annotation" : [ ],
                   "pointType" : {
                     "type" : "NamedTypeSpecifier",
-                    "localId" : "370",
+                    "localId" : "726",
                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                     "annotation" : [ ]
                   }
                 },
                 "low" : {
                   "type" : "DateTime",
-                  "localId" : "352",
+                  "localId" : "708",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "annotation" : [ ],
                   "signature" : [ ],
                   "year" : {
                     "type" : "Literal",
-                    "localId" : "353",
+                    "localId" : "709",
                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                     "value" : "2013",
                     "annotation" : [ ]
                   },
                   "month" : {
                     "type" : "Literal",
-                    "localId" : "354",
+                    "localId" : "710",
                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                     "value" : "3",
                     "annotation" : [ ]
                   },
                   "day" : {
                     "type" : "Literal",
-                    "localId" : "355",
+                    "localId" : "711",
                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                     "value" : "1",
                     "annotation" : [ ]
                   },
                   "hour" : {
                     "type" : "Literal",
-                    "localId" : "356",
+                    "localId" : "712",
                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                     "value" : "0",
                     "annotation" : [ ]
                   },
                   "minute" : {
                     "type" : "Literal",
-                    "localId" : "357",
+                    "localId" : "713",
                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                     "value" : "0",
                     "annotation" : [ ]
                   },
                   "second" : {
                     "type" : "Literal",
-                    "localId" : "358",
+                    "localId" : "714",
                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                     "value" : "0",
                     "annotation" : [ ]
                   },
                   "millisecond" : {
                     "type" : "Literal",
-                    "localId" : "359",
+                    "localId" : "715",
                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                     "value" : "0",
                     "annotation" : [ ]
@@ -1063,55 +3387,55 @@ module.exports['Retrieve'] = {
                 },
                 "high" : {
                   "type" : "DateTime",
-                  "localId" : "360",
+                  "localId" : "716",
                   "resultTypeName" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "annotation" : [ ],
                   "signature" : [ ],
                   "year" : {
                     "type" : "Literal",
-                    "localId" : "361",
+                    "localId" : "717",
                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                     "value" : "2013",
                     "annotation" : [ ]
                   },
                   "month" : {
                     "type" : "Literal",
-                    "localId" : "362",
+                    "localId" : "718",
                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                     "value" : "3",
                     "annotation" : [ ]
                   },
                   "day" : {
                     "type" : "Literal",
-                    "localId" : "363",
+                    "localId" : "719",
                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                     "value" : "31",
                     "annotation" : [ ]
                   },
                   "hour" : {
                     "type" : "Literal",
-                    "localId" : "364",
+                    "localId" : "720",
                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                     "value" : "0",
                     "annotation" : [ ]
                   },
                   "minute" : {
                     "type" : "Literal",
-                    "localId" : "365",
+                    "localId" : "721",
                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                     "value" : "0",
                     "annotation" : [ ]
                   },
                   "second" : {
                     "type" : "Literal",
-                    "localId" : "366",
+                    "localId" : "722",
                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                     "value" : "0",
                     "annotation" : [ ]
                   },
                   "millisecond" : {
                     "type" : "Literal",
-                    "localId" : "367",
+                    "localId" : "723",
                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                     "value" : "0",
                     "annotation" : [ ]

--- a/test/elm/external/external-test.ts
+++ b/test/elm/external/external-test.ts
@@ -11,7 +11,8 @@ const { p1 } = require('./patients');
 describe('Retrieve', () => {
   let findRecordsSpy: sinon.SinonSpy<any[], any>;
   beforeEach(function () {
-    setup(this, data, [p1], vsets, {}, new Repository(data));
+    this.patientFixture = structuredClone(p1);
+    setup(this, data, [this.patientFixture], vsets, {}, new Repository(data));
     findRecordsSpy = sinon.spy(this.ctx, 'findRecords');
   });
 
@@ -84,6 +85,218 @@ describe('Retrieve', () => {
 
   it('should find conditions by specific pharyngitis concept', async function () {
     const e = await this.conditionsByConcept.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by ValueSet using the default comparator', async function () {
+    const e = await this.conditionsByVS.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by code list using the default comparator', async function () {
+    const e = await this.conditionsByCodeList.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should error on conditions by CodeSystem using the default comparator', async function () {
+    const e = this.conditionsByCS.exec(this.ctx);
+    e.should.be.rejectedWith(Error);
+  });
+
+  it('should error on conditions by CodeSystem using in', async function () {
+    const e = this.conditionsByCodeInCS.exec(this.ctx);
+    e.should.be.rejectedWith(Error);
+  });
+
+  it('should error on conditions by CodeSystem using equality', async function () {
+    const e = this.conditionsByCodeEqualsCS.exec(this.ctx);
+    e.should.be.rejectedWith(Error);
+  });
+
+  it('should error on conditions by CodeSystem using equivalence', async function () {
+    const e = this.conditionsByCodeEquivCS.exec(this.ctx);
+    e.should.be.rejectedWith(Error);
+  });
+
+  it('should find conditions by ValueSet using in', async function () {
+    const e = await this.conditionsByCodeInVS.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by ValueSet using equivalence', async function () {
+    const e = await this.conditionsByCodeEquivVS.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by code using in', async function () {
+    const e = await this.conditionsByCodeInCode.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by code list using in', async function () {
+    const e = await this.conditionsByCodeInCodeList.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by code list using equality', async function () {
+    const e = await this.conditionsByCodeEqualsCodeList.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by code list using equivalence', async function () {
+    const e = await this.conditionsByCodeEquivCodeList.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by specific pharyngitis code by equality when code matches exactly', async function () {
+    const e = await this.conditionsByCodeEqualsCode.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by specific pharyngitis concept by equality when code matches exactly', async function () {
+    const e = await this.conditionsByCodeEqualsConcept.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should NOT find conditions by specific pharyngitis code by equality when code does not match exactly', async function () {
+    this.patientFixture['records'][1]['code']['display'] = 'Viral pharyngitis'; // original is 'Viral pharyngitis (disorder)'
+    const e = await this.conditionsByCodeEqualsCode.exec(this.ctx);
+    should(e).have.length(0);
+    this.ctx.evaluatedRecords.should.have.length(0);
+  });
+
+  it('should NOT find conditions by specific pharyngitis concept by equality when code does not match exactly', async function () {
+    this.patientFixture['records'][1]['code']['display'] = 'Viral pharyngitis'; // original is 'Viral pharyngitis (disorder)'
+    const e = await this.conditionsByCodeEqualsConcept.exec(this.ctx);
+    should(e).have.length(0);
+    this.ctx.evaluatedRecords.should.have.length(0);
+  });
+
+  it('should find conditions by specific pharyngitis code by equivalence when code matches exactly', async function () {
+    const e = await this.conditionsByCodeEquivCode.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by specific pharyngitis code by equivalence when code does not match exactly', async function () {
+    this.patientFixture['records'][1]['code']['display'] = 'Viral pharyngitis'; // original is 'Viral pharyngitis (disorder)'
+    const e = await this.conditionsByCodeEquivCode.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by specific pharyngitis concept by equivalence when code matches exactly', async function () {
+    const e = await this.conditionsByCodeEquivConcept.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by specific pharyngitis concept by equivalence when code does not match exactly', async function () {
+    this.patientFixture['records'][1]['code']['display'] = 'Viral pharyngitis'; // original is 'Viral pharyngitis (disorder)'
+    const e = await this.conditionsByCodeEquivConcept.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by code in concept', async function () {
+    const e = await this.conditionsByCodeInConcept.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by code = ValueSet', async function () {
+    const e = await this.conditionsByCodeEqualsVS.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by bodySite in ValueSet', async function () {
+    const e = await this.conditionsByBodySiteInVS.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by bodySite = ValueSet', async function () {
+    const e = await this.conditionsByBodySiteEqualsVS.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by bodySite ~ ValueSet', async function () {
+    const e = await this.conditionsByBodySiteEquivVS.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by bodySite in code', async function () {
+    const e = await this.conditionsByBodySiteInCode.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by bodySite = code', async function () {
+    const e = await this.conditionsByBodySiteEqualsCode.exec(this.ctx);
+    should(e).have.length(1);
+    e[0].id.should.equal('http://cqframework.org/3/2');
+    this.ctx.evaluatedRecords.should.have.length(1);
+    this.ctx.evaluatedRecords.should.containDeep(e);
+  });
+
+  it('should find conditions by bodySite ~ code', async function () {
+    const e = await this.conditionsByBodySiteEquivCode.exec(this.ctx);
     should(e).have.length(1);
     e[0].id.should.equal('http://cqframework.org/3/2');
     this.ctx.evaluatedRecords.should.have.length(1);

--- a/test/elm/external/patients.js
+++ b/test/elm/external/patients.js
@@ -26,6 +26,20 @@ const p1 = {
         version: '2013-09',
         display: 'Viral pharyngitis (disorder)'
       },
+      bodySite: [
+        {
+          code: '2175005',
+          system: '2.16.840.1.113883.6.96',
+          version: '2013-09',
+          display: 'Structure of pharyngeal cavity (body structure)'
+        },
+        {
+          code: '45206002',
+          system: '2.16.840.1.113883.6.96',
+          version: '2013-09',
+          display: 'Nasal structure (body structure)'
+        }
+      ],
       period: { low: '1982-03-12', high: '1982-03-26' }
     },
     {

--- a/test/elm/external/valuesets.js
+++ b/test/elm/external/valuesets.js
@@ -1,29 +1,102 @@
 module.exports = {
   '2.16.840.1.113883.3.464.1003.102.12.1011': {
     20140501: [
-      { code: '034.0', system: '2.16.840.1.113883.6.103', version: '2013' },
-      { code: '1532007', system: '2.16.840.1.113883.6.96', version: '2013-09' },
-      { code: '43878008', system: '2.16.840.1.113883.6.96', version: '2013-09' }
+      {
+        code: '034.0',
+        system: '2.16.840.1.113883.6.103',
+        version: '2013',
+        display: 'Streptococcal sore throat'
+      },
+      {
+        code: '1532007',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: 'Viral pharyngitis (disorder)'
+      },
+      {
+        code: '43878008',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: 'Streptococcal sore throat (disorder)'
+      }
     ]
   },
   '2.16.840.1.113883.3.464.1003.101.12.1061': {
     20140501: [
-      { code: '185349003', system: '2.16.840.1.113883.6.96', version: '2013-09' },
-      { code: '270427003', system: '2.16.840.1.113883.6.96', version: '2013-09' },
-      { code: '406547006', system: '2.16.840.1.113883.6.96', version: '2013-09' }
+      {
+        code: '185349003',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: 'Encounter for check up (procedure)'
+      },
+      {
+        code: '270427003',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: 'Patient-initiated encounter (procedure)'
+      },
+      {
+        code: '406547006',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: 'Urgent follow-up (procedure)'
+      }
     ]
   },
   '2.16.840.1.113883.3.526.3.1010': {
     20140501: [
-      { code: '109264009', system: '2.16.840.1.113883.6.96', version: '2013-09' },
-      { code: '109383000', system: '2.16.840.1.113883.6.96', version: '2013-09' },
-      { code: '109962001', system: '2.16.840.1.113883.6.96', version: '2013-09' }
+      {
+        code: '109264009',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: 'Overlapping malignant neoplasm of skin (disorder)'
+      },
+      {
+        code: '109383000',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: 'Malignant mesothelioma of pericardium (disorder)'
+      },
+      {
+        code: '109962001',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: "Diffuse non-Hodgkin's lymphoma (disorder)"
+      }
     ]
   },
   '2.16.840.1.113883.3.526.3.1240': {
     20140501: [
-      { code: 'G0438', system: '2.16.840.1.113883.6.285', version: '2014' },
-      { code: 'G0439', system: '2.16.840.1.113883.6.285', version: '2014' }
+      {
+        code: 'G0438',
+        system: '2.16.840.1.113883.6.285',
+        version: '2014',
+        display:
+          'Annual wellness visit; includes a personalized prevention plan of service (PPPS), initial visit'
+      },
+      {
+        code: 'G0439',
+        system: '2.16.840.1.113883.6.285',
+        version: '2014',
+        display:
+          'Annual wellness visit, includes a personalized prevention plan of service (PPPS), subsequent visit'
+      }
+    ]
+  },
+  '2.16.840.1.113762.1.4.1181.77': {
+    20140501: [
+      {
+        code: '45206002',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: 'Nasal structure (body structure)'
+      },
+      {
+        code: '12406000',
+        system: '2.16.840.1.113883.6.96',
+        version: '2013-09',
+        display: 'Little finger structure (body structure)'
+      }
     ]
   }
 };


### PR DESCRIPTION
TL;DR:

This PR implements Retrieve.codeComparator, so retrieves now honor `in`, `=`, and `~` semantics for ValueSets, Codes, Concepts, and code lists, including multi-valued code properties. Exact equality is now supported and compares code displays, while equivalence continues to match code/system only. CodeSystem retrieves are intentionally unsupported but wired up so that if the appropriate terminology lookups are ever implemented, they will work here.

---

This PR implements proper support for the [codeComparator property of a Retrieve](https://cql.hl7.org/04-logicalspecification.html#codecomparator) (implements #293). After a lot of thinking, testing, and discussion about this, it turns out this PR doesn't change that much about how Retrieves are handled but it does tune the implementation to be a little more aligned to the spec, and fixes a few cases that were not on the happy path.

#### Spec / Background
For context, there are 3 key parts to a Retrieve that are relevant to this discussion. 1, the `codeProperty`, 2, the `codeComparator`, and 3, the `codes` (or `terminology`). For example, in `[Condition: bodySite in "myValueSet"]` -- `codeProperty` is `bodySite`, `codeComparator` is `in`, and `codes` is `myValueSet`. If the `codes` is specified but the `codeProperty` and `codeComparator` are not, those fields are populated in translation based on the model. (there's a default `codeProperty` for every resource type, and a default operator for whichever type `codes` is). So `codeComparator` is always present, and currently allows 3 values (`~`, `=`, and `in`).

Note from this point on I'll refer to the `codeProperty` and the value of that field on a given resource as the "Left-Hand Side" or LHS, and I'll refer to the `codes` or `terminology` that it's being compared to as the "Right-Hand Side" or RHS. So eg, `bodySite in myValueSet`, `bodySite` is the LHS and `myValueSet` is the RHS. Otherwise referring to "codes" gets too confusing. 

#### Implementation 
The core of the comparison logic is performed in `Retrieve.recordMatchesCodeOrVS` (src/elm/external.ts). Previously, this would only look at the type of the RHS to appropriately call `hasMatch` on either a single ValueSet object or on the elements of a code list. Now, this branches out into 3 separate functions for each codeComparator type, with further branches based on the type of the RHS to call the appropriate function.

Now, the happy path of this is pretty easy to see what should happen: `[Condition: code in "myValueSet"]` or `[Condition: code = "mySingleCode"]`. But it turns out that the operators in a Retrieve operate differently than they do in a standalone definition, and are much more permissive. Combinations that would be generally be illegal, eg `"mySingleCode" = "myCodeSystem"`, are allowed in a Retrieve, eg `[Condition: code = "myCodeSystem"]`. We discussed this a little bit on Zulip: [#cql > Retrieve.codeComparator implementation details](https://chat.fhir.org/#narrow/channel/179220-cql/topic/Retrieve.2EcodeComparator.20implementation.20details/with/609251783)
The takeaway from that is that it is intentional, it's meant to be flexible but also consistent for the user, but the execution engine does have to concern itself with the different combinations.

However, while the ELM translator permits every combination of operators and operands in a Retrieve, even combinations that are not allowed standalone, for valid combinations it does try to be smart about the types, and will list-promote or expand value sets in certain cases. For example:
`[Condition: code = "myValueSet"]` --> the resulting Retrieve.codes is an `ExpandValueSet` on a `ValueSetRef` and gets passed into `recordMatchesCodeOrVS` as a list of Codes
`[Condition: code in "myValueSet"]` --> the resulting Retrieve.codes is a plain `ValueSetRef` and gets passed into `recordMatchesCodeOrVS` as a ValueSet object
So my takeaway here is, we should generally consider a ValueSet and Code[] to be equivalent, if possible. 

And beyond that, it actually turns out that because of list promotion, even if in the CQL the RHS is a single Code, it will be represented in the resulting Retrieve.codes as a ToList wrapping that code. So even if the CQL says `code = myCode`, it's really `code = { myCode }`.
This means that there's no way to distinguish from the ELM whether the CQL was originally written as a single code or as a list/Concept/ValueSet that contained only a single code. So that greatly reduces the number of combinations we have to consider, but it also means that some of the trivial combinations get folded up into less obvious combinations and we have to make implementation decisions. 

Start with the `=` operator for equality. So now implementing this I see a few options:
1. Use regular list equality, LHS = RHS. `{ code1 } = { code1 }` is true, but `{ code1 } = { code1, code2 }` is false.
2. Interpret the intent of the operator as "some exact match exists between the LHS and RHS". `{ code1 } = { code1, code2 }` is now true. 
3. Different logic depending on the size of RHS. Assume that a list with a single item was list-promoted, anything larger was originally a list.

Let's consider a couple examples to help decide:

- `[Condition: code = mySingleCode]` 
  - I imagine this is probably the most common example
  - Condition.code is 0..1 so this would likely work "as expected" no matter how we implement it
- `[Condition: bodySite = mySingleCode]` - reminder Condition.bodySite is 0..*. 
  - If a given condition has 2 bodySite codes, this could become a comparison `{ code1, code2 } =  { code1 }` . Should this evaluate to true? I think so.
  - Option (1) means "exactly this list" which may be uncommon in a retrieve. (1) would return false in this example.
- `[Condition: bodySite = myConcept]`
  - Again bodySite is 0..*, and a concept may have multiple codes. List equality as (1) means "exactly this list" which could be a valid use case, but I expect most of the time that's not what's expected.
- `[Condition: bodySite = myCodeList]`
  - What if someone wanted to search for a Condition with exactly a specific list of codes, ie, not just a single code but multiple? Regular list equality as in (1) would allow this possibility, but (2) does not.

Approach (3) might produce a better result in some of these cases, but would also result in inconsistent and potentially unexpected behavior in others, so my preference is not to go that route. 
So that leaves (2). More permissive than (1), there's no example that should return false in (2) but true in (1).

#### Final Implementation Approach
So after all that, I implemented the operators with the interpretation that `~` and `=` mean "some element from the LHS matches some element from the RHS", and not "the entirety of the LHS matches the entirety of the RHS". [`in` for CodeSystems](https://cql.hl7.org/09-b-cqlreference.html#in-codesystem) and [`in` for ValueSets](https://cql.hl7.org/09-b-cqlreference.html#in-valueset) are both defined to have equivalence semantics, so `~` and `in` are essentially the same, and both implement essentially the same logic as previously existed. So the only thing that is really "new" here is support for the `=` operator, as well as more specific Error messages when calling the few illegal combinations.

#### Supporting Changes

- In order for any comparison using `=` to work, the code display needs to be populated, but previously there were some paths that copy code objects without copying the display. Those were fixed here, and various test fixtures and test cases were updated as well. (Possibly more than needed but only for consistency within a single file, eg, the valuesets fixture)
- The logic that looks up the `codeProperty` had been assuming the field was a single code, but this is not necessarily true and there are many fields that are a list of codes, eg `Condition.bodySite` which is a 0..* CodeableConcept. Ideally there would be a data-model-aware generic getter, but for now that doesn't exist. I wasn't sure whether it was better to update `getCode` to possibly return a list, so I added a new function `getCodeOrCodes` which always returns a list even if getting a single code.
- Added a `CodeSystem.hasMatch` function that just throws an error for now. The InCodeSystem operation is not supported yet (https://github.com/cqframework/cql-execution/issues/289) and too large to implement here, and it felt cleaner to add that "not yet implemented" error in a `CodeSystem` member function rather than the function handling the `in` operator. However, it turns out the code execution flow doesn't make it this far, since earlier on the code tries to evaluate the CodeSystem as if it were a ValueSet and that lookup fails. I didn't modify that earlier step since there's no real way to make it work without a full implementation, so the impact is just that the error message might not be the most ideal for the situation.


Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

**Submitter:**

- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [ ] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name:

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
