### PR TITLE
CQL Test Server Updates

### DIFF
--- a/DEPENDENCY_NOTES.md
+++ b/DEPENDENCY_NOTES.md
@@ -1,6 +1,5 @@
 The following notes about the app's dependencies should be revisited and resolved when possible:
 
-As of 2026-07-27:
+As of 2026-08-26:
 
 - `@types/node`: Consider updating to `26.x` in the future, but for now `24.x` still has plent of time in LTS.
-- `tslog` (test-server only): `5.x` is ESM-only and replaces v4's flat logger settings such as `hideLogPositionForProduction` and `prettyLogTemplate`. Updating will require some migration.

--- a/test-server/package-lock.json
+++ b/test-server/package-lock.json
@@ -9,17 +9,17 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cqframework/cql": "^4.0.0-beta.1",
+        "@cqframework/cql": "^5.2.0",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
-        "tslog": "^4.11.0"
+        "tslog": "^5.1.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
         "@types/fhir": "^0.0.44",
         "@types/node": "^24.13.3",
         "copyfiles": "^2.4.1",
-        "oxlint": "^1.79.0",
+        "oxlint": "^1.80.0",
         "prettier": "^3.9.6",
         "tsx": "^4.23.12",
         "typescript": "^7.0.2",
@@ -27,11 +27,13 @@
       }
     },
     "node_modules/@cqframework/cql": {
-      "version": "4.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@cqframework/cql/-/cql-4.0.0-beta.1.tgz",
-      "integrity": "sha512-eXjVLLGyvnrOULnTS3KuFOdyMWogTl9dYLVgFVeDDZsRIbwGB0XMxVauYrnXqK4OEONz+R41W/yYuwFfCQDX/A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@cqframework/cql/-/cql-5.2.0.tgz",
+      "integrity": "sha512-XvbxkqT4KZmeSMtTO6jik7KJzNs8gPT+OALFGacXYiIjTOqSi7lvXMDQiQvYSYXg+nrSogCJpBnPbpwsiUL7Hg==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@js-joda/core": "3.2.0",
+        "@js-joda/timezone": "2.23.0",
         "saxes": "6.0.0"
       }
     },
@@ -484,6 +486,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@js-joda/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@js-joda/timezone": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@js-joda/timezone/-/timezone-2.23.0.tgz",
+      "integrity": "sha512-33rPV8ORT66Httd/IHQaymTZ//MbjF0WRB58JOUT0G04/a9cB5Q0RFTV1+T4XjIjHr+nY5QkO6KppqgogsJs+Q==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "@js-joda/core": ">=1.11.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.146.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
@@ -495,9 +512,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.79.0.tgz",
-      "integrity": "sha512-TebFaaMklO/RXzTv7PucaCq9l3X6D1gA+C8H6K4njtjFOV+zWE9MKLpulcJZN9bzytbUbQIY0mZuz12nQ5Kv4Q==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.80.0.tgz",
+      "integrity": "sha512-RM3Plj+biQpxa5d1GOOX6ciDlcUROmm4OZ/pLTpitkQt2mJv4jhtY4cbgaetOm5UKWZe05/TGQ6o1Vl8EOHkrA==",
       "cpu": [
         "arm"
       ],
@@ -512,9 +529,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.79.0.tgz",
-      "integrity": "sha512-KqqnOtAVgNsPPF0YSodkFZA1O80jcKoCZCTu3bgsszxA+MrMP9TLzfXitKjEj1FmrPprKDMdRDMmY3weESO9sg==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.80.0.tgz",
+      "integrity": "sha512-YlO5JEf0Yr2bUUlu8O8daVcUxtcGGbcSmyV7E7nSbJbfAdxTE0PFPwgnIlw7wXJaTYjb+qs5hI5q3jxUkI7cAw==",
       "cpu": [
         "arm64"
       ],
@@ -529,9 +546,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.79.0.tgz",
-      "integrity": "sha512-BVC2nsMzqQzRDPc5RhixkZ+m1p7iH4bxRRvqkbwDXX0PlQKm1BPy8J8cRjnAFafOq2QzI+BfO3vE8w2GZ3CBag==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.80.0.tgz",
+      "integrity": "sha512-BULDOyO3AhsmdWfQeIUCykDt3dd7XZBGLhp1eIh56skRv01O+cNjNPwXMIbeW1x4+pxcln5if72wcRgViVo7PA==",
       "cpu": [
         "arm64"
       ],
