### PR TITLE
WIP of HighBoundary and LowBoundary

### DIFF
--- a/src/datatypes/datetime.ts
+++ b/src/datatypes/datetime.ts
@@ -844,6 +844,61 @@ export class DateTime extends AbstractDate {
     );
   }
 
+  highBoundary(precision?: number) {
+    return this._boundary('high', precision);
+  }
+
+  lowBoundary(precision?: number) {
+    return this._boundary('low', precision);
+  }
+
+  _boundary(mode: 'high' | 'low', precision?: number) {
+    const currentPrecision = this.getPrecisionValue();
+
+    if (precision === currentPrecision) {
+      return this.copy();
+    }
+
+    const precisionValueMap = this.isTime()
+      ? TIME_PRECISION_VALUE_MAP
+      : DATETIME_PRECISION_VALUE_MAP;
+
+    const maxPossiblePrecision = Math.max(...precisionValueMap.values());
+    if (precision == null) {
+      precision = maxPossiblePrecision;
+    } else if (precision > maxPossiblePrecision) {
+      return null;
+    }
+
+    // find the field that maps to the given precision integer
+    // TODO: be permissive or not?
+    const fieldEntry = precisionValueMap.entries().find(([_k, v]) => v === precision);
+    if (!fieldEntry) {
+      throw new Error(`Invalid precision: ${precision}`);
+    }
+    const precisionKey = fieldEntry[0];
+
+    if (precision < currentPrecision) {
+      return this.reducedPrecision(precisionKey);
+    }
+
+    const returnVal = this.copy();
+
+    const startFieldIndex = DateTime.FIELDS.indexOf(this.getPrecision()!);
+    const endFieldIndex = DateTime.FIELDS.indexOf(precisionKey);
+    const fieldsToSet = DateTime.FIELDS.slice(startFieldIndex + 1, endFieldIndex + 1);
+    // startFieldIndex +1 because we don't want to set that field, that's the highest precision field currently set
+    // endFieldIndex +1 because we do want to set that field, and slice end param is exclusive
+
+    for (const field of fieldsToSet) {
+      // @ts-ignore
+      returnVal[field] =
+        mode === 'high' ? returnVal.getFieldCieling(field) : returnVal.getFieldFloor(field);
+    }
+
+    return returnVal;
+  }
+
   isUTC() {
     // A timezoneOffset of 0 indicates UTC time.
     return !this.timezoneOffset;
@@ -1139,6 +1194,52 @@ export class Date extends AbstractDate {
       wholeLuxonDuration(b.low.diff(a.high, unitField), unitField),
       wholeLuxonDuration(b.high.diff(a.low, unitField), unitField)
     );
+  }
+
+  highBoundary(precision?: number) {
+    return this._boundary('high', precision);
+  }
+
+  lowBoundary(precision?: number) {
+    return this._boundary('low', precision);
+  }
+
+  _boundary(mode: 'high' | 'low', precision?: number) {
+    const currentPrecision = this.getPrecisionValue();
+
+    if (precision === currentPrecision) {
+      return this.copy();
+    }
+
+    const maxPossiblePrecision = DATETIME_PRECISION_VALUE_MAP.get(Date.Unit.DAY)!;
+    const requestedPrecision = precision ?? maxPossiblePrecision;
+    if (requestedPrecision > maxPossiblePrecision) {
+      return null;
+    }
+
+    const fieldEntry = DATETIME_PRECISION_VALUE_MAP.entries().find(
+      ([_key, value]) => value === requestedPrecision
+    );
+    if (!fieldEntry) {
+      throw new Error(`Invalid precision: ${requestedPrecision}`);
+    }
+    const precisionKey = fieldEntry[0];
+
+    if (requestedPrecision < currentPrecision) {
+      return this.reducedPrecision(precisionKey);
+    }
+
+    const result = this.copy();
+    const startFieldIndex = Date.FIELDS.indexOf(this.getPrecision()!);
+    const endFieldIndex = Date.FIELDS.indexOf(precisionKey);
+    const fieldsToSet = Date.FIELDS.slice(startFieldIndex + 1, endFieldIndex + 1);
+
+    for (const field of fieldsToSet) {
+      // @ts-ignore
+      result[field] = mode === 'high' ? result.getFieldCieling(field) : result.getFieldFloor(field);
+    }
+
+    return result;
   }
 
   getPrecision() {

--- a/src/elm/arithmetic.ts
+++ b/src/elm/arithmetic.ts
@@ -10,7 +10,7 @@ import {
 import { Uncertainty } from '../datatypes/uncertainty';
 import { Context } from '../runtime/context';
 import { build } from './builder';
-import { DateTime } from '../datatypes/datetime';
+import { Date, DateTime } from '../datatypes/datetime';
 import {
   ELM_DECIMAL_TYPE,
   ELM_DATETIME_TYPE,
@@ -565,5 +565,46 @@ export class Predecessor extends Expression {
       return null;
     }
     return predecessor;
+  }
+}
+
+export class HighBoundary extends Expression {
+  constructor(json: any) {
+    super(json);
+  }
+
+  async exec(ctx: Context) {
+    const [input, precision] = await this.execArgs(ctx);
+    if (input == null) {
+      return null;
+    }
+    // Decimal, Date, DateTime, and Time values.
+    if (input instanceof DateTime || input instanceof Date) {
+      // CQL Time is a DateTime
+      return input.highBoundary(precision);
+    } else {
+      // Decimal not yet implemented
+    }
+  }
+}
+
+export class LowBoundary extends Expression {
+  constructor(json: any) {
+    super(json);
+  }
+
+  async exec(ctx: Context) {
+    const [input, precision] = await this.execArgs(ctx);
+    if (input == null) {
+      return null;
+    }
+
+    // Decimal, Date, DateTime, and Time values.
+    if (input instanceof DateTime || input instanceof Date) {
+      // CQL Time is a DateTime
+      return input.lowBoundary(precision);
+    } else {
+      // Decimal not yet implemented
+    }
   }
 }

--- a/test/datatypes/date-test.ts
+++ b/test/datatypes/date-test.ts
@@ -852,6 +852,23 @@ describe('Date.getPrecisionValue', () => {
   });
 });
 
