### PR TITLE
Update CQL URLs to link to CQL R2 (2.0)

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -95,7 +95,7 @@ In order for the CQL execution framework to determine if a code is in a valueset
 
 ### MessageListener
 
-The CQL specification defines a [Message](https://cql.hl7.org/09-b-cqlreference.html#message) operator that "provides a run-time mechanism for returning messages, warnings, traces, and errors to the calling environment." To support this, the CQL execution framework supports a "MessageListener" API. A MessageListener class must contain an `onMessage` function which will be called by the CQL execution framework if the `condition` passed to the `Message` operator is `true`:
+The CQL specification defines a [Message](https://cql.hl7.org/R2/09-b-cqlreference.html#message) operator that "provides a run-time mechanism for returning messages, warnings, traces, and errors to the calling environment." To support this, the CQL execution framework supports a "MessageListener" API. A MessageListener class must contain an `onMessage` function which will be called by the CQL execution framework if the `condition` passed to the `Message` operator is `true`:
 ```typescript
 onMessage(source: any, code: string, severity: string, message: string) {
   // do something with the message

--- a/src/datatypes/interval.ts
+++ b/src/datatypes/interval.ts
@@ -78,7 +78,7 @@ export class Interval {
     return new Interval(newLow, newHigh, this.lowClosed, this.highClosed, this.pointType);
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#contains
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#contains
   contains(item: any, precision?: any) {
     if (item != null && item.isInterval) {
       throw new Error('Argument to contains must be a point');
@@ -93,7 +93,7 @@ export class Interval {
     );
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#properly-includes
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#properly-includes
   properContains(item: any, precision?: any) {
     // From contains: "If the second argument is null, the result is null."
     if (item == null) {
@@ -110,7 +110,7 @@ export class Interval {
     );
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#properly-includes
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#properly-includes
   properlyIncludes(other: any, precision?: any) {
     // "For the interval-interval overload, if either argument is null, the result is null."
     if (other == null) {
@@ -130,7 +130,7 @@ export class Interval {
     );
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#includes
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#includes
   includes(other: any, precision?: any) {
     // "For the interval-interval overload, if either argument is null, the result is null."
     if (other == null) {
@@ -151,7 +151,7 @@ export class Interval {
     );
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#included-in
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#included-in
   includedIn(other: any, precision?: any) {
     // "For the interval-interval overload, if either argument is null, the result is null."
     if (other == null) {
@@ -170,7 +170,7 @@ export class Interval {
     );
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#overlaps
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#overlaps
   overlaps(other: any, precision?: any) {
     // "If either argument is null, the result is null."
     if (other == null) {
@@ -187,7 +187,7 @@ export class Interval {
     );
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#overlaps
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#overlaps
   overlapsAfter(other: any, precision?: any) {
     // "If either argument is null, the result is null."
     if (other == null) {
@@ -201,7 +201,7 @@ export class Interval {
     );
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#overlaps
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#overlaps
   overlapsBefore(other: any, precision?: any) {
     // "If either argument is null, the result is null."
     if (other == null) {
@@ -215,7 +215,7 @@ export class Interval {
     );
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#union
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#union
   union(other: any) {
     // "If either argument is null, the result is null."
     if (other == null) {
@@ -253,7 +253,7 @@ export class Interval {
     );
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#intersect
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#intersect
   intersect(other: any) {
     // "If either argument is null, the result is null."
     if (other == null) {
@@ -292,7 +292,7 @@ export class Interval {
     );
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#except
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#except
   except(other: any) {
     // "If either argument is null, the result is null."
     if (other === null) {
@@ -339,7 +339,7 @@ export class Interval {
     return null;
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#same-as-2
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#same-as-2
   sameAs(other: any, precision?: any) {
     // "If either or both arguments are null, the result is null."
     if (other === null) {
@@ -373,7 +373,7 @@ export class Interval {
     }
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#same-or-after-2
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#same-or-after-2
   sameOrBefore(other: any, precision?: any) {
     // "If either or both arguments are null, the result is null."
     if (other === null) {
@@ -401,7 +401,7 @@ export class Interval {
     return cmp.lessThanOrEquals(left.end(), right.start(), precision);
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#same-or-after-2
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#same-or-after-2
   sameOrAfter(other: any, precision?: any) {
     // "If either or both arguments are null, the result is null."
     if (other === null) {
@@ -429,7 +429,7 @@ export class Interval {
     return cmp.greaterThanOrEquals(left.start(), right.end(), precision);
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#equal-1
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#equal-1
   equals(other: any) {
     // "If either argument is null, the result is null."
     if (other == null) {
@@ -449,7 +449,7 @@ export class Interval {
     );
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#after-1
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#after-1
   after(other: any, precision?: any) {
     // "If either argument is null, the result is null."
     if (other == null) {
@@ -467,7 +467,7 @@ export class Interval {
     return cmp.greaterThan(this.start(), other.end(), precision);
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#before-1
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#before-1
   before(other: any, precision?: any) {
     // "If either argument is null, the result is null."
     if (other == null) {
@@ -485,7 +485,7 @@ export class Interval {
     return cmp.lessThan(this.end(), other.start(), precision);
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#meets
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#meets
   meets(other: any, precision?: any) {
     // "If either argument is null, the result is null."
     if (other == null) {
@@ -503,7 +503,7 @@ export class Interval {
     );
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#meets
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#meets
   meetsAfter(other: any, precision?: any) {
     // "If either argument is null, the result is null."
     if (other == null) {
@@ -528,7 +528,7 @@ export class Interval {
     }
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#meets
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#meets
   meetsBefore(other: any, precision?: any) {
     // "If either argument is null, the result is null."
     if (other == null) {
@@ -556,7 +556,7 @@ export class Interval {
     }
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#start
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#start
   start() {
     // "If the low boundary of the interval is closed and null, this operator returns the minimum
     // value for the point type of the interval."
@@ -581,7 +581,7 @@ export class Interval {
     return this.lowClosed ? this.low : successor(this.low, this.pointType);
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#end
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#end
   end() {
     // "If the high boundary of the interval is closed and null, this operator returns the maximum
     // value for the point type of the interval."
@@ -606,7 +606,7 @@ export class Interval {
     return this.highClosed ? this.high : predecessor(this.high, this.pointType);
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#starts
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#starts
   starts(other: any, precision?: any) {
     // "If either argument is null, the result is null."
     if (other == null) {
@@ -634,7 +634,7 @@ export class Interval {
     }
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#ends
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#ends
   ends(other: any, precision?: any) {
     // "If either argument is null, the result is null."
     if (other == null) {
@@ -662,7 +662,7 @@ export class Interval {
     }
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#width
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#width
   width() {
     // "Note that because CQL defines duration and difference operations for date and time valued
     // intervals, width is not defined for intervals of these types."
@@ -680,7 +680,7 @@ export class Interval {
     return limitDecimalPrecision(subtract(end, start, this.pointType));
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#size
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#size
   size() {
     // "Note that because CQL defines duration and difference operations for date and time valued
     // intervals, size is not defined for intervals of these types."
@@ -700,7 +700,7 @@ export class Interval {
     );
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#size
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#size
   getPointSize() {
     // "... point-size is determined by successor of minimum T - minimum T"
     let minValue = minValueForType(this.pointType, getQuantityInstanceForMinMax(this));
@@ -726,7 +726,7 @@ export class Interval {
     throw new Error('Point type of interval cannot be determined.');
   }
 
-  // https://build.fhir.org/ig/HL7/cql/09-b-cqlreference.html#point-from
+  // https://cql.hl7.org/R2/09-b-cqlreference.html#point-from
   pointFrom() {
     // "The point from operator extracts the single point from a unit interval."
     const start = this.start();

--- a/src/datatypes/interval.ts
+++ b/src/datatypes/interval.ts
@@ -23,8 +23,6 @@ import {
 import { MIN_FLOAT_VALUE } from '../util/limits';
 import { Quantity } from './quantity';
 
-// TODO: Replace all build.fhir.org URL references with stable references once CQL 2.0 is pulished
-
 export class Interval {
   constructor(
     public low: any,

--- a/src/elm/clinical.ts
+++ b/src/elm/clinical.ts
@@ -298,7 +298,7 @@ export class CalculateAge extends Expression {
     // From the spec: "Note that for AgeInYears and AgeInMonths, the birthDate is specified as a
     // Date and Today() is used to obtain the current date; whereas with the other precisions,
     // birthDate is specified as a DateTime, and Now() is used to obtain the current DateTime."
-    // See: https://cql.hl7.org/09-b-cqlreference.html#age
+    // See: https://cql.hl7.org/R2/09-b-cqlreference.html#age
     let asOf: dt.Date | dt.DateTime;
     if (
       this.precision.toLowerCase() === dt.DateTime.Unit.YEAR ||

--- a/src/elm/query.ts
+++ b/src/elm/query.ts
@@ -247,7 +247,7 @@ export class Query extends Expression {
     });
 
     // Iterate over the cartesian product of the sources.
-    // See: https://cql.hl7.org/03-developersguide.html#multi-source-queries
+    // See: https://cql.hl7.org/R2/03-developersguide.html#multi-source-queries
     const cartesian = cartesianProductOf(sourceResults);
     let returnedValues: any[] = [];
     for (const combo of cartesian) {

--- a/src/types/type-specifiers.interfaces.ts
+++ b/src/types/type-specifiers.interfaces.ts
@@ -6,7 +6,7 @@ import {
   ELM_CHOICE_TYPE_SPECIFIER
 } from '../util/elmTypes';
 
-// Types derived from http://cql.hl7.org/04-logicalspecification.html#typespecifier
+// Types derived from http://cql.hl7.org/R2/04-logicalspecification.html#typespecifier
 
 /*
  * Utility type for any possible TypeSpecifier


### PR DESCRIPTION
Now that [CQL 2.0](https://cql.hl7.org/R2/) has been released, update all URLs to point to pages under `https://cql.hl7.org/R2/`. I also checked to confirm that older links to the CQL spec were still correct when moved to R2 and that the corresponding quotes had not changed (when applicable). I did not do this for all of the build.fhir.org links in the interval code because there were not any changes to the spec since that version of the CI build.

**Submitter:**

- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [n/a] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `npm run check` to run tests, lint, and prettier)
- [n/a] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- 
**Reviewer:**

Name:

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