@@ -546,9 +563,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.79.0.tgz",
-      "integrity": "sha512-p6Lm+snmhGuLKL1+CpCV8L6ijkE/qJzK2H2jG9+eKJT0n31RbY4FLsdhexekgP3bLpw4Kgde+9DZuDZQ4yIInA==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.80.0.tgz",
+      "integrity": "sha512-YJ4JzLw7N5TDSQFlA0hAQGHvnDZgyypm1yunObVWcWiF9KM7eGCJKYKLgTC2Fi/57OdnBhbj4OkzPGdFQJ6HyA==",
       "cpu": [
         "x64"
       ],
@@ -563,9 +580,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.79.0.tgz",
-      "integrity": "sha512-qDMm0dXZnoHyRqSL4N4xUq82T4sqK5cbKSjvd/dF/YbMUXc2R1wEPf+vmA5S0qUmi0nwXfNbjXBtZaIqzQLIMg==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.80.0.tgz",
+      "integrity": "sha512-AYUIk5QnL0s8oWAYsREZwkRYy1SupJTXALo93J1TgzHywxQtdM99FecRMQ87MXEdPQ0j1TmEpeeq3fGNkpvMqg==",
       "cpu": [
         "x64"
       ],
@@ -580,9 +597,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.79.0.tgz",
-      "integrity": "sha512-2od7s0nuKPzqyUZAWk9KkCyGg7eI9dwFPZg+20lB15fKFkVZ0c9ZFxqPfiBAyDTlTkh9stPI0t+JlPCqMbItVA==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.80.0.tgz",
+      "integrity": "sha512-9hBZVANupQ89W9dXyE0n8doCyaW5pDyGn3y6XlIMPZ+rIKuyqkr3SNUXmVJIhuvUq0NBU3RBiSXXE69l4XI6KA==",
       "cpu": [
         "arm"
       ],
@@ -597,9 +614,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.79.0.tgz",
-      "integrity": "sha512-ZOQUjkzDnvlhSE3+tWC3YXx94MMl+sYMlwH+u1+YGApGHOJP/YAc8ZBRFOXZ6eOBmxtXAWuS/fBcdZr8qqNO1A==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.80.0.tgz",
+      "integrity": "sha512-SvS2uKqzY+pbfuvAHzH4338R6Zwo805GAwrIMVvK1KxoOWCIjZUdfzTCvilD7z6JK91v011+zYMryabhDo2AsQ==",
       "cpu": [
         "arm"
       ],
@@ -614,9 +631,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.79.0.tgz",
-      "integrity": "sha512-lu158FR4nGqGeRS3BQvtG85wRgU/Fy4MD5Cxp1hzJXizGiLo6u2742wJSCDKh8cFcZntvX7fcxlq4mMmfryH1g==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.80.0.tgz",
+      "integrity": "sha512-tCLadyqRVL3pQTRPNg7cjXKvcvS4fbyXeQHhKk5BTJ1oftQln5/yIIWbu/Xom/DX41zv2P9QGt6+D/TtQVtY3A==",
       "cpu": [
         "arm64"
       ],
@@ -631,9 +648,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.79.0.tgz",
-      "integrity": "sha512-mbpKQeE2aflTjddaHK7MP8KP/OFbUM++lt5M635ENM8IyIdK0jm2t9pb+2v9mVVIvhF6TqA4l7F79Pll1mi+uw==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.80.0.tgz",
+      "integrity": "sha512-XfpCNRlOPcLlJl4Bn/FUhjqlR6BVavEykERBf/MV7YA9VZDa5g5znVqYhyviMafcxS9Pe/i/kPvHNO0U6svEHQ==",
       "cpu": [
         "arm64"
       ],
@@ -648,9 +665,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.79.0.tgz",
-      "integrity": "sha512-WpGNua7gaxaHnpSDeog2ji8IDHn/QLPl9LPzwkR/FvVv58vT5BcXjRXnU+wbu3N75cpeha8CdC7ho/U2OIsB4g==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.80.0.tgz",
+      "integrity": "sha512-3I4yMwcFG9NeO8ioY6JBBuKsIm5GL/x7MATt1S4tVWaxPu5HcJ+XnLUbcVBTxG8q2Wu56HSj+NmXQiVYb1lp6A==",
       "cpu": [
         "ppc64"
       ],