+describe('Date boundary functions', () => {
+  it('returns the high boundary at the requested precision', () => {
+    Date.parse('2014').highBoundary(6).should.eql(Date.parse('2014-12'));
+    Date.parse('2014').highBoundary().should.eql(Date.parse('2014-12-31'));
+  });
+
+  it('returns the low boundary at the requested precision', () => {
+    Date.parse('2014').lowBoundary(6).should.eql(Date.parse('2014-01'));
+    Date.parse('2014').lowBoundary().should.eql(Date.parse('2014-01-01'));
+  });
+
+  it('returns null when the requested precision exceeds the implementation maximum', () => {
+    should(Date.parse('2014').highBoundary(9)).be.null();
+    should(Date.parse('2014').lowBoundary(9)).be.null();
+  });
+});
+
 describe('Date.getDateTime', () => {
   it('should return a DateTime that has the passed in timeZoneOffset', () => {
     const d = new Date(2000, 12, 1);

--- a/test/datatypes/datetime-test.ts
+++ b/test/datatypes/datetime-test.ts
@@ -3985,3 +3985,29 @@ describe('DateTime.getPrecisionValue', () => {
     DateTime.parse('0000-01-01T12:55:14.456').getPrecisionValue().should.equal(9);
   });
 });
+
+describe('DateTime.highBoundary', () => {
+  it('should properly get high boundary for a date', () => {
+    DateTime.parse('2014').highBoundary(6).should.eql(DateTime.parse('2014-12'));
+
+  });
+
+  it('should properly get high boundary for a datetime', () => {
+    DateTime.parse('2014-01-01T08').highBoundary(17).should.eql(DateTime.parse('2014-01-01T08:59:59.999'));
+  });
+
+  it('should properly get high boundary through day precision', () => {
+    DateTime.parse('2014').highBoundary().should.eql(DateTime.parse('2014-12-31T23:59:59.999'));
+  });
+});
+
+describe('DateTime.lowBoundary', () => {
+  it('should properly get low boundary for a date', () => {
+    DateTime.parse('2014').lowBoundary(6).should.eql(DateTime.parse('2014-01'));
+
+  });
+
+  it('should properly get high boundary for a datetime', () => {
+    DateTime.parse('2014-01-01T08').lowBoundary(17).should.eql(DateTime.parse('2014-01-01T08:00:00.000'));
+  });
+});


### PR DESCRIPTION
This PR is a Work-In-Progress of implementing the HighBoundary and LowBoundary operators. (closes #159) 

Turns out this depends on CQL Decimal specifics, so I didn't want to implement this before the upcoming "BigDecimal" work. Putting this up as a WIP/Draft mostly so that we don't forget about it if the BigDecimal effort takes a long time. The Date/Time/DateTime versions should be functional but there is likely some cleanup and de-duplication possible.

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

**Submitter:**

- [ ] This pull request describes why these changes were made
- [ ] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass
- [ ] Code coverage has not gone down and all code touched or added is covered.
- [ ] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [ ] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [ ] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name:

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