@@ -665,9 +682,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.79.0.tgz",
-      "integrity": "sha512-tK1E93A5LVzISg4ngpKJnfTs7EqtIUceGI7MQ4GyDjJiLi8wPCkEyKlj2xkyKWZ1yzkDJyLHTBJ5/iFWRdnJvg==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.80.0.tgz",
+      "integrity": "sha512-E1wAKymkpe1/E8helzBKdm81OBOF+ezxRyXRMEuik3ZpWDER5CPOKZwF66RsdwW98uwZv8UTFremUQtC1CzdJA==",
       "cpu": [
         "riscv64"
       ],
@@ -682,9 +699,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.79.0.tgz",
-      "integrity": "sha512-qhQvUIrngXivA2A9pQ+xPCychztn/5qUv7yS3gDwXv3w7Rag+eTeeXWmRyx+t7XsW5x6LuY/8AsTq36UgFIblg==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.80.0.tgz",
+      "integrity": "sha512-+gLRGD4sIo3+VA++iham5UxD9tKSoJ/VOrROCEXIcknrYtQg6iIQgvjN0cpiRF7N6UYC7pJbvHJlDnMge5LRpQ==",
       "cpu": [
         "riscv64"
       ],
@@ -699,9 +716,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.79.0.tgz",
-      "integrity": "sha512-sv6AaVgU/eE6u+6WFiQVDcPPwTxP6IJMSB9k701W2r/r6Tx465e8vPvVyRxquNH4Vy6KwRNu90mVbxXJN8+5gg==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.80.0.tgz",
+      "integrity": "sha512-aR0PrzHj9leW3NmzBAAP4EzdoBNoJcs9sjnIQPIwyRnBGYrRbXUIpEB5Q39AqK3PLY5JK5uEhDQDiUa1QSAstw==",
       "cpu": [
         "s390x"
       ],
@@ -716,9 +733,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.79.0.tgz",
-      "integrity": "sha512-iFZL02deziHslb3jEX9KdqlAkYoo4fGyotchKDzdfK1f5mxlIBeiQeHhvK3iFpuEJSB4ma/qeFn9oxPiwnhUPQ==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.80.0.tgz",
+      "integrity": "sha512-vSVh5cSo3Xxs6ghBCcFJlpbkbENzDog1qXtoXLa/HC3aCrR4XO76GZbXmQoCPHnu99nQpdCeC3H9tdNICfDh7A==",
       "cpu": [
         "x64"
       ],
@@ -733,9 +750,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.79.0.tgz",
-      "integrity": "sha512-3DtZR2raqObnh7wXZoFYFd0Fw7skBvcb3f7A+/lkEiDuh8hrE6vv9b/62Qxao1a9/OeHLw/FcXlXzgsW9wTRFg==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.80.0.tgz",
+      "integrity": "sha512-FfzBXpNQ8u7/ZI/p8bl73MeZ508Ax3hxWp3SiJpEFiC+BB9XcXy5FAZHTLKDPSzrUpxQZSZJAVdDmuJp/+HDBQ==",
       "cpu": [
         "x64"
       ],
@@ -750,9 +767,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.79.0.tgz",
-      "integrity": "sha512-Oatt4GuA1WJkqzk2ozx4HrWROOi7opV3AKDw/U8qDIqeTqzsjn5K2x3REJMNjU3/KU/Bkq96Zi3CknaiDTaC/Q==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.80.0.tgz",
+      "integrity": "sha512-zMzbkumtmprCgRwoYNzcB3iC39fXdJIMLMU33KdCjEGLlJGOEt1+LwQ4LF8ndLzAEKVz4BR0y3V6Xrkk3Nm3yA==",
       "cpu": [
         "arm64"
       ],
@@ -767,9 +784,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.79.0.tgz",
-      "integrity": "sha512-NAgZr9Qp8nIA9rpo0JEvwiabTF/2UVqBNnupBG9X4kxXcQoScJUTi+qHhvabb9s/thgj5wQ4XcIaJvb+ZMgoKw==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.80.0.tgz",
+      "integrity": "sha512-ib6iRcrXsk4t1fm3iKcwksyWh1ZkZXC/2mEzakl0ai2+6HZunf1WWMZ/xP9EJAvw9g9K4UVTC3NF/+G2qLrbTQ==",
       "cpu": [
         "arm64"
       ],
@@ -784,9 +801,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.79.0.tgz",
-      "integrity": "sha512-+KyXjIvcpaXmWW/j9NNY5yWjrIVxaX18VyIheQy3jwc2GSYgpCr7MGI/HxIGQ/shAL5IWEKbhsqoMpAO5Stiog==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.80.0.tgz",
+      "integrity": "sha512-xhRWBMpLxZvgKAH6+DJZmpP+W8Y8UdQOSU1JfxSWNXsaBaRGW77j+1hCuNHlzj7OH4SPN8fYd1q0o2qrDtoVyw==",
       "cpu": [
         "ia32"
       ],
@@ -801,9 +818,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.79.0.tgz",
-      "integrity": "sha512-mEelcCMMBS57sIXh2veGMNy+pQwuGtcMxHxGIZWQ5Ba9pJ5jCCUFOZB9E2JhBaxGsURe+WGe0zJp4RVre52gpQ==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.80.0.tgz",
+      "integrity": "sha512-yAnO7lwBYQnz2pcfBPIGQQZWIX5zd5R/1aAKIF3oE+TVj7IhoHcROjOkz3sRDngzqhfPKfFaXqug5j5rE5dn6Q==",
       "cpu": [
         "x64"
       ],
@@ -2933,9 +2950,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.79.0.tgz",
-      "integrity": "sha512-hVJ9hq9m2unPS+Of4eJJgCPdIeCC+3DHEUX3tkmrPJr3OK2hz7PhXwgC+ZP71ZcYu8cCDEtQrqLxWNvxBppBVg==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.80.0.tgz",
+      "integrity": "sha512-5nTiSps4qdbCWLbxzuO00alHkEO2exR9YMN/ig6QXWrLsYSG0KaObOAM+l6oU2LcKPWoSAGYbkZIGEu1ViiWKA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2948,25 +2965,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.79.0",
-        "@oxlint/binding-android-arm64": "1.79.0",
-        "@oxlint/binding-darwin-arm64": "1.79.0",
-        "@oxlint/binding-darwin-x64": "1.79.0",
-        "@oxlint/binding-freebsd-x64": "1.79.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.79.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.79.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.79.0",
-        "@oxlint/binding-linux-arm64-musl": "1.79.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.79.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.79.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.79.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.79.0",
-        "@oxlint/binding-linux-x64-gnu": "1.79.0",
-        "@oxlint/binding-linux-x64-musl": "1.79.0",
-        "@oxlint/binding-openharmony-arm64": "1.79.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.79.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.79.0",
-        "@oxlint/binding-win32-x64-msvc": "1.79.0"
+        "@oxlint/binding-android-arm-eabi": "1.80.0",
+        "@oxlint/binding-android-arm64": "1.80.0",
+        "@oxlint/binding-darwin-arm64": "1.80.0",
+        "@oxlint/binding-darwin-x64": "1.80.0",
+        "@oxlint/binding-freebsd-x64": "1.80.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.80.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.80.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.80.0",
+        "@oxlint/binding-linux-arm64-musl": "1.80.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.80.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.80.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.80.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.80.0",
+        "@oxlint/binding-linux-x64-gnu": "1.80.0",
+        "@oxlint/binding-linux-x64-musl": "1.80.0",
+        "@oxlint/binding-openharmony-arm64": "1.80.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.80.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.80.0",
+        "@oxlint/binding-win32-x64-msvc": "1.80.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=7.0.2001",
@@ -3509,12 +3526,15 @@
       }
     },
     "node_modules/tslog": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/tslog/-/tslog-4.11.0.tgz",
-      "integrity": "sha512-gBe0FTKkRpOv3DenGipjQWQe073jNd1cOLj3nYfVM0/NP29sQzAIx6kfyfTTsQOiWMC+B+tSr289lNXtu7HCmQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/tslog/-/tslog-5.1.0.tgz",
+      "integrity": "sha512-g77ALovust2HNBX/63ePEJwetIeX0Vi/dlzqBO+ZAg+aERB54KMmaz/khNPxhFpaxKQ6RQj65sK6vIhj1SJgjQ==",
       "license": "MIT",
+      "bin": {
+        "tslog": "esm/subpaths/cli.js"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/fullstack-build/tslog?sponsor=1"

--- a/test-server/package.json
+++ b/test-server/package.json
@@ -20,17 +20,17 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@cqframework/cql": "^4.0.0-beta.1",
+    "@cqframework/cql": "^5.2.0",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
-    "tslog": "^4.11.0"
+    "tslog": "^5.1.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",
     "@types/fhir": "^0.0.44",
     "@types/node": "^24.13.3",
     "copyfiles": "^2.4.1",
-    "oxlint": "^1.79.0",
+    "oxlint": "^1.80.0",
     "prettier": "^3.9.6",
     "tsx": "^4.23.12",
     "typescript": "^7.0.2",

--- a/test-server/src/convert/convert.ts
+++ b/test-server/src/convert/convert.ts
@@ -132,13 +132,10 @@ function toParameter(
     case cqlTypeString.match(/^Interval<System.Date(Time)?>$/)?.[0]:
       return toPeriodParameter(name, result);
     case cqlTypeString.match(/^Interval<System.Quantity>$/)?.[0]:
-      // Apparently the intention of the CQL-to-FHIR mappings is to map numeric intervals to Ranges too,
-      // but as of early April 2026, the CQL Test Runner fails all tests that map numeric intervals to
-      // Ranges, so for now let those cases fall through to Interval-to-Tuple conversion below.
-      // case cqlTypeString.match(/^Interval<System.Decimal>$/)?.[0]:
-      // case cqlTypeString.match(/^Interval<System.Integer>$/)?.[0]:
-      // case cqlTypeString.match(/^Interval<System.Long>$/)?.[0]:
-      const isIntegerOrLong = false; // /^Interval<System.(Integer|Long)>$/.test(cqlTypeString);
+    case cqlTypeString.match(/^Interval<System.Decimal>$/)?.[0]:
+    case cqlTypeString.match(/^Interval<System.Integer>$/)?.[0]:
+    case cqlTypeString.match(/^Interval<System.Long>$/)?.[0]:
+      const isIntegerOrLong = /^Interval<System.(Integer|Long)>$/.test(cqlTypeString);
       return toRangeParameter(name, result, isIntegerOrLong);
     case cqlTypeString.match(/^Interval<.+>$/)?.[0]:
       return toIntervalTupleParameter(name, result, typeSpecifier);
@@ -254,10 +251,10 @@ function toPeriodParameter(name: string, result: Interval) {
 function toRangeParameter(name: string, result: Interval, isIntegerOrLong: boolean) {
   const rangeResult = result.toClosed();
   const rangeParam = { name, valueRange: {} as Range };
-  if (rangeResult.low) {
+  if (rangeResult.low != null) {
     rangeParam.valueRange.low = toFhirQuantity(rangeResult.low, isIntegerOrLong);
   }
-  if (rangeResult.high) {
+  if (rangeResult.high != null) {
     rangeParam.valueRange.high = toFhirQuantity(rangeResult.high, isIntegerOrLong);
   }
   return rangeParam;
@@ -308,9 +305,9 @@ function toChoiceParameter(name: string, result: any, typeSpecifier: AnyTypeSpec
 function toFhirQuantity(val: CqlQuantity | number, isIntegerOrLong = false): FhirQuantity {
   let fq: FhirQuantity;
   if (typeof val === 'number') {
-    fq = { value: val };
+    fq = { value: val, system: 'http://unitsofmeasure.org', code: '1' };
   } else if (typeof val === 'bigint') {
-    fq = { value: Number(val) };
+    fq = { value: Number(val), system: 'http://unitsofmeasure.org', code: '1' };
   } else {
     const cq = val as CqlQuantity;
     fq = { value: cq.value } as FhirQuantity;

--- a/test-server/src/logger.ts
+++ b/test-server/src/logger.ts
@@ -1,9 +1,13 @@
 import { Logger } from 'tslog';
 
 const logger = new Logger({
-  hideLogPositionForProduction: true,
-  prettyInspectOptions: { depth: null },
-  prettyLogTemplate: '{{logLevelName}}\t'
+  stack: {
+    capture: 'off'
+  },
+  pretty: {
+    inspectOptions: { depth: null },
+    template: '{{logLevelName}}\t'
+  }
 });
 
 export default logger;

--- a/test-server/tests/convert/convert.test.ts
+++ b/test-server/tests/convert/convert.test.ts
@@ -20,6 +20,14 @@ function cqlTypeExt(type: string) {
   return [{ url: 'http://hl7.org/fhir/StructureDefinition/cqf-cqlType', valueString: type }];
 }
 
+function quantityPrecisionExt(precision: number) {
+  return {
+    extension: [
+      { url: 'http://hl7.org/fhir/StructureDefinition/quantity-precision', valueInteger: precision }
+    ]
+  };
+}
+
 function timePrecisionExt(code: string) {
   return {
     extension: [{ url: 'http://hl7.org/fhir/StructureDefinition/time-precision', valueCode: code }]
@@ -549,7 +557,7 @@ describe('convert.toParameters', () => {
       });
     });
 
-    it('maps Interval<Integer> to tuple parts (low/lowClosed/high/highClosed)', () => {
+    it('maps Interval<Integer> to FHIR Range', () => {
       const typeSpec = {
         type: 'IntervalTypeSpecifier',
         pointType: { type: 'NamedTypeSpecifier', name: '{urn:hl7-org:elm-types:r1}Integer' }
@@ -560,12 +568,20 @@ describe('convert.toParameters', () => {
           {
             extension: cqlTypeExt('Interval<System.Integer>'),
             name: 'return',
-            part: [
-              { name: 'low', valueInteger: 1 },
-              { name: 'lowClosed', valueBoolean: false },
-              { name: 'high', valueInteger: 5 },
-              { name: 'highClosed', valueBoolean: true }
-            ]
+            valueRange: {
+              low: {
+                value: 2,
+                _value: quantityPrecisionExt(0),
+                code: '1',
+                system: 'http://unitsofmeasure.org'
+              },
+              high: {
+                value: 5,
+                _value: quantityPrecisionExt(0),
+                code: '1',
+                system: 'http://unitsofmeasure.org'
+              }
+            }
           }
         ]
       });
@@ -692,7 +708,7 @@ describe('convert.toParameters', () => {
       });
     });
 
-    it('maps uncertainty with unequal low/high to an Interval tuple', () => {
+    it('maps uncertainty with unequal low/high to a Range', () => {
       const u = new Uncertainty(1, 5);
       expect(toParameters(u, 'System.Integer')).toEqual({
         resourceType: 'Parameters',
@@ -700,12 +716,20 @@ describe('convert.toParameters', () => {
           {
             extension: cqlTypeExt('System.Integer'),
             name: 'return',
-            part: [
-              { name: 'low', valueInteger: 1 },
-              { name: 'lowClosed', valueBoolean: true },
-              { name: 'high', valueInteger: 5 },
-              { name: 'highClosed', valueBoolean: true }
-            ]
+            valueRange: {
+              low: {
+                value: 1,
+                _value: quantityPrecisionExt(0),
+                code: '1',
+                system: 'http://unitsofmeasure.org'
+              },
+              high: {
+                value: 5,
+                _value: quantityPrecisionExt(0),
+                code: '1',
+                system: 'http://unitsofmeasure.org'
+              }
+            }
           }
         ]
       });


### PR DESCRIPTION
This PR contains the following CQL Test Server changes:
- Represent numeric intervals as Ranges
- Fix range conversion bug for boundaries whose value is 0
- Add default unit '1' to numeric range quantities
- Update dependencies

This brings us more in line with the Using CQL specification now that the CQL Tests Runner has fixed some of their bugs related to numeric interval representations.

If you'd like to manually test this, use the CQL Tests Runner [mitre-wip](https://github.com/cqframework/cql-tests-runner/tree/mitre-wip) branch:
1. Start the server on this PR's branch first: `cd test-server` then `npm run dev`.
2. Run the following on the CQL Tests Runner `mitre-wip` branch:
   ```sh
   npm install
   git submodule update --init --recursive
   npx tsx src/bin/cql-tests.ts run-tests conf/cql-execution-local.json ./results
   ```
3. Inspect the results in the test runner's `./results` folder. My last run had 1639 passing, 83 skipped, 101 failed.

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

**Submitter:**

- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `npm run check` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
**Reviewer:**

Name:

- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
